### PR TITLE
GCM diagnostics

### DIFF
--- a/.dev/climaformat.jl
+++ b/.dev/climaformat.jl
@@ -77,7 +77,7 @@ if haskey(opts, :help)
     exit(0)
 end
 if isempty(ARGS)
-    filenames = readlines(`git diff --name-only --diff-filter=AM HEAD`)
+    filenames = readlines(`git diff --name-only --diff-filter=AM master`)
     filter!(f -> endswith(f, ".jl"), filenames)
 else
     filenames = ARGS

--- a/docs/src/DevDocs/DiagnosticVariables.md
+++ b/docs/src/DevDocs/DiagnosticVariables.md
@@ -1,10 +1,16 @@
-# CliMA Diagnostic Variable List
+# Diagnostic Variable List
 
-This document contains the diagnostic variables in CliMA.
+This is a list of all the diagnostic variables that the `ClimateMachine`
+can produce, partitioned into groups.
 
 ## LES Diagnostics
 
+Unless other noted, these fields are density-weighted using horizontally
+averaged density.
+
 ### default
+
+#### 1D fields (time, z)
 
 | short name | description                                                                |
 |:-----------|:---------------------------------------------------------------------------|
@@ -21,8 +27,8 @@ This document contains the diagnostic variables in CliMA.
 | thl        | liquid-ice potential temperature                                           |
 | et         | total specific energy                                                      |
 | ei         | specific internal energy                                                   |
-| ht         | total specific enthalpy                                                    |
-| hm         | specific enthalpy                                                          |
+| ht         | specific enthalpy based on total energy                                    |
+| hi         | specific enthalpy based on internal energy                                 |
 | var\_u      | variance of x-velocity                                                     |
 | var\_v      | variance of y-velocity                                                     |
 | var\_w      | variance of z-velocity                                                     |
@@ -46,12 +52,20 @@ This document contains the diagnostic variables in CliMA.
 | w\_qt\_sgs   | vertical sgs flux of total specific humidity                               |
 | w\_ht\_sgs   | vertical sgs flux of total specific enthalpy                               |
 | cld\_frac   | cloud fraction                                                             |
+| lwp        | liquid water path                                                          |
+
+#### Scalars (time)
+
+| short name      | description                                                                           |
+|:----------------|:--------------------------------------------------------------------------------------|
 | cld\_cover  | cloud cover                                                                |
 | cld\_top    | cloud top                                                                  |
 | cld\_base   | cloud base                                                                 |
-| lwp        | liquid water path                                                          |
+
 
 ### core
+
+#### 1D fields (time, z)
 
 | short name      | description                                                                           |
 |:----------------|:--------------------------------------------------------------------------------------|
@@ -78,3 +92,126 @@ This document contains the diagnostic variables in CliMA.
 | cov\_qt\_thl\_core | cloud core covariance of total specific humidity and liquid-ice potential temperature |
 | cov\_qt\_ei\_core  | cloud core covariance of total specific humidity and specific internal energy         |
 | core\_frac       | cloud core (q\_liq > 0 and w > 0) fraction                                             |
+
+
+## GCM Diagnostics
+
+- Based on [this issue](https://github.com/CliMA/ClimateMachine.jl/issues/214).
+- GCM diagnostic variables are not currently density weigted.
+
+### default (for Dry Held-Suarez)
+
+#### 3D fields (time, long, lat, level)
+
+| short name | description                                                                |
+|:-----------|:---------------------------------------------------------------------------|
+| u          | zonal velocity (along longitude)                                           |
+| v          | meridional velocity (along latitude)                                       |
+| w          | vertical velocity (along altitude)                                         |
+| rho        | density                                                                    |
+|                                                                                         |
+| temp       | air temperature                                                            |
+| pres       | air pressure                                                               |
+| thd        | dry potential temperature                                                  |
+|                                                                                         |
+| et         | total specific energy                                                      |
+| ei         | specific internal energy                                                   |
+| ht         | specific enthalpy from total energy                                        |
+| hi         | specific enthalpy from internal energy                                     |
+|                                                                                         |
+| vort       | relative vorticity                                                         |
+
+### default (for Moist Aquaplanet)
+
+These are in addition to Held-Suarez.
+
+### 3D fields (time, long, lat, level)
+
+| short name | description                                                                |
+|:-----------|:---------------------------------------------------------------------------|
+| qt         | total specific humidity                                                    |
+| ql         | liquid water specific humidity                                             |
+| qv         | water vapour specific humidity                                             |
+| qi         | ice specific humidity                                                      |
+| thv        | virtual potential temperature                                              |
+| thl        | liquid-ice potential temperature                                           |
+
+### To be implemented (for Dry Held-Suarez)
+
+#### 2D fields (time, lat, level)
+
+| short name | description                                                                |
+|:-----------|:---------------------------------------------------------------------------|
+| stream_euler | Eulerian meridional streamfunction                                        |
+
+#### 2D fields (time, long, lat)                                       
+
+| short name | description                                                                |
+|:-----------|:---------------------------------------------------------------------------|
+
+#### 3D fields (long, lat, level)
+
+| short name | description                                                                |
+|:-----------|:---------------------------------------------------------------------------|
+| stream     | horizontal streamfunction (Laplacian of vort)                              |
+| pv\_qg     | potential vorticity (f + vort + f/N d2/dz2 stream)                         |
+| pv\_ertel  | Ertel potential vorticity                                                  |
+| div        | divergence                                                                 |
+|                                                                                         |
+| var\_uu\_zonal  | variances using zonal mean (also for vv, ww, TT, option for others)   |
+| cov\_uv\_zonal  | covariances using zonal mean (also for uw, vw, uT, vT, wT, option for others) |
+|                                                                                         |
+| var\_uu\_time   | variances using time mean (also for vv, ww, TT, option for others)    |
+| cov\_uv\_time   | covariances using time mean (also for uw, vw, uT, vT, wT, option for others) |
+|                                                                                         |
+| var\_uu\_bandpass  | (co)variances using a Lanczos filter (also for vv, ww, TT, option for others) |
+| cov\_uv\_bandpass  | (co)variances using a Lanczos filter (also for uw, vw, uT, vT, wT, option for others) |
+
+#### Spectral decomposition (time, lat, level, wavenumber)
+
+| short name | description                                                                |
+|:-----------|:---------------------------------------------------------------------------|
+| power\_spec_eke  | eddy kinetic energy power spectrum                                   |
+
+
+### To be implemented (for Moist Aquaplanet)
+
+This are in addition to Held-Suarez.
+
+#### 2D fields (time, long, lat)
+
+| short name | description                                                                |
+|:-----------|:---------------------------------------------------------------------------|
+| toa\_sw\_do    | top of atmosphere (TOA) downwelling shortwave flux                     |
+| toa\_sw_up     | TOA Upwelling shortwave flux                                           |
+| toa\_lw\_up    | TOA Upwelling longwave flux                                            |
+| toa\_sw\_sfc   | up- and downwelling shortwave flux at surface                          |
+| toa\_lw\_sfc   | up- and downwelling longwave flux at surface                           |
+| sensible\_sfc  | sensible heat flux at surface                                          |
+| latent\_sfc    | latent heat flux at surface                                            |
+| T\_sfc         | surface air temperature                                                |
+| rain\_sfc      | rain rate at surface                                                   |
+| snow\_sfc      | snow rate at surface                                                   |
+
+#### 3D fields (time, long, lat, level)                            
+
+| short name | description                                                                |
+|:-----------|:---------------------------------------------------------------------------|
+| rh           | relative humidity                                                        |
+| cld\_frac    | cloud fraction                                                           |
+| mse          | moist static energy                                                      |
+
+#### More complex diagnostics, e.g. extremes
+
+| short name | description                                                                |
+|:-----------|:---------------------------------------------------------------------------|
+| rain_thres    | frequency with which a given rain rate threshold at the surface is exceeded   |
+| temp_thres    | frequency with which a given temperature threshold at the surface is exceeded |
+| track_loc     | frequency of tracked features (e.g. cyclones, blocking)                       |
+| track_int     | intensity of tracked features (e.g. cyclones, blocking)                       |
+
+### To be implemented (for full GCM, additional to all above)
+
+| short name | description                                                                |
+|:-----------|:---------------------------------------------------------------------------|
+| xx            | (Later: sea ice cover, leaf temperature, soil temperature, ...)         |

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -151,7 +151,7 @@ function held_suarez_forcing!(
 end
 
 function config_diagnostics(FT, driver_config)
-    interval = "100000steps" # chosen to allow a single diagnostics collection
+    interval = "40000steps" # chosen to allow a single diagnostics collection
 
     _planet_radius = FT(planet_radius(param_set))
 
@@ -167,12 +167,13 @@ function config_diagnostics(FT, driver_config)
         resolution,
     )
 
-    dgngrp = setup_dump_state_and_aux_diagnostics(
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosGCMConfigType(),
         interval,
         driver_config.name,
         interpol = interpol,
-        project = true,
     )
+
     return ClimateMachine.DiagnosticsConfiguration([dgngrp])
 end
 
@@ -182,7 +183,7 @@ function main()
     poly_order = 5                           # discontinuous Galerkin polynomial order
     n_horz = 5                               # horizontal element number
     n_vert = 5                               # vertical element number
-    n_days = 120                             # experiment day number
+    n_days = 50                              # experiment day number
     timestart = FT(0)                        # start time (s)
     timeend = FT(n_days * day(param_set))    # end time (s)
 

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -462,9 +462,16 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax)
 end
 
 function config_diagnostics(driver_config)
