### PR TITLE
Allow passing MPIStateArrays to kernels

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -105,9 +105,9 @@ version = "0.2.0"
 
 [[CompilerSupportLibraries_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "b57c5d019367c90f234a7bc7e24ff0a84971da5d"
+git-tree-sha1 = "067567a322fe466c5ec8d01413eee7127bd11699"
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.2.0+1"
+version = "0.3.1+0"
 
 [[Conda]]
 deps = ["JSON", "VersionParsing"]
@@ -236,21 +236,21 @@ version = "0.5.0"
 
 [[GenericSVD]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "c59a30ef95fa4b5e0567c1911652e0c70a5d055c"
+git-tree-sha1 = "62909c3eda8a25b5673a367d1ad2392ebb265211"
 uuid = "01680d73-4ee2-5a08-a1aa-533608c188bb"
-version = "0.2.2"
+version = "0.3.0"
 
 [[GenericSchur]]
 deps = ["LinearAlgebra", "Printf"]
-git-tree-sha1 = "2f9297b94eaf14170d2694a9f3f313f293e0df23"
+git-tree-sha1 = "43b4dc5648028be2c6e96201aa3653903bd1af21"
 uuid = "c145ed77-6b09-5dd9-b285-bf645a82121e"
-version = "0.3.0"
+version = "0.4.0"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
-git-tree-sha1 = "8d9bdd55c9d0d6ddf08f8b5229f90b7f274b6777"
+git-tree-sha1 = "cd60d9a575d3b70c026d7e714212fd4ecf86b4bb"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.8.12"
+version = "0.8.13"
 
 [[IniFile]]
 deps = ["Test"]
@@ -324,10 +324,10 @@ uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 version = "0.12.0"
 
 [[MacroTools]]
-deps = ["DataStructures", "Markdown", "Random"]
-git-tree-sha1 = "07ee65e03e28ca88bc9a338a3726ae0c3efaa94b"
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "f7d2e3f654af75f01ec49be82c231c382214223a"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.4"
+version = "0.5.5"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -367,9 +367,9 @@ version = "0.3.3"
 
 [[OpenBLAS_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "858f107d79a016d9511e34186fe2af11566ba762"
+git-tree-sha1 = "139adbff69e8149e68824994b68f06a61a5a2797"
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.7+7"
+version = "0.3.7+8"
 
 [[OpenSpecFun_jll]]
 deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
@@ -385,9 +385,9 @@ version = "1.1.0"
 
 [[PDMats]]
 deps = ["Arpack", "LinearAlgebra", "SparseArrays", "SuiteSparse", "Test"]
-git-tree-sha1 = "5f303510529486bb02ac4d70da8295da38302194"
+git-tree-sha1 = "2fc6f50ddd959e462f0a2dbc802ddf2a539c6e35"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.9.11"
+version = "0.9.12"
 
 [[Parsers]]
 deps = ["Dates", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Climate Modeling Alliance"]
 version = "0.1.0"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 CUDAapi = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
 CUDAdrv = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -44,7 +44,7 @@ end
 function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment = false)
 
     bl = dg.balancelaw
-    device = typeof(Q.data) <: Array ? CPU() : CUDA()
+    device = MPIStateArrays.device(Q)
 
     grid = dg.grid
     topology = grid.topology
@@ -101,10 +101,10 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment = false)
             Val(dim),
             Val(N),
             dg.diffusion_direction,
-            Q.data,
-            Qvisc.data,
-            Qhypervisc_grad.data,
-            auxstate.data,
+            Q,
+            Qvisc,
+            Qhypervisc_grad,
+            auxstate,
             grid.vgeo,
             t,
             grid.D,
@@ -129,10 +129,10 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment = false)
             Val(N),
             dg.diffusion_direction,
             dg.gradnumflux,
-            Q.data,
-            Qvisc.data,
-            Qhypervisc_grad.data,
-            auxstate.data,
+            Q,
+            Qvisc,
+            Qhypervisc_grad,
+            auxstate,
             grid.vgeo,
             grid.sgeo,
             t,
@@ -173,8 +173,8 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment = false)
             Val(dim),
             Val(N),
             dg.diffusion_direction,
-            Qhypervisc_grad.data,
-            Qhypervisc_div.data,
+            Qhypervisc_grad,
+            Qhypervisc_div,
             grid.vgeo,
             grid.D,
             topology.realelems;
@@ -192,8 +192,8 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment = false)
             Val(N),
             dg.diffusion_direction,
             CentralDivPenalty(),
-            Qhypervisc_grad.data,
-            Qhypervisc_div.data,
+            Qhypervisc_grad,
+            Qhypervisc_div,
             grid.vgeo,
             grid.sgeo,
             grid.vmap⁻,
@@ -217,10 +217,10 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment = false)
             Val(dim),
             Val(N),
             dg.diffusion_direction,
