### PR TITLE
Added TurbConv to new framework

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -81,7 +81,6 @@ Computes flux `F` in:
 ∂t
 ```
 Where
-
  - `F_{adv}`      Advective flux                                  , see [`flux_advective!`]@ref()    for this term
  - `F_{press}`    Pressure flux                                   , see [`flux_pressure!`]@ref()     for this term
  - `F_{nondiff}`  Fluxes that do *not* contain gradients          , see [`flux_nondiffusive!`]@ref() for this term
@@ -90,7 +89,7 @@ Where
 function flux!(m::AtmosModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real)
   flux_advective!(m, flux, state, diffusive, aux, t)
   flux_pressure!(m, flux, state, diffusive, aux, t)
-  # flux_nondiffusive!(m, flux, state, diffusive, aux, t)
+  flux_nondiffusive!(m, flux, state, diffusive, aux, t)
   flux_diffusive!(m, flux, state, diffusive, aux, t)
 end
 
@@ -116,8 +115,8 @@ function flux_pressure!(m::AtmosModel, flux::Grad, state::Vars, diffusive::Vars,
   flux.ρe += u*p
 end
 
-# function flux_nondiffusive!(m::AtmosModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real)
-# end
+function flux_nondiffusive!(m::AtmosModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real)
+end
 
 function flux_diffusive!(m::AtmosModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real)
   ρinv = 1/state.ρ
@@ -131,6 +130,7 @@ function flux_diffusive!(m::AtmosModel, flux::Grad, state::Vars, diffusive::Vars
   flux.ρu += ρτ
   flux.ρe += ρτ*u
   flux_diffusive!(m.moisture, flux, state, diffusive, aux, t)
+  flux_diffusive!(m.turbconv, flux, state, diffusive, aux, t)
 end
 
 function wavespeed(m::AtmosModel, nM, state::Vars, aux::Vars, t::Real)
@@ -145,6 +145,7 @@ function gradvariables!(m::AtmosModel, transform::Vars, state::Vars, aux::Vars, 
   transform.u = ρinv * state.ρu
 
   gradvariables!(m.moisture, transform, state, aux, t)
+  gradvariables!(m.turbconv, transform, state, aux, t)
 end
 
 function diffusive!(m::AtmosModel, diffusive::Vars, ∇transform::Grad, state::Vars, aux::Vars, t::Real)
@@ -167,6 +168,7 @@ function diffusive!(m::AtmosModel, diffusive::Vars, ∇transform::Grad, state::V
 
   # diffusivity of moisture components
   diffusive!(m.moisture, diffusive, ∇transform, state, aux, t, ρν)
+  diffusive!(m.turbconv, diffusive, ∇transform, state, aux, t, ρν)
 end
 
 function update_aux!(m::AtmosModel, state::Vars, diffusive::Vars, aux::Vars, t::Real)

--- a/src/Atmos/Model/EDMF/EDMF.jl
+++ b/src/Atmos/Model/EDMF/EDMF.jl
@@ -1,0 +1,192 @@
+#### Eddy-Diffusivity Mass-Flux (EDMF)
+
+export EDMF
+"""
+    EDMF <: TurbulenceConvection
+
+The EDMF turbulence convection model. This model extends `AtmosModel`
+by adding `1+n_updrafts` prognostic equations, via additional `sub-domain`
+to the grid mean equations (`AtmosModel` equations).
+"""
+struct EDMF{N,AF,MOM,E,M,TKE,SM,ML,ED,P,B} <: TurbulenceConvection{N}
+  "Area fraction model"
+  area_frac::AF
+  "Momentum model"
+  momentum::MOM
+  "Energy model"
+  energy::E
+  "Moisture model"
+  moisture::M
+  "Turbulent kinetic energy model"
+  tke::TKE
+  "Surface model"
+  surface::SM
+  "Mixing length model"
+  mix_len::ML
+  "Entrainment-Detrainment model"
+  entr_detr::ED
+  "Pressure model"
+  pressure::P
+  "Buoyancy model"
+  buoyancy::B
+end
+
+EDMF{N}(args...) where N = EDMF{N,typeof.(args)...}(args...)
+
+function vars_state(edmf::EDMF{N}, T) where N
+  @vars begin
+    area_frac::vars_state(edmf.area_frac,T, Val(N))
+    momentum::vars_state(edmf.momentum,T, Val(N))
+    energy::vars_state(edmf.energy,T, Val(N))
+    moisture::vars_state(edmf.moisture,T, Val(N))
+    tke::vars_state(edmf.tke,T, Val(N))
+  end
+end
+function vars_gradient(edmf::EDMF{N}, T) where N
+  @vars begin
+    area_frac::vars_gradient(edmf.area_frac,T)
+    momentum::vars_gradient(edmf.momentum,T)
+    energy::vars_gradient(edmf.energy,T)
+    moisture::vars_gradient(edmf.moisture,T)
+    tke::vars_gradient(edmf.tke,T)
+
+    surface::vars_gradient(edmf.surface,T)
+    mix_len::vars_gradient(edmf.mix_len,T, Val(N))
+    entr_detr::vars_gradient(edmf.entr_detr,T, Val(N))
+    pressure::vars_gradient(edmf.pressure,T)
+    buoyancy::vars_gradient(edmf.buoyancy,T, Val(N))
+  end
+end
+function vars_aux(edmf::EDMF{N}, T) where N
+  @vars begin
+    area_frac::vars_aux(edmf.area_frac,T)
+    momentum::vars_aux(edmf.momentum,T)
+    energy::vars_aux(edmf.energy,T)
+    moisture::vars_aux(edmf.moisture,T)
+    tke::vars_aux(edmf.tke,T)
+
+    surface::vars_aux(edmf.surface,T)
+    mix_len::vars_aux(edmf.mix_len,T, Val(N))
+    entr_detr::vars_aux(edmf.entr_detr,T, Val(N))
+    pressure::vars_aux(edmf.pressure,T)
+    buoyancy::vars_aux(edmf.buoyancy,T, Val(N))
+  end
+end
+
+function update_aux!(       ::TurbulenceConvection, state::Vars, diffusive::Vars, aux::Vars, t::Real);end
+function gradvariables!(    ::TurbulenceConvection, transform::Vars, state::Vars, aux::Vars, t::Real);end
+function flux!(             ::TurbulenceConvection, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real);end
+function source!(           ::TurbulenceConvection, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real);end
+function boundarycondition!(::TurbulenceConvection, stateP::Vars, diffP::Vars, auxP::Vars, nM, stateM::Vars, diffM::Vars, auxM::Vars, bctype, t);end
+
+include("subdomain_index_helper.jl")
+include("area_frac.jl")
+include("momentum.jl")
+include("energy.jl")
+include("moisture.jl")
+include("tke.jl")
+include("surface.jl")
+include("mixing_length.jl")
+include("entr_detr.jl")
+include("pressure.jl")
+include("buoyancy.jl")
+
+"""
+    flux!(m::AtmosModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real)
+Computes flux `F` in:
+```
+∂Y
+-- = - ∇ • (F_{adv} + F_{press} + F_{nondiff} + F_{diff}) + S(Y)
+∂t
+```
+Where
+ - `F_{adv}`      Advective flux                                  , see [`flux_advective!`]@ref()    for this term
+ - `F_{press}`    Pressure flux                                   , see [`flux_pressure!`]@ref()     for this term
+ - `F_{nondiff}`  Fluxes that do *not* contain gradients          , see [`flux_nondiffusive!`]@ref() for this term
+ - `F_{diff}`     Fluxes that contain gradients of state variables, see [`flux_diffusive!`]@ref()    for this term
+"""
+function flux!(edmf::EDMF, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real)
+  flux_advective!(edmf.area_frac, flux, state, diffusive, aux, t)
+  flux_advective!(edmf.momentum , flux, state, diffusive, aux, t)
+  flux_advective!(edmf.energy   , flux, state, diffusive, aux, t)
+  flux_advective!(edmf.moisture , flux, state, diffusive, aux, t)
+  flux_advective!(edmf.tke      , flux, state, diffusive, aux, t)
+
+  flux_pressure!(edmf.momentum , flux, state, diffusive, aux, t)
+  flux_pressure!(edmf.tke      , flux, state, diffusive, aux, t)
+
+  flux_nondiffusive!(edmf.area_frac, flux, state, diffusive, aux, t)
+  flux_nondiffusive!(edmf.momentum , flux, state, diffusive, aux, t)
+  flux_nondiffusive!(edmf.energy   , flux, state, diffusive, aux, t)
+  flux_nondiffusive!(edmf.moisture , flux, state, diffusive, aux, t)
+  flux_nondiffusive!(edmf.tke      , flux, state, diffusive, aux, t)
+
+  flux_diffusive!(edmf.area_frac, flux, state, diffusive, aux, t)
+  flux_diffusive!(edmf.momentum , flux, state, diffusive, aux, t)
+  flux_diffusive!(edmf.energy   , flux, state, diffusive, aux, t)
+  flux_diffusive!(edmf.moisture , flux, state, diffusive, aux, t)
+  flux_diffusive!(edmf.tke      , flux, state, diffusive, aux, t)
+end
+
+function gradvariables!(edmf::EDMF, transform::Vars, state::Vars, aux::Vars, t::Real)
+  gradvariables!(edmf, edmf.area_frac, transform, state, aux, t)
+  gradvariables!(edmf, edmf.momentum , transform, state, aux, t)
+  gradvariables!(edmf, edmf.energy   , transform, state, aux, t)
+  gradvariables!(edmf, edmf.moisture , transform, state, aux, t)
+  gradvariables!(edmf, edmf.tke      , transform, state, aux, t)
+
+  gradvariables!(edmf, edmf.surface  , transform, state, aux, t)
+  gradvariables!(edmf, edmf.mix_len  , transform, state, aux, t)
+  gradvariables!(edmf, edmf.entr_detr, transform, state, aux, t)
+  gradvariables!(edmf, edmf.pressure , transform, state, aux, t)
+  gradvariables!(edmf, edmf.buoyancy , transform, state, aux, t)
+end
+
+function update_aux!(edmf::EDMF, state::Vars, diffusive::Vars, ∇transform::Grad, aux::Vars, t::Real)
+  diagnose_env!(edmf, edmf.area_frac, state, aux)
+  diagnose_env!(edmf, edmf.momentum , state, aux)
+  diagnose_env!(edmf, edmf.energy   , state, aux)
+  diagnose_env!(edmf, edmf.moisture , state, aux)
+  diagnose_env!(edmf, edmf.tke      , state, aux)
+
+  update_aux!(edmf, edmf.area_frac, transform, state, aux, t)
+  update_aux!(edmf, edmf.momentum , transform, state, aux, t)
+  update_aux!(edmf, edmf.energy   , transform, state, aux, t)
+  update_aux!(edmf, edmf.moisture , transform, state, aux, t)
+  update_aux!(edmf, edmf.tke      , transform, state, aux, t)
+
+  update_aux!(edmf, edmf.surface  , transform, state, aux, t)
+  update_aux!(edmf, edmf.mix_len  , transform, state, aux, t)
+  update_aux!(edmf, edmf.entr_detr, transform, state, aux, t)
+  update_aux!(edmf, edmf.pressure , transform, state, aux, t)
+  update_aux!(edmf, edmf.buoyancy , transform, state, aux, t)
+end
+
+
+"""
+    source!(edmf::EDMF, source::Vars, state::Vars, aux::Vars, t::Real)
+
+Computes flux `S(Y)` in:
+
+```
+∂Y
+-- = - ∇ • F + S(Y)
+∂t
+```
+"""
+function source!(edmf::EDMF, source::Vars, state::Vars, aux::Vars, t::Real)
+  source!(edmf, edmf.area_frac, source, state, aux, t)
+  source!(edmf, edmf.momentum , source, state, aux, t)
+  source!(edmf, edmf.energy   , source, state, aux, t)
+  source!(edmf, edmf.moisture , source, state, aux, t)
+  source!(edmf, edmf.tke      , source, state, aux, t)
+end
+
+function boundarycondition!(edmf::EDMF, stateP::Vars, diffP::Vars, auxP::Vars, nM, stateM::Vars, diffM::Vars, auxM::Vars, bctype, t)
+  boundarycondition!(edmf, edmf.area_frac, stateP, diffP, auxP, nM, stateM, diffM, auxM, bctype, t)
+  boundarycondition!(edmf, edmf.momentum , stateP, diffP, auxP, nM, stateM, diffM, auxM, bctype, t)
+  boundarycondition!(edmf, edmf.energy   , stateP, diffP, auxP, nM, stateM, diffM, auxM, bctype, t)
+  boundarycondition!(edmf, edmf.moisture , stateP, diffP, auxP, nM, stateM, diffM, auxM, bctype, t)
+  boundarycondition!(edmf, edmf.tke      , stateP, diffP, auxP, nM, stateM, diffM, auxM, bctype, t)
+end
+

--- a/src/Atmos/Model/EDMF/area_frac.jl
+++ b/src/Atmos/Model/EDMF/area_frac.jl
@@ -1,0 +1,59 @@
+#### Area fraction Model
+abstract type AreaFractionModel{T} end
+
+export ConstantAreaFrac, PrognosticAreaFrac
+
+vars_state(    ::AreaFractionModel, T, N) = @vars()
+vars_gradient( ::AreaFractionModel, T, N) = @vars()
+vars_diffusive(::AreaFractionModel, T, N) = @vars()
+vars_aux(      ::AreaFractionModel, T, N) = @vars()
+
+function update_aux!(       edmf::EDMF{N}, m::AreaFractionModel, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function gradvariables!(    edmf::EDMF{N}, m::AreaFractionModel, transform::Vars, state::Vars, aux::Vars, t::Real) where N; end
+function flux_diffusive!(   edmf::EDMF{N}, m::AreaFractionModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_nondiffusive!(edmf::EDMF{N}, m::AreaFractionModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_advective!(   edmf::EDMF{N}, m::AreaFractionModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function source!(           edmf::EDMF{N}, m::AreaFractionModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function boundarycondition!(edmf::EDMF{N}, m::AreaFractionModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+
+"""
+    ConstantAreaFrac{T} <: AreaFractionModel{T}
+
+Constant area fraction model. Area fraction is prescribed
+using this model.
+"""
+struct ConstantAreaFrac{N, T} <: AreaFractionModel{T}
+  ρa::NTuple{N, T}
+end
+
+"""
+    PrognosticAreaFrac{T} <: AreaFractionModel{T}
+
+Prognostic area fraction model. Area fraction is solved for
+using this model.
+"""
+struct PrognosticAreaFrac{T} <: AreaFractionModel{T} end
+
+vars_state(m::PrognosticAreaFrac, T, N) = @vars(ρa::SVector{N,T})
+
+function flux_advective!(edmf::EDMF{N}, m::PrognosticAreaFrac, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+    ρinv = 1/state.turbconv.area_frac.ρ[i]
+    flux.turbconv.area_frac.ρa[i] = ρinv*state.turbconv.area_frac.ρa[i]*state.turbconv.area_frac.ρu[i]
+  end
+end
+
+function source!(edmf::EDMF{N}, m::PrognosticAreaFrac, source::Vars, state::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  DT = eltype(state)
+  @inbounds for i in id.up
+    source.turbconv.area_frac.ρa[i] = aux.turbconv.entr_detr.εδ_ρa[i]
+  end
+  source.turbconv.area_frac.ρa[id.en] = sum([DT(0) - aux.turbconv.entr_detr.εδ_ρa[i] for i in id.up])
+end
+
+function diagnose_env!(edmf::EDMF{N}, m::PrognosticAreaFrac, state::Vars, aux::Vars) where N
+  id = idomains(N)
+  state.turbconv.area_frac.ρa[id.en] = state.ρa  - sum([state.turbconv.area_frac.ρa[i] for i in id.up])
+end

--- a/src/Atmos/Model/EDMF/buoyancy.jl
+++ b/src/Atmos/Model/EDMF/buoyancy.jl
@@ -1,0 +1,46 @@
+#### Buoyancy Model
+abstract type AbstractBuoyancyModel{T} end
+struct BuoyancyModel{T} <: AbstractBuoyancyModel{T} end
+BuoyancyModel(::Type{T}) where T = BuoyancyModel{T}()
+
+export BuoyancyModel
+
+vars_state(    ::BuoyancyModel, T) = @vars()
+vars_gradient( ::BuoyancyModel, T) = @vars()
+vars_diffusive(::BuoyancyModel, T) = @vars()
+vars_aux(      ::BuoyancyModel, T, N) = @vars(buoyancy::SVector{N,T})
+
+function update_aux!(   edmf::EDMF{N}, m::BuoyancyModel, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function gradvariables!(edmf::EDMF{N}, m::BuoyancyModel, transform::Vars, state::Vars, aux::Vars, t::Real) where N; end
+
+function update_aux!(edmf::EDMF{N,A,M,TKE,SM,ML,ED,P,BuoyancyModel}, state::Vars, diffusive::Vars, ∇transform::Grad, aux::Vars, t::Real) where {N,A,M,TKE,SM,ML,ED,P}
+  id = idomains(N)
+  DT = eltype(state.ρ)
+
+  @inbounds for i in (id.en, id.up...)
+    ts = thermo_state(edmf, state, aux, i)
+    R_m = gas_constant_air(ts)
+    T = air_temperature(ts)
+    α_i = R_m*T/aux.pressure
+    α_0 = 1/state.ρ
+    aux.turbconv.buoyancy[i] = grav*DT((big(α_i) - big(α_0))/α_0)
+  end
+  S = big(DT(0))
+  @inbounds for i in (id.en, id.up...)
+    a_i = (1/state.ρ)*state.turbconv.ρa[i]
+    B_i = aux.turbconv.buoyancy[i]
+    S += big(B_i)*big(a_i)
+  end
+  aux.buoyancy = DT(S)
+  @inbounds for i in (id.en, id.up...)
+    aux.turbconv.buoyancy[i] = DT(aux.turbconv.buoyancy[i] - S)
+  end
+
+  S = big(DT(0))
+  @inbounds for i in (id.en, id.up...)
+    a_i = (1/state.ρ)*state.turbconv.ρa[i]
+    S += big(aux.turbconv.buoyancy[i])*big(a_i)
+  end
+  aux.buoyancy = DT(S)
+
+end

--- a/src/Atmos/Model/EDMF/energy.jl
+++ b/src/Atmos/Model/EDMF/energy.jl
@@ -1,0 +1,42 @@
+#### Energy Model
+abstract type AbstractEnergyModel{T} end
+
+struct EnergyModel{T} <: AbstractEnergyModel{T} end
+EnergyModel(::Type{T}) where T = EnergyModel{T}()
+
+export EnergyModel
+
+vars_state(    ::AbstractEnergyModel, T, N) = @vars()
+vars_gradient( ::AbstractEnergyModel, T, N) = @vars()
+vars_diffusive(::AbstractEnergyModel, T, N) = @vars()
+vars_aux(      ::AbstractEnergyModel, T, N) = @vars(ρe_int::SVector{N,T})
+
+function update_aux!(       edmf::EDMF{N}, m::AbstractEnergyModel, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function gradvariables!(    edmf::EDMF{N}, m::AbstractEnergyModel, transform::Vars, state::Vars, aux::Vars, t::Real) where N; end
+function flux_diffusive!(   edmf::EDMF{N}, m::AbstractEnergyModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_nondiffusive!(edmf::EDMF{N}, m::AbstractEnergyModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_advective!(   edmf::EDMF{N}, m::AbstractEnergyModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function source!(           edmf::EDMF{N}, m::AbstractEnergyModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function boundarycondition!(edmf::EDMF{N}, m::AbstractEnergyModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+
+function flux_advective!(edmf::EDMF{N}, m::EnergyModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+    ρinv = 1/state.ρ
+    flux.turbconv.energy.ρe[i] = state.turbconv.momentum.ρu[i] * ρinv*state.turbconv.energy.ρe[i]
+  end
+end
+
+function flux_pressure!(edmf::EDMF{N}, m::EnergyModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+    ρinv = 1/state.ρ
+    p = pressure(edmf, state, aux, i)
+    flux.turbconv.energy.ρe[i] += ρinv*state.turbconv.momentum.ρu*p
+  end
+end
+
+function diagnose_env!(edmf::EDMF{N}, m::EnergyModel, state::Vars, aux::Vars) where N
+  id = idomains(N)
+  state.turbconv.energy.ρe[id.en] = state.ρe  - sum([state.turbconv.energy.ρe[i] for i in id.up])
+end

--- a/src/Atmos/Model/EDMF/entr_detr.jl
+++ b/src/Atmos/Model/EDMF/entr_detr.jl
@@ -1,0 +1,191 @@
+#### Entrainment-Detrainment Model
+abstract type EntrDetrModel{T} end
+
+export ConstantEntrDetr, BOverW2
+
+vars_state(    ::EntrDetrModel, T) = @vars()
+vars_gradient( ::EntrDetrModel, T) = @vars()
+vars_diffusive(::EntrDetrModel, T) = @vars()
+vars_aux(      ::EntrDetrModel, T) = @vars()
+
+function update_aux!(       edmf::EDMF{N}, m::EntrDetrModel, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function gradvariables!(    edmf::EDMF{N}, m::EntrDetrModel, transform::Vars, state::Vars, aux::Vars, t::Real) where N; end
+function flux_diffusive!(   edmf::EDMF{N}, m::EntrDetrModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_nondiffusive!(edmf::EDMF{N}, m::EntrDetrModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_advective!(   edmf::EDMF{N}, m::EntrDetrModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function source!(           edmf::EDMF{N}, m::EntrDetrModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+
+"""
+    ConstantEntrDetr{T} <: EntrDetrModel{T}
+
+Constant entrainment-detrainment model.
+"""
+struct ConstantEntrDetr{T} <: EntrDetrModel{T}
+  c_ε::T
+  c_δ_0::T
+  δ_B::T
+  denom_limiter::T
+end
+
+"""
+    ConstantEntrDetr(::Type{T}) where T
+
+Default values for constant entrainment-detrainment model.
+"""
+function ConstantEntrDetr(::Type{T}) where T
+  c_ε = T(0.1)
+  c_δ_0 = T(0.1)
+  δ_B = T(0.004)
+  denom_limiter = T(1e-2)
+  return ConstantEntrDetr{T}(c_ε, c_δ_0, δ_B, denom_limiter)
+end
+
+function vars_aux(m::ConstantEntrDetr, T, N)
+  @vars begin
+    δ_model::SVector{N,T}
+    εδ_ρa::SVector{N,T}
+    εδ_ρu::SVector{N,T}
+    εδ_ρe::SVector{N,T}
+    εδ_q_tot::SVector{N,T}
+    εδ_tke::SVector{N,T}
+  end
+end
+
+@inline function safe_divide(m::ConstantEntrDetr, a, b)
+  return a/(max(b, m.denom_limiter))
+end
+
+function update_aux!(edmf::EDMF{N,PrognosticAreaFrac,M,TKE,SM,ML,ED,P,B}, m::ConstantEntrDetr{T}, state::Vars, diffusive::Vars, ∇transform::Grad, aux::Vars, t::Real) where {N,M,TKE,SM,ML,ED,P,B,T}
+
+  id = idomains(N)
+
+  @inbounds for ϕ in (:ρa, :ρu, :ρe, :q_tot, :tke, :cv_q_tot_q_tot, :cv_e_int_e_int, :cv_e_int_q_tot)
+    @inbounds for i in (id.en, id.up...)
+      ts = thermo_state(edmf, state, aux, i)
+      q_pt = PhasePartition(ts)
+
+      ρa_i = getfield(state.turbconv, :ρa)[i]
+      ϕ_i = ϕ==:ρu ? getfield(state.turbconv, ϕ)[i][3] : getfield(state.turbconv, ϕ)[i]
+      w_i = getfield(state.turbconv, :ρu)[i][3]
+      ϕ_env = getfield(state.turbconv, ϕ)[id.en]
+      ϕ_env = getfield(state.turbconv, ϕ)[id.en]
+      w_env = getfield(state.turbconv, :ρu)[id.en][3]
+      B_i = aux.turbconv.buoyancy[i]
+
+      ε_i = m.c_ε
+      δ_i = m.c_δ_0
+      aux.turbconv.δ_model[i] = δ_i
+
+      δ_i_ϕ_i = δ_i*ϕ_i
+      ε_i_ϕ_e = ε_i*ϕ_env
+      ρaw_k = ρa_i * abs(w_i)
+      if ϕ==:ρa
+        aux.turbconv.εδ_ρa = ρaw_k * (-δ_i + ε_i)
+      elseif ϕ==:ρu
+        aux.turbconv.εδ_ρu = ρaw_k * (-δ_i_ϕ_i + ε_i_ϕ_e)
+      elseif ϕ==:ρe
+        aux.turbconv.εδ_ρe = ρaw_k * (-δ_i_ϕ_i + ε_i_ϕ_e)
+      elseif ϕ==:q_tot
+        aux.turbconv.εδ_q_tot = ρaw_k * (-δ_i_ϕ_i + ε_i_ϕ_e)
+      elseif ϕ==:tke
+        aux.turbconv.εδ_tke = ρaw_k * (-δ_i_ϕ_i + ε_i*(ϕ_env + 1/2*(w_env-w_i)^2) )
+      elseif ϕ==:cv_q_tot_q_tot
+        # TODO: Add computations for cv_q_tot_q_tot
+      elseif ϕ==:cv_e_int_e_int
+        # TODO: Add computations for cv_e_int_e_int
+      elseif ϕ==:cv_e_int_q_tot
+        # TODO: Add computations for cv_e_int_q_tot
+      else
+        error("Bad field in "*@__FILE__)
+      end
+    end
+  end
+end
+
+"""
+    BOverW2{N, T} <: EntrDetrModel{N}
+
+Yair's entrainment-detrainment model.
+"""
+struct BOverW2{T} <: EntrDetrModel{T}
+  c_ε::T
+  δ_B::T
+  c_δ_0::T
+  denom_limiter::T
+end
+
+"""
+    BOverW2(::Type{T}) where T
+
+Default values for Yair's entrainment-detrainment model.
+"""
+function BOverW2(::Type{T}) where T
+  c_ε = T(0.12)
+  δ_B = T(0.004)
+  c_δ_0 = T(0.12)
+  denom_limiter = T(1e-2)
+  return BOverW2{T}(c_ε, c_δ_0, δ_B, denom_limiter)
+end
+
+function vars_aux(m::BOverW2, T, N)
+  @vars begin
+    δ_model::SVector{N,T}
+    εδ_ρa::SVector{N,T}
+    εδ_ρu::SVector{N,T}
+    εδ_ρe::SVector{N,T}
+    εδ_q_tot::SVector{N,T}
+    εδ_tke::SVector{N,T}
+  end
+end
+
+@inline function safe_divide(m::BOverW2, a, b)
+  return a/(max(b, m.denom_limiter))
+end
+
+function update_aux!(edmf::EDMF{N,PrognosticAreaFrac,M,TKE,SM,ML,ED,P,B}, m::BOverW2{T}, state::Vars, diffusive::Vars, ∇transform::Grad, aux::Vars, t::Real) where {N,M,TKE,SM,ML,ED,P,B,T}
+
+  id = idomains(N)
+
+  for ϕ in (:ρa, :ρu, :ρe, :q_tot, :tke, :cv_q_tot_q_tot, :cv_e_int_e_int, :cv_e_int_q_tot)
+    for i in (id.en, id.up...)
+      ts = thermo_state(edmf, state, aux, i)
+      q_pt = PhasePartition(ts)
+
+      ρa_i = getfield(state.turbconv, :ρa)[i]
+      ϕ_i = ϕ==:ρu ? getfield(state.turbconv, ϕ)[i][3] : getfield(state.turbconv, ϕ)[i]
+      w_i = getfield(state.turbconv, :ρu)[i][3]
+      ϕ_env = getfield(state.turbconv, ϕ)[id.en]
+      ϕ_env = getfield(state.turbconv, ϕ)[id.en]
+      w_env = getfield(state.turbconv, :ρu)[id.en][3]
+      B_i = aux.turbconv.buoyancy[i]
+
+      ε_i = m.c_ε*safe_divide(m, max(B_i, 0), w_i^2)
+      δ_i = m.c_δ_0*safe_divide(m, abs(min(B_i, 0)), w_i^2) + m.δ_B*T(q_pt.liq > T(0))
+      aux.turbconv.δ_model[i] = δ_i
+
+      δ_i_ϕ_i = δ_i*ϕ_i
+      ε_i_ϕ_e = ε_i*ϕ_env
+      ρaw_k = ρa_i * abs(w_i)
+      if ϕ==:ρa
+        aux.turbconv.εδ_ρa = ρaw_k * (-δ_i + ε_i)
+      elseif ϕ==:ρu
+        aux.turbconv.εδ_ρu = ρaw_k * (-δ_i_ϕ_i + ε_i_ϕ_e)
+      elseif ϕ==:ρe
+        aux.turbconv.εδ_ρe = ρaw_k * (-δ_i_ϕ_i + ε_i_ϕ_e)
+      elseif ϕ==:q_tot
+        aux.turbconv.εδ_q_tot = ρaw_k * (-δ_i_ϕ_i + ε_i_ϕ_e)
+      elseif ϕ==:tke
+        aux.turbconv.εδ_tke = ρaw_k * (-δ_i_ϕ_i + ε_i*(ϕ_env + 1/2*(w_env-w_i)^2) )
+      elseif ϕ==:cv_q_tot_q_tot
+        # TODO: Add computations for cv_q_tot_q_tot
+      elseif ϕ==:cv_e_int_e_int
+        # TODO: Add computations for cv_e_int_e_int
+      elseif ϕ==:cv_e_int_q_tot
+        # TODO: Add computations for cv_e_int_q_tot
+      else
+        error("Bad field in "*@__FILE__)
+      end
+    end
+  end
+end
+

--- a/src/Atmos/Model/EDMF/mixing_length.jl
+++ b/src/Atmos/Model/EDMF/mixing_length.jl
@@ -1,0 +1,95 @@
+#### Mixing Length Model
+abstract type MixingLengthModel{T} end
+
+using ..PlanetParameters
+export ConstantMixingLength, DynamicMixingLength
+
+vars_state(    ::MixingLengthModel, T) = @vars()
+vars_gradient( ::MixingLengthModel, T) = @vars()
+vars_diffusive(::MixingLengthModel, T) = @vars()
+vars_aux(      ::MixingLengthModel, T, N) = @vars(l_mix::SVector{N,T})
+
+function update_aux!(   edmf::EDMF{N}, m::MixingLengthModel, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function gradvariables!(edmf::EDMF{N}, m::MixingLengthModel, transform::Vars, state::Vars, aux::Vars, t::Real) where N; end
+
+"""
+    ConstantMixingLength{N, T} <: MixingLengthModel{N}
+
+Constant mixing length model.
+"""
+struct ConstantMixingLength{T} <: MixingLengthModel{T}
+  l_mix::T
+end
+ConstantMixingLength(::Type{T}) where T = ConstantMixingLength{T}(100)
+
+function update_aux!(edmf::EDMF{N}, m::ConstantMixingLength, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  for i in (id.en, id.up...)
+    aux.turbconv.l_mix[i] = m.l_mix
+  end
+end
+
+"""
+    DynamicMixingLength{T} <: MixingLengthModel{T}
+
+Dynamic mixing length model.
+"""
+struct DynamicMixingLength{T} <: MixingLengthModel{T}
+  Prandtl_neutral::T
+  c_ε::T
+  c_K::T
+  ω_1::T
+  ω_2::T
+  c_1::Tuple{T, T}
+  c_2::Tuple{T, T}
+  denom_limiter::T
+end
+
+"""
+    DynamicMixingLength(::Type{T}) where T
+
+Default values for dynamic mixing length.
+"""
+function DynamicMixingLength(::Type{T}) where T
+  Prandtl_neutral = T(0.74)
+  c_ε = T(0.12)
+  c_K = T(0.1)
+  ω_1 = T(40/13)
+  ω_2 = ω_1+1
+  c_1 = NTuple{2, T}([-100.0, 0.2])
+  c_2 = NTuple{2, T}([2.7, -1.0])
+  denom_limiter =  T(1e-2)
+  return DynamicMixingLength{T}(Prandtl_neutral, c_ε, c_K, ω_1, ω_2, c_1, c_2, denom_limiter)
+end
+
+vars_aux(m::DynamicMixingLength, T, N) = @vars(θ_virt::SVector{N,T},
+                                               S_squared::SVector{N,T})
+vars_gradient(m::DynamicMixingLength, T, N) = @vars(θ_virt::SVector{N,T})
+
+function ϕ_m(m, ξ, obukhov_length)
+  a_L, b_L = obukhov_length<0 ? m.c_1 : m.c_2
+  return (1+a_L*ξ)^(-b_L)
+end
+
+function update_aux!(edmf::EDMF{N}, m::DynamicMixingLength, ∇transform::Grad, state::Vars, aux::Vars) where N
+  id = idomains(N)
+  L = Vector(undef, 3)
+  # obukhov_length, ustar, windspeed = compute_surface_fluxes(m, state, aux)
+  z = aux.coordinates.z
+
+  ∇u = ∇transform.u
+  aux.turbconv.mix_len.S_squared[id.en] = ∇u[1,3]^2 + ∇u[2,3]^2 + ∇u[3,3]^2
+
+  buoyancy_freq = grav*∇transform.turbconv.mix_len.θ_virt[id.en]/aux.turbconv.mix_len.θ_virt[id.en]
+  L[1] = sqrt(c_w*state.turbconv.tke.tke[id.en])/buoyancy_freq
+  ξ = z/obukhov_length
+  κ_star = ustar/sqrt(state.turbconv.tke.tke[id.en])
+  L[2] = k_Karman*z/(m.c_K*κ_star*ϕ_m(m, ξ, obukhov_length))
+  R_g = ∇transform.turbconv.buoyancy.buoyancy[id.en]/aux.turbconv.mix_len.S_squared[id.en]
+  Pr_z = obukhov_length <0 ? m.Prandtl_neutral : m.Prandtl_neutral*(1+m.ω_2*R_g - sqrt(-4*R_g+(1+m.ω_2*R_g)^2))/(2*R_g)
+  discriminant = aux.turbconv.mix_len.S_squared[id.en] - ∇transform.turbconv.buoyancy.buoyancy[id.en]/Pr_z
+  L[3] = sqrt(m.c_ε/m.c_K)*sqrt(state.turbconv.tke.tke[id.en])*1/sqrt(max(discriminant, m.denom_limiter))
+  l_mix = sum([L[j]*exp(-L[j]) for j in 1:3])/sum([exp(-L[j]) for j in 1:3])
+
+  aux.turbconv.l_mix[id.en] = l_mix
+end

--- a/src/Atmos/Model/EDMF/moisture.jl
+++ b/src/Atmos/Model/EDMF/moisture.jl
@@ -1,0 +1,94 @@
+#### Moisture component in atmosphere model
+abstract type EDMFMoistureModel end
+
+export EDMFDryModel, EDMFEquilMoist
+
+vars_state(    ::EDMFMoistureModel, T, N) = @vars()
+vars_gradient( ::EDMFMoistureModel, T, N) = @vars()
+vars_diffusive(::EDMFMoistureModel, T, N) = @vars()
+vars_aux(      ::EDMFMoistureModel, T, N) = @vars()
+
+function update_aux!(       edmf::EDMF{N}, m::EDMFMoistureModel, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function gradvariables!(    edmf::EDMF{N}, m::EDMFMoistureModel, transform::Vars, state::Vars, aux::Vars, t::Real) where N; end
+function flux_diffusive!(   edmf::EDMF{N}, m::EDMFMoistureModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_nondiffusive!(edmf::EDMF{N}, m::EDMFMoistureModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_advective!(   edmf::EDMF{N}, m::EDMFMoistureModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function source!(           edmf::EDMF{N}, m::EDMFMoistureModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function boundarycondition!(edmf::EDMF{N}, m::EDMFMoistureModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+
+function internal_energy(edmf::EDMF{N}, m::EDMFMoistureModel, state::Vars, aux::Vars) where N
+  T = eltype(state)
+  id = idomains(N)
+  e_int = similar(state.turbconv.ρ)
+  @inbounds for i in (id.env, id.up...)
+    ρinv = 1 / state.ρ
+    ρe_kin = ρinv*sum(abs2, state.turbconv.momentum.ρu[i])/2
+    ρe_pot = state.turbconv.area_frac.ρa[i] * grav * aux.coord.z
+    ρe_int = state.turbconv.energy.ρe[i] - ρe_kin - ρe_pot
+    e_int[i] = ρinv*ρe_int
+  end
+  return e_int
+end
+
+temperature(edmf::EDMF, state::Vars, aux::Vars, i) = air_temperature(thermo_state(edmf, state, aux, i))
+pressure(edmf::EDMF, state::Vars, aux::Vars, i) = air_pressure(thermo_state(edmf, state, aux, i))
+soundspeed(edmf::EDMF, state::Vars, aux::Vars, i) = soundspeed_air(thermo_state(edmf, state, aux, i))
+
+"""
+    EDMFDryModel
+
+Assumes the moisture components is in the dry limit.
+"""
+struct EDMFDryModel <: EDMFMoistureModel end
+
+vars_aux(::EDMFDryModel, T, N) = @vars(e_int::T)
+function update_aux!(edmf::EDMF, m::EDMFDryModel, state::Vars, diffusive::Vars, aux::Vars, t::Real)
+  aux.turbconv.energy.e_int = internal_energy(edmf, m, state, aux)
+  nothing
+end
+
+function thermo_state(edmf::EDMF{N,AF,EDMFDryModel,TKE,SM,ML,ED,P,B}, state::Vars, aux::Vars, i) where {N,AF,TKE,SM,ML,ED,P,B}
+  if i==idomains(N).gm
+    PhaseDry(aux.moisture.e_int, state.ρ)
+  else
+    PhaseDry(aux.turbconv.energy.e_int[i], state.ρ)
+  end
+end
+
+"""
+    EDMFEquilMoist
+
+Assumes the moisture components are computed via thermodynamic equilibrium.
+"""
+struct EDMFEquilMoist <: EDMFMoistureModel
+end
+vars_state(::EDMFEquilMoist,T, N) = @vars(ρq_tot::T)
+vars_gradient(::EDMFEquilMoist,T, N) = @vars(q_tot::T, total_enthalpy::T)
+vars_diffusive(::EDMFEquilMoist,T, N) = @vars(ρd_q_tot::SVector{3,T}, ρ_SGS_enthalpyflux::SVector{3,T})
+vars_aux(::EDMFEquilMoist,T, N) = @vars(e_int::T, temperature::T)
+
+function update_aux!(edmf::EDMF{N}, m::EDMFEquilMoist, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  aux.turbconv.energy.e_int = internal_energy(edmf, m, state, aux)
+  id = idomains(N)
+  @inbounds for i in (id.env, id.up...)
+    TS = PhaseEquil(aux.turbconv.energy.e_int[i], get_phase_partition(m, state, i).tot, state.ρ)
+    aux.turbconv.moisture.temperature[i] = air_temperature(TS)
+  end
+  nothing
+end
+
+function get_phase_partition(edmf::EDMF{N}, m::EDMFEquilMoist, state::Vars, i) where N
+  if i==idomains(N).gm
+    PhasePartition(state.moisture.ρq_tot/state.ρ)
+  else
+    PhasePartition(state.turbconv.moisture.ρq_tot[i]/state.ρ)
+  end
+end
+
+function thermo_state(edmf::EDMF{N,AF,EDMFEquilMoist,TKE,SM,ML,ED,P,B}, state::Vars, aux::Vars, i) where {N,AF,TKE,SM,ML,ED,P,B}
+  if i==idomains(N).gm
+    PhaseEquil(aux.moisture.e_int, state.ρ, state.moisture.ρq_tot/state.ρ, aux.moisture.temperature)
+  else
+    PhaseEquil(aux.turbconv.energy.e_int[i], state.ρ, state.turbconv.moisture.ρq_tot[i]/state.ρ, aux.turbconv.moisture.temperature[i])
+  end
+end

--- a/src/Atmos/Model/EDMF/momentum.jl
+++ b/src/Atmos/Model/EDMF/momentum.jl
@@ -1,0 +1,60 @@
+#### Momentum Model
+abstract type AbstractMomentumModel{T} end
+
+struct MomentumModel{T} <: AbstractMomentumModel{T} end
+MomentumModel(::Type{T}) where T = MomentumModel{T}()
+
+export MomentumModel
+
+vars_state(    ::AbstractMomentumModel, T, N) = @vars(ρu::SMatrix{3,N+1,T})
+vars_gradient( ::AbstractMomentumModel, T, N) = @vars(ρu::SMatrix{3,N+1,T})
+vars_diffusive(::AbstractMomentumModel, T, N) = @vars()
+vars_aux(      ::AbstractMomentumModel, T, N) = @vars(ρu::SMatrix{3,N+1,T})
+
+function gradvariables!(    edmf::EDMF{N}, m::AbstractMomentumModel, transform::Vars, state::Vars, aux::Vars, t::Real) where N; end
+function update_aux!(       edmf::EDMF{N}, m::AbstractMomentumModel, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_diffusive!(   edmf::EDMF{N}, m::AbstractMomentumModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_nondiffusive!(edmf::EDMF{N}, m::AbstractMomentumModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_advective!(   edmf::EDMF{N}, m::AbstractMomentumModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function source!(           edmf::EDMF{N}, m::AbstractMomentumModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function boundarycondition!(edmf::EDMF{N}, m::AbstractMomentumModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+
+function diagnose_env!(edmf::EDMF{N}, m::MomentumModel, state::Vars, aux::Vars) where N
+  id = idomains(N)
+  state.turbconv.momentum.ρu[id.en] = state.ρu .- sum([state.turbconv.momentum.ρu[i] for i in id.up])
+end
+
+function flux_advective!(edmf::EDMF{N}, m::MomentumModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+    ρinv = 1/state.ρ
+    flux.turbconv.momentum.ρu[i] = ρinv*state.turbconv.momentum.ρu[i] .* state.turbconv.momentum.ρu[i]'
+  end
+end
+
+function flux_pressure!(edmf::EDMF{N}, m::MomentumModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+    ρinv = 1/state.ρ
+    p = pressure(edmf, state, aux, i)
+    flux.turbconv.momentum.ρu[i] += p*I
+  end
+end
+
+function flux_nondiffusive!(edmf::EDMF{N}, m::MomentumModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+  end
+end
+
+function flux_diffusive!(edmf::EDMF{N}, m::MomentumModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+  end
+end
+
+function gradvariables!(edmf::EDMF{N}, m::MomentumModel, transform::Vars, state::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+  end
+end

--- a/src/Atmos/Model/EDMF/pressure.jl
+++ b/src/Atmos/Model/EDMF/pressure.jl
@@ -1,0 +1,8 @@
+#### Pressure Model
+abstract type AbstractPressureModel{T} end
+
+export PressureModel
+
+struct PressureModel{T} <: AbstractPressureModel{T} end
+PressureModel(::Type{T}) where T = PressureModel{T}()
+

--- a/src/Atmos/Model/EDMF/subdomain_index_helper.jl
+++ b/src/Atmos/Model/EDMF/subdomain_index_helper.jl
@@ -1,0 +1,26 @@
+### Subdomain index helper
+
+"""
+    SubdomainIdx{N}
+
+Indexes for each sub-domain
+"""
+struct SubdomainIdx{N}
+  gm::Int
+  en::Int
+  up::NTuple{N,Int}
+end
+
+function Base.iterate(i::SubdomainIdx{N}, state=1) where N
+  state == i.gm ? (i.gm, state+1) :
+  state == i.en ? (i.en, state+1) :
+  state == last(i.up)+1 ? nothing :
+  (i.up[state-2], state+1)
+end
+
+"""
+    idomains(::Val{N})
+
+Defines indexing for sub-domain decomposition
+"""
+idomains(::Val{N}) where N = SubdomainIdx{N}(1, 2, ntuple(i -> i+2, N))

--- a/src/Atmos/Model/EDMF/surface.jl
+++ b/src/Atmos/Model/EDMF/surface.jl
@@ -1,0 +1,134 @@
+
+#### Surface model
+abstract type AbstractSurfaceModel{T} end
+export SurfaceModel
+
+using ..SurfaceFluxes
+
+function update_aux!(edmf::EDMF{N}, ::AbstractSurfaceModel, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+
+vars_state(    ::AbstractSurfaceModel, T) = @vars()
+vars_gradient( ::AbstractSurfaceModel, T) = @vars()
+vars_diffusive(::AbstractSurfaceModel, T) = @vars()
+vars_aux(      ::AbstractSurfaceModel, T) = @vars()
+vars_inputs(   ::AbstractSurfaceModel, T) = @vars()
+
+struct SurfaceModel{T} <: AbstractSurfaceModel{T}
+  TCV_w_e_int::T
+  TCV_w_q_tot::T
+  exch_coeff_e_int::T
+  exch_coeff_q_tot::T
+  surface_scalar_coeff::T
+  x_initial::Vector{T}
+  x_ave::Vector{T}
+  x_s::Vector{T}
+  z_0::Vector{T}
+  F_exchange::Vector{T}
+  dimensionless_number::Vector{T}
+  θ_bar::T
+  Δz::T
+  z::T
+  a::T
+end
+function SurfaceModel(::Type{DT}) where DT
+  TCV_w_e_int = DT(1.0)
+  TCV_w_q_tot = DT(1.0)
+  exch_coeff_e_int = DT(1.0)
+  exch_coeff_q_tot = DT(1.0)
+  surface_scalar_coeff = DT(1.0)
+  θ_bar = DT(1.0)
+  Δz = DT(1.0)
+  z = DT(1.0)
+  a = DT(1.0)
+  x_initial = DT[1.0, 1.0]
+  x_ave = DT[1.0, 1.0]
+  x_s = DT[1.0, 1.0]
+  z_0 = DT[1.0, 1.0]
+  F_exchange = DT[1.0, 1.0]
+  dimensionless_number = DT[1.0, 1.0]
+  return SurfaceModel{DT}(TCV_w_e_int, TCV_w_q_tot, exch_coeff_e_int,
+                          exch_coeff_q_tot, surface_scalar_coeff,
+                          x_initial, x_ave, x_s, z_0, F_exchange,
+                          dimensionless_number, θ_bar, Δz, z, a)
+end
+
+
+function surface_fluxes(edmf::EDMF{N}, m::SurfaceModel, state::Vars, aux::Vars) where N
+  id = idomains(N)
+  windspeed = horizontal_windspeed(m)
+  ts = thermo_state(edmf, state, aux)
+  args = m.x_initial, m.x_ave, m.x_s, m.z_0, m.F_exchange, m.dimensionless_number, m.θ_bar, m.Δz, m.z, m.a
+  sfc = surface_conditions(args...)
+
+  # z_L1 = z_first_interior(aux) # need functionality
+  inversion_height = aux.inversion_height # computing this requires argmax_z(BulkRichardsonNumber(z)), and is a single value per column
+  wstar = convective_velocity_scale(sfc.bflux, inversion_height)
+
+  tke_surf        = surface_tke(ustar, z_L1, sfc.L_MO, wstar)
+  var_q_tot       = surface_variance(  ustar, z_L1, sfc.L_MO, m.TCV_w_q_tot, m.TCV_w_q_tot)
+  var_e_int       = surface_variance(  ustar, z_L1, sfc.L_MO, m.TCV_w_e_int, m.TCV_w_e_int)
+  var_e_int_q_tot = surface_variance(  ustar, z_L1, sfc.L_MO, m.TCV_w_e_int, m.TCV_w_q_tot)
+
+  e_int_flux = m.TCV_w_e_int .+ m.surface_scalar_coeff*m.exch_coeff_e_int*windspeed*sqrt(var_e_int)
+  q_tot_flux = m.TCV_w_q_tot .+ m.surface_scalar_coeff*m.exch_coeff_q_tot*windspeed*sqrt(var_q_tot)
+
+  return e_int_flux, q_tot_flux, var_q_tot, var_e_int, var_e_int_q_tot, tke_surf, windspeed
+end
+
+
+#### pure functions
+
+using Statistics
+function percentile_bounds_mean_norm(low_percentile::R, high_percentile::R, n_samples::R) where R
+    x = rand(Normal(), n_samples)
+    xp_low = quantile(Normal(), low_percentile)
+    xp_high = quantile(Normal(), high_percentile)
+    filter!(y -> xp_low<y<xp_high, x)
+    return Statistics.mean(x)
+end
+
+"""
+    surface_tke(ustar, wstar, z_L1, MoninObhukovLen)
+
+The surface turbulent kinetic energy
+
+ - `ustar` friction velocity
+ - `wstar` convective velocity
+ - `z_L1` elevation at the first grid level
+ - `MoninObhukovLen` Monin-Obhukov length
+"""
+function surface_tke(ustar::R, z_L1::R, MoninObhukovLen::R, wstar::R) where R
+  if MoninObhukovLen < 0
+    return 3.75 * ustar^2 + 0.2 * wstar^2 + ustar^2*cbrt((z_L1/MoninObhukovLen)^2)
+  else
+    return 3.75 * ustar^2
+  end
+end
+
+"""
+    surface_variance(ustar, z_L1, MoninObhukovLen, flux1, flux2)
+
+The surface variance given
+
+ - `ustar` friction velocity
+ - `wstar` convective velocity
+ - `z_L1` elevation at the first grid level
+ - `MoninObhukovLen` Monin-Obhukov length
+"""
+function surface_variance(ustar::R, z_L1::R, MoninObhukovLen::R, flux1::R, flux2::R) where R
+  if MoninObhukovLen < 0
+    return 4 * flux1*flux2/(ustar^2) * (1 - 8.3 * z_L1/MoninObhukovLen)^(-2/3)
+  else
+    return 4 * flux1*flux2/(ustar^2)
+  end
+end
+
+"""
+    convective_velocity_scale(bflux::R, inversion_height::R) where R
+
+The convective velocity scale, given:
+ `bflux` buoyancy flux
+ `inversion_height` inversion height
+FIXME: add reference
+"""
+convective_velocity_scale(bflux::R, inversion_height::R) where R = cbrt(max(bflux * inversion_height, R(0)))

--- a/src/Atmos/Model/EDMF/tke.jl
+++ b/src/Atmos/Model/EDMF/tke.jl
@@ -1,0 +1,53 @@
+#### Turbulent Kinetic Energy Model
+abstract type AbstractTKEModel{T} end
+struct TKEModel{T} <: AbstractTKEModel{T} end
+TKEModel(::Type{T}) where T = TKEModel{T}()
+
+export TKEModel
+
+vars_state(    ::AbstractTKEModel, T, N) = @vars()
+vars_gradient( ::AbstractTKEModel, T, N) = @vars()
+vars_diffusive(::AbstractTKEModel, T, N) = @vars()
+vars_aux(      ::AbstractTKEModel, T, N) = @vars(tke::SVector{N,T})
+function update_aux!(       edmf::EDMF{N}, m::AbstractTKEModel, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function gradvariables!(    edmf::EDMF{N}, m::AbstractTKEModel, transform::Vars, state::Vars, aux::Vars, t::Real) where N; end
+function flux_diffusive!(   edmf::EDMF{N}, m::AbstractTKEModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_nondiffusive!(edmf::EDMF{N}, m::AbstractTKEModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function flux_advective!(   edmf::EDMF{N}, m::AbstractTKEModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function source!(           edmf::EDMF{N}, m::AbstractTKEModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+function boundarycondition!(edmf::EDMF{N}, m::AbstractTKEModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N; end
+
+function diagnose_env!(edmf::EDMF{N}, m::TKEModel, state::Vars, aux::Vars) where N
+  id = idomains(N)
+  state.turbconv.tke[id.en] = state.tke  - sum([state.turbconv.tke[i] for i in id.up])
+end
+
+function flux_advective!(edmf::EDMF{N}, m::TKEModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+  end
+end
+
+function flux_pressure!(edmf::EDMF{N}, m::TKEModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+  end
+end
+
+function flux_nondiffusive!(edmf::EDMF{N}, m::TKEModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+  end
+end
+
+function flux_diffusive!(edmf::EDMF{N}, m::TKEModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+  end
+end
+
+function gradvariables!(edmf::EDMF{N}, m::TKEModel, transform::Vars, state::Vars, aux::Vars, t::Real) where N
+  id = idomains(N)
+  @inbounds for i in id.up
+  end
+end

--- a/src/Atmos/Model/turbconv.jl
+++ b/src/Atmos/Model/turbconv.jl
@@ -1,0 +1,13 @@
+#### Turbulence Convection
+abstract type TurbulenceConvection{N} end
+
+
+"""
+    horizontal_windspeed(state::Vars)
+
+Computes the horizontal windspeed
+"""
+@inline horizontal_windspeed(state::Vars) = sqrt(state.ρu[1]^2 + state.ρu[2]^2)
+
+include(joinpath("EDMF","EDMF.jl"))
+

--- a/test/DGmethods/compressible_Navier_Stokes/BOMEX.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/BOMEX.jl
@@ -1,0 +1,68 @@
+using MPI
+using CLIMA
+using CLIMA.Mesh.Topologies
+using CLIMA.Mesh.Grids
+using CLIMA.DGmethods
+using CLIMA.DGmethods.NumericalFluxes
+using CLIMA.MPIStateArrays
+using CLIMA.LowStorageRungeKuttaMethod
+using CLIMA.ODESolvers
+using CLIMA.GenericCallbacks
+using CLIMA.Atmos
+using CLIMA.VariableTemplates
+using CLIMA.MoistThermodynamics
+using CLIMA.PlanetParameters
+using LinearAlgebra
+using StaticArrays
+using Logging, Printf, Dates
+using CLIMA.Vtk
+
+
+@static if haspkg("CuArrays")
+  using CUDAdrv
+  using CUDAnative
+  using CuArrays
+  CuArrays.allowscalar(false)
+  const ArrayTypes = (CuArray, )
+else
+  const ArrayTypes = (Array, )
+end
+
+if !@isdefined integration_testing
+  const integration_testing =
+    parse(Bool, lowercase(get(ENV,"JULIA_CLIMA_INTEGRATION_TESTING","false")))
+end
+
+using CLIMA.Atmos
+
+DFloat = Float32
+const μ_exact = 10
+
+function edmf_init_state!(state::Vars, aux::Vars, (x,y,z), t)
+end
+
+function edmf_source!(source::Vars, state::Vars, aux::Vars, t::Real)
+end
+
+∑a_up = 0.1
+n_up = 2
+a_initial = ntuple(i -> i==1 ? DFloat(1-∑a_up) : DFloat(∑a_up/n_up), n_up+1)
+
+model = AtmosModel(ConstantViscosityWithDivergence(DFloat(μ_exact)),
+                   EDMF{n_up}(ConstantAreaFrac(a_initial),
+                              MomentumModel(DFloat),
+                              EnergyModel(DFloat),
+                              EDMFDryModel(),
+                              TKEModel(DFloat),
+                              SurfaceModel(DFloat),
+                              ConstantMixingLength(DFloat),
+                              ConstantEntrDetr(DFloat),
+                              PressureModel(DFloat),
+                              BuoyancyModel(DFloat)
+                              ),
+                   DryModel(),
+                   NoRadiation(),
+                   edmf_source!,
+                   InitStateBC(),
+                   edmf_init_state!)
+


### PR DESCRIPTION
This PR
 - Adds the sub-domains for EDMF model
 - Adds aux functions for computing several source terms and aux variables
   - [x] EDMF buoyancy
   - [x] EDMF entrainment-detrainment
   - [x] EDMF mixing length
   - [x] EDMF moisture auxiliary functions
 - Tests that an `AtmosModel` can be constructed with the `EDMF` sub-model

Design questions:

 - Should any of the EDMF fields be included by default (e.g. velocity/energy?) Right now, they are composed to allow for flexibility, but accessing velocities is a bit verbose (`atmosmodel.turbconv.momentum.ρu`)

Additional needed functionality:

 - [ ] Surface fluxes / BCs
 - [ ] EDMF Momentum sources
 - [ ] EDMF Momentum fluxes
 - [ ] EDMF Energy sources
 - [ ] EDMF Energy fluxes
 - [ ] EDMF moisture sources
 - [ ] EDMF moisture fluxes