-    default_dgngrp =
-        setup_atmos_default_diagnostics("2500steps", driver_config.name)
-    core_dgngrp = setup_atmos_core_diagnostics("2500steps", driver_config.name)
+    default_dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
+        "2500steps",
+        driver_config.name,
+    )
+    core_dgngrp = setup_atmos_core_diagnostics(
+        AtmosLESConfigType(),
+        "2500steps",
+        driver_config.name,
+    )
     return ClimateMachine.DiagnosticsConfiguration([
         default_dgngrp,
         core_dgngrp,

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -344,7 +344,11 @@ end
 
 function config_diagnostics(driver_config)
     interval = "10000steps"
-    dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
+        interval,
+        driver_config.name,
+    )
     return ClimateMachine.DiagnosticsConfiguration([dgngrp])
 end
 

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -122,7 +122,11 @@ end
 
 function config_diagnostics(driver_config)
     interval = "10000steps"
-    dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
+        interval,
+        driver_config.name,
+    )
     return ClimateMachine.DiagnosticsConfiguration([dgngrp])
 end
 

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -2,31 +2,26 @@
     Diagnostics
 
 Accumulate mean fields and covariance statistics on the computational grid.
-
 """
 module Diagnostics
 
 export DiagnosticsGroup,
     setup_atmos_default_diagnostics,
     setup_atmos_core_diagnostics,
-    setup_dump_state_and_aux_diagnostics,
-    VecGrad,
-    compute_vec_grad,
-    SphericalCoord,
-    compute_vec_grad_spherical,
-    Vorticity,
-    compute_vorticity
+    setup_dump_state_and_aux_diagnostics
 
+using CuArrays
 using Dates
 using FileIO
 using JLD2
+using KernelAbstractions
 using MPI
 using OrderedCollections
 using Printf
 using StaticArrays
 import KernelAbstractions: CPU
 
-using ClimateMachine
+using ..ConfigTypes
 using ..DGmethods
 using ..DGmethods:
     number_state_conservative,
@@ -40,6 +35,11 @@ using ..MPIStateArrays
 using ..VariableTemplates
 using ..Writers
 
+using CLIMAParameters
+using CLIMAParameters.Planet: planet_radius
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
 Base.@kwdef mutable struct Diagnostic_Settings
     mpicomm::MPI.Comm = MPI.COMM_WORLD
     dg::Union{Nothing, DGModel} = nothing
@@ -52,7 +52,8 @@ const Settings = Diagnostic_Settings()
 """
     init(mpicomm, dg, Q, starttime, output_dir)
 