-            Qhypervisc_grad.data,
-            Qhypervisc_div.data,
-            Q.data,
-            auxstate.data,
+            Qhypervisc_grad,
+            Qhypervisc_div,
+            Q,
+            auxstate,
             grid.vgeo,
             grid.ω,
             grid.D,
@@ -240,10 +240,10 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment = false)
             Val(N),
             dg.diffusion_direction,
             CentralHyperDiffusiveFlux(),
-            Qhypervisc_grad.data,
-            Qhypervisc_div.data,
-            Q.data,
-            auxstate.data,
+            Qhypervisc_grad,
+            Qhypervisc_div,
+            Q,
+            auxstate,
             grid.vgeo,
             grid.sgeo,
             grid.vmap⁻,
@@ -269,11 +269,11 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment = false)
         Val(dim),
         Val(N),
         dg.direction,
-        dQdt.data,
-        Q.data,
-        Qvisc.data,
-        Qhypervisc_grad.data,
-        auxstate.data,
+        dQdt,
+        Q,
+        Qvisc,
+        Qhypervisc_grad,
+        auxstate,
         grid.vgeo,
         t,
         grid.ω,
@@ -311,11 +311,11 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment = false)
         dg.direction,
         dg.numfluxnondiff,
         dg.numfluxdiff,
-        dQdt.data,
-        Q.data,
-        Qvisc.data,
-        Qhypervisc_grad.data,
-        auxstate.data,
+        dQdt,
+        Q,
+        Qvisc,
+        Qhypervisc_grad,
+        auxstate,
         grid.vgeo,
         grid.sgeo,
         t,
