### PR TITLE
Functions for using the Non-Equil-Thermodynamics in atmos moiture model

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -275,7 +275,7 @@ function gradvariables!(
     transform.u = ρinv * state.ρu
     transform.h_tot = total_specific_enthalpy(atmos, atmos.moisture, state, aux)
 
-    gradvariables!(atmos.moisture, transform, state, aux, t)
+    gradvariables!(atmos.moisture, atmos, transform, state, aux, t)
     gradvariables!(atmos.turbulence, transform, state, aux, t)
 end
 

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -187,6 +187,7 @@ end
 
 function gradvariables!(
     moist::EquilMoist,
+    atmos::AtmosModel,
     transform::Vars,
     state::Vars,
     aux::Vars,
@@ -238,4 +239,122 @@ function flux_diffusive!(moist::EquilMoist, flux::Grad, state::Vars, d_q_tot)
     flux.ρ += d_q_tot * state.ρ
     flux.ρu += d_q_tot .* state.ρu'
     flux.moisture.ρq_tot += d_q_tot * state.ρ
+end
+"""
+  NonEquilMoist
+
+  Assumes that there isn't any thermodynamic equilibrium
+"""
+
+struct NonEquilMoist <: MoistureModel end
+
+vars_state(::NonEquilMoist    ,FT) = @vars(ρq_tot::FT, ρq_liq::FT, ρq_ice::FT)
+vars_gradient(::NonEquilMoist ,FT) = @vars(q_tot::FT,q_liq::FT, q_ice::FT, h_tot::FT)
+vars_diffusive(::NonEquilMoist,FT) = @vars(∇q_tot::SVector{3,FT}, ∇q_liq::SVector{3,FT}, ∇q_ice::SVector{3,FT})
+vars_aux(::NonEquilMoist      ,FT) = @vars(temperature::FT, θ_v::FT, q_liq::FT, q_ice::FT, p::FT,src_qliq::FT)
+
+@inline function atmos_nodal_update_aux!(
+    moist::NonEquilMoist, 
+    atmos::AtmosModel,
+    state::Vars,
+    aux::Vars,
+    t::Real
+)
+    TS = thermo_state(moist, atmos.orientation, state, aux)
+    aux.moisture.temperature = air_temperature(TS)
+    q_p_sat = PhasePartition_equil(air_temperature(TS),
+				   state.ρ,state.moisture.ρq_tot)
+    aux.moisture.src_qliq = conv_q_vap_to_q_liq(q_p_sat,
+						PhasePartition(TS))
+    aux.moisture.θ_v = virtual_pottemp(TS)
+    aux.moisture.q_liq = PhasePartition(TS).liq
+    aux.moisture.q_ice = PhasePartition(TS).ice
+    aux.moisture.p = air_pressure(TS)
+    return nothing
+end
+
+function thermo_state(
+    moist::NonEquilMoist,
+    orientation::Orientation,
+    state::Vars,
+    aux::Vars
+)
+    FT = eltype(state)
+    ρinv = 1/state.ρ
+    e_int = internal_energy(moist, orientation, state, aux)
+    q_pt = PhasePartition{FT}(state.moisture.ρq_tot*ρinv,
+			    state.moisture.ρq_liq*ρinv,
+			    state.moisture.ρq_ice*ρinv)
+    return PhaseNonEquil{FT}(e_int, state.ρ, q_pt)
+end
+
+function gradvariables!(
+    moist::NonEquilMoist,
+    atmos::AtmosModel,
+    transform::Vars,
+    state::Vars,
+    aux::Vars,
+    t::Real
+)
+    ρinv = 1/state.ρ
+    transform.moisture.q_tot = state.moisture.ρq_tot * ρinv
+    phase = thermo_state(moist, atmos.orientation, state, aux)
+    R_m = gas_constant_air(phase)
+    T = air_temperature(phase)
+    e_tot = state.ρe * ρinv
+    transform.moisture.h_tot = e_tot + R_m*T
+    transform.moisture.q_liq = state.moisture.ρq_liq * ρinv
+    transform.moisture.q_ice = state.moisture.ρq_ice * ρinv
+end
+
+function diffusive!(
+    moist::NonEquilMoist,
+    diffusive::Vars,
+    ∇transform::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real
+)
+    diffusive.moisture.∇q_tot =  ∇transform.moisture.q_tot
+    diffusive.moisture.∇q_liq =  ∇transform.moisture.q_liq
+    diffusive.moisture.∇q_ice =  ∇transform.moisture.q_ice
+end
+
+function flux_moisture!(
+    moist::NonEquilMoist,
+    atmos::AtmosModel,
+    flux::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real
+)
+  ρ = state.ρ
+  u = state.ρu / ρ
+  #z = altitude(atmos.orientation, aux)
+  #usub = subsidence_velocity(atmos.subsidence, z)
+  #ẑ = vertical_unit_vector(atmos.orientation, aux)
+  u_tot = u #.- usub * ẑ
+  flux.moisture.ρq_tot += u_tot * state.moisture.ρq_tot
+  flux.moisture.ρq_liq += u_tot * state.moisture.ρq_liq
+  flux.moisture.ρq_ice += u_tot * state.moisture.ρq_ice
+end
+
+function flux_diffusive!(
+    moist::NonEquilMoist,
+    flux::Grad,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
+    D_t
+)
+    d_q_tot = (-D_t) .* diffusive.moisture.ρd_q_tot
+    d_q_liq = (-D_t) .* diffusive.moisture.ρd_q_liq
+    d_q_ice = (-D_t) .* diffusive.moisture.ρd_q_ice
+    u = state.ρu / state.ρ
+    flux.ρ += d_q_tot * state.ρ
+    flux.ρu += d_q_tot .* u' * state.ρ
+    flux.moisture.ρq_tot += d_q_tot * state.ρ
+    flux.moisture.ρq_liq += d_q_liq * state.ρ
+    flux.moisture.ρq_ice += d_q_ice * state.ρ
 end

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -248,24 +248,32 @@ end
 
 struct NonEquilMoist <: MoistureModel end
 
-vars_state(::NonEquilMoist    ,FT) = @vars(ρq_tot::FT, ρq_liq::FT, ρq_ice::FT)
-vars_gradient(::NonEquilMoist ,FT) = @vars(q_tot::FT,q_liq::FT, q_ice::FT, h_tot::FT)
-vars_diffusive(::NonEquilMoist,FT) = @vars(∇q_tot::SVector{3,FT}, ∇q_liq::SVector{3,FT}, ∇q_ice::SVector{3,FT})
-vars_aux(::NonEquilMoist      ,FT) = @vars(temperature::FT, θ_v::FT, q_liq::FT, q_ice::FT, p::FT,src_qliq::FT)
+vars_state(::NonEquilMoist, FT) = @vars(ρq_tot::FT, ρq_liq::FT, ρq_ice::FT)
+vars_gradient(::NonEquilMoist, FT) =
+    @vars(q_tot::FT, q_liq::FT, q_ice::FT, h_tot::FT)
+vars_diffusive(::NonEquilMoist, FT) = @vars(
+    ∇q_tot::SVector{3, FT},
+    ∇q_liq::SVector{3, FT},
+    ∇q_ice::SVector{3, FT}
+)
+vars_aux(::NonEquilMoist, FT) =
+    @vars(temperature::FT, θ_v::FT, q_liq::FT, q_ice::FT, p::FT, src_qliq::FT)
 
 @inline function atmos_nodal_update_aux!(
-    moist::NonEquilMoist, 
+    moist::NonEquilMoist,
     atmos::AtmosModel,
     state::Vars,
     aux::Vars,
-    t::Real
+    t::Real,
 )
     TS = thermo_state(moist, atmos.orientation, state, aux)
     aux.moisture.temperature = air_temperature(TS)
-    q_p_sat = PhasePartition_equil(air_temperature(TS),
-				   state.ρ,state.moisture.ρq_tot)
-    aux.moisture.src_qliq = conv_q_vap_to_q_liq(q_p_sat,
-						PhasePartition(TS))
+    q_p_sat = PhasePartition_equil(
+        air_temperature(TS),
+        state.ρ,
+        state.moisture.ρq_tot,
+    )
+    aux.moisture.src_qliq = conv_q_vap_to_q_liq(q_p_sat, PhasePartition(TS))
     aux.moisture.θ_v = virtual_pottemp(TS)
     aux.moisture.q_liq = PhasePartition(TS).liq
     aux.moisture.q_ice = PhasePartition(TS).ice
@@ -277,14 +285,16 @@ function thermo_state(
     moist::NonEquilMoist,
     orientation::Orientation,
     state::Vars,
-    aux::Vars
+    aux::Vars,
 )
     FT = eltype(state)
-    ρinv = 1/state.ρ
+    ρinv = 1 / state.ρ
     e_int = internal_energy(moist, orientation, state, aux)
-    q_pt = PhasePartition{FT}(state.moisture.ρq_tot*ρinv,
-			    state.moisture.ρq_liq*ρinv,
-			    state.moisture.ρq_ice*ρinv)
+    q_pt = PhasePartition{FT}(
+        state.moisture.ρq_tot * ρinv,
+        state.moisture.ρq_liq * ρinv,
+        state.moisture.ρq_ice * ρinv,
+    )
     return PhaseNonEquil{FT}(e_int, state.ρ, q_pt)
 end
 
@@ -294,15 +304,15 @@ function gradvariables!(
     transform::Vars,
     state::Vars,
     aux::Vars,
-    t::Real
+    t::Real,
 )
-    ρinv = 1/state.ρ
+    ρinv = 1 / state.ρ
     transform.moisture.q_tot = state.moisture.ρq_tot * ρinv
     phase = thermo_state(moist, atmos.orientation, state, aux)
     R_m = gas_constant_air(phase)
     T = air_temperature(phase)
     e_tot = state.ρe * ρinv
-    transform.moisture.h_tot = e_tot + R_m*T
+    transform.moisture.h_tot = e_tot + R_m * T
     transform.moisture.q_liq = state.moisture.ρq_liq * ρinv
     transform.moisture.q_ice = state.moisture.ρq_ice * ρinv
 end
@@ -313,11 +323,11 @@ function diffusive!(
     ∇transform::Grad,
     state::Vars,
     aux::Vars,
-    t::Real
+    t::Real,
 )
-    diffusive.moisture.∇q_tot =  ∇transform.moisture.q_tot
-    diffusive.moisture.∇q_liq =  ∇transform.moisture.q_liq
-    diffusive.moisture.∇q_ice =  ∇transform.moisture.q_ice
+    diffusive.moisture.∇q_tot = ∇transform.moisture.q_tot
+    diffusive.moisture.∇q_liq = ∇transform.moisture.q_liq
+    diffusive.moisture.∇q_ice = ∇transform.moisture.q_ice
 end
 
 function flux_moisture!(
@@ -326,17 +336,17 @@ function flux_moisture!(
     flux::Grad,
     state::Vars,
     aux::Vars,
-    t::Real
+    t::Real,
 )
-  ρ = state.ρ
-  u = state.ρu / ρ
-  #z = altitude(atmos.orientation, aux)
-  #usub = subsidence_velocity(atmos.subsidence, z)
-  #ẑ = vertical_unit_vector(atmos.orientation, aux)
-  u_tot = u #.- usub * ẑ
-  flux.moisture.ρq_tot += u_tot * state.moisture.ρq_tot
-  flux.moisture.ρq_liq += u_tot * state.moisture.ρq_liq
-  flux.moisture.ρq_ice += u_tot * state.moisture.ρq_ice
+    ρ = state.ρ
+    u = state.ρu / ρ
+    #z = altitude(atmos.orientation, aux)
+    #usub = subsidence_velocity(atmos.subsidence, z)
+    #ẑ = vertical_unit_vector(atmos.orientation, aux)
+    u_tot = u #.- usub * ẑ
+    flux.moisture.ρq_tot += u_tot * state.moisture.ρq_tot
+    flux.moisture.ρq_liq += u_tot * state.moisture.ρq_liq
+    flux.moisture.ρq_ice += u_tot * state.moisture.ρq_ice
 end
 
 function flux_diffusive!(
@@ -346,7 +356,7 @@ function flux_diffusive!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
-    D_t
+    D_t,
 )
     d_q_tot = (-D_t) .* diffusive.moisture.ρd_q_tot
     d_q_liq = (-D_t) .* diffusive.moisture.ρd_q_liq

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -244,6 +244,11 @@ end
   NonEquilMoist
 
   Assumes that there isn't any thermodynamic equilibrium
+  
+  Adds addtional moisture variable for cloud water ρq_liq and cloud ice ρq_ice::FT that are transported in the same way as ρq_tot
+
+  The equilibrium phase partition is calculated and used as a reference to compute the source term for the cloud phase.
+
 """
 
 struct NonEquilMoist <: MoistureModel end
@@ -309,10 +314,6 @@ function gradvariables!(
     ρinv = 1 / state.ρ
     transform.moisture.q_tot = state.moisture.ρq_tot * ρinv
     phase = thermo_state(moist, atmos.orientation, state, aux)
-    R_m = gas_constant_air(phase)
-    T = air_temperature(phase)
-    e_tot = state.ρe * ρinv
-    transform.moisture.h_tot = e_tot + R_m * T
     transform.moisture.q_liq = state.moisture.ρq_liq * ρinv
     transform.moisture.q_ice = state.moisture.ρq_ice * ρinv
 end
@@ -340,13 +341,9 @@ function flux_moisture!(
 )
     ρ = state.ρ
     u = state.ρu / ρ
-    #z = altitude(atmos.orientation, aux)
-    #usub = subsidence_velocity(atmos.subsidence, z)
-    #ẑ = vertical_unit_vector(atmos.orientation, aux)
-    u_tot = u #.- usub * ẑ
-    flux.moisture.ρq_tot += u_tot * state.moisture.ρq_tot
-    flux.moisture.ρq_liq += u_tot * state.moisture.ρq_liq
-    flux.moisture.ρq_ice += u_tot * state.moisture.ρq_ice
+    flux.moisture.ρq_tot += u * state.moisture.ρq_tot
+    flux.moisture.ρq_liq += u * state.moisture.ρq_liq
+    flux.moisture.ρq_ice += u * state.moisture.ρq_ice
 end
 
 function flux_diffusive!(

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -157,6 +157,14 @@ function atmos_source!(
 end
 
 struct CloudSource <: Source end
-function atmos_source!(s::CloudSource, m::AtmosModel, source::Vars, state::Vars, diffusive::Vars, aux::Vars, t::Real)
-  source.moisture.ρq_liq += state.ρ * aux.moisture.src_qliq
+function atmos_source!(
+    s::CloudSource,
+    m::AtmosModel,
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
+)
+    source.moisture.ρq_liq += state.ρ * aux.moisture.src_qliq
 end

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -155,3 +155,8 @@ function atmos_source!(
         source.ρu -= β_sponge * (state.ρu .- state.ρ * s.u_relaxation)
     end
 end
+
+struct CloudSource <: Source end
+function atmos_source!(s::CloudSource, m::AtmosModel, source::Vars, state::Vars, diffusive::Vars, aux::Vars, t::Real)
+  source.moisture.ρq_liq += state.ρ * aux.moisture.src_qliq
+end

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -156,6 +156,10 @@ function atmos_source!(
     end
 end
 
+"""
+Source term for cloud formation
+"""
+
 struct CloudSource <: Source end
 function atmos_source!(
     s::CloudSource,


### PR DESCRIPTION
# Description

Modifications were made to moistur.jl and source.jl to enable work to be done using NonEquilMoist thermodynamics.

<!--- Please fill out the following section --->

I have tested these functions using what's present in PR #601. @charleskawczynski This has been made as a separate PR so that this can be merged into master independently of the squall-line driver while that continues to be worked on. @trontrytel Any suggestions for a quick and simple quantitative test of these functionalities?


<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