-Initialize the diagnostics collection module -- save the parameters into `Settings`.
+Initialize the diagnostics collection module -- save the parameters into
+`Settings`.
 """
 function init(
     mpicomm::MPI.Comm,
@@ -68,224 +69,20 @@ function init(
     Settings.output_dir = output_dir
 end
 
-"""
-    DiagnosticsGroup
-
-Holds a set of diagnostics that share a collection interval, a filename prefix,
-and an interpolation.
-
-TODO: to be completed; will be restructured.
-"""
-mutable struct DiagnosticsGroup
-    name::String
-    init::Function
-    fini::Function
-    collect::Function
-    interval::String
-    out_prefix::String
-    writer::AbstractWriter
-    interpol::Union{Nothing, InterpolationTopology}
-    project::Bool
-    num::Int
-
-    DiagnosticsGroup(
-        name,
-        init,
-        fini,
-        collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-        project,
-    ) = new(
-        name,
-        init,
-        fini,
-        collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-        project,
-        0,
-    )
-end
-
-function (dgngrp::DiagnosticsGroup)(currtime; init = false, fini = false)
-    if init
-        dgngrp.init(dgngrp, currtime)
-    end
-    dgngrp.collect(dgngrp, currtime)
-    if fini
-        dgngrp.fini(dgngrp, currtime)
-    end
-    dgngrp.num += 1
-end
-
-"""
-    setup_atmos_default_diagnostics(
-        interval::String,
-        out_prefix::String;
-        writer = NetCDFWriter(),
-        interpol = nothing,
-        project = true,
-    )
-
-Create and return a `DiagnosticsGroup` containing the "AtmosDefault"
-diagnostics. All the diagnostics in the group will run at the specified
-`interval`, be interpolated to the specified boundaries and resolution,
-and will be written to files prefixed by `out_prefix` using `writer`.
-"""
-function setup_atmos_default_diagnostics(
-    interval::String,
-    out_prefix::String;
-    writer = NetCDFWriter(),
-    interpol = nothing,
-    project = true,
-)
-    return DiagnosticsGroup(
-        "AtmosDefault",
-        Diagnostics.atmos_default_init,
-        Diagnostics.atmos_default_fini,
-        Diagnostics.atmos_default_collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-        project,
-    )
-end
-
-"""
-    setup_atmos_core_diagnostics(
-            interval::Int,
-            out_prefix::String;
-            writer::AbstractWriter,
-            interpol = nothing,
-            project  = true)
-
-Create and return a `DiagnosticsGroup` containing the "AtmosCore"
-diagnostics. All the diagnostics in the group will run at the
-specified `interval`, be interpolated to the specified boundaries
-and resolution, and will be written to files prefixed by `out_prefix`
-using `writer`.
-"""
-function setup_atmos_core_diagnostics(
-    interval::String,
-    out_prefix::String;
-    writer = NetCDFWriter(),
-    interpol = nothing,
-    project = true,
-)
-    return DiagnosticsGroup(
-        "AtmosCore",
-        Diagnostics.atmos_core_init,
-        Diagnostics.atmos_core_fini,
-        Diagnostics.atmos_core_collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-        project,
-    )
-end
-
-"""
-    setup_dump_state_and_aux_diagnostics(
-        interval::String,
-        out_prefix::String;
-        writer = NetCDFWriter(),
-        interpol = nothing,
-        project = true,
-    )
-
-Create and return a `DiagnosticsGroup` containing a diagnostic that
-simply dumps the state and aux variables at the specified `interval`
-after being interpolated, into NetCDF files prefixed by `out_prefix`.
-"""
-function setup_dump_state_and_aux_diagnostics(
-    interval::String,
-    out_prefix::String;
-    writer = NetCDFWriter(),
-    interpol = nothing,
-    project = true,
-)
-    return DiagnosticsGroup(
-        "DumpStateAndAux",
-        Diagnostics.dump_state_and_aux_init,
-        Diagnostics.dump_state_and_aux_fini,
-        Diagnostics.dump_state_and_aux_collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-        project,
-    )
-end
-
-"""
-    visitQ()
-
-Helper macro to iterate over the DG grid. Generates the needed loops
-and indices: `eh`, `ev`, `e`, `k,`, `j`, `i`, `ijk`.
-"""
-macro visitQ(nhorzelem, nvertelem, Nqk, Nq, expr)
-    return esc(quote
-        for eh in 1:nhorzelem
-            for ev in 1:nvertelem
-                e = ev + (eh - 1) * nvertelem
-                for k in 1:Nqk
-                    for j in 1:Nq
-                        for i in 1:Nq
-                            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
-                            $expr
-                        end
-                    end
-                end
-            end
-        end
-    end)
-end
-
-# Helpers to extract data from the various state arrays
-function extract_state_conservative(dg, state_conservative, ijk, e)
-    bl = dg.balance_law
-    FT = eltype(state_conservative)
-    num_state_conservative = number_state_conservative(bl, FT)
-    local_state_conservative = MArray{Tuple{num_state_conservative}, FT}(undef)
-    for s in 1:num_state_conservative
-        local_state_conservative[s] = state_conservative[ijk, s, e]
-    end
-    return Vars{vars_state_conservative(bl, FT)}(local_state_conservative)
-end
-function extract_state_auxiliary(dg, state_auxiliary, ijk, e)
-    bl = dg.balance_law
-    FT = eltype(state_auxiliary)
-    num_state_auxiliary = number_state_auxiliary(bl, FT)
-    local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
-    for s in 1:num_state_auxiliary
-        local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
-    end
-    return Vars{vars_state_auxiliary(bl, FT)}(local_state_auxiliary)
-end
-function extract_state_gradient_flux(dg, state_gradient_flux, ijk, e)
-    bl = dg.balance_law
-    FT = eltype(state_gradient_flux)
-    num_state_gradient_flux = number_state_gradient_flux(bl, FT)
-    local_state_gradient_flux =
-        MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-    for s in 1:num_state_gradient_flux
-        local_state_gradient_flux[s] = state_gradient_flux[ijk, s, e]
-    end
-    return Vars{vars_state_gradient_flux(bl, FT)}(local_state_gradient_flux)
-end
-
+include("variables.jl")
+include("helpers.jl")
 include("atmos_common.jl")
 include("thermo.jl")
-include("atmos_default.jl")
-include("atmos_core.jl")
-include("dump_state_and_aux.jl")
-include("diagnostic_fields.jl")
+include("groups.jl")
+
+"""
+    __init()__
+
+Module initialization function. Currently, only fills in all currently
+defined diagnostic variables.
+"""
+function __init__()
+    setup_variables()
+end
 
 end # module Diagnostics

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -1,0 +1,302 @@
+# # Dry Atmosphere GCM diagnostics
+# 
+# This file computes selected diagnostics for the GCM and outputs them
+# on the spherical interpolated diagnostic grid.
+#
+# Use it by calling `Diagnostics.setup_atmos_default_diagnostics()`.
+#
+# TODO:
+# - enable zonal means and calculation of covariances using those means
+#   - ds.T_zm = mean(.*1., ds.T; dims = 3)
+#   - ds.u_zm = mean((ds.u); dims = 3 )
+#   - v_zm = mean(ds.v; dims = 3)
+#   - w_zm = mean(ds.w; dims = 3)
+#   - ds.uvcovariance = (ds.u .- ds.u_zm) * (ds.v .- v_zm)
+#   - ds.vTcovariance = (ds.v .- v_zm) * (ds.T .- ds.T_zm)
+# - add more variables, including horiz streamfunction from laplacial of vorticity (LN)
+# - density weighting
+# - maybe change thermo/dyn separation to local/nonlocal vars?
+
+using LinearAlgebra
+using Printf
+using Statistics
+
+using ..Atmos
+using ..Atmos: thermo_state, turbulence_tensors
+
+include("diagnostic_fields.jl")
+
+function atmos_gcm_default_init(dgngrp::DiagnosticsGroup, currtime)
+    if !(dgngrp.interpol isa InterpolationCubedSphere)
+        @warn """
+            Diagnostics ($dgngrp.name): currently requires `InterpolationCubedSphere`!
+            """
+    end
+end
+
+# 3D variables
+function vars_atmos_gcm_default_simple_3d(atmos::AtmosModel, FT)
+    @vars begin
+        u::FT
+        v::FT
+        w::FT
+        rho::FT
+        temp::FT
+        pres::FT
+        thd::FT                 # θ_dry
+        et::FT                  # e_tot
+        ei::FT                  # e_int
+        ht::FT
+        hi::FT
+        vort::FT                # Ω₃
+
+        moisture::vars_atmos_gcm_default_simple_3d(atmos.moisture, FT)
+    end
+end
+vars_atmos_gcm_default_simple_3d(::MoistureModel, FT) = @vars()
+function vars_atmos_gcm_default_simple_3d(m::EquilMoist, FT)
+    @vars begin
+        qt::FT                  # q_tot
+        ql::FT                  # q_liq
+        qv::FT                  # q_vap
+        qi::FT                  # q_ice
+        thv::FT                 # θ_vir
+        thl::FT                 # θ_liq
+
+    end
+end
+num_atmos_gcm_default_simple_3d_vars(m, FT) =
+    varsize(vars_atmos_gcm_default_simple_3d(m, FT))
+atmos_gcm_default_simple_3d_vars(m, array) =
+    Vars{vars_atmos_gcm_default_simple_3d(m, eltype(array))}(array)
+
+function atmos_gcm_default_simple_3d_vars!(
+    atmos::AtmosModel,
+    state_conservative,
+    thermo,
+    dyni,
+    vars,
+)
+    vars.u = state_conservative.ρu[1] / state_conservative.ρ
+    vars.v = state_conservative.ρu[2] / state_conservative.ρ
+    vars.w = state_conservative.ρu[3] / state_conservative.ρ
+    vars.rho = state_conservative.ρ
+    vars.temp = thermo.temp
+    vars.pres = thermo.pres
+    vars.thd = thermo.θ_dry
+    vars.et = state_conservative.ρe / state_conservative.ρ
+    vars.ei = thermo.e_int
+    vars.ht = thermo.h_tot
+    vars.hi = thermo.h_int
+
+    vars.vort = dyni.Ω₃
+
+    atmos_gcm_default_simple_3d_vars!(
+        atmos.moisture,
+        state_conservative,
+        thermo,
+        vars,
+    )
+
+    return nothing
+end
+function atmos_gcm_default_simple_3d_vars!(
+    ::MoistureModel,
+    state_conservative,
+    thermo,
+    vars,
+)
+    return nothing
+end
+function atmos_gcm_default_simple_3d_vars!(
+    moist::EquilMoist,
+    state_conservative,
+    thermo,
+    vars,
+)
+    vars.moisture.qt = state_conservative.moisture.ρq_tot / state_conservative.ρ
+    vars.moisture.ql = thermo.moisture.q_liq
+    vars.moisture.qv = thermo.moisture.q_vap
+    vars.moisture.qi = thermo.moisture.q_ice
+    vars.moisture.thv = thermo.moisutre.θ_vir
+    vars.moisture.thl = thermo.moisture.θ_liq_ice
+
+    return nothing
+end
+
+# Dynamic variables
+function vars_dyn(FT)
+    @vars begin
+        Ω₁::FT
+        Ω₂::FT
+        Ω₃::FT
+    end
+end
+dyn_vars(array) = Vars{vars_dyn(eltype(array))}(array)
+
+"""
+    atmos_gcm_default_collect(bl, currtime)
+
+    Master function that performs a global grid traversal to compute various
+    diagnostics using the above functions.
+"""
+function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
+    interpol = dgngrp.interpol
+    if !(interpol isa InterpolationCubedSphere)
+        @warn """
+            Diagnostics ($dgngrp.name): currently requires `InterpolationCubedSphere`!
+            """
+        return nothing
+    end
+
+    mpicomm = Settings.mpicomm
+    dg = Settings.dg
+    Q = Settings.Q
+    mpirank = MPI.Comm_rank(mpicomm)
+    bl = dg.balance_law
+    grid = dg.grid
+    topology = grid.topology
+    N = polynomialorder(grid)
+    Nq = N + 1
+    Nqk = dimensionality(grid) == 2 ? 1 : Nq
+    npoints = Nq * Nq * Nqk
+    nrealelem = length(topology.realelems)
+    nvertelem = topology.stacksize
+    nhorzelem = div(nrealelem, nvertelem)
+
+    # get needed arrays onto the CPU
+    device = array_device(Q)
+    if device isa CPU
+        ArrayType = Array
+        state_data = Q.realdata
+        aux_data = dg.state_auxiliary.realdata
+    else
+        ArrayType = CuArray
+        state_data = Array(Q.realdata)
+        aux_data = Array(dg.state_auxiliary.realdata)
+    end
+    FT = eltype(state_data)
+
+    # TODO: can this be done in one pass?
+    #
+    # Non-local vars, e.g. relative vorticity
+    vgrad = VectorGradients(dg, Q)
+    vort = Vorticity(dg, vgrad)
+
+    # Compute thermo variables
+    thermo_array = Array{FT}(undef, npoints, num_thermo(bl, FT), nrealelem)
+    @visitQ nhorzelem nvertelem Nqk Nq begin
+        state_conservative = extract_state_conservative(dg, state_data, ijk, e)
+        state_auxiliary = extract_state_auxiliary(dg, aux_data, ijk, e)
+
+        thermo = thermo_vars(bl, view(thermo_array, ijk, :, e))
+        compute_thermo!(bl, state_conservative, state_auxiliary, thermo)
+    end
+
+    # Interpolate the state, thermo and dyn vars to sphere (u and vorticity
+    # need projection to zonal, merid). All this may happen on the GPU.
+    istate =
+        ArrayType{FT}(undef, interpol.Npl, number_state_conservative(bl, FT))
+    interpolate_local!(interpol, Q.realdata, istate)
+
+    ithermo = ArrayType{FT}(undef, interpol.Npl, num_thermo(bl, FT))
+    interpolate_local!(interpol, ArrayType(thermo_array), ithermo)
+
+    idyn = ArrayType{FT}(undef, interpol.Npl, size(vort.data, 2))
+    interpolate_local!(interpol, vort.data, idyn)
+
+    # TODO: get indices here without hard-coding them
+    _ρu, _ρv, _ρw = 2, 3, 4
+    project_cubed_sphere!(interpol, istate, (_ρu, _ρv, _ρw))
+    _Ω₁, _Ω₂, _Ω₃ = 1, 2, 3
+    project_cubed_sphere!(interpol, idyn, (_Ω₁, _Ω₂, _Ω₃))
+
+    # FIXME: accumulating to rank 0 is not scalable
+    all_state_data = accumulate_interpolated_data(mpicomm, interpol, istate)
+    all_thermo_data = accumulate_interpolated_data(mpicomm, interpol, ithermo)
+    all_dyn_data = accumulate_interpolated_data(mpicomm, interpol, idyn)
+
+    if mpirank == 0
+        # get dimensions for the interpolated grid
+        dims = dimensions(dgngrp.interpol)
+
+        # adjust the level dimension for `planet_radius`
+        level_val = dims["level"]
+        dims["level"] =
+            (level_val[1] .- FT(planet_radius(param_set)), level_val[2])
+
+        # set up the array for the diagnostic variables based on the interpolated grid
+        nlong = length(dims["long"][1])
+        nlat = length(dims["lat"][1])
+        nlevel = length(dims["level"][1])
+
+        simple_3d_vars_array = Array{FT}(
+            undef,
+            1,
+            nlong,
+            nlat,
+            nlevel,
+            num_atmos_gcm_default_simple_3d_vars(bl, FT),
+        )
+
+        @visitI nlong nlat nlevel begin
+            statei = Vars{vars_state_conservative(bl, FT)}(view(
+                all_state_data,
+                lo,
+                la,
+                le,
+                :,
+            ))
+            thermoi = thermo_vars(bl, view(all_thermo_data, lo, la, le, :))
+            dyni = dyn_vars(view(all_dyn_data, lo, la, le, :))
+            simple_3d_vars = atmos_gcm_default_simple_3d_vars(
+                bl,
+                view(simple_3d_vars_array, 1, lo, la, le, :),
+            )
+
+            atmos_gcm_default_simple_3d_vars!(
+                bl,
+                statei,
+                thermoi,
+                dyni,
+                simple_3d_vars,
+            )
+        end
+
+        # assemble the diagnostics for writing
+        dim_names = tuple("time", collect(keys(dims))...)
+        varvals = OrderedDict()
+        varnames = map(
+            s -> startswith(s, "moisture.") ? s[10:end] : s,
+            flattenednames(vars_atmos_gcm_default_simple_3d(bl, FT)),
+        )
+        for (vari, varname) in enumerate(varnames)
+            var = Variables[varname]
+            varvals[varname] = (
+                dim_names,
+                simple_3d_vars_array[:, :, :, :, vari],
+                OrderedDict(
+                    "units" => var.units,
+                    "long_name" => var.long,
+                    "standard_name" => var.standard,
+                ),
+            )
+        end
+
+        # write output
+        dprefix = @sprintf(
+            "%s_%s_%s_num%04d",
+            dgngrp.out_prefix,
+            dgngrp.name,
+            Settings.starttime,
+            dgngrp.num
+        )
+        dfilename = joinpath(Settings.output_dir, dprefix)
+        write_data(dgngrp.writer, dfilename, dims, varvals, currtime)
+    end
+
+    MPI.Barrier(mpicomm)
+    return nothing
+end # function collect
+
+function atmos_gcm_default_fini(dgngrp::DiagnosticsGroup, currtime) end

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -6,18 +6,18 @@ using ..MoistThermodynamics
 using LinearAlgebra
 
 """