@@ -364,8 +364,8 @@ function init_ode_state(
             bl,
             Val(dim),
             Val(N),
-            state.data,
-            auxstate.data,
+            state,
+            auxstate,
             grid.vgeo,
             topology.realelems,
             args...;
@@ -381,8 +381,8 @@ function init_ode_state(
             bl,
             Val(dim),
             Val(N),
-            h_state.data,
-            h_auxstate.data,
+            h_state,
+            h_auxstate,
             Array(grid.vgeo),
             topology.realelems,
             args...;
@@ -420,7 +420,7 @@ function indefinite_stack_integral!(
     t::Real,
 )
 
-    device = typeof(Q.data) <: Array ? CPU() : CUDA()
+    device = MPIStateArrays.device(Q)
 
     grid = dg.grid
     topology = grid.topology
@@ -443,8 +443,8 @@ function indefinite_stack_integral!(
         Val(dim),
         Val(N),
         Val(nvertelem),
-        Q.data,
-        auxstate.data,
+        Q,
+        auxstate,
         grid.vgeo,
         grid.Imat,
         1:nhorzelem;
@@ -462,7 +462,7 @@ function reverse_indefinite_stack_integral!(
     t::Real,
 )
 
-    device = typeof(auxstate.data) <: Array ? CPU() : CUDA()
+    device = MPIStateArrays.device(auxstate)
 
     grid = dg.grid
     topology = grid.topology
@@ -485,8 +485,8 @@ function reverse_indefinite_stack_integral!(
         Val(dim),
         Val(N),
         Val(nvertelem),
-        Q.data,
-        auxstate.data,
+        Q,
+        auxstate,
         1:nhorzelem;
         ndrange = (nhorzelem * Nq, Nqk),
         dependencies = (event,),
@@ -502,7 +502,7 @@ function nodal_update_aux!(
     t::Real;
     diffusive = false,
 )
-    device = typeof(Q.data) <: Array ? CPU() : CUDA()
+    device = MPIStateArrays.device(Q)
 
     grid = dg.grid
     topology = grid.topology
@@ -523,9 +523,9 @@ function nodal_update_aux!(
             Val(dim),
             Val(N),
             f!,
-            Q.data,
-            dg.auxstate.data,
-            dg.diffstate.data,
+            Q,
+            dg.auxstate,
+            dg.diffstate,
             t,
             topology.realelems;
             ndrange = Np * nrealelem,
@@ -537,8 +537,8 @@ function nodal_update_aux!(
             Val(dim),
             Val(N),
             f!,
-            Q.data,
-            dg.auxstate.data,
+            Q,
+            dg.auxstate,
             t,
             topology.realelems;
             ndrange = Np * nrealelem,
@@ -600,9 +600,9 @@ function courant(
             Val(N),
             pointwise_courant,
             local_courant,
-            Q.data,
-            dg.auxstate.data,
-            dg.diffstate.data,
+            Q,
+            dg.auxstate,
+            dg.diffstate,
             topology.realelems,
             direction,
             Δt;
@@ -626,7 +626,7 @@ function copy_stack_field_down!(
     fldout,
 )
 
-    device = typeof(auxstate.data) <: Array ? CPU() : CUDA()
+    device = MPIStateArrays.device(auxstate)
 
     grid = dg.grid
     topology = grid.topology
@@ -646,7 +646,7 @@ function copy_stack_field_down!(
         Val(dim),
         Val(N),
         Val(nvertelem),
-        auxstate.data,
+        auxstate,
         1:nhorzelem,
         Val(fldin),
         Val(fldout);

--- a/src/LinearSolvers/ColumnwiseLUSolver.jl
+++ b/src/LinearSolvers/ColumnwiseLUSolver.jl
@@ -151,7 +151,7 @@ function band_forward!(Q, A, dg::DGModel)
 
     event = Event(device)
     event = band_forward_knl!(device, (Nq, Nqj))(
-        Q.data,
+        Q,
         A,
         Val(Nq),
         Val(Nqj),
@@ -188,7 +188,7 @@ function band_back!(Q, A, dg::DGModel)
 
     event = Event(device)
     event = band_back_knl!(device, (Nq, Nqj))(
-        Q.data,
+        Q,
         A,
         Val(Nq),
         Val(Nqj),
@@ -334,7 +334,7 @@ function banded_matrix(
                     Val(dim),
                     Val(N),
                     Val(nvertelem),
-                    Q.data,
+                    Q,
                     k,
                     s,
                     ev,
@@ -359,7 +359,7 @@ function banded_matrix(
                     Val(q),
                     Val(eband + 1),
                     A,
-                    dQ.data,
+                    dQ,
                     k,
                     s,
                     ev,
@@ -422,9 +422,9 @@ function banded_matrix_vector_product!(
         Val(nvertelem),
         Val(p),
         Val(q),
-        dQ.data,
+        dQ,
         A,
-        Q.data,
+        Q,
         1:nhorzelem,
         1:nvertelem;
         ndrange = (nvertelem * Nq, nhorzelem * Nqj, Nq),

--- a/src/LinearSolvers/GeneralizedConjugateResidualSolver.jl
+++ b/src/LinearSolvers/GeneralizedConjugateResidualSolver.jl
@@ -139,37 +139,32 @@ function LS.doiteration!(
         end
 
         if k < K
-            rv_nextp = realview(p[k + 1])
-            rv_L_nextp = realview(L_p[k + 1])
+            nextp = p[k + 1]
+            L_nextp = L_p[k + 1]
         else # restart
-            rv_nextp = realview(p[1])
-            rv_L_nextp = realview(L_p[1])
+            nextp = p[1]
+            L_nextp = L_p[1]
         end
-
-        rv_residual = realview(residual)
-        rv_p = realview.(p)
-        rv_L_p = realview.(L_p)
-        rv_L_residual = realview(L_residual)
 
         groupsize = 256
         T = eltype(alpha)
 
         event = Event(device(Q))
         event = LS.linearcombination!(device(Q), groupsize)(
-            rv_nextp,
+            nextp,
             (one(T), alpha[1:k]...),
-            (rv_residual, rv_p[1:k]...),
+            (residual, p[1:k]...),
             false;
-            ndrange = length(rv_nextp),
+            ndrange = length(realview(nextp)),
             dependencies = (event,),
         )
 
         event = LS.linearcombination!(device(Q), groupsize)(
-            rv_L_nextp,
+            L_nextp,
             (one(T), alpha[1:k]...),
-            (rv_L_residual, rv_L_p[1:k]...),
+            (L_residual, L_p[1:k]...),
             false;
-            ndrange = length(rv_nextp),
+            ndrange = length(realview(nextp)),
             dependencies = (event,),
         )
         wait(device(Q), event)

--- a/src/LinearSolvers/GeneralizedMinimalResidualSolver.jl
+++ b/src/LinearSolvers/GeneralizedMinimalResidualSolver.jl
@@ -156,16 +156,14 @@ function LS.doiteration!(
     y = SVector{j}(@views UpperTriangular(H[1:j, 1:j]) \ g0[1:j])
 
     ## compose the solution
-    rv_Q = realview(Q)
-    rv_krylov_basis = realview.(krylov_basis)
     groupsize = 256
     event = Event(device(Q))
     event = LS.linearcombination!(device(Q), groupsize)(
-        rv_Q,
+        Q,
         y,
-        rv_krylov_basis,
+        krylov_basis,
         true;
-        ndrange = length(rv_Q),
+        ndrange = length(realview(Q)),
         dependencies = (event,),
     )
     wait(device(Q), event)

--- a/src/ODESolvers/MultirateInfinitesimalStepMethod.jl
+++ b/src/ODESolvers/MultirateInfinitesimalStepMethod.jl
@@ -208,12 +208,12 @@ function dostep!(
         groupsize = 256
         event = Event(device(Q))
         event = update!(device(Q), groupsize)(
-            realview(Q),
-            realview(offset),
+            Q,
+            offset,
             Val(i),
-            realview(yn),
-            map(realview, ΔYnj[1:(i - 2)]),
-            map(realview, fYnj[1:(i - 1)]),
+            yn,
+            ΔYnj[1:(i - 2)],
+            fYnj[1:(i - 1)],
             α[i, :],
             β[i, :],
             γ[i, :],
@@ -235,7 +235,7 @@ function dostep!(
         #   solve!(Q, fastsolver, p; numberofsteps = mis.nsubsteps)  #(1c)
         # especially if we want to use StormerVerlet, but need some way to pass in `offset`
         for k in 1:(mis.nsubsteps)
-            dostep!(Q, fastsolver, p, τ, dτ, FT(1), realview(offset))  #(1c)
+            dostep!(Q, fastsolver, p, τ, dτ, FT(1), offset)  #(1c)
             τ += dτ
         end
     end

--- a/src/ODESolvers/MultirateRungeKuttaMethod.jl
+++ b/src/ODESolvers/MultirateRungeKuttaMethod.jl
@@ -111,13 +111,11 @@ function dostep!(
     time::Real,
     dt::AbstractFloat,
     in_slow_δ = nothing,
-    in_slow_rv_dQ = nothing,
+    in_slow_dQ = nothing,
     in_slow_scaling = nothing,
 ) where {SS <: LSRK2N}
     slow = mrrk.slow_solver
     fast = mrrk.fast_solver
-
-    slow_rv_dQ = realview(slow.dQ)
 
     groupsize = 256
 
@@ -136,8 +134,8 @@ function dostep!(
             # update solution and scale RHS
             event = Event(device(Q))
             event = update!(device(Q), groupsize)(
-                slow_rv_dQ,
-                in_slow_rv_dQ,
+                slow.dQ,
+                in_slow_dQ,
                 in_slow_δ,
                 slow_scaling;
                 ndrange = length(realview(Q)),
@@ -175,7 +173,7 @@ function dostep!(
                 fast_time,
                 fast_dt,
                 slow_δ,
-                slow_rv_dQ,
+                slow.dQ,
                 slow_rka,
             )
         end


### PR DESCRIPTION
# Description

This PR enables passing `MPIStateArray`s directly to GPU kernels by using `Adapt.jl`. This is convenient and cleans up a lot of code in `ODESolvers` that was creating views just for that purpose. 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
