### PR TITLE
Automate tutorial files from pages array

### DIFF
--- a/docs/pages_helper.jl
+++ b/docs/pages_helper.jl
@@ -1,0 +1,45 @@
+"""
+    get_second
+
+Gets `second` in nested array of `Pair`s
+and filters empty entries.
+"""
+function get_second end
+
+get_second(x::String) = x
+get_second(x::Pair{String, String}) = x.second
+get_second(x::Pair{String, T}) where {T} = get_second(x.second)
+get_second(A::Array{T}) where {T} =
+    filter(y -> !isempty(y), [get_second(x) for x in A if !isempty(x)])
+
+"""
+    flatten_to_array_of_strings(A)
+
+Recursive `flatten` of nested array of strings.
+"""
+function flatten_to_array_of_strings(A)
+    V = String[]
+    for a in A
+        if a isa String
+            push!(V, a)
+        else
+            push!(V, flatten_to_array_of_strings(a)...)
+        end
+    end
+    return V
+end
+
+"""
+    transform_second
+
+Transform `second` in nested array of `Pair`s.
+"""
+function transform_second end
+
+transform_second(transform, x::String) = transform(x)
+transform_second(transform, x::Pair{String, String}) =
+    Pair(x.first, transform_second(transform, x.second))
+transform_second(transform, x::Pair{String, T}) where {T} =
+    Pair(x.first, transform_second(transform, x.second))
+transform_second(transform, A::Array{T}) where {T} =
+    Any[transform_second(transform, x) for x in A]


### PR DESCRIPTION
# Description


This PR assembles the tutorials array, and then grabs, flattens and transforms their paths so that they can be filtered and fed into Literate. This reduces the redundancy between the array and list of tutorial files.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