-    atmos_default_init(bl, currtime)
+    atmos_les_default_init(bl, currtime)
 
-Initialize the 'AtmosDefault' diagnostics group.
+Initialize the 'AtmosLESDefault' diagnostics group.
 """
-function atmos_default_init(dgngrp::DiagnosticsGroup, currtime)
+function atmos_les_default_init(dgngrp::DiagnosticsGroup, currtime)
     atmos_collect_onetime(Settings.mpicomm, Settings.dg, Settings.Q)
 
     return nothing
 end
 
 # Simple horizontal averages
-function vars_atmos_default_simple(m::AtmosModel, FT)
+function vars_atmos_les_default_simple(m::AtmosModel, FT)
     @vars begin
         u::FT
         v::FT
@@ -25,32 +25,34 @@ function vars_atmos_default_simple(m::AtmosModel, FT)
         avg_rho::FT             # ρ
         rho::FT                 # ρρ
         temp::FT
+        pres::FT
         thd::FT                 # θ_dry
-        thv::FT                 # θ_vir
         et::FT                  # e_tot
         ei::FT                  # e_int
         ht::FT
-        hm::FT
+        hi::FT
         w_ht_sgs::FT
 
-        moisture::vars_atmos_default_simple(m.moisture, FT)
+        moisture::vars_atmos_les_default_simple(m.moisture, FT)
     end
 end
-vars_atmos_default_simple(::MoistureModel, FT) = @vars()
-function vars_atmos_default_simple(m::EquilMoist, FT)
+vars_atmos_les_default_simple(::MoistureModel, FT) = @vars()
+function vars_atmos_les_default_simple(m::EquilMoist, FT)
     @vars begin
         qt::FT                  # q_tot
         ql::FT                  # q_liq
         qv::FT                  # q_vap
+        thv::FT                 # θ_vir
         thl::FT                 # θ_liq
         w_qt_sgs::FT
     end
 end
-num_atmos_default_simple_vars(m, FT) = varsize(vars_atmos_default_simple(m, FT))
-atmos_default_simple_vars(m, array) =
-    Vars{vars_atmos_default_simple(m, eltype(array))}(array)
+num_atmos_les_default_simple_vars(m, FT) =
+    varsize(vars_atmos_les_default_simple(m, FT))
+atmos_les_default_simple_vars(m, array) =
+    Vars{vars_atmos_les_default_simple(m, eltype(array))}(array)
 
-function atmos_default_simple_sums!(
+function atmos_les_default_simple_sums!(
     atmos::AtmosModel,
     state_conservative,
     state_gradient_flux,
@@ -65,13 +67,13 @@ function atmos_default_simple_sums!(
     sums.w += MH * state_conservative.ρu[3]
     sums.avg_rho += MH * state_conservative.ρ
     sums.rho += MH * state_conservative.ρ * state_conservative.ρ
-    sums.temp += MH * thermo.T * state_conservative.ρ
+    sums.temp += MH * thermo.temp * state_conservative.ρ
+    sums.pres += MH * thermo.pres * state_conservative.ρ
     sums.thd += MH * thermo.θ_dry * state_conservative.ρ
-    sums.thv += MH * thermo.θ_vir * state_conservative.ρ
     sums.et += MH * state_conservative.ρe
     sums.ei += MH * thermo.e_int * state_conservative.ρ
     sums.ht += MH * thermo.h_tot * state_conservative.ρ
-    sums.hm += MH * thermo.h_moi * state_conservative.ρ
+    sums.hi += MH * thermo.h_int * state_conservative.ρ
 
     ν, D_t, _ = turbulence_tensors(
         atmos,
@@ -83,7 +85,7 @@ function atmos_default_simple_sums!(
     d_h_tot = -D_t .* state_gradient_flux.∇h_tot
     sums.w_ht_sgs += MH * d_h_tot[end] * state_conservative.ρ
 
-    atmos_default_simple_sums!(
+    atmos_les_default_simple_sums!(
         atmos.moisture,
         state_conservative,
         state_gradient_flux,
@@ -95,7 +97,7 @@ function atmos_default_simple_sums!(
 
     return nothing
 end
-function atmos_default_simple_sums!(
+function atmos_les_default_simple_sums!(
     ::MoistureModel,
     state_conservative,
     state_gradient_flux,
@@ -106,7 +108,7 @@ function atmos_default_simple_sums!(
 )
     return nothing
 end
-function atmos_default_simple_sums!(
+function atmos_les_default_simple_sums!(
     moist::EquilMoist,
     state_conservative,
     state_gradient_flux,
@@ -118,6 +120,7 @@ function atmos_default_simple_sums!(
     sums.moisture.qt += MH * state_conservative.moisture.ρq_tot
     sums.moisture.ql += MH * thermo.moisture.q_liq * state_conservative.ρ
     sums.moisture.qv += MH * thermo.moisture.q_vap * state_conservative.ρ
+    sums.moisture.thv += MH * thermo.moisture.θ_vir * state_conservative.ρ
     sums.moisture.thl += MH * thermo.moisture.θ_liq_ice * state_conservative.ρ
     d_q_tot = (-D_t) .* state_gradient_flux.moisture.∇q_tot
     sums.moisture.w_qt_sgs += MH * d_q_tot[end] * state_conservative.ρ
@@ -126,7 +129,7 @@ function atmos_default_simple_sums!(
 end
 
 # Variances and covariances
-function vars_atmos_default_ho(m::AtmosModel, FT)
+function vars_atmos_les_default_ho(m::AtmosModel, FT)
     @vars begin
         var_u::FT               # u′u′
         var_v::FT               # v′v′
@@ -139,14 +142,13 @@ function vars_atmos_default_ho(m::AtmosModel, FT)
         cov_w_v::FT             # w′v′
         cov_w_rho::FT           # w′ρ′
         cov_w_thd::FT           # w′θ_dry′
-        cov_w_thv::FT           # w′θ_v′
         cov_w_ei::FT            # w′e_int′
 
-        moisture::vars_atmos_default_ho(m.moisture, FT)
+        moisture::vars_atmos_les_default_ho(m.moisture, FT)
     end
 end
-vars_atmos_default_ho(::MoistureModel, FT) = @vars()
-function vars_atmos_default_ho(m::EquilMoist, FT)
+vars_atmos_les_default_ho(::MoistureModel, FT) = @vars()
+function vars_atmos_les_default_ho(m::EquilMoist, FT)
     @vars begin
         var_qt::FT              # q_tot′q_tot′
         var_thl::FT             # θ_liq_ice′θ_liq_ice′
@@ -154,16 +156,17 @@ function vars_atmos_default_ho(m::EquilMoist, FT)
         cov_w_qt::FT            # w′q_tot′
         cov_w_ql::FT            # w′q_liq′
         cov_w_qv::FT            # w′q_vap′
+        cov_w_thv::FT           # w′θ_v′
         cov_w_thl::FT           # w′θ_liq_ice′
         cov_qt_thl::FT          # q_tot′θ_liq_ice′
         cov_qt_ei::FT           # q_tot′e_int′
     end
 end
-num_atmos_default_ho_vars(m, FT) = varsize(vars_atmos_default_ho(m, FT))
-atmos_default_ho_vars(m, array) =
-    Vars{vars_atmos_default_ho(m, eltype(array))}(array)
+num_atmos_les_default_ho_vars(m, FT) = varsize(vars_atmos_les_default_ho(m, FT))
+atmos_les_default_ho_vars(m, array) =
+    Vars{vars_atmos_les_default_ho(m, eltype(array))}(array)
 
-function atmos_default_ho_sums!(
+function atmos_les_default_ho_sums!(
     atmos::AtmosModel,
     state_conservative,
     thermo,
@@ -179,7 +182,6 @@ function atmos_default_ho_sums!(
     w′ = w - ha.w
     e_int′ = thermo.e_int - ha.ei
     θ_dry′ = thermo.θ_dry - ha.thd
-    θ_vir′ = thermo.θ_vir - ha.thv
 
     sums.var_u += MH * u′^2 * state_conservative.ρ
     sums.var_v += MH * v′^2 * state_conservative.ρ
@@ -198,10 +200,9 @@ function atmos_default_ho_sums!(
     sums.cov_w_rho +=
         MH * w′ * (state_conservative.ρ - ha.avg_rho) * state_conservative.ρ
     sums.cov_w_thd += MH * w′ * θ_dry′ * state_conservative.ρ
-    sums.cov_w_thv += MH * w′ * θ_vir′ * state_conservative.ρ
     sums.cov_w_ei += MH * w′ * e_int′ * state_conservative.ρ
 
-    atmos_default_ho_sums!(
+    atmos_les_default_ho_sums!(
         atmos.moisture,
         state_conservative,
         thermo,
@@ -214,7 +215,7 @@ function atmos_default_ho_sums!(
 
     return nothing
 end
-function atmos_default_ho_sums!(
+function atmos_les_default_ho_sums!(
     ::MoistureModel,
     state_conservative,
     thermo,
@@ -226,7 +227,7 @@ function atmos_default_ho_sums!(
 )
     return nothing
 end
-function atmos_default_ho_sums!(
+function atmos_les_default_ho_sums!(
     moist::EquilMoist,
     state_conservative,
     thermo,
@@ -240,6 +241,7 @@ function atmos_default_ho_sums!(
     q_tot′ = q_tot - ha.moisture.qt
     q_liq′ = thermo.moisture.q_liq - ha.moisture.ql
     q_vap′ = thermo.moisture.q_vap - ha.moisture.qv
+    θ_vir′ = thermo.moisture.θ_vir - ha.moisture.thv
     θ_liq_ice′ = thermo.moisture.θ_liq_ice - ha.moisture.thl
 
     sums.moisture.var_qt += MH * q_tot′^2 * state_conservative.ρ
@@ -248,6 +250,7 @@ function atmos_default_ho_sums!(
     sums.moisture.cov_w_qt += MH * w′ * q_tot′ * state_conservative.ρ
     sums.moisture.cov_w_ql += MH * w′ * q_liq′ * state_conservative.ρ
     sums.moisture.cov_w_qv += MH * w′ * q_vap′ * state_conservative.ρ
+    sums.moisture.cov_w_thv += MH * w′ * θ_vir′ * state_conservative.ρ
     sums.moisture.cov_w_thl += MH * w′ * θ_liq_ice′ * state_conservative.ρ
     sums.moisture.cov_qt_thl += MH * q_tot′ * θ_liq_ice′ * state_conservative.ρ
     sums.moisture.cov_qt_ei += MH * q_tot′ * e_int′ * state_conservative.ρ
@@ -256,12 +259,12 @@ function atmos_default_ho_sums!(
 end
 
 """
-    atmos_default_collect(bl, currtime)
+    atmos_les_default_collect(bl, currtime)
 
-Collect the various 'AtmosDefault' diagnostic variables for the
+Collect the various 'AtmosLESDefault' diagnostic variables for the
 current timestep and write them into a file.
 """
-function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
+function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     mpicomm = Settings.mpicomm
     dg = Settings.dg
     Q = Settings.Q
@@ -302,7 +305,7 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
     thermo_array =
         [zeros(FT, num_thermo(bl, FT)) for _ in 1:npoints, _ in 1:nrealelem]
     simple_sums = [
-        zeros(FT, num_atmos_default_simple_vars(bl, FT))
+        zeros(FT, num_atmos_les_default_simple_vars(bl, FT))
         for _ in 1:(Nqk * nvertelem)
     ]
     ql_gt_0_z = [zeros(FT, (Nq * Nq * nhorzelem)) for _ in 1:(Nqk * nvertelem)]
@@ -324,8 +327,8 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
         thermo = thermo_vars(bl, thermo_array[ijk, e])
         compute_thermo!(bl, state_conservative, state_auxiliary, thermo)
 
-        simple = atmos_default_simple_vars(bl, simple_sums[evk])
-        atmos_default_simple_sums!(
+        simple = atmos_les_default_simple_vars(bl, simple_sums[evk])
+        atmos_les_default_simple_sums!(
             bl,
             state_conservative,
             state_gradient_flux,
@@ -352,10 +355,10 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
 
     # reduce horizontal sums and cloud data across ranks and compute averages
     simple_avgs = [
-        zeros(FT, num_atmos_default_simple_vars(bl, FT))
+        zeros(FT, num_atmos_les_default_simple_vars(bl, FT))
         for _ in 1:(Nqk * nvertelem)
     ]
-    cld_frac = zeros(FT, Nqk * nvertelem)
+    cld_frac = zeros(FT, 1, Nqk * nvertelem)
     for evk in 1:(Nqk * nvertelem)
         MPI.Allreduce!(simple_sums[evk], simple_avgs[evk], +, mpicomm)
         simple_avgs[evk] .= simple_avgs[evk] ./ repdvsr[evk]
@@ -390,11 +393,11 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
     # complete density averaging
     simple_varnames = map(
         s -> startswith(s, "moisture.") ? s[10:end] : s,
-        flattenednames(vars_atmos_default_simple(bl, FT)),
+        flattenednames(vars_atmos_les_default_simple(bl, FT)),
     )
     for vari in 1:length(simple_varnames)
         for evk in 1:(Nqk * nvertelem)
-            simple_ha = atmos_default_simple_vars(bl, simple_avgs[evk])
+            simple_ha = atmos_les_default_simple_vars(bl, simple_avgs[evk])
             avg_rho = simple_ha.avg_rho
             if simple_varnames[vari] != "avg_rho"
                 simple_avgs[evk][vari] /= avg_rho
@@ -404,7 +407,7 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
 
     # compute the variances and covariances
     ho_sums = [
-        zeros(FT, num_atmos_default_ho_vars(bl, FT))
+        zeros(FT, num_atmos_les_default_ho_vars(bl, FT))
         for _ in 1:(Nqk * nvertelem)
     ]
     @visitQ nhorzelem nvertelem Nqk Nq begin
@@ -415,9 +418,9 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
         thermo = thermo_vars(bl, thermo_array[ijk, e])
         MH = host_vgeo[ijk, grid.MHid, e]
 
-        simple_ha = atmos_default_simple_vars(bl, simple_avgs[evk])
-        ho = atmos_default_ho_vars(bl, ho_sums[evk])
-        atmos_default_ho_sums!(
+        simple_ha = atmos_les_default_simple_vars(bl, simple_avgs[evk])
+        ho = atmos_les_default_ho_vars(bl, ho_sums[evk])
+        atmos_les_default_ho_sums!(
             bl,
             state_conservative,
             thermo,
@@ -429,7 +432,7 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
 
     # reduce across ranks and compute averages
     ho_avgs = [
-        zeros(FT, num_atmos_default_ho_vars(bl, FT))
+        zeros(FT, num_atmos_les_default_ho_vars(bl, FT))
         for _ in 1:(Nqk * nvertelem)
     ]
     for evk in 1:(Nqk * nvertelem)
@@ -443,33 +446,32 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
     if mpirank == 0
         varvals = OrderedDict()
         for vari in 1:length(simple_varnames)
-            davg = zeros(FT, Nqk * nvertelem)
+            davg = zeros(FT, 1, Nqk * nvertelem)
             for evk in 1:(Nqk * nvertelem)
                 davg[evk] = simple_avgs[evk][vari]
             end
-            varvals[simple_varnames[vari]] = (("z",), davg)
+            varvals[simple_varnames[vari]] = (("time", "z"), davg, Dict())
         end
 
         ho_varnames = map(
             s -> startswith(s, "moisture.") ? s[10:end] : s,
-            flattenednames(vars_atmos_default_ho(bl, FT)),
+            flattenednames(vars_atmos_les_default_ho(bl, FT)),
         )
         for vari in 1:length(ho_varnames)
-            davg = zeros(FT, Nqk * nvertelem)
+            davg = zeros(FT, 1, Nqk * nvertelem)
             for evk in 1:(Nqk * nvertelem)
-                simple_ha = atmos_default_simple_vars(bl, simple_avgs[evk])
+                simple_ha = atmos_les_default_simple_vars(bl, simple_avgs[evk])
                 avg_rho = simple_ha.avg_rho
                 davg[evk] = ho_avgs[evk][vari] / avg_rho
             end
-            varvals[ho_varnames[vari]] = (("z",), davg)
+            varvals[ho_varnames[vari]] = (("time", "z"), davg, Dict())
         end
 
-        # FIXME properly
         if isa(bl.moisture, EquilMoist)
-            varvals["cld_frac"] = (("z",), cld_frac)
-            varvals["cld_top"] = (("t",), cld_top)
-            varvals["cld_base"] = (("t",), cld_base)
-            varvals["cld_cover"] = (("t",), cld_cover)
+            varvals["cld_frac"] = (("time", "z"), cld_frac, Dict())
+            varvals["cld_top"] = (("time",), cld_top, Dict())
+            varvals["cld_base"] = (("time",), cld_base, Dict())
+            varvals["cld_cover"] = (("time",), cld_cover, Dict())
         end
 
         # write output
@@ -484,7 +486,7 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
         write_data(
             dgngrp.writer,
             dfilename,
-            OrderedDict("z" => zvals),
+            OrderedDict("z" => (zvals, Dict())),
             varvals,
             currtime,
         )
@@ -494,4 +496,4 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
     return nothing
 end # function collect
 
-function atmos_default_fini(dgngrp::DiagnosticsGroup, currtime) end
+function atmos_les_default_fini(dgngrp::DiagnosticsGroup, currtime) end

--- a/src/Diagnostics/dump_state_and_aux.jl
+++ b/src/Diagnostics/dump_state_and_aux.jl
@@ -1,47 +1,20 @@
 function dump_state_and_aux_init(dgngrp, currtime)
-    @assert dgngrp.interpol !== nothing
-end
-
-function get_dims(dgngrp)
-    if dgngrp.interpol !== nothing
-        if dgngrp.interpol isa InterpolationBrick
-            if array_device(dgngrp.interpol.x1g) isa CPU
-                h_x1g = dgngrp.interpol.x1g
-                h_x2g = dgngrp.interpol.x2g
-                h_x3g = dgngrp.interpol.x3g
-            else
-                h_x1g = Array(dgngrp.interpol.x1g)
-                h_x2g = Array(dgngrp.interpol.x2g)
-                h_x3g = Array(dgngrp.interpol.x3g)
-            end
-            dims = OrderedDict("x" => h_x1g, "y" => h_x2g, "z" => h_x3g)
-        elseif dgngrp.interpol isa InterpolationCubedSphere
-            if array_device(dgngrp.interpol.rad_grd) isa CPU
-                h_rad_grd = dgngrp.interpol.rad_grd
-                h_lat_grd = dgngrp.interpol.lat_grd
-                h_long_grd = dgngrp.interpol.long_grd
-            else
-                h_rad_grd = Array(dgngrp.interpol.rad_grd)
-                h_lat_grd = Array(dgngrp.interpol.lat_grd)
-                h_long_grd = Array(dgngrp.interpol.long_grd)
-            end
-            dims = OrderedDict(
-                "rad" => h_rad_grd,
-                "lat" => h_lat_grd,
-                "long" => h_long_grd,
-            )
-        else
-            error("Unsupported interpolation topology $(dgngrp.interpol)")
-        end
-    else
-        error("Dump of non-interpolated data currently unsupported")
+    if isnothing(dgngrp.interpol)
+        @warn """
+            Diagnostics ($dgngrp.name): requires interpolation!
+            """
     end
-
-    return dims
 end
 
 function dump_state_and_aux_collect(dgngrp, currtime)
-    DA = ClimateMachine.array_type()
+    interpol = dgngrp.interpol
+    if isnothing(interpol)
+        @warn """
+            Diagnostics ($dgngrp.name): requires interpolation!
+            """
+        return nothing
+    end
+
     mpicomm = Settings.mpicomm
     dg = Settings.dg
     Q = Settings.Q
@@ -61,59 +34,43 @@ function dump_state_and_aux_collect(dgngrp, currtime)
     auxfilename = joinpath(Settings.output_dir, "$(dprefix)_aux")
 
     statenames = flattenednames(vars_state_conservative(bl, FT))
-    #statenames = ("rho", "rhou", "rhov", "rhow", "rhoe")
     auxnames = flattenednames(vars_state_auxiliary(bl, FT))
 
-    all_state_data = nothing
-    all_aux_data = nothing
-    if dgngrp.interpol !== nothing
-        istate = DA(Array{FT}(
-            undef,
-            dgngrp.interpol.Npl,
-            number_state_conservative(bl, FT),
-        ))
-        interpolate_local!(dgngrp.interpol, Q.data, istate)
+    istate = similar(Q.data, interpol.Npl, number_state_conservative(bl, FT))
+    interpolate_local!(interpol, Q.data, istate)
 
-        if dgngrp.project
-            if dgngrp.interpol isa InterpolationCubedSphere
-                # TODO: get indices here without hard-coding them
-                _ρu, _ρv, _ρw = 2, 3, 4
-                project_cubed_sphere!(dgngrp.interpol, istate, (_ρu, _ρv, _ρw))
-            else
-                error("Can only project for InterpolationCubedSphere")
-            end
-        end
-
-        all_state_data =
-            accumulate_interpolated_data(mpicomm, dgngrp.interpol, istate)
-
-        iaux = DA(Array{FT}(
-            undef,
-            dgngrp.interpol.Npl,
-            number_state_auxiliary(bl, FT),
-        ))
-        interpolate_local!(dgngrp.interpol, dg.state_auxiliary.data, iaux)
-
-        all_aux_data =
-            accumulate_interpolated_data(mpicomm, dgngrp.interpol, iaux)
-    else
-        error("Dump of non-interpolated data currently unsupported")
+    if interpol isa InterpolationCubedSphere
+        # TODO: get indices here without hard-coding them
+        _ρu, _ρv, _ρw = 2, 3, 4
+        project_cubed_sphere!(interpol, istate, (_ρu, _ρv, _ρw))
     end
 
+    all_state_data = accumulate_interpolated_data(mpicomm, interpol, istate)
+
+    iaux = similar(
+        dg.state_auxiliary.data,
+        interpol.Npl,
+        number_state_auxiliary(bl, FT),
+    )
+    interpolate_local!(interpol, dg.state_auxiliary.data, iaux)
+
+    all_aux_data = accumulate_interpolated_data(mpicomm, interpol, iaux)
+
     if mpirank == 0
-        dims = get_dims(dgngrp)
+        dims = dimensions(interpol)
         dim_names = tuple(collect(keys(dims))...)
 
         statevarvals = OrderedDict()
         for i in 1:number_state_conservative(bl, FT)
             statevarvals[statenames[i]] =
-                (dim_names, all_state_data[:, :, :, i])
+                (dim_names, all_state_data[:, :, :, i], Dict())
         end
         write_data(dgngrp.writer, statefilename, dims, statevarvals, currtime)
 
         auxvarvals = OrderedDict()
         for i in 1:number_state_auxiliary(bl, FT)
-            auxvarvals[auxnames[i]] = (dim_names, all_aux_data[:, :, :, i])
+            auxvarvals[auxnames[i]] =
+                (dim_names, all_aux_data[:, :, :, i], Dict())
         end
         write_data(dgngrp.writer, auxfilename, dims, auxvarvals, currtime)
     end

--- a/src/Diagnostics/groups.jl
+++ b/src/Diagnostics/groups.jl
@@ -1,0 +1,191 @@
+"""
+    DiagnosticsGroup
+
+Holds a set of diagnostics that share a collection interval, a filename
+prefix, and an interpolation.
+
+TODO: will be restructured to be defined as groups of `DiagnosticVariable`s.
+"""
+mutable struct DiagnosticsGroup
+    name::String
+    init::Function
+    fini::Function
+    collect::Function
+    interval::String
+    out_prefix::String
+    writer::AbstractWriter
+    interpol::Union{Nothing, InterpolationTopology}
+    num::Int
+
+    DiagnosticsGroup(
+        name,
+        init,
+        fini,
+        collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    ) = new(
+        name,
+        init,
+        fini,
+        collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+        0,
+    )
+end
+
+function (dgngrp::DiagnosticsGroup)(currtime; init = false, fini = false)
+    if init
+        dgngrp.init(dgngrp, currtime)
+    end
+    dgngrp.collect(dgngrp, currtime)
+    if fini
+        dgngrp.fini(dgngrp, currtime)
+    end
+    dgngrp.num += 1
+end
+
+include("atmos_les_default.jl")
+"""
+    setup_atmos_default_diagnostics(
+        ::AtmosLESConfigType,
+        interval::String,
+        out_prefix::String;
+        writer = NetCDFWriter(),
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing the "AtmosDefault"
+diagnostics for LES configurations. All the diagnostics in the group will
+run at the specified `interval`, be interpolated to the specified boundaries
+and resolution, and will be written to files prefixed by `out_prefix` using
+`writer`.
+"""
+function setup_atmos_default_diagnostics(
+    ::AtmosLESConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    return DiagnosticsGroup(
+        "AtmosLESDefault",
+        Diagnostics.atmos_les_default_init,
+        Diagnostics.atmos_les_default_fini,
+        Diagnostics.atmos_les_default_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
+include("atmos_gcm_default.jl")
+"""
+    setup_atmos_default_diagnostics(
+        ::AtmosGCMConfigType,
+        interval::Int,
+        out_prefix::String;
+        writer::AbstractWriter,
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing the "AtmosDefault"
+diagnostics for GCM configurations. All the diagnostics in the group will run
+at the specified `interval`, be interpolated to the specified boundaries and
+resolution, and will be written to files prefixed by `out_prefix` using
+`writer`.
+"""
+function setup_atmos_default_diagnostics(
+    ::AtmosGCMConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    @assert !isnothing(interpol)
+
+    return DiagnosticsGroup(
+        "AtmosGCMDefault",
+        Diagnostics.atmos_gcm_default_init,
+        Diagnostics.atmos_gcm_default_fini,
+        Diagnostics.atmos_gcm_default_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
+include("atmos_les_core.jl")
+"""
+    setup_atmos_core_diagnostics(
+        ::AtmosLESConfigType,
+        interval::Int,
+        out_prefix::String;
+        writer::AbstractWriter,
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing the "AtmosLESCore" diagnostics
+for LES configurations. All the diagnostics in the group will run at the
+specified `interval`, be interpolated to the specified boundaries and
+resolution, and will be written to files prefixed by `out_prefix` using
+`writer`.
+"""
+function setup_atmos_core_diagnostics(
+    ::AtmosLESConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    return DiagnosticsGroup(
+        "AtmosLESCore",
+        Diagnostics.atmos_les_core_init,
+        Diagnostics.atmos_les_core_fini,
+        Diagnostics.atmos_les_core_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
+include("dump_state_and_aux.jl")
+"""
+    setup_dump_state_and_aux_diagnostics(
+        ::ClimateMachineConfigType,
+        interval::String,
+        out_prefix::String;
+        writer = NetCDFWriter(),
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing a diagnostic that
+simply dumps the state and aux variables at the specified `interval`
+after being interpolated, into NetCDF files prefixed by `out_prefix`.
+"""
+function setup_dump_state_and_aux_diagnostics(
+    ::ClimateMachineConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    return DiagnosticsGroup(
+        "DumpStateAndAux",
+        Diagnostics.dump_state_and_aux_init,
+        Diagnostics.dump_state_and_aux_fini,
+        Diagnostics.dump_state_and_aux_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end

--- a/src/Diagnostics/helpers.jl
+++ b/src/Diagnostics/helpers.jl
@@ -1,0 +1,71 @@
+# Miscellaneous helper macros and functions
+#
+
+# Helper macro to iterate over the DG grid. Generates the needed loops
+# and indices: `eh`, `ev`, `e`, `k,`, `j`, `i`, `ijk`.
+macro visitQ(nhorzelem, nvertelem, Nqk, Nq, expr)
+    return esc(
+        quote
+            for eh in 1:($nhorzelem)
+                for ev in 1:($nvertelem)
+                    e = ev + (eh - 1) * $nvertelem
+                    for k in 1:($Nqk)
+                        for j in 1:($Nq)
+                            for i in 1:($Nq)
+                                ijk = i + $Nq * ((j - 1) + $Nq * (k - 1))
+                                $expr
+                            end
+                        end
+                    end
+                end
+            end
+        end,
+    )
+end
+
+# Helper macro to iterate over a 3D array. Used for walking the
+# interpolated grid.
+macro visitI(nlong, nlat, nlevel, expr)
+    return esc(quote
+        for lo in 1:($nlong)
+            for la in 1:($nlat)
+                for le in 1:($nlevel)
+                    $expr
+                end
+            end
+        end
+    end)
+end
+
+# Helpers to extract data from the various state arrays
+function extract_state_conservative(dg, state_conservative, ijk, e)
+    bl = dg.balance_law
+    FT = eltype(state_conservative)
+    num_state_conservative = number_state_conservative(bl, FT)
+    local_state_conservative = MArray{Tuple{num_state_conservative}, FT}(undef)
+    for s in 1:num_state_conservative
+        local_state_conservative[s] = state_conservative[ijk, s, e]
+    end
+    return Vars{vars_state_conservative(bl, FT)}(local_state_conservative)
+end
+function extract_state_auxiliary(dg, state_auxiliary, ijk, e)
+    bl = dg.balance_law
+    FT = eltype(state_auxiliary)
+    num_state_auxiliary = number_state_auxiliary(bl, FT)
+    local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+    for s in 1:num_state_auxiliary
+        local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
+    end
+    return Vars{vars_state_auxiliary(bl, FT)}(local_state_auxiliary)
+end
+function extract_state_gradient_flux(dg, state_gradient_flux, ijk, e)
+    bl = dg.balance_law
+    FT = eltype(state_gradient_flux)
+    num_state_gradient_flux = number_state_gradient_flux(bl, FT)
+    local_state_gradient_flux =
+        MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+    for s in 1:num_state_gradient_flux
+        local_state_gradient_flux[s] = state_gradient_flux[ijk, s, e]
+    end
+    return Vars{vars_state_gradient_flux(bl, FT)}(local_state_gradient_flux)
+end

--- a/src/Diagnostics/thermo.jl
+++ b/src/Diagnostics/thermo.jl
@@ -4,16 +4,16 @@ using ..Atmos: MoistureModel
 # Helpers to gather the thermodynamic variables across the DG grid
 #
 
-function vars_thermo(m::AtmosModel, FT)
+function vars_thermo(atmos::AtmosModel, FT)
     @vars begin
-        T::FT
+        temp::FT
+        pres::FT
         θ_dry::FT
-        θ_vir::FT
         e_int::FT
         h_tot::FT
-        h_moi::FT
+        h_int::FT
 
-        moisture::vars_thermo(m.moisture, FT)
+        moisture::vars_thermo(atmos.moisture, FT)
     end
 end
 vars_thermo(::MoistureModel, FT) = @vars()
@@ -22,27 +22,27 @@ function vars_thermo(m::EquilMoist, FT)
         q_liq::FT
         q_ice::FT
         q_vap::FT
+        θ_vir::FT
         θ_liq_ice::FT
     end
 end
 num_thermo(bl, FT) = varsize(vars_thermo(bl, FT))
 thermo_vars(bl, array) = Vars{vars_thermo(bl, eltype(array))}(array)
 
-# visitor function, to use with `@visitQ`
+# compute thermodynamic variables visitor function, to use with `@visitQ`
 function compute_thermo!(atmos::AtmosModel, state, aux, thermo)
     e_tot = state.ρe / state.ρ
     ts = thermo_state(atmos, state, aux)
     e_int = internal_energy(ts)
 
-    thermo.T = air_temperature(ts)
+    thermo.temp = air_temperature(ts)
+    thermo.pres = air_pressure(ts)
     thermo.θ_dry = dry_pottemp(ts)
-    thermo.θ_vir = virtual_pottemp(ts)
     thermo.e_int = e_int
 
-    # Moist and total henthalpy
     R_m = gas_constant_air(ts)
-    thermo.h_tot = e_tot + R_m * thermo.T
-    thermo.h_moi = e_int + R_m * thermo.T
+    thermo.h_tot = e_tot + R_m * thermo.temp
+    thermo.h_int = e_int + R_m * thermo.temp
 
     compute_thermo!(atmos.moisture, state, aux, ts, thermo)
 
@@ -57,6 +57,7 @@ function compute_thermo!(moist::EquilMoist, state, aux, ts, thermo)
     thermo.moisture.q_liq = Phpart.liq
     thermo.moisture.q_ice = Phpart.ice
     thermo.moisture.q_vap = vapor_specific_humidity(ts)
+    thermo.moisture.θ_vir = virtual_pottemp(ts)
     thermo.moisture.θ_liq_ice = liquid_ice_pottemp(ts)
 
     return nothing

--- a/src/Diagnostics/variables.jl
+++ b/src/Diagnostics/variables.jl
@@ -1,0 +1,84 @@
+"""
+    DiagnosticVariable
+
+Currently only holds information about a diagnostics variable.
+
+Standard names are from:
+http://cfconventions.org/Data/cf-standard-names/71/build/cf-standard-name-table.html
+
+TODO: will expand to include definition (code) as well.
+"""
+struct DiagnosticVariable
+    short::String
+    units::String
+    long::String
+    standard::String
+end
+const Variables = OrderedDict{String, DiagnosticVariable}()
+
+"""
+    setup_variables()
+
+Called at module initialization to define all currently defined diagnostic
+variables.
+"""
+function setup_variables()
+    Variables["u"] =
+        DiagnosticVariable("u", "m s**-1", "zonal wind", "eastward_wind")
+    Variables["v"] =
+        DiagnosticVariable("v", "m s**-1", "meridional wind", "northward_wind")
+    Variables["w"] = DiagnosticVariable(
+        "w",
+        "m s**-1",
+        "vertical wind",
+        "upward_air_velocity",
+    )
+    Variables["rho"] =
+        DiagnosticVariable("rho", "kg m**-3", "air density", "air_density")
+    Variables["temp"] =
+        DiagnosticVariable("temp", "K", "air temperature", "air_temperature")
+    Variables["pres"] =
+        DiagnosticVariable("pres", "Pa", "air pressure", "air_pressure")
+    Variables["thd"] = DiagnosticVariable(
+        "thd",
+        "K",
+        "dry potential temperature",
+        "air_potential_temperature",
+    )
+    Variables["thv"] = DiagnosticVariable(
+        "thv",
+        "K",
+        "virtual potential temperature",
+        "virtual_potential_temperature",
+    )
+    Variables["et"] = DiagnosticVariable(
+        "et",
+        "J kg**-1",
+        "total specific energy",
+        "specific_dry_energy_of_air",
+    )
+    Variables["ei"] = DiagnosticVariable(
+        "ei",
+        "J kg**-1",
+        "internal specific energy",
+        "internal_energy",
+    )
+    Variables["ht"] = DiagnosticVariable(
+        "ht",
+        "J kg**-1",
+        "specific enthalpy based on total energy",
+        "",
+    )
+    Variables["hi"] = DiagnosticVariable(
+        "hi",
+        "J kg**-1",
+        "specific enthalpy based on internal energy",
+        "atmosphere_enthalpy_content",
+    )
+    Variables["vort"] = DiagnosticVariable(
+        "vort",
+        "s**-1",
+        "vertical component of relative velocity",
+        "atmosphere_relative_velocity",
+    )
+end

--- a/src/InputOutput/Writers/Writers.jl
+++ b/src/InputOutput/Writers/Writers.jl
@@ -4,8 +4,11 @@
 Abstracts writing dimensioned data so that output can be to a NetCDF
 file or to a JLD2 file.
 
-Currently, a single file per time of writing is envisioned. Thus, a
-`t` dimension is implicitly defined as `[1]`.
+Currently, a single file per time of writing is used. Thus, a `time`
+dimension is implicitly defined of length 1, with a value of the
+current simulation time.
+
+TODO: use an unlimited dimension for time and append?
 """
 
 module Writers
@@ -29,9 +32,11 @@ and variable values to a file. Specialized by every `Writer` subtype.
 # Arguments:
 # - `writer`: instance of a subtype of `AbstractWriter`.
 # - `filename`: into which to write data (without extension).
-# - `dims`: Dict of dimension name to axis.
-# - `varvals`: Tuple of a k-tuple of dimension names and a Dict, of
-# variable name to k-dimensional array of values.
+# - `dims`: Dict of dimension name to 2-tuple of dimension values and Dict
+#   of attributes.
+# - `varvals`: Dict of variable name to 3-tuple of a k-tuple of dimension
+#   names, k-dimensional array of values, and Dict of attributes.
+#   variable name to k-dimensional array of values.
 # - `simtime`: Current simulation time.
 """
 function write_data end

--- a/src/InputOutput/Writers/jld2_writer.jl
+++ b/src/InputOutput/Writers/jld2_writer.jl
@@ -9,14 +9,15 @@ function write_data(jld::JLD2Writer, filename, dims, varvals, simtime)
         for di in 1:length(dimnames)
             ds["dim_$di"] = dimnames[di]
         end
-        for (dn, dv) in dims
+        ds["dim_time"] = "time"
+        for (dn, (dv, _)) in dims
             ds[dn] = dv
         end
-        ds["t"] = [1]
-        for (vn, vv) in varvals
-            ds[vn] = vv[2]
-        end
+        ds["time"] = [1]
         ds["simtime"] = [simtime]
+        for (vn, (_, vv, _)) in varvals
+            ds[vn] = vv
+        end
     end
     return nothing
 end

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -120,7 +120,11 @@ end
 
 function config_diagnostics(driver_config)
     interval = "10000steps"
-    dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
+        interval,
+        driver_config.name,
+    )
     return ClimateMachine.DiagnosticsConfiguration([dgngrp])
 end
 #-------------------------------------------------------------------------

--- a/test/Diagnostics/runtests.jl
+++ b/test/Diagnostics/runtests.jl
@@ -1,5 +1,6 @@
 using MPI, Test
-include("../testhelpers.jl")
+
+include(joinpath("..", "testhelpers.jl"))
 
 @testset "Diagnostics" begin
     runmpi(joinpath(@__DIR__, "sin_test.jl"), ntasks = 2)

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -9,6 +9,7 @@ using Test
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
+using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
@@ -102,6 +103,7 @@ end
 function config_diagnostics(driver_config)
     interval = "100steps"
     dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
         interval,
         replace(driver_config.name, " " => "_"),
         writer = JLD2Writer(),

--- a/test/InputOutput/Writers/runtests.jl
+++ b/test/InputOutput/Writers/runtests.jl
@@ -6,13 +6,13 @@ using ClimateMachine.Writers
 
 @testset "Writers" begin
     odims = OrderedDict(
-        "x" => collect(1:5),
-        "y" => collect(1:5),
-        "z" => collect(1010:10:1050),
+        "x" => (collect(1:5), Dict()),
+        "y" => (collect(1:5), Dict()),
+        "z" => (collect(1010:10:1050), Dict()),
     )
     ovars = OrderedDict(
-        "v1" => (("x", "y", "z"), rand(5, 5, 5)),
-        "v2" => (("x", "y", "z"), rand(5, 5, 5)),
+        "v1" => (("x", "y", "z"), rand(5, 5, 5), Dict()),
+        "v2" => (("x", "y", "z"), rand(5, 5, 5), Dict()),
     )
     jfn, _ = mktemp()
     jfull = full_name(JLD2Writer(), jfn)

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -344,7 +344,7 @@ function run_cubed_sphere_interpolation_test()
         ) # sets up the interpolation structure
         iv = DA(Array{FT}(undef, intrp_cs.Npl, nvars))             # allocating space for the interpolation variable
         if pid == 0
-            fiv = DA(Array{FT}(undef, n_rad, n_lat, n_long, nvars))    # allocating space for the full interpolation variables accumulated on proc# 0
+            fiv = DA(Array{FT}(undef, n_long, n_lat, n_rad, nvars))    # allocating space for the full interpolation variables accumulated on proc# 0
         else
             fiv = DA(Array{FT}(undef, 0, 0, 0, 0))
         end
@@ -367,13 +367,13 @@ function run_cubed_sphere_interpolation_test()
             x2g = similar(x1g)
             x3g = similar(x1g)
 
-            fex = zeros(FT, nrad, nlat, nlong, nvars)
+            fex = zeros(FT, nlong, nlat, nrad, nvars)
 
             for vari in 1:nvars
-                for k in 1:nlong, j in 1:nlat, i in 1:nrad
-                    x1g_ijk = rad[i] * cosd(lat[j]) * cosd(long[k]) # inclination -> latitude; azimuthal -> longitude.
-                    x2g_ijk = rad[i] * cosd(lat[j]) * sind(long[k]) # inclination -> latitude; azimuthal -> longitude.
-                    x3g_ijk = rad[i] * sind(lat[j])
+                for i in 1:nlong, j in 1:nlat, k in 1:nrad
+                    x1g_ijk = rad[k] * cosd(lat[j]) * cosd(long[i]) # inclination -> latitude; azimuthal -> longitude.
+                    x2g_ijk = rad[k] * cosd(lat[j]) * sind(long[i]) # inclination -> latitude; azimuthal -> longitude.
+                    x3g_ijk = rad[k] * sind(lat[j])
 
                     fex[i, j, k, vari] =
                         fcn(x1g_ijk / xmax, x2g_ijk / ymax, x3g_ijk / zmax)
@@ -381,20 +381,20 @@ function run_cubed_sphere_interpolation_test()
             end
 
             if projectv
-                for k in 1:nlong, j in 1:nlat, i in 1:nrad
+                for i in 1:nlong, j in 1:nlat, k in 1:nrad
                     fex[i, j, k, _ρu] =
-                        fex[i, j, k, _ρ] * cosd(lat[j]) * cosd(long[k]) +
-                        fex[i, j, k, _ρ] * cosd(lat[j]) * sind(long[k]) +
-                        fex[i, j, k, _ρ] * sind(lat[j])
+                        -fex[i, j, k, _ρ] * sind(long[i]) +
+                        fex[i, j, k, _ρ] * cosd(long[i])
 
                     fex[i, j, k, _ρv] =
-                        -fex[i, j, k, _ρ] * sind(lat[j]) * cosd(long[k])
-                    -fex[i, j, k, _ρ] * sind(lat[j]) * sind(long[k]) +
+                        -fex[i, j, k, _ρ] * sind(lat[j]) * cosd(long[i])
+                    -fex[i, j, k, _ρ] * sind(lat[j]) * sind(long[i]) +
                     fex[i, j, k, _ρ] * cosd(lat[j])
 
                     fex[i, j, k, _ρw] =
-                        -fex[i, j, k, _ρ] * sind(long[k]) +
-                        fex[i, j, k, _ρ] * cosd(long[k])
+                        fex[i, j, k, _ρ] * cosd(lat[j]) * cosd(long[i]) +
+                        fex[i, j, k, _ρ] * cosd(lat[j]) * sind(long[i]) +
+                        fex[i, j, k, _ρ] * sind(lat[j])
                 end
             end
 

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -170,7 +170,11 @@ end
 
 function config_diagnostics(driver_config)
     interval = "10000steps"
-    dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
+        interval,
+        driver_config.name,
+    )
     return ClimateMachine.DiagnosticsConfiguration([dgngrp])
 end
 

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -271,7 +271,6 @@ dgn_config = setup_dump_state_and_aux_diagnostics(
     interval,
     driver_config.name,
     interpol = interpol,
-    project = true,
 )
 nothing # hide
 

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -291,7 +291,11 @@ end
 # Here we define the diagnostic configuration specific to this problem.
 function config_diagnostics(driver_config)
     interval = "10000steps"
-    dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
+        interval,
+        driver_config.name,
+    )
     return ClimateMachine.DiagnosticsConfiguration([dgngrp])
 end
 

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -59,7 +59,6 @@ const param_set = EarthParameterSet()
 using ClimateMachine
 using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
-using ClimateMachine.Writers
 using ClimateMachine.DGmethods
 using ClimateMachine.DGmethods.NumericalFluxes
 using ClimateMachine.DGmethods: BalanceLaw, LocalGeometry


### PR DESCRIPTION
# Description

This adds a GCM diagnostics group. [These](https://github.com/CliMA/ClimateMachine.jl/blob/ln/new-dgngrp/src/Diagnostics/atmos_gcm_default.jl#L38-L67) diagnostics are currently in this group. Attributes have been added to the NetCDF files to comply with the CF convention. 

Some refactoring of the Diagnostics module accompanies this. Also:
- Includes #1082.
- Closes #1165.

Some remaining things will be addressed in subsequent PRs:
- Density weighting.
- More diagnostics:
  - Variances and covariances
  - Means/covariances based time-window convolution (e.g. Lanczos filtering)
  - Horizontal divergence, streamfunction (from the Laplacian of vorticity), potential vorticity
  - Ability for user-defined diagnostics (general kernels for gradients, etc.) 
- Aggregation of files using unlimited time dimension
- Support for all diagnostics to be collected on GPU (right now GPU used only where necessary, e.g. vorticity calculation)

The Held Suarez experiment now uses this group by default.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [X] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
