### PR TITLE
Reworking the Remainder Model

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -36,7 +36,6 @@ ClimateMachine.Atmos.Rain
 ## Reference states
 
 ```@docs
-ClimateMachine.Atmos.RemainderModel
 ClimateMachine.Atmos.HydrostaticState
 ClimateMachine.Atmos.InitStateBC
 ClimateMachine.Atmos.ReferenceState

--- a/docs/src/APIs/Numerics/DGMethods/DGMethods.md
+++ b/docs/src/APIs/Numerics/DGMethods/DGMethods.md
@@ -4,6 +4,10 @@
 CurrentModule = ClimateMachine.DGMethods
 ```
 
+```@docs
+remainder_DGModel
+```
+
 ## Mathematical Formulation
 
 to be filled

--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -27,6 +27,7 @@ cpu_gpu = [
   { file = "test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl", slurmargs = ["--ntasks=3"], args = [] },
+  { file = "test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl", slurmargs = ["--ntasks=3"], args = [] },

--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -20,6 +20,7 @@ cpu_gpu = [
   { file = "test/Arrays/varsindex.jl", slurmargs = ["--ntasks=1"], args = [] },
   { file = "test/Diagnostics/diagnostic_fields_test.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGMethods/vars_test.jl", slurmargs = ["--ntasks=1"], args = [] },
+  { file = "test/Numerics/DGMethods/remainder_model.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGMethods/Euler/isentropicvortex.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl", slurmargs = ["--ntasks=3"], args = [] },

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -25,7 +25,11 @@ using ..TemperatureProfiles
 import ..Thermodynamics: internal_energy
 using ..MPIStateArrays: MPIStateArray
 using ..Mesh.Grids:
-    VerticalDirection, HorizontalDirection, min_node_distance, EveryDirection
+    VerticalDirection,
+    HorizontalDirection,
+    min_node_distance,
+    EveryDirection,
+    Direction
 
 using ClimateMachine.BalanceLaws:
     BalanceLaw, number_state_conservative, num_integrals

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -1,7 +1,6 @@
 module Atmos
 
-export AtmosModel,
-    AtmosAcousticLinearModel, AtmosAcousticGravityLinearModel, RemainderModel
+export AtmosModel, AtmosAcousticLinearModel, AtmosAcousticGravityLinearModel
 
 using CLIMAParameters
 using CLIMAParameters.Planet: grav, cp_d
@@ -342,7 +341,6 @@ include("source.jl")
 include("tracers.jl")
 include("boundaryconditions.jl")
 include("linear.jl")
-include("remainder.jl")
 include("courant.jl")
 include("filters.jl")
 

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -503,7 +503,14 @@ end
     flux.ρe += d_h_tot * state.ρ
 end
 
-@inline function wavespeed(m::AtmosModel, nM, state::Vars, aux::Vars, t::Real)
+@inline function wavespeed(
+    m::AtmosModel,
+    nM,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
     ρinv = 1 / state.ρ
     u = ρinv * state.ρu
     uN = abs(dot(nM, u))

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -362,6 +362,7 @@ equations.
     state::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     ρ = state.ρ
     ρinv = 1 / ρ

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -129,7 +129,14 @@ flux_second_order!(
     aux::Vars,
     t::Real,
 ) = nothing
-function wavespeed(lm::AtmosLinearModel, nM, state::Vars, aux::Vars, t::Real)
+function wavespeed(
+    lm::AtmosLinearModel,
+    nM,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
     ref = aux.ref_state
     return soundspeed_air(lm.atmos.param_set, ref.T)
 end

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -175,6 +175,7 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     FT = eltype(state)
     ref = aux.ref_state
@@ -209,6 +210,7 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     FT = eltype(state)
     ref = aux.ref_state

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -235,9 +235,9 @@ function source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
-    direction,
-)
-    if direction isa VerticalDirection || direction isa EveryDirection
+    ::NTuple{1, Dir},
+) where {Dir <: Direction}
+    if Dir === VerticalDirection || Dir === EveryDirection
         ∇Φ = ∇gravitational_potential(lm.atmos.orientation, aux)
         source.ρu -= state.ρ * ∇Φ
     end

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -40,13 +40,7 @@ function flux_second_order!(
     t::Real,
     D_t,
 ) end
-function flux_first_order!(
-    ::MoistureModel,
-    flux::Grad,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-) end
+function flux_first_order!(::MoistureModel, _...) end
 function compute_gradient_argument!(
     ::MoistureModel,
     transform::Vars,

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -42,13 +42,7 @@ function flux_second_order!(
     aux::Vars,
     t::Real,
 ) end
-function flux_first_order!(
-    ::PrecipitationModel,
-    flux::Grad,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-) end
+function flux_first_order!(::PrecipitationModel, _...) end
 function compute_gradient_argument!(
     ::PrecipitationModel,
     transform::Vars,

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -191,7 +191,8 @@ function transform_post_gradient_laplacian! end
         n⁻,
         state_conservative::Vars,
         state_auxiliary::Vars,
-        t::Real
+        t::Real,
+        direction
     )
 
 wavespeed

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -109,7 +109,8 @@ function init_state_auxiliary! end
         flux::Grad,
         state_conservative::Vars,
         state_auxiliary::Vars,
-        t::Real
+        t::Real,
+        directions
     )
 
 Compute first-order flux terms in balance law equation

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -22,6 +22,7 @@ using ..BalanceLaws:
     vars_state_conservative,
     vars_state_auxiliary,
     update_auxiliary_state!
+using ..DGMethods: RemainderModel
 using ..DGMethods.NumericalFluxes
 using ..HydrostaticBoussinesq
 using ..Mesh.Grids

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -22,7 +22,7 @@ using ..BalanceLaws:
     vars_state_conservative,
     vars_state_auxiliary,
     update_auxiliary_state!
-using ..DGMethods: RemainderModel
+using ..DGMethods: RemainderModel, remainder_DGModel
 using ..DGMethods.NumericalFluxes
 using ..HydrostaticBoussinesq
 using ..Mesh.Grids

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -22,7 +22,7 @@ using ..BalanceLaws:
     vars_state_conservative,
     vars_state_auxiliary,
     update_auxiliary_state!
-using ..DGMethods: RemainderModel, remainder_DGModel
+using ..DGMethods: remainder_DGModel
 using ..DGMethods.NumericalFluxes
 using ..HydrostaticBoussinesq
 using ..Mesh.Grids

--- a/src/Driver/SolverTypes/MISSolverType.jl
+++ b/src/Driver/SolverTypes/MISSolverType.jl
@@ -37,6 +37,11 @@ fast and slow dynamics respectively, depending on the state `Q`.
 - `nsubsteps` (Int): Integer denoting the total number of times
     to substep the fast process.
     Default: `50`
+- `discrete_splitting` (Boolean): Boolean denoting whether a PDE level or
+    discretized level splitting should be used. If `true` then the PDE is
+    discretized in such a way that `f_fast + f_slow` is equivalent to
+    discretizing the original PDE directly.
+    Default: `false`
 
 ### References
     @article{KnothWensch2014,
@@ -61,6 +66,8 @@ struct MISSolverType{DS} <: AbstractSolverType
     fast_method::Function
     # Substepping parameter for the fast processes
     nsubsteps::Int
+    # Whether to use a PDE level or discrete splitting
+    discrete_splitting::Bool
 
     function MISSolverType(;
         splitting_type = SlowFastSplitting(),
@@ -68,6 +75,7 @@ struct MISSolverType{DS} <: AbstractSolverType
         mis_method = MIS2,
         fast_method = LSRK54CarpenterKennedy,
         nsubsteps = 50,
+        discrete_splitting = false,
     )
 
         DS = typeof(splitting_type)
@@ -78,6 +86,7 @@ struct MISSolverType{DS} <: AbstractSolverType
             mis_method,
             fast_method,
             nsubsteps,
+            discrete_splitting,
         )
     end
 end
@@ -137,19 +146,17 @@ function solversetup(
     # Using the RemainderModel, we subtract away the
     # fast processes and define a DG model for the
     # slower processes (advection and diffusion)
-    slow_dg = remainder_DGModel(
-        dg,
-        (fast_dg,),
-        dg.numerical_flux_first_order,
-        dg.numerical_flux_second_order,
-        dg.numerical_flux_gradient,
-        state_auxiliary = dg.state_auxiliary,
-        state_gradient_flux = dg.state_gradient_flux,
-        states_higher_order = dg.states_higher_order,
-        # Ensure diffusion direction is passed to the correct
-        # DG model
-        diffusion_direction = diffusion_direction,
+    remainder_kwargs = (
+        numerical_flux_first_order = (
+            ode_solver.discrete_splitting ?
+                    (
+                dg.numerical_flux_first_order,
+                (dg.numerical_flux_first_order,),
+            ) :
+                    dg.numerical_flux_first_order
+        ),
     )
+    slow_dg = remainder_DGModel(dg, (fast_dg,); remainder_kwargs...)
 
     solver = ode_solver.mis_method(
         slow_dg,

--- a/src/Driver/SolverTypes/MISSolverType.jl
+++ b/src/Driver/SolverTypes/MISSolverType.jl
@@ -138,7 +138,7 @@ function solversetup(
     # fast processes and define a DG model for the
     # slower processes (advection and diffusion)
     slow_model = RemainderModel(dg.balance_law, (fast_model,))
-    slow_dg = DGModel(
+    slow_dg = remainder_DGModel(
         slow_model,
         dg.grid,
         dg.numerical_flux_first_order,

--- a/src/Driver/SolverTypes/MISSolverType.jl
+++ b/src/Driver/SolverTypes/MISSolverType.jl
@@ -137,10 +137,9 @@ function solversetup(
     # Using the RemainderModel, we subtract away the
     # fast processes and define a DG model for the
     # slower processes (advection and diffusion)
-    slow_model = RemainderModel(dg.balance_law, (fast_model,))
     slow_dg = remainder_DGModel(
-        slow_model,
-        dg.grid,
+        dg,
+        (fast_dg,),
         dg.numerical_flux_first_order,
         dg.numerical_flux_second_order,
         dg.numerical_flux_gradient,

--- a/src/Driver/SolverTypes/MultirateSolverType.jl
+++ b/src/Driver/SolverTypes/MultirateSolverType.jl
@@ -49,6 +49,10 @@ fast and slow dynamics respectively, depending on the state `Q`.
 - `timestep_ratio` (Int): Integer denoting the ratio between the slow
     and fast time-step sizes.
     Default: `100`
+- `discrete_splitting` (Boolean): Boolean denoting whether a PDE level or
+    discretized level splitting should be used. If `true` then the PDE is
+    discretized in such a way that `f_fast + f_slow` is equivalent to
+    discretizing the original PDE directly.
 
 ### References
     @article{SchlegelKnothArnoldWolke2012,
@@ -78,6 +82,8 @@ struct MultirateSolverType{DS} <: AbstractSolverType
     fast_method::Function
     # The ratio between slow and fast time-step sizes
     timestep_ratio::Int
+    # Whether to use a PDE level or discrete splitting
+    discrete_splitting::Bool
 
     function MultirateSolverType(;
         splitting_type = SlowFastSplitting(),
@@ -87,6 +93,7 @@ struct MultirateSolverType{DS} <: AbstractSolverType
         slow_method = LSRK54CarpenterKennedy,
         fast_method = LSRK54CarpenterKennedy,
         timestep_ratio = 100,
+        discrete_splitting = false,
     )
 
         DS = typeof(splitting_type)
@@ -99,6 +106,7 @@ struct MultirateSolverType{DS} <: AbstractSolverType
             slow_method,
             fast_method,
             timestep_ratio,
+            discrete_splitting,
         )
     end
 end
@@ -186,19 +194,17 @@ function solversetup(
     # Using the RemainderModel, we subtract away the
     # fast processes and define a DG model for the
     # slower processes (advection and diffusion)
-    slow_dg = remainder_DGModel(
-        dg,
-        (fast_dg,),
-        dg.numerical_flux_first_order,
-        dg.numerical_flux_second_order,
-        dg.numerical_flux_gradient,
-        state_auxiliary = dg.state_auxiliary,
-        state_gradient_flux = dg.state_gradient_flux,
-        states_higher_order = dg.states_higher_order,
-        # Ensure diffusion direction is passed to the correct
-        # DG model
-        diffusion_direction = diffusion_direction,
+    remainder_kwargs = (
+        numerical_flux_first_order = (
+            ode_solver.discrete_splitting ?
+                    (
+                dg.numerical_flux_first_order,
+                (dg.numerical_flux_first_order,),
+            ) :
+                    dg.numerical_flux_first_order
+        ),
     )
+    slow_dg = remainder_DGModel(dg, (fast_dg,); remainder_kwargs...)
 
     slow_solver = ode_solver.slow_method(slow_dg, Q; dt = dt)
     fast_dt = dt / ode_solver.timestep_ratio

--- a/src/Driver/SolverTypes/MultirateSolverType.jl
+++ b/src/Driver/SolverTypes/MultirateSolverType.jl
@@ -186,10 +186,9 @@ function solversetup(
     # Using the RemainderModel, we subtract away the
     # fast processes and define a DG model for the
     # slower processes (advection and diffusion)
-    slow_model = RemainderModel(dg.balance_law, (fast_model,))
     slow_dg = remainder_DGModel(
-        slow_model,
-        dg.grid,
+        dg,
+        (fast_dg,),
         dg.numerical_flux_first_order,
         dg.numerical_flux_second_order,
         dg.numerical_flux_gradient,

--- a/src/Driver/SolverTypes/MultirateSolverType.jl
+++ b/src/Driver/SolverTypes/MultirateSolverType.jl
@@ -187,7 +187,7 @@ function solversetup(
     # fast processes and define a DG model for the
     # slower processes (advection and diffusion)
     slow_model = RemainderModel(dg.balance_law, (fast_model,))
-    slow_dg = DGModel(
+    slow_dg = remainder_DGModel(
         slow_model,
         dg.grid,
         dg.numerical_flux_first_order,

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -43,6 +43,9 @@ function DGModel(
     )
 end
 
+# Include the remainder model for composing DG models and balance laws
+include("remainder.jl")
+
 function (dg::DGModel)(
     tendency,
     state_conservative,

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -609,22 +609,16 @@ function restart_auxiliary_state(bl, grid, aux_data)
 end
 
 # fallback
-function update_auxiliary_state!(
-    dg::DGModel,
-    balance_law::BalanceLaw,
-    state_conservative::MPIStateArray,
-    t::Real,
-    elems::UnitRange,
-)
+function update_auxiliary_state!(dg, balance_law, state_conservative, t, elems)
     return false
 end
 
 function update_auxiliary_state_gradient!(
     dg::DGModel,
-    balance_law::BalanceLaw,
-    state_conservative::MPIStateArray,
-    t::Real,
-    elems::UnitRange,
+    balance_law,
+    state_conservative,
+    t,
+    elems,
 )
     return false
 end

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -1,7 +1,4 @@
 using .NumericalFluxes:
-    NumericalFluxGradient,
-    NumericalFluxFirstOrder,
-    NumericalFluxSecondOrder,
     numerical_flux_gradient!,
     numerical_flux_first_order!,
     numerical_flux_second_order!,
@@ -458,8 +455,8 @@ end
 
 @doc """
     interface_tendency!(balance_law::BalanceLaw, Val(polyorder),
-            numerical_flux_first_order::NumericalFluxFirstOrder,
-            numerical_flux_second_order::NumericalFluxSecondOrder,
+            numerical_flux_first_order,
+            numerical_flux_second_order,
             tendency, state_conservative, state_gradient_flux, state_auxiliary,
             vgeo, sgeo, t, vmap⁻, vmap⁺, elemtobndy,
             elems)
@@ -472,8 +469,8 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
     ::Val{dim},
     ::Val{polyorder},
     direction,
-    numerical_flux_first_order::NumericalFluxFirstOrder,
-    numerical_flux_second_order::NumericalFluxSecondOrder,
+    numerical_flux_first_order,
+    numerical_flux_second_order,
     tendency,
     state_conservative,
     state_gradient_flux,
@@ -1117,7 +1114,7 @@ end
     ::Val{dim},
     ::Val{polyorder},
     direction,
-    numerical_flux_gradient::NumericalFluxGradient,
+    numerical_flux_gradient,
     state_conservative,
     state_gradient_flux,
     Qhypervisc_grad,

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -274,7 +274,7 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
                     local_state_auxiliary,
                 ),
                 t,
-                direction,
+                (direction,),
             )
 
             @unroll for s in 1:num_state_conservative
@@ -487,7 +487,7 @@ end
                     local_state_auxiliary,
                 ),
                 t,
-                direction,
+                (direction,),
             )
 
             @unroll for s in 1:num_state_conservative

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -140,6 +140,7 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
                     local_state_auxiliary,
                 ),
                 t,
+                direction,
             )
 
             @unroll for s in 1:num_state_conservative
@@ -355,6 +356,7 @@ end
                     local_state_auxiliary,
                 ),
                 t,
+                direction,
             )
 
             @unroll for s in 1:num_state_conservative
@@ -557,6 +559,12 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
     @inbounds e[1] = elems[eI]
 
     @inbounds for f in faces
+        # The remainder model needs to know which direction of face the model is
+        # being evaluated for. So faces 1:(nface - 2) are flagged as
+        # `HorizontalDirection()` faces and the remaining two faces are
+        # `VerticalDirection()` faces
+        face_direction =
+            f in 1:(nface - 2) ? HorizontalDirection() : VerticalDirection()
         e⁻ = e[1]
         normal_vector = SVector(
             sgeo[_n1, n, f, e⁻],
@@ -627,6 +635,7 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
                     local_state_auxiliary⁺nondiff,
                 ),
                 t,
+                face_direction,
             )
             numerical_flux_second_order!(
                 numerical_flux_second_order,
@@ -694,6 +703,7 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
                 ),
                 bctype,
                 t,
+                face_direction,
                 Vars{vars_state_conservative(balance_law, FT)}(
                     local_state_conservative_bottom1,
                 ),

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -140,7 +140,7 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
                     local_state_auxiliary,
                 ),
                 t,
-                direction,
+                (direction,),
             )
 
             @unroll for s in 1:num_state_conservative
@@ -188,6 +188,66 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
                 end
                 if dim == 3 && direction isa EveryDirection
                     local_flux_3[s] = M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
+                end
+            end
+
+            # In the case of the remainder model we may need to loop through the
+            # models to add in restricted direction componennts
+            if direction isa EveryDirection && balance_law isa RemBL
+                if rembl_has_subs_direction(HorizontalDirection(), balance_law)
+                    fill!(local_flux, -zero(eltype(local_flux)))
+                    flux_first_order!(
+                        balance_law,
+                        Grad{vars_state_conservative(balance_law, FT)}(
+                            local_flux,
+                        ),
+                        Vars{vars_state_conservative(balance_law, FT)}(
+                            local_state_conservative,
+                        ),
+                        Vars{vars_state_auxiliary(balance_law, FT)}(
+                            local_state_auxiliary,
+                        ),
+                        t,
+                        (HorizontalDirection(),),
+                    )
+                    @unroll for s in 1:num_state_conservative
+                        F1, F2, F3 =
+                            local_flux[1, s], local_flux[2, s], local_flux[3, s]
+                        shared_flux[1, i, j, s] +=
+                            M * (ξ1x1 * F1 + ξ1x2 * F2 + ξ1x3 * F3)
+                        if dim == 3
+                            shared_flux[2, i, j, s] +=
+                                M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
+                        end
+                    end
+                end
+                if rembl_has_subs_direction(VerticalDirection(), balance_law)
+                    fill!(local_flux, -zero(eltype(local_flux)))
+                    flux_first_order!(
+                        balance_law,
+                        Grad{vars_state_conservative(balance_law, FT)}(
+                            local_flux,
+                        ),
+                        Vars{vars_state_conservative(balance_law, FT)}(
+                            local_state_conservative,
+                        ),
+                        Vars{vars_state_auxiliary(balance_law, FT)}(
+                            local_state_auxiliary,
+                        ),
+                        t,
+                        (VerticalDirection(),),
+                    )
+                    @unroll for s in 1:num_state_conservative
+                        F1, F2, F3 =
+                            local_flux[1, s], local_flux[2, s], local_flux[3, s]
+                        if dim == 2
+                            shared_flux[2, i, j, s] +=
+                                M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
+                        elseif dim == 3
+                            local_flux_3[s] +=
+                                M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
+                        end
+                    end
                 end
             end
 
@@ -356,7 +416,7 @@ end
                     local_state_auxiliary,
                 ),
                 t,
-                direction,
+                (direction,),
             )
 
             @unroll for s in 1:num_state_conservative
@@ -564,7 +624,8 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
         # `HorizontalDirection()` faces and the remaining two faces are
         # `VerticalDirection()` faces
         face_direction =
-            f in 1:(nface - 2) ? HorizontalDirection() : VerticalDirection()
+            f in 1:(nface - 2) ? (EveryDirection(), HorizontalDirection()) :
+            (EveryDirection(), VerticalDirection())
         e⁻ = e[1]
         normal_vector = SVector(
             sgeo[_n1, n, f, e⁻],

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -146,6 +146,7 @@ function numerical_boundary_flux_first_order!(
     state_auxiliary⁺::Vars{A},
     bctype,
     t,
+    direction,
     state1⁻::Vars{S},
     aux1⁻::Vars{A},
 ) where {S, A}
@@ -174,6 +175,7 @@ function numerical_boundary_flux_first_order!(
         state_conservative⁺,
         state_auxiliary⁺,
         t,
+        direction,
     )
 end
 
@@ -203,6 +205,7 @@ function numerical_flux_first_order!(
     state_conservative⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
     t,
+    direction,
 ) where {S, A}
 
     numerical_flux_first_order!(
@@ -215,6 +218,7 @@ function numerical_flux_first_order!(
         state_conservative⁺,
         state_auxiliary⁺,
         t,
+        direction,
     )
 
     fluxᵀn = parent(fluxᵀn)
@@ -277,6 +281,7 @@ function numerical_flux_first_order!(
     state_conservative⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
     t,
+    direction,
 ) where {S, A}
 
     FT = eltype(fluxᵀn)
@@ -291,6 +296,7 @@ function numerical_flux_first_order!(
         state_conservative⁻,
         state_auxiliary⁻,
         t,
+        direction,
     )
 
     flux⁺ = similar(fluxᵀn, Size(3, num_state_conservative))
@@ -301,6 +307,7 @@ function numerical_flux_first_order!(
         state_conservative⁺,
         state_auxiliary⁺,
         t,
+        direction,
     )
 
     fluxᵀn .+= (flux⁻ + flux⁺)' * (normal_vector / 2)

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -228,6 +228,7 @@ function numerical_flux_first_order!(
         state_conservative⁻,
         state_auxiliary⁻,
         t,
+        direction,
     )
     wavespeed⁺ = wavespeed(
         balance_law,
@@ -235,6 +236,7 @@ function numerical_flux_first_order!(
         state_conservative⁺,
         state_auxiliary⁺,
         t,
+        direction,
     )
     max_wavespeed = max.(wavespeed⁻, wavespeed⁺)
     penalty =

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -213,16 +213,17 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     m = parent(flux)
-    flux_first_order!(rem_balance_law.main, flux, state, aux, t)
+    flux_first_order!(rem_balance_law.main, flux, state, aux, t, direction)
 
     flux_s = similar(flux)
     m_s = parent(flux_s)
 
     for sub in rem_balance_law.subs
         fill!(m_s, -zero(eltype(m_s)))
-        flux_first_order!(sub, flux_s, state, aux, t)
+        flux_first_order!(sub, flux_s, state, aux, t, direction)
         m .-= m_s
     end
     nothing

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -362,24 +362,51 @@ end
         args...,
     )
 
-The wavespeed for a remainder model is defined to be the difference of the wavespeed
-of the main model and the sum of the subcomponents.
+The wavespeed for a remainder model is defined to be the difference of the
+wavespeed of the main model and the sum of the subcomponents.
 
 Note: Defining the wavespeed in this manner can result in a smaller value than
 the actually wavespeed of the remainder physics model depending on the
 composition of the models.
 """
-function wavespeed(rem::RemBL, nM, state::Vars, aux::Vars, t::Real)
+function wavespeed(
+    rem_balance_law::RemBL,
+    nM,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+    dir::Dirs,
+) where {ND, Dirs <: NTuple{ND, Direction}}
     FT = eltype(state)
 
-    ws = fill(-zero(FT), MVector{number_state_conservative(rem.main, FT), FT})
-    rs = fill(-zero(FT), MVector{number_state_conservative(rem.main, FT), FT})
+    ws = fill(
+        -zero(FT),
+        MVector{number_state_conservative(rem_balance_law.main, FT), FT},
+    )
+    rs = fill(
+        -zero(FT),
+        MVector{number_state_conservative(rem_balance_law.main, FT), FT},
+    )
 
-    ws .= wavespeed(rem.main, nM, state, aux, t)
+    # Compute the main components wavespeed
+    if rem_balance_law.maindir isa Union{Dirs.types...}
+        ws .= wavespeed(
+            rem_balance_law.main,
+            nM,
+            state,
+            aux,
+            t,
+            (rem_balance_law.maindir,),
+        )
+    end
 
-    for sub in rem.subs
-        num_state = static(number_state_conservative(sub, Float32))
-        @inbounds rs[static(1):num_state] .+= wavespeed(sub, nM, state, aux, t)
+    # Compute the sub components wavespeed
+    for (sub, subdir) in zip(rem_balance_law.subs, rem_balance_law.subsdir)
+        @inbounds if subdir isa Union{Dirs.types...}
+            num_state = static(number_state_conservative(sub, Float32))
+            rs[static(1):num_state] .+=
+                wavespeed(sub, nM, state, aux, t, (subdir,))
+        end
     end
 
     ws .-= rs

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -27,7 +27,7 @@ import ..BalanceLaws:
     reverse_integral_set_auxiliary_state!
 
 """
-    RemainderModel(main::BalanceLaw, subcomponents::Tuple)
+    RemBL(main::BalanceLaw, subcomponents::Tuple)
 
 Compute the "remainder" contribution of the `main` model, after subtracting
 `subcomponents`.
@@ -35,7 +35,7 @@ Compute the "remainder" contribution of the `main` model, after subtracting
 Currently only the `flux_nondiffusive!` and `source!` are handled by the
 remainder model
 """
-struct RemainderModel{M, S} <: BalanceLaw
+struct RemBL{M, S} <: BalanceLaw
     main::M
     subs::S
 end
@@ -59,7 +59,7 @@ function remainder_DGModel(
     diffusion_direction = maindg.diffusion_direction,
     modeldata = maindg.modeldata,
 )
-    balance_law = RemainderModel(
+    balance_law = RemBL(
         maindg.balance_law,
         ntuple(i -> subsdg[i].balance_law, length(subsdg)),
     )
@@ -79,77 +79,70 @@ function remainder_DGModel(
 end
 
 # Inherit most of the functionality from the main model
-vars_state_conservative(rem_balance_law::RemainderModel, FT) =
+vars_state_conservative(rem_balance_law::RemBL, FT) =
     vars_state_conservative(rem_balance_law.main, FT)
 
-vars_state_gradient(rem_balance_law::RemainderModel, FT) =
+vars_state_gradient(rem_balance_law::RemBL, FT) =
     vars_state_gradient(rem_balance_law.main, FT)
 
-vars_state_gradient_flux(rem_balance_law::RemainderModel, FT) =
+vars_state_gradient_flux(rem_balance_law::RemBL, FT) =
     vars_state_gradient_flux(rem_balance_law.main, FT)
 
-vars_state_auxiliary(rem_balance_law::RemainderModel, FT) =
+vars_state_auxiliary(rem_balance_law::RemBL, FT) =
     vars_state_auxiliary(rem_balance_law.main, FT)
 
-vars_integrals(rem_balance_law::RemainderModel, FT) =
+vars_integrals(rem_balance_law::RemBL, FT) =
     vars_integrals(rem_balance_law.main, FT)
 
-vars_reverse_integrals(rem_balance_law::RemainderModel, FT) =
+vars_reverse_integrals(rem_balance_law::RemBL, FT) =
     vars_integrals(rem_balance_law.main, FT)
 
-vars_gradient_laplacian(rem_balance_law::RemainderModel, FT) =
+vars_gradient_laplacian(rem_balance_law::RemBL, FT) =
     vars_gradient_laplacian(rem_balance_law.main, FT)
 
-vars_hyperdiffusive(rem_balance_law::RemainderModel, FT) =
+vars_hyperdiffusive(rem_balance_law::RemBL, FT) =
     vars_hyperdiffusive(rem_balance_law.main, FT)
 
-update_auxiliary_state!(dg::DGModel, rem_balance_law::RemainderModel, args...) =
+update_auxiliary_state!(dg::DGModel, rem_balance_law::RemBL, args...) =
     update_auxiliary_state!(dg, rem_balance_law.main, args...)
 
-update_auxiliary_state_gradient!(
-    dg::DGModel,
-    rem_balance_law::RemainderModel,
-    args...,
-) = update_auxiliary_state_gradient!(dg, rem_balance_law.main, args...)
+update_auxiliary_state_gradient!(dg::DGModel, rem_balance_law::RemBL, args...) =
+    update_auxiliary_state_gradient!(dg, rem_balance_law.main, args...)
 
-integral_load_auxiliary_state!(rem_balance_law::RemainderModel, args...) =
+integral_load_auxiliary_state!(rem_balance_law::RemBL, args...) =
     integral_load_auxiliary_state!(rem_balance_law.main, args...)
 
-integral_set_auxiliary_state!(rem_balance_law::RemainderModel, args...) =
+integral_set_auxiliary_state!(rem_balance_law::RemBL, args...) =
     integral_set_auxiliary_state!(rem_balance_law.main, args...)
 
-reverse_integral_load_auxiliary_state!(
-    rem_balance_law::RemainderModel,
-    args...,
-) = reverse_integral_load_auxiliary_state!(rem_balance_law.main, args...)
+reverse_integral_load_auxiliary_state!(rem_balance_law::RemBL, args...) =
+    reverse_integral_load_auxiliary_state!(rem_balance_law.main, args...)
 
-reverse_integral_set_auxiliary_state!(
-    rem_balance_law::RemainderModel,
-    args...,
-) = reverse_integral_set_auxiliary_state!(rem_balance_law.main, args...)
+reverse_integral_set_auxiliary_state!(rem_balance_law::RemBL, args...) =
+    reverse_integral_set_auxiliary_state!(rem_balance_law.main, args...)
 
-transform_post_gradient_laplacian!(rem_balance_law::RemainderModel, args...) =
+transform_post_gradient_laplacian!(rem_balance_law::RemBL, args...) =
     transform_post_gradient_laplacian!(rem_balance_law.main, args...)
 
-flux_second_order!(rem_balance_law::RemainderModel, args...) =
+flux_second_order!(rem_balance_law::RemBL, args...) =
     flux_second_order!(rem_balance_law.main, args...)
 
-compute_gradient_argument!(rem_balance_law::RemainderModel, args...) =
+compute_gradient_argument!(rem_balance_law::RemBL, args...) =
     compute_gradient_argument!(rem_balance_law.main, args...)
 
-compute_gradient_flux!(rem_balance_law::RemainderModel, args...) =
+compute_gradient_flux!(rem_balance_law::RemBL, args...) =
     compute_gradient_flux!(rem_balance_law.main, args...)
 
-boundary_state!(nf, rem_balance_law::RemainderModel, args...) =
+boundary_state!(nf, rem_balance_law::RemBL, args...) =
     boundary_state!(nf, rem_balance_law.main, args...)
 
-init_state_auxiliary!(rem_balance_law::RemainderModel, args...) =
+init_state_auxiliary!(rem_balance_law::RemBL, args...) =
     init_state_auxiliary!(rem_balance_law.main, args...)
 
-init_state_conservative!(rem_balance_law::RemainderModel, args...) =
+init_state_conservative!(rem_balance_law::RemBL, args...) =
     init_state_conservative!(rem_balance_law.main, args...)
 
-function wavespeed(rem::RemainderModel, nM, state::Vars, aux::Vars, t::Real)
+function wavespeed(rem::RemBL, nM, state::Vars, aux::Vars, t::Real)
     FT = eltype(state)
 
     ws = fill(-zero(FT), MVector{number_state_conservative(rem.main, FT), FT})
@@ -168,12 +161,12 @@ function wavespeed(rem::RemainderModel, nM, state::Vars, aux::Vars, t::Real)
 end
 
 import .NumericalFluxes: normal_boundary_flux_second_order!
-boundary_state!(nf, rem_balance_law::RemainderModel, x...) =
+boundary_state!(nf, rem_balance_law::RemBL, x...) =
     boundary_state!(nf, rem_balance_law.main, x...)
 
 normal_boundary_flux_second_order!(
     nf,
-    rem_balance_law::RemainderModel,
+    rem_balance_law::RemBL,
     fluxᵀn::Vars{S},
     args...,
 ) where {S} = normal_boundary_flux_second_order!(
@@ -183,11 +176,11 @@ normal_boundary_flux_second_order!(
     args...,
 )
 
-init_state_auxiliary!(rem_balance_law::RemainderModel, _...) = nothing
-init_state_conservative!(rem_balance_law::RemainderModel, _...) = nothing
+init_state_auxiliary!(rem_balance_law::RemBL, _...) = nothing
+init_state_conservative!(rem_balance_law::RemBL, _...) = nothing
 
 function flux_first_order!(
-    rem_balance_law::RemainderModel,
+    rem_balance_law::RemBL,
     flux::Grad,
     state::Vars,
     aux::Vars,
@@ -208,7 +201,7 @@ function flux_first_order!(
 end
 
 function source!(
-    rem_balance_law::RemainderModel,
+    rem_balance_law::RemBL,
     source::Vars,
     state::Vars,
     diffusive::Vars,

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -27,17 +27,42 @@ import ..BalanceLaws:
     reverse_integral_set_auxiliary_state!
 
 """
-    RemBL(main::BalanceLaw, subcomponents::Tuple)
+    RemBL(
+        main::BalanceLaw,
+        subcomponents::Tuple,
+        maindir::Direction,
+        subsdir::Tuple,
+    )
 
-Compute the "remainder" contribution of the `main` model, after subtracting
-`subcomponents`.
-
-Currently only the `flux_nondiffusive!` and `source!` are handled by the
-remainder model
+Balance law for holding remainder model information. Direction is put here since
+direction is so intertwined with the DGModel_kernels, that it is easier to hande
+this in this container.
 """
-struct RemBL{M, S} <: BalanceLaw
+struct RemBL{M, S, MD, SD} <: BalanceLaw
     main::M
     subs::S
+    maindir::MD
+    subsdir::SD
+end
+
+"""
+    rembl_has_subs_direction(
+        direction::Direction,
+        rem_balance_law::RemBL,
+    )
+
+Query whether the `rem_balance_law` has any subcomponent balance laws operating
+in the direction `direction`
+"""
+@generated function rembl_has_subs_direction(
+    ::Dir,
+    ::RemBL{MainBL, SubsBL, MainDir, SubsDir},
+) where {Dir <: Direction, MainBL, SubsBL, MainDir, SubsDir <: Tuple}
+    if Dir in SubsDir.types
+        return :(true)
+    else
+        return :(false)
+    end
 end
 
 
@@ -45,7 +70,6 @@ end
     remainder_DGModel(
         maindg::DGModel,
         subsdg::NTuple{NumModels, DGModel};
-        direction = EveryDirection(),
         numerical_flux_first_order,
         numerical_flux_second_order,
         numerical_flux_gradient,
@@ -75,7 +99,6 @@ data and arrays are aliased to the `maindg` values.
 function remainder_DGModel(
     maindg::DGModel,
     subsdg::NTuple{NumModels, DGModel};
-    direction = EveryDirection(),
     numerical_flux_first_order = maindg.numerical_flux_first_order,
     numerical_flux_second_order = maindg.numerical_flux_second_order,
     numerical_flux_gradient = maindg.numerical_flux_gradient,
@@ -85,10 +108,6 @@ function remainder_DGModel(
     diffusion_direction = maindg.diffusion_direction,
     modeldata = maindg.modeldata,
 ) where {NumModels}
-    balance_law = RemBL(
-        maindg.balance_law,
-        ntuple(i -> subsdg[i].balance_law, length(subsdg)),
-    )
     FT = eltype(state_auxiliary)
 
     # If any of these asserts fail, the remainder model will need to be extended
@@ -106,9 +125,27 @@ function remainder_DGModel(
         @assert num_gradient_laplacian(subdg.balance_law, FT) == 0
         @assert num_hyperdiffusive(subdg.balance_law, FT) == 0
 
+        # Do not currenlty support nested remainder models
+        # For this to work the way directions and numerical fluxes are handled
+        # would need to be updated.
+        @assert !(subdg.balance_law isa RemBL)
+
         @assert num_integrals(subdg.balance_law, FT) == 0
         @assert num_reverse_integrals(subdg.balance_law, FT) == 0
+
+        # The remainder model requires that the subcomponent direction be
+        # included in the main model directions
+        @assert (
+            maindg.direction isa EveryDirection ||
+            maindg.direction === subdg.direction
+        )
     end
+    balance_law = RemBL(
+        maindg.balance_law,
+        ntuple(i -> subsdg[i].balance_law, length(subsdg)),
+        maindg.direction,
+        ntuple(i -> subsdg[i].direction, length(subsdg)),
+    )
 
 
     DGModel(
@@ -120,7 +157,7 @@ function remainder_DGModel(
         state_auxiliary,
         state_gradient_flux,
         states_higher_order,
-        direction,
+        maindg.direction,
         diffusion_direction,
         modeldata,
     )
@@ -213,18 +250,39 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
-    direction,
-)
+    ::Dirs,
+) where {NumDirs, Dirs <: NTuple{NumDirs, Direction}}
     m = parent(flux)
-    flux_first_order!(rem_balance_law.main, flux, state, aux, t, direction)
+    if rem_balance_law.maindir isa Union{Dirs.types...}
+        flux_first_order!(
+            rem_balance_law.main,
+            flux,
+            state,
+            aux,
+            t,
+            (rem_balance_law.maindir,),
+        )
+    end
 
     flux_s = similar(flux)
     m_s = parent(flux_s)
 
-    for sub in rem_balance_law.subs
-        fill!(m_s, -zero(eltype(m_s)))
-        flux_first_order!(sub, flux_s, state, aux, t, direction)
-        m .-= m_s
+    # Force the loop to unroll to get type stability on the GPU
+    @inbounds ntuple(Val(length(rem_balance_law.subs))) do k
+        Base.@_inline_meta
+        if rem_balance_law.subsdir[k] isa Union{Dirs.types...}
+            sub = rem_balance_law.subs[k]
+            fill!(m_s, -zero(eltype(m_s)))
+            flux_first_order!(
+                sub,
+                flux_s,
+                state,
+                aux,
+                t,
+                (rem_balance_law.subsdir[k],),
+            )
+            m .-= m_s
+        end
     end
     nothing
 end
@@ -255,18 +313,45 @@ function source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
-    direction,
-)
+    ::Dir,
+) where {Dir <: Direction}
     m = parent(source)
-    source!(rem_balance_law.main, source, state, diffusive, aux, t, direction)
+    if EveryDirection() isa Dir ||
+       rem_balance_law.maindir isa EveryDirection ||
+       rem_balance_law.maindir isa Dir
+        source!(
+            rem_balance_law.main,
+            source,
+            state,
+            diffusive,
+            aux,
+            t,
+            rem_balance_law.maindir,
+        )
+    end
 
     source_s = similar(source)
     m_s = parent(source_s)
 
-    for sub in rem_balance_law.subs
-        fill!(m_s, -zero(eltype(m_s)))
-        source!(sub, source_s, state, diffusive, aux, t, direction)
-        m .-= m_s
+    # Force the loop to unroll to get type stability on the GPU
+    ntuple(Val(length(rem_balance_law.subs))) do k
+        Base.@_inline_meta
+        @inbounds if EveryDirection() isa Dir ||
+                     rem_balance_law.subsdir[k] isa EveryDirection ||
+                     rem_balance_law.subsdir[k] isa Dir
+            sub = rem_balance_law.subs[k]
+            fill!(m_s, -zero(eltype(m_s)))
+            source!(
+                sub,
+                source_s,
+                state,
+                diffusive,
+                aux,
+                t,
+                rem_balance_law.subsdir[k],
+            )
+            m .-= m_s
+        end
     end
     nothing
 end
@@ -346,46 +431,71 @@ function numerical_flux_first_order!(
     state_auxiliary⁻::Vars{A},
     state_conservative⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
-    x...,
-) where {NumSubFluxes, S, A}
+    t,
+    ::Dirs,
+) where {NumSubFluxes, S, A, Dirs <: NTuple{2, Direction}}
     # Call the numerical flux for the main model
-    @inbounds numerical_flux_first_order!(
-        numerical_fluxes[1],
-        rem_balance_law.main,
-        fluxᵀn,
-        normal_vector,
-        state_conservative⁻,
-        state_auxiliary⁻,
-        state_conservative⁺,
-        state_auxiliary⁺,
-        x...,
-    )
-
-    # Create put the sub model fluxes
-    a_fluxᵀn = parent(fluxᵀn)
-    sub_fluxᵀn = similar(fluxᵀn)
-    a_sub_fluxᵀn = parent(sub_fluxᵀn)
-
-    FT = eltype(a_sub_fluxᵀn)
-    @unroll for k in 1:NumSubFluxes
-        @inbounds sub = rem_balance_law.subs[k]
-        @inbounds nf = numerical_fluxes[2][k]
-        # compute this submodels flux
-        fill!(a_sub_fluxᵀn, -zero(FT))
-        numerical_flux_first_order!(
-            nf,
-            sub,
-            sub_fluxᵀn,
+    if rem_balance_law.maindir isa Union{Dirs.types...}
+        @inbounds numerical_flux_first_order!(
+            numerical_fluxes[1],
+            rem_balance_law.main,
+            fluxᵀn,
             normal_vector,
             state_conservative⁻,
             state_auxiliary⁻,
             state_conservative⁺,
             state_auxiliary⁺,
-            x...,
+            t,
+            (rem_balance_law.maindir,),
         )
+    end
 
-        # Subtract off this sub models flux
-        a_fluxᵀn .-= a_sub_fluxᵀn
+    # Create put the sub model fluxes
+    a_fluxᵀn = parent(fluxᵀn)
+
+    # Force the loop to unroll to get type stability on the GPU
+    ntuple(Val(length(rem_balance_law.subs))) do k
+        Base.@_inline_meta
+        @inbounds if rem_balance_law.subsdir[k] isa Union{Dirs.types...}
+            sub = rem_balance_law.subs[k]
+            nf = numerical_fluxes[2][k]
+
+            FT = eltype(a_fluxᵀn)
+            num_state_conservative = number_state_conservative(sub, FT)
+
+            a_sub_fluxᵀn = MVector{num_state_conservative, FT}(undef)
+            a_sub_state_conservative⁻ =
+                MVector{num_state_conservative, FT}(undef)
+            a_sub_state_conservative⁺ =
+                MVector{num_state_conservative, FT}(undef)
+
+            state_rng = static(1):static(number_state_conservative(sub, FT))
+            a_sub_fluxᵀn .= a_fluxᵀn[state_rng]
+            a_sub_state_conservative⁻ .= parent(state_conservative⁻)[state_rng]
+            a_sub_state_conservative⁺ .= parent(state_conservative⁺)[state_rng]
+
+            # compute this submodels flux
+            fill!(a_sub_fluxᵀn, -zero(eltype(a_sub_fluxᵀn)))
+            numerical_flux_first_order!(
+                nf,
+                sub,
+                Vars{vars_state_conservative(sub, FT)}(a_sub_fluxᵀn),
+                normal_vector,
+                Vars{vars_state_conservative(sub, FT)}(
+                    a_sub_state_conservative⁻,
+                ),
+                state_auxiliary⁻,
+                Vars{vars_state_conservative(sub, FT)}(
+                    a_sub_state_conservative⁺,
+                ),
+                state_auxiliary⁺,
+                t,
+                (rem_balance_law.subsdir[k],),
+            )
+
+            # Subtract off this sub models flux
+            a_fluxᵀn[state_rng] .-= a_sub_fluxᵀn
+        end
     end
 end
 
@@ -428,8 +538,12 @@ function numerical_boundary_flux_first_order!(
     state_auxiliary⁻::Vars{A},
     state_conservative⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
-    x...,
-) where {NumSubFluxes, S, A}
+    bctype,
+    t,
+    ::Dirs,
+    state_conservative1⁻::Vars{S},
+    state_auxiliary1⁻::Vars{A},
+) where {NumSubFluxes, S, A, Dirs <: NTuple{2, Direction}}
     # Since the fluxes are allowed to modified these we need backups so they can
     # be reset as we go
     a_state_conservative⁺ = parent(state_conservative⁺)
@@ -440,48 +554,84 @@ function numerical_boundary_flux_first_order!(
 
 
     # Call the numerical flux for the main model
-    @inbounds numerical_boundary_flux_first_order!(
-        numerical_fluxes[1],
-        rem_balance_law.main,
-        fluxᵀn,
-        normal_vector,
-        state_conservative⁻,
-        state_auxiliary⁻,
-        state_conservative⁺,
-        state_auxiliary⁺,
-        x...,
-    )
-
-    # Create put the sub model fluxes
-    a_fluxᵀn = parent(fluxᵀn)
-    sub_fluxᵀn = similar(fluxᵀn)
-    a_sub_fluxᵀn = parent(sub_fluxᵀn)
-
-    FT = eltype(a_sub_fluxᵀn)
-    @unroll for k in 1:NumSubFluxes
-        @inbounds sub = rem_balance_law.subs[k]
-        @inbounds nf = numerical_fluxes[2][k]
-
-        # reset the plus-side data
-        a_state_conservative⁺ .= a_back_state_conservative⁺
-        a_state_auxiliary⁺ .= a_back_state_auxiliary⁺
-
-        # compute this submodels flux
-        fill!(a_sub_fluxᵀn, -zero(FT))
-        numerical_boundary_flux_first_order!(
-            nf,
-            sub,
-            sub_fluxᵀn,
+    if rem_balance_law.maindir isa Union{Dirs.types...}
+        @inbounds numerical_boundary_flux_first_order!(
+            numerical_fluxes[1],
+            rem_balance_law.main,
+            fluxᵀn,
             normal_vector,
             state_conservative⁻,
             state_auxiliary⁻,
             state_conservative⁺,
             state_auxiliary⁺,
-            x...,
+            bctype,
+            t,
+            (rem_balance_law.maindir,),
+            state_conservative1⁻,
+            state_auxiliary1⁻,
         )
+    end
 
-        # Subtract off this sub models flux
-        a_fluxᵀn .-= a_sub_fluxᵀn
+    # Create put the sub model fluxes
+    a_fluxᵀn = parent(fluxᵀn)
+
+    # Force the loop to unroll to get type stability on the GPU
+    ntuple(Val(length(rem_balance_law.subs))) do k
+        Base.@_inline_meta
+        @inbounds if rem_balance_law.subsdir[k] isa Union{Dirs.types...}
+            sub = rem_balance_law.subs[k]
+            nf = numerical_fluxes[2][k]
+
+            # reset the plus-side data
+            a_state_conservative⁺ .= a_back_state_conservative⁺
+            a_state_auxiliary⁺ .= a_back_state_auxiliary⁺
+
+            FT = eltype(a_fluxᵀn)
+            num_state_conservative = number_state_conservative(sub, FT)
+
+            a_sub_fluxᵀn = MVector{num_state_conservative, FT}(undef)
+            a_sub_state_conservative⁻ =
+                MVector{num_state_conservative, FT}(undef)
+            a_sub_state_conservative⁺ =
+                MVector{num_state_conservative, FT}(undef)
+            a_sub_state_conservative1⁻ =
+                MVector{num_state_conservative, FT}(undef)
+
+            state_rng = static(1):static(number_state_conservative(sub, FT))
+            a_sub_fluxᵀn .= a_fluxᵀn[state_rng]
+            a_sub_state_conservative⁻ .= parent(state_conservative⁻)[state_rng]
+            a_sub_state_conservative⁺ .= parent(state_conservative⁺)[state_rng]
+            a_sub_state_conservative1⁻ .=
+                parent(state_conservative1⁻)[state_rng]
+
+
+            # compute this submodels flux
+            fill!(a_sub_fluxᵀn, -zero(eltype(a_sub_fluxᵀn)))
+            numerical_boundary_flux_first_order!(
+                nf,
+                sub,
+                Vars{vars_state_conservative(sub, FT)}(a_sub_fluxᵀn),
+                normal_vector,
+                Vars{vars_state_conservative(sub, FT)}(
+                    a_sub_state_conservative⁻,
+                ),
+                state_auxiliary⁻,
+                Vars{vars_state_conservative(sub, FT)}(
+                    a_sub_state_conservative⁺,
+                ),
+                state_auxiliary⁺,
+                bctype,
+                t,
+                (rem_balance_law.subsdir[k],),
+                Vars{vars_state_conservative(sub, FT)}(
+                    a_sub_state_conservative1⁻,
+                ),
+                state_auxiliary1⁻,
+            )
+
+            # Subtract off this sub models flux
+            a_fluxᵀn[state_rng] .-= a_sub_fluxᵀn
+        end
     end
 end
 

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -1,5 +1,30 @@
 using StaticNumbers
 
+import ..BalanceLaws:
+    vars_state_conservative,
+    vars_state_auxiliary,
+    vars_state_gradient,
+    vars_state_gradient_flux,
+    vars_integrals,
+    vars_reverse_integrals,
+    vars_gradient_laplacian,
+    vars_hyperdiffusive,
+    init_state_conservative!,
+    init_state_auxiliary!,
+    flux_first_order!,
+    flux_second_order!,
+    compute_gradient_flux!,
+    compute_gradient_argument!,
+    source!,
+    transform_post_gradient_laplacian!,
+    wavespeed,
+    boundary_state!,
+    update_auxiliary_state!,
+    integral_load_auxiliary_state!,
+    integral_set_auxiliary_state!,
+    reverse_integral_load_auxiliary_state!,
+    reverse_integral_set_auxiliary_state!
+
 """
     RemainderModel(main::BalanceLaw, subcomponents::Tuple)
 
@@ -118,6 +143,7 @@ function wavespeed(rem::RemainderModel, nM, state::Vars, aux::Vars, t::Real)
     return ws
 end
 
+import .NumericalFluxes: normal_boundary_flux_second_order!
 boundary_state!(nf, rem::RemainderModel, x...) =
     boundary_state!(nf, rem.main, x...)
 function normal_boundary_flux_second_order!(
@@ -156,15 +182,8 @@ function normal_boundary_flux_second_order!(
     )
 end
 
-init_state_auxiliary!(rem::RemainderModel, aux::Vars, geom::LocalGeometry) =
-    nothing
-init_state_conservative!(
-    rem::RemainderModel,
-    state::Vars,
-    aux::Vars,
-    coords,
-    t,
-) = nothing
+init_state_auxiliary!(rem::RemainderModel, _...) = nothing
+init_state_conservative!(rem::RemainderModel, _...) = nothing
 
 function flux_first_order!(
     rem::RemainderModel,

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -57,9 +57,9 @@ end
     )
 
 
-Constructs a [`DGModel`](@ref DGModel) from the `maindg` model and the tuple of
-`subsdg` models. The concept of a remainder model is that it computes the
-contribution of the  model after subtracting all of the subcomponents.
+Constructs a `DGModel` from the `maindg` model and the tuple of `subsdg` models.
+The concept of a remainder model is that it computes the contribution of the
+model after subtracting all of the subcomponents.
 
 By default the numerical fluxes are set to be a tuple of the main models
 numerical flux and the splitting is done at the PDE level (e.g., the remainder
@@ -89,6 +89,28 @@ function remainder_DGModel(
         maindg.balance_law,
         ntuple(i -> subsdg[i].balance_law, length(subsdg)),
     )
+    FT = eltype(state_auxiliary)
+
+    # If any of these asserts fail, the remainder model will need to be extended
+    # to allow for it; see `flux_first_order!` and `source!` below.
+    for subdg in subsdg
+        @assert number_state_conservative(subdg.balance_law, FT) <=
+                number_state_conservative(maindg.balance_law, FT)
+
+        @assert number_state_auxiliary(subdg.balance_law, FT) ==
+                number_state_auxiliary(maindg.balance_law, FT)
+
+        @assert number_state_gradient(subdg.balance_law, FT) == 0
+        @assert number_state_gradient_flux(subdg.balance_law, FT) == 0
+
+        @assert num_gradient_laplacian(subdg.balance_law, FT) == 0
+        @assert num_hyperdiffusive(subdg.balance_law, FT) == 0
+
+        @assert num_integrals(subdg.balance_law, FT) == 0
+        @assert num_reverse_integrals(subdg.balance_law, FT) == 0
+    end
+
+
     DGModel(
         balance_law,
         maindg.grid,
@@ -168,24 +190,23 @@ init_state_auxiliary!(rem_balance_law::RemBL, args...) =
 init_state_conservative!(rem_balance_law::RemBL, args...) =
     init_state_conservative!(rem_balance_law.main, args...)
 
-function wavespeed(rem::RemBL, nM, state::Vars, aux::Vars, t::Real)
-    FT = eltype(state)
+"""
+    function flux_first_order!(
+        rem_balance_law::RemBL,
+        flux::Grad,
+        state::Vars,
+        aux::Vars,
+        t::Real,
+        directions,
+    )
 
-    ws = fill(-zero(FT), MVector{number_state_conservative(rem.main, FT), FT})
-    rs = fill(-zero(FT), MVector{number_state_conservative(rem.main, FT), FT})
+Evaluate the remainder flux by first evaluating the main flux and subtracting
+the subcomponent fluxes.
 
-    ws .= wavespeed(rem.main, nM, state, aux, t)
-
-    for sub in rem.subs
-        num_state = static(number_state_conservative(sub, Float32))
-        @inbounds rs[static(1):num_state] .+= wavespeed(sub, nM, state, aux, t)
-    end
-
-    ws .-= rs
-
-    return ws
-end
-
+Only models which have directions that are included in the `directions` tuple
+are evaluated. When these models are evaluated the models underlying `direction`
+is passed (not the original `directions` argument).
+"""
 function flux_first_order!(
     rem_balance_law::RemBL,
     flux::Grad,
@@ -207,6 +228,25 @@ function flux_first_order!(
     nothing
 end
 
+
+"""
+    function source!(
+        rem_balance_law::RemBL,
+        source::Vars,
+        state::Vars,
+        diffusive::Vars,
+        aux::Vars,
+        t::Real,
+        directions,
+    )
+
+Evaluate the remainder source by first evaluating the main source and subtracting
+the subcomponent sources.
+
+Only models which have directions that are included in the `directions` tuple
+are evaluated. When these models are evaluated the models underlying `direction`
+is passed (not the original `directions` argument).
+"""
 function source!(
     rem_balance_law::RemBL,
     source::Vars,
@@ -228,6 +268,37 @@ function source!(
         m .-= m_s
     end
     nothing
+end
+
+"""
+    function wavespeed(
+        rem_balance_law::RemBL,
+        args...,
+    )
+
+The wavespeed for a remainder model is defined to be the difference of the wavespeed
+of the main model and the sum of the subcomponents.
+
+Note: Defining the wavespeed in this manner can result in a smaller value than
+the actually wavespeed of the remainder physics model depending on the
+composition of the models.
+"""
+function wavespeed(rem::RemBL, nM, state::Vars, aux::Vars, t::Real)
+    FT = eltype(state)
+
+    ws = fill(-zero(FT), MVector{number_state_conservative(rem.main, FT), FT})
+    rs = fill(-zero(FT), MVector{number_state_conservative(rem.main, FT), FT})
+
+    ws .= wavespeed(rem.main, nM, state, aux, t)
+
+    for sub in rem.subs
+        num_state = static(number_state_conservative(sub, Float32))
+        @inbounds rs[static(1):num_state] .+= wavespeed(sub, nM, state, aux, t)
+    end
+
+    ws .-= rs
+
+    return ws
 end
 
 # Here the fluxes are pirated to handle the case of tuples of fluxes

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -313,12 +313,12 @@ function source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
-    ::Dir,
-) where {Dir <: Direction}
+    ::Dirs,
+) where {NumDirs, Dirs <: NTuple{NumDirs, Direction}}
     m = parent(source)
-    if EveryDirection() isa Dir ||
+    if EveryDirection() isa Union{Dirs.types...} ||
        rem_balance_law.maindir isa EveryDirection ||
-       rem_balance_law.maindir isa Dir
+       rem_balance_law.maindir isa Union{Dirs.types...}
         source!(
             rem_balance_law.main,
             source,
@@ -326,7 +326,7 @@ function source!(
             diffusive,
             aux,
             t,
-            rem_balance_law.maindir,
+            (rem_balance_law.maindir,),
         )
     end
 
@@ -336,9 +336,9 @@ function source!(
     # Force the loop to unroll to get type stability on the GPU
     ntuple(Val(length(rem_balance_law.subs))) do k
         Base.@_inline_meta
-        @inbounds if EveryDirection() isa Dir ||
+        @inbounds if EveryDirection() isa Union{Dirs.types...} ||
                      rem_balance_law.subsdir[k] isa EveryDirection ||
-                     rem_balance_law.subsdir[k] isa Dir
+                     rem_balance_law.subsdir[k] isa Union{Dirs.types...}
             sub = rem_balance_law.subs[k]
             fill!(m_s, -zero(eltype(m_s)))
             source!(
@@ -348,7 +348,7 @@ function source!(
                 diffusive,
                 aux,
                 t,
-                rem_balance_law.subsdir[k],
+                (rem_balance_law.subsdir[k],),
             )
             m .-= m_s
         end

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -28,102 +28,87 @@ import ..BalanceLaws:
 """
     RemainderModel(main::BalanceLaw, subcomponents::Tuple)
 
-Compute the "remainder" contribution of the `main` model, after subtracting `subcomponents`.
+Compute the "remainder" contribution of the `main` model, after subtracting
+`subcomponents`.
+
+Currently only the `flux_nondiffusive!` and `source!` are handled by the
+remainder model
 """
 struct RemainderModel{M, S} <: BalanceLaw
     main::M
     subs::S
 end
 
-vars_state_conservative(rem::RemainderModel, FT) =
-    vars_state_conservative(rem.main, FT)
-vars_state_gradient(rem::RemainderModel, FT) = vars_state_gradient(rem.main, FT)
-vars_state_gradient_flux(rem::RemainderModel, FT) =
-    vars_state_gradient_flux(rem.main, FT)
-vars_state_auxiliary(rem::RemainderModel, FT) =
-    vars_state_auxiliary(rem.main, FT)
-vars_integrals(rem::RemainderModel, FT) = vars_integrals(rem.main, FT)
-vars_reverse_integrals(rem::RemainderModel, FT) = vars_integrals(rem.main, FT)
-vars_gradient_laplacian(rem::RemainderModel, FT) =
-    vars_gradient_laplacian(rem.main, FT)
-vars_hyperdiffusive(rem::RemainderModel, FT) = vars_hyperdiffusive(rem.main, FT)
+# Inherit most of the functionality from the main model
+vars_state_conservative(rem_balance_law::RemainderModel, FT) =
+    vars_state_conservative(rem_balance_law.main, FT)
 
-update_auxiliary_state!(
+vars_state_gradient(rem_balance_law::RemainderModel, FT) =
+    vars_state_gradient(rem_balance_law.main, FT)
+
+vars_state_gradient_flux(rem_balance_law::RemainderModel, FT) =
+    vars_state_gradient_flux(rem_balance_law.main, FT)
+
+vars_state_auxiliary(rem_balance_law::RemainderModel, FT) =
+    vars_state_auxiliary(rem_balance_law.main, FT)
+
+vars_integrals(rem_balance_law::RemainderModel, FT) =
+    vars_integrals(rem_balance_law.main, FT)
+
+vars_reverse_integrals(rem_balance_law::RemainderModel, FT) =
+    vars_integrals(rem_balance_law.main, FT)
+
+vars_gradient_laplacian(rem_balance_law::RemainderModel, FT) =
+    vars_gradient_laplacian(rem_balance_law.main, FT)
+
+vars_hyperdiffusive(rem_balance_law::RemainderModel, FT) =
+    vars_hyperdiffusive(rem_balance_law.main, FT)
+
+update_auxiliary_state!(dg::DGModel, rem_balance_law::RemainderModel, args...) =
+    update_auxiliary_state!(dg, rem_balance_law.main, args...)
+
+update_auxiliary_state_gradient!(
     dg::DGModel,
-    rem::RemainderModel,
-    Q::MPIStateArray,
-    t::Real,
-    elems::UnitRange,
-) = update_auxiliary_state!(dg, rem.main, Q, t, elems)
+    rem_balance_law::RemainderModel,
+    args...,
+) = update_auxiliary_state_gradient!(dg, rem_balance_law.main, args...)
 
-integral_load_auxiliary_state!(
-    rem::RemainderModel,
-    integ::Vars,
-    state::Vars,
-    aux::Vars,
-) = integral_load_auxiliary_state!(rem.main, integ, state, aux)
+integral_load_auxiliary_state!(rem_balance_law::RemainderModel, args...) =
+    integral_load_auxiliary_state!(rem_balance_law.main, args...)
 
-integral_set_auxiliary_state!(rem::RemainderModel, aux::Vars, integ::Vars) =
-    integral_set_auxiliary_state!(rem.main, aux, integ)
+integral_set_auxiliary_state!(rem_balance_law::RemainderModel, args...) =
+    integral_set_auxiliary_state!(rem_balance_law.main, args...)
 
 reverse_integral_load_auxiliary_state!(
-    rem::RemainderModel,
-    integ::Vars,
-    state::Vars,
-    aux::Vars,
-) = reverse_integral_load_auxiliary_state!(rem.main, integ, state, aux)
+    rem_balance_law::RemainderModel,
+    args...,
+) = reverse_integral_load_auxiliary_state!(rem_balance_law.main, args...)
 
 reverse_integral_set_auxiliary_state!(
-    rem::RemainderModel,
-    aux::Vars,
-    integ::Vars,
-) = reverse_integral_set_auxiliary_state!(rem.main, aux, integ)
+    rem_balance_law::RemainderModel,
+    args...,
+) = reverse_integral_set_auxiliary_state!(rem_balance_law.main, args...)
 
-function transform_post_gradient_laplacian!(
-    rem::RemainderModel,
-    hyperdiffusive::Vars,
-    hypertransform::Grad,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-)
-    transform_post_gradient_laplacian!(
-        rem.main,
-        hyperdiffusive,
-        hypertransform,
-        state,
-        aux,
-        t,
-    )
-end
-function flux_second_order!(
-    rem::RemainderModel,
-    flux::Grad,
-    state::Vars,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
-    aux::Vars,
-    t::Real,
-)
-    flux_second_order!(rem.main, flux, state, diffusive, hyperdiffusive, aux, t)
-end
+transform_post_gradient_laplacian!(rem_balance_law::RemainderModel, args...) =
+    transform_post_gradient_laplacian!(rem_balance_law.main, args...)
 
-compute_gradient_argument!(
-    rem::RemainderModel,
-    transform::Vars,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-) = compute_gradient_argument!(rem.main, transform, state, aux, t)
+flux_second_order!(rem_balance_law::RemainderModel, args...) =
+    flux_second_order!(rem_balance_law.main, args...)
 
-compute_gradient_flux!(
-    rem::RemainderModel,
-    diffusive::Vars,
-    ∇transform::Grad,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-) = compute_gradient_flux!(rem.main, diffusive, ∇transform, state, aux, t)
+compute_gradient_argument!(rem_balance_law::RemainderModel, args...) =
+    compute_gradient_argument!(rem_balance_law.main, args...)
+
+compute_gradient_flux!(rem_balance_law::RemainderModel, args...) =
+    compute_gradient_flux!(rem_balance_law.main, args...)
+
+boundary_state!(nf, rem_balance_law::RemainderModel, args...) =
+    boundary_state!(nf, rem_balance_law.main, args...)
+
+init_state_auxiliary!(rem_balance_law::RemainderModel, args...) =
+    init_state_auxiliary!(rem_balance_law.main, args...)
+
+init_state_conservative!(rem_balance_law::RemainderModel, args...) =
+    init_state_conservative!(rem_balance_law.main, args...)
 
 function wavespeed(rem::RemainderModel, nM, state::Vars, aux::Vars, t::Real)
     FT = eltype(state)
@@ -144,61 +129,38 @@ function wavespeed(rem::RemainderModel, nM, state::Vars, aux::Vars, t::Real)
 end
 
 import .NumericalFluxes: normal_boundary_flux_second_order!
-boundary_state!(nf, rem::RemainderModel, x...) =
-    boundary_state!(nf, rem.main, x...)
-function normal_boundary_flux_second_order!(
-    nf,
-    rem::RemainderModel,
-    fluxᵀn::Vars{S},
-    n⁻,
-    state⁻,
-    diff⁻,
-    hyperdiff⁻,
-    aux⁻,
-    state⁺,
-    diff⁺,
-    hyperdiff⁺,
-    aux⁺,
-    bctype::Integer,
-    t,
-    args...,
-) where {S}
-    normal_boundary_flux_second_order!(
-        nf,
-        rem.main,
-        fluxᵀn,
-        n⁻,
-        state⁻,
-        diff⁻,
-        hyperdiff⁻,
-        aux⁻,
-        state⁺,
-        diff⁺,
-        hyperdiff⁺,
-        aux⁺,
-        bctype,
-        t,
-        args...,
-    )
-end
+boundary_state!(nf, rem_balance_law::RemainderModel, x...) =
+    boundary_state!(nf, rem_balance_law.main, x...)
 
-init_state_auxiliary!(rem::RemainderModel, _...) = nothing
-init_state_conservative!(rem::RemainderModel, _...) = nothing
+normal_boundary_flux_second_order!(
+    nf,
+    rem_balance_law::RemainderModel,
+    fluxᵀn::Vars{S},
+    args...,
+) where {S} = normal_boundary_flux_second_order!(
+    nf,
+    rem_balance_law.main,
+    fluxᵀn,
+    args...,
+)
+
+init_state_auxiliary!(rem_balance_law::RemainderModel, _...) = nothing
+init_state_conservative!(rem_balance_law::RemainderModel, _...) = nothing
 
 function flux_first_order!(
-    rem::RemainderModel,
+    rem_balance_law::RemainderModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
 )
-    m = getfield(flux, :array)
-    flux_first_order!(rem.main, flux, state, aux, t)
+    m = parent(flux)
+    flux_first_order!(rem_balance_law.main, flux, state, aux, t)
 
     flux_s = similar(flux)
-    m_s = getfield(flux_s, :array)
+    m_s = parent(flux_s)
 
-    for sub in rem.subs
+    for sub in rem_balance_law.subs
         fill!(m_s, 0)
         flux_first_order!(sub, flux_s, state, aux, t)
         m .-= m_s
@@ -207,7 +169,7 @@ function flux_first_order!(
 end
 
 function source!(
-    rem::RemainderModel,
+    rem_balance_law::RemainderModel,
     source::Vars,
     state::Vars,
     diffusive::Vars,
@@ -215,13 +177,13 @@ function source!(
     t::Real,
     direction,
 )
-    m = getfield(source, :array)
-    source!(rem.main, source, state, diffusive, aux, t, direction)
+    m = parent(source)
+    source!(rem_balance_law.main, source, state, diffusive, aux, t, direction)
 
     source_s = similar(source)
-    m_s = getfield(source_s, :array)
+    m_s = parent(source_s)
 
-    for sub in rem.subs
+    for sub in rem_balance_law.subs
         fill!(m_s, 0)
         source!(sub, source_s, state, diffusive, aux, t, direction)
         m .-= m_s

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -41,21 +41,31 @@ struct RemainderModel{M, S} <: BalanceLaw
 end
 
 function remainder_DGModel(
-    balance_law,
-    grid,
+    maindg,
+    subsdg,
     numerical_flux_first_order,
     numerical_flux_second_order,
     numerical_flux_gradient;
-    state_auxiliary = create_auxiliary_state(balance_law, grid),
-    state_gradient_flux = create_gradient_state(balance_law, grid),
-    states_higher_order = create_higher_order_states(balance_law, grid),
+    state_auxiliary = maindg.state_auxiliary,
+    state_gradient_flux = create_gradient_state(
+        maindg.balance_law,
+        maindg.grid,
+    ),
+    states_higher_order = create_higher_order_states(
+        maindg.balance_law,
+        maindg.grid,
+    ),
     direction = EveryDirection(),
-    diffusion_direction = direction,
-    modeldata = nothing,
+    diffusion_direction = maindg.diffusion_direction,
+    modeldata = maindg.modeldata,
 )
+    balance_law = RemainderModel(
+        maindg.balance_law,
+        ntuple(i -> subsdg[i].balance_law, length(subsdg)),
+    )
     DGModel(
         balance_law,
-        grid,
+        maindg.grid,
         numerical_flux_first_order,
         numerical_flux_second_order,
         numerical_flux_gradient,

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -113,8 +113,8 @@ init_state_conservative!(rem_balance_law::RemainderModel, args...) =
 function wavespeed(rem::RemainderModel, nM, state::Vars, aux::Vars, t::Real)
     FT = eltype(state)
 
-    ws = fill(0, MVector{number_state_conservative(rem.main, FT), FT})
-    rs = fill(0, MVector{number_state_conservative(rem.main, FT), FT})
+    ws = fill(-zero(FT), MVector{number_state_conservative(rem.main, FT), FT})
+    rs = fill(-zero(FT), MVector{number_state_conservative(rem.main, FT), FT})
 
     ws .= wavespeed(rem.main, nM, state, aux, t)
 
@@ -161,7 +161,7 @@ function flux_first_order!(
     m_s = parent(flux_s)
 
     for sub in rem_balance_law.subs
-        fill!(m_s, 0)
+        fill!(m_s, -zero(eltype(m_s)))
         flux_first_order!(sub, flux_s, state, aux, t)
         m .-= m_s
     end
@@ -184,7 +184,7 @@ function source!(
     m_s = parent(source_s)
 
     for sub in rem_balance_law.subs
-        fill!(m_s, 0)
+        fill!(m_s, -zero(eltype(m_s)))
         source!(sub, source_s, state, diffusive, aux, t, direction)
         m .-= m_s
     end

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -1,4 +1,5 @@
 using StaticNumbers
+export remainder_DGModel
 
 import ..BalanceLaws:
     vars_state_conservative,
@@ -37,6 +38,34 @@ remainder model
 struct RemainderModel{M, S} <: BalanceLaw
     main::M
     subs::S
+end
+
+function remainder_DGModel(
+    balance_law,
+    grid,
+    numerical_flux_first_order,
+    numerical_flux_second_order,
+    numerical_flux_gradient;
+    state_auxiliary = create_auxiliary_state(balance_law, grid),
+    state_gradient_flux = create_gradient_state(balance_law, grid),
+    states_higher_order = create_higher_order_states(balance_law, grid),
+    direction = EveryDirection(),
+    diffusion_direction = direction,
+    modeldata = nothing,
+)
+    DGModel(
+        balance_law,
+        grid,
+        numerical_flux_first_order,
+        numerical_flux_second_order,
+        numerical_flux_gradient,
+        state_auxiliary,
+        state_gradient_flux,
+        states_higher_order,
+        direction,
+        diffusion_direction,
+        modeldata,
+    )
 end
 
 # Inherit most of the functionality from the main model

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -40,25 +40,51 @@ struct RemBL{M, S} <: BalanceLaw
     subs::S
 end
 
+
+"""
+    remainder_DGModel(
+        maindg::DGModel,
+        subsdg::NTuple{NumModels, DGModel};
+        direction = EveryDirection(),
+        numerical_flux_first_order,
+        numerical_flux_second_order,
+        numerical_flux_gradient,
+        state_auxiliary,
+        state_gradient_flux,
+        states_higher_order,
+        diffusion_direction,
+        modeldata,
+    )
+
+
+Constructs a [`DGModel`](@ref DGModel) from the `maindg` model and the tuple of
+`subsdg` models. The concept of a remainder model is that it computes the
+contribution of the  model after subtracting all of the subcomponents.
+
+By default the numerical fluxes are set to be a tuple of the main models
+numerical flux and the splitting is done at the PDE level (e.g., the remainder
+model is calculated prior to discretization). If instead a tuple of numerical
+fluxes is passed in the main numerical flux is evaluated first and then the
+subcomponent numerical fluxes are subtracted off. This is discretely different
+(for the Rusanov / local Lax-Friedrichs flux) than defining a numerical flux for
+the remainder of the physics model.
+
+The other parameters are set to the value in the `maindg` component, mainly the
+data and arrays are aliased to the `maindg` values.
+"""
 function remainder_DGModel(
-    maindg,
-    subsdg,
-    numerical_flux_first_order,
-    numerical_flux_second_order,
-    numerical_flux_gradient;
-    state_auxiliary = maindg.state_auxiliary,
-    state_gradient_flux = create_gradient_state(
-        maindg.balance_law,
-        maindg.grid,
-    ),
-    states_higher_order = create_higher_order_states(
-        maindg.balance_law,
-        maindg.grid,
-    ),
+    maindg::DGModel,
+    subsdg::NTuple{NumModels, DGModel};
     direction = EveryDirection(),
+    numerical_flux_first_order = maindg.numerical_flux_first_order,
+    numerical_flux_second_order = maindg.numerical_flux_second_order,
+    numerical_flux_gradient = maindg.numerical_flux_gradient,
+    state_auxiliary = maindg.state_auxiliary,
+    state_gradient_flux = maindg.state_gradient_flux,
+    states_higher_order = maindg.states_higher_order,
     diffusion_direction = maindg.diffusion_direction,
     modeldata = maindg.modeldata,
-)
+) where {NumModels}
     balance_law = RemBL(
         maindg.balance_law,
         ntuple(i -> subsdg[i].balance_law, length(subsdg)),
@@ -160,25 +186,6 @@ function wavespeed(rem::RemBL, nM, state::Vars, aux::Vars, t::Real)
     return ws
 end
 
-import .NumericalFluxes: normal_boundary_flux_second_order!
-boundary_state!(nf, rem_balance_law::RemBL, x...) =
-    boundary_state!(nf, rem_balance_law.main, x...)
-
-normal_boundary_flux_second_order!(
-    nf,
-    rem_balance_law::RemBL,
-    fluxᵀn::Vars{S},
-    args...,
-) where {S} = normal_boundary_flux_second_order!(
-    nf,
-    rem_balance_law.main,
-    fluxᵀn,
-    args...,
-)
-
-init_state_auxiliary!(rem_balance_law::RemBL, _...) = nothing
-init_state_conservative!(rem_balance_law::RemBL, _...) = nothing
-
 function flux_first_order!(
     rem_balance_law::RemBL,
     flux::Grad,
@@ -222,3 +229,204 @@ function source!(
     end
     nothing
 end
+
+# Here the fluxes are pirated to handle the case of tuples of fluxes
+import ..DGMethods.NumericalFluxes:
+    NumericalFluxFirstOrder,
+    numerical_flux_first_order!,
+    numerical_boundary_flux_first_order!,
+    normal_boundary_flux_second_order!
+
+"""
+    function numerical_flux_first_order!(
+        numerical_fluxes::Tuple{
+            NumericalFluxFirstOrder,
+            NTuple{NumSubFluxes, NumericalFluxFirstOrder},
+        },
+        rem_balance_law::RemBL,
+        fluxᵀn::Vars{S},
+        normal_vector::SVector,
+        state_conservative⁻::Vars{S},
+        state_auxiliary⁻::Vars{A},
+        state_conservative⁺::Vars{S},
+        state_auxiliary⁺::Vars{A},
+        t,
+        directions,
+    )
+
+When the `numerical_fluxes` are a tuple and the balance law is a remainder
+balance law the main components numerical flux is evaluated then all the
+subcomponent numerical fluxes are evaluated and subtracted.
+
+Only models which have directions that are included in the `directions` tuple
+are evaluated. When these models are evaluated the models underlying `direction`
+is passed (not the original `directions` argument).
+"""
+function numerical_flux_first_order!(
+    numerical_fluxes::Tuple{
+        NumericalFluxFirstOrder,
+        NTuple{NumSubFluxes, NumericalFluxFirstOrder},
+    },
+    rem_balance_law::RemBL,
+    fluxᵀn::Vars{S},
+    normal_vector::SVector,
+    state_conservative⁻::Vars{S},
+    state_auxiliary⁻::Vars{A},
+    state_conservative⁺::Vars{S},
+    state_auxiliary⁺::Vars{A},
+    x...,
+) where {NumSubFluxes, S, A}
+    # Call the numerical flux for the main model
+    @inbounds numerical_flux_first_order!(
+        numerical_fluxes[1],
+        rem_balance_law.main,
+        fluxᵀn,
+        normal_vector,
+        state_conservative⁻,
+        state_auxiliary⁻,
+        state_conservative⁺,
+        state_auxiliary⁺,
+        x...,
+    )
+
+    # Create put the sub model fluxes
+    a_fluxᵀn = parent(fluxᵀn)
+    sub_fluxᵀn = similar(fluxᵀn)
+    a_sub_fluxᵀn = parent(sub_fluxᵀn)
+
+    FT = eltype(a_sub_fluxᵀn)
+    @unroll for k in 1:NumSubFluxes
+        @inbounds sub = rem_balance_law.subs[k]
+        @inbounds nf = numerical_fluxes[2][k]
+        # compute this submodels flux
+        fill!(a_sub_fluxᵀn, -zero(FT))
+        numerical_flux_first_order!(
+            nf,
+            sub,
+            sub_fluxᵀn,
+            normal_vector,
+            state_conservative⁻,
+            state_auxiliary⁻,
+            state_conservative⁺,
+            state_auxiliary⁺,
+            x...,
+        )
+
+        # Subtract off this sub models flux
+        a_fluxᵀn .-= a_sub_fluxᵀn
+    end
+end
+
+"""
+    function numerical_boundary_flux_first_order!(
+        numerical_fluxes::Tuple{
+            NumericalFluxFirstOrder,
+            NTuple{NumSubFluxes, NumericalFluxFirstOrder},
+        },
+        rem_balance_law::RemBL,
+        fluxᵀn::Vars{S},
+        normal_vector::SVector,
+        state_conservative⁻::Vars{S},
+        state_auxiliary⁻::Vars{A},
+        state_conservative⁺::Vars{S},
+        state_auxiliary⁺::Vars{A},
+        bctype,
+        t,
+        directions,
+        args...,
+    )
+
+When the `numerical_fluxes` are a tuple and the balance law is a remainder
+balance law the main components numerical flux is evaluated then all the
+subcomponent numerical fluxes are evaluated and subtracted.
+
+Only models which have directions that are included in the `directions` tuple
+are evaluated. When these models are evaluated the models underlying `direction`
+is passed (not the original `directions` argument).
+"""
+function numerical_boundary_flux_first_order!(
+    numerical_fluxes::Tuple{
+        NumericalFluxFirstOrder,
+        NTuple{NumSubFluxes, NumericalFluxFirstOrder},
+    },
+    rem_balance_law::RemBL,
+    fluxᵀn::Vars{S},
+    normal_vector::SVector,
+    state_conservative⁻::Vars{S},
+    state_auxiliary⁻::Vars{A},
+    state_conservative⁺::Vars{S},
+    state_auxiliary⁺::Vars{A},
+    x...,
+) where {NumSubFluxes, S, A}
+    # Since the fluxes are allowed to modified these we need backups so they can
+    # be reset as we go
+    a_state_conservative⁺ = parent(state_conservative⁺)
+    a_state_auxiliary⁺ = parent(state_auxiliary⁺)
+
+    a_back_state_conservative⁺ = copy(a_state_conservative⁺)
+    a_back_state_auxiliary⁺ = copy(a_state_auxiliary⁺)
+
+
+    # Call the numerical flux for the main model
+    @inbounds numerical_boundary_flux_first_order!(
+        numerical_fluxes[1],
+        rem_balance_law.main,
+        fluxᵀn,
+        normal_vector,
+        state_conservative⁻,
+        state_auxiliary⁻,
+        state_conservative⁺,
+        state_auxiliary⁺,
+        x...,
+    )
+
+    # Create put the sub model fluxes
+    a_fluxᵀn = parent(fluxᵀn)
+    sub_fluxᵀn = similar(fluxᵀn)
+    a_sub_fluxᵀn = parent(sub_fluxᵀn)
+
+    FT = eltype(a_sub_fluxᵀn)
+    @unroll for k in 1:NumSubFluxes
+        @inbounds sub = rem_balance_law.subs[k]
+        @inbounds nf = numerical_fluxes[2][k]
+
+        # reset the plus-side data
+        a_state_conservative⁺ .= a_back_state_conservative⁺
+        a_state_auxiliary⁺ .= a_back_state_auxiliary⁺
+
+        # compute this submodels flux
+        fill!(a_sub_fluxᵀn, -zero(FT))
+        numerical_boundary_flux_first_order!(
+            nf,
+            sub,
+            sub_fluxᵀn,
+            normal_vector,
+            state_conservative⁻,
+            state_auxiliary⁻,
+            state_conservative⁺,
+            state_auxiliary⁺,
+            x...,
+        )
+
+        # Subtract off this sub models flux
+        a_fluxᵀn .-= a_sub_fluxᵀn
+    end
+end
+
+"""
+    normal_boundary_flux_second_order!(nf, rem_balance_law::RemBL, args...)
+
+Currently the main models `normal_boundary_flux_second_order!` is called. If the
+subcomponents models have second order terms this would need to be updated.
+"""
+normal_boundary_flux_second_order!(
+    nf,
+    rem_balance_law::RemBL,
+    fluxᵀn::Vars{S},
+    args...,
+) where {S} = normal_boundary_flux_second_order!(
+    nf,
+    rem_balance_law.main,
+    fluxᵀn,
+    args...,
+)

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -10,12 +10,13 @@ using KernelAbstractions
 export DiscontinuousSpectralElementGrid, AbstractGrid
 export dofs_per_element, arraytype, dimensionality, polynomialorder
 export referencepoints, min_node_distance, get_z
-export EveryDirection, HorizontalDirection, VerticalDirection
+export EveryDirection, HorizontalDirection, VerticalDirection, Direction
 
 abstract type Direction end
 struct EveryDirection <: Direction end
 struct HorizontalDirection <: Direction end
 struct VerticalDirection <: Direction end
+Base.in(::T, ::S) where {T <: Direction, S <: Direction} = T == S
 
 abstract type AbstractGrid{
     FloatType,

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -421,6 +421,7 @@ t -> time, not used
     Q::Vars,
     A::Vars,
     t::Real,
+    direction,
 )
     FT = eltype(Q)
     _grav::FT = grav(m.param_set)

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -87,6 +87,7 @@ end
     q::Vars,
     α::Vars,
     t::Real,
+    direction,
 )
     U = @SVector [q.U[1], q.U[2], -0]
     η = q.η

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -205,7 +205,7 @@ flux_second_order!(::LinearDrag, _...) = nothing
     return nothing
 end
 
-@inline wavespeed(m::SWModel, n⁻, q::Vars, α::Vars, t::Real) = m.c
+@inline wavespeed(m::SWModel, n⁻, q::Vars, α::Vars, t::Real, direction) = m.c
 
 @inline function source!(
     m::SWModel{P},

--- a/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
@@ -357,6 +357,7 @@ end
     state::Vars,
     aux::Vars,
     t::Real,
+    _...,
 )
     FT = eltype(state)
     @inbounds begin

--- a/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
@@ -380,6 +380,7 @@ end
     state::Vars,
     aux::Vars,
     t::Real,
+    _...,
 )
     FT = eltype(state)
     @inbounds begin

--- a/test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl
@@ -123,6 +123,7 @@ function boundary_state!(
     state::Vars,
     aux::Vars,
     t::Real,
+    _...,
 )
     @inbounds u = state.ρu / state.ρ
     return abs(dot(nM, u))
@@ -134,6 +135,7 @@ end
     state::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     FT = eltype(state)
     @inbounds begin

--- a/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
@@ -188,6 +188,7 @@ end
     state::Vars,
     aux::Vars,
     t::Real,
+    _...,
 )
     FT = eltype(state)
 

--- a/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
@@ -208,6 +208,7 @@ end
     state::Vars,
     aux::Vars,
     t::Real,
+    _...,
 )
     FT = eltype(state)
 

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -5,7 +5,7 @@ using ClimateMachine.Mesh.Topologies:
 using ClimateMachine.Mesh.Grids:
     DiscontinuousSpectralElementGrid, VerticalDirection
 using ClimateMachine.Mesh.Filters
-using ClimateMachine.DGMethods: DGModel, init_ode_state
+using ClimateMachine.DGMethods: DGModel, init_ode_state, remainder_DGModel
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
     CentralNumericalFluxGradient,
@@ -68,17 +68,20 @@ function main()
     expected_result[Float64] = 9.5073452847149594e+13
 
     for FT in (Float32, Float64)
-        result = run(
-            mpicomm,
-            polynomialorder,
-            numelem_horz,
-            numelem_vert,
-            timeend,
-            outputtime,
-            ArrayType,
-            FT,
-        )
-        @test result ≈ expected_result[FT]
+        for split_explicit_implicit in (false, true)
+            result = run(
+                mpicomm,
+                polynomialorder,
+                numelem_horz,
+                numelem_vert,
+                timeend,
+                outputtime,
+                ArrayType,
+                FT,
+                split_explicit_implicit,
+            )
+            @test result ≈ expected_result[FT]
+        end
     end
 end
 
@@ -91,6 +94,7 @@ function run(
     outputtime,
     ArrayType,
     FT,
+    split_explicit_implicit,
 )
 
     setup = AcousticWaveSetup{FT}()
@@ -158,14 +162,24 @@ function run(
 
     linearsolver = ManyColumnLU()
 
+    if split_explicit_implicit
+        rem_dg = remainder_DGModel(
+            dg,
+            (lineardg,);
+            numerical_flux_first_order = (
+                dg.numerical_flux_first_order,
+                (lineardg.numerical_flux_first_order,),
+            ),
+        )
+    end
     odesolver = ARK2GiraldoKellyConstantinescu(
-        dg,
+        split_explicit_implicit ? rem_dg : dg,
         lineardg,
         LinearBackwardEulerSolver(linearsolver; isadjustable = false),
         Q;
         dt = dt,
         t0 = 0,
-        split_explicit_implicit = false,
+        split_explicit_implicit = split_explicit_implicit,
     )
 
     filterorder = 18

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -1,0 +1,376 @@
+using ClimateMachine
+using ClimateMachine.ConfigTypes
+using ClimateMachine.Mesh.Topologies:
+    StackedCubedSphereTopology, cubedshellwarp, grid1d
+using ClimateMachine.Mesh.Grids:
+    DiscontinuousSpectralElementGrid,
+    VerticalDirection,
+    HorizontalDirection,
+    EveryDirection,
+    min_node_distance
+using ClimateMachine.Mesh.Filters
+using ClimateMachine.DGMethods: DGModel, init_ode_state, remainder_DGModel
+using ClimateMachine.DGMethods.NumericalFluxes:
+    RusanovNumericalFlux,
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxSecondOrder
+using ClimateMachine.ODESolvers
+using ClimateMachine.SystemSolvers
+using ClimateMachine.VTK: writevtk, writepvtu
+using ClimateMachine.GenericCallbacks:
+    EveryXWallTimeSeconds, EveryXSimulationSteps
+using ClimateMachine.Thermodynamics:
+    air_density,
+    soundspeed_air,
+    internal_energy,
+    PhaseDry_given_pT,
+    PhasePartition
+using ClimateMachine.TemperatureProfiles: IsothermalProfile
+using ClimateMachine.Atmos:
+    AtmosModel,
+    DryModel,
+    NoPrecipitation,
+    NoRadiation,
+    NTracers,
+    ConstantViscosityWithDivergence,
+    vars_state_conservative,
+    vars_state_auxiliary,
+    Gravity,
+    HydrostaticState,
+    AtmosAcousticGravityLinearModel,
+    AtmosAcousticLinearModel
+using ClimateMachine.Orientations:
+    SphericalOrientation, gravitational_potential, altitude, latitude, longitude
+using ClimateMachine.VariableTemplates: flattenednames
+
+using CLIMAParameters
+using CLIMAParameters.Planet: planet_radius
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
+
+const output_vtk = false
+
+const ntracers = 1
+
+function main()
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 5
+    numelem_horz = 10
+    numelem_vert = 5
+
+    timeend = 60 * 60
+    # timeend = 33 * 60 * 60 # Full simulation
+    outputtime = 60 * 60
+
+    expected_result = Dict()
+    expected_result[Float64, true] = 9.5073337869322578e+13
+    expected_result[Float64, false] = 9.5073455070673781e+13
+
+    @testset "acoustic wave" begin
+        for FT in (Float64,)# Float32)
+            for explicit in (true, false)
+                result = run(
+                    mpicomm,
+                    polynomialorder,
+                    numelem_horz,
+                    numelem_vert,
+                    timeend,
+                    outputtime,
+                    ArrayType,
+                    FT,
+                    explicit,
+                )
+                @test result ≈ expected_result[FT, explicit]
+            end
+        end
+    end
+end
+
+function run(
+    mpicomm,
+    polynomialorder,
+    numelem_horz,
+    numelem_vert,
+    timeend,
+    outputtime,
+    ArrayType,
+    FT,
+    explicit_solve,
+)
+
+    setup = AcousticWaveSetup{FT}()
+
+    _planet_radius::FT = planet_radius(param_set)
+    vert_range = grid1d(
+        _planet_radius,
+        FT(_planet_radius + setup.domain_height),
+        nelem = numelem_vert,
+    )
+    topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)
+
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = polynomialorder,
+        meshwarp = cubedshellwarp,
+    )
+    hmnd = min_node_distance(grid, HorizontalDirection())
+    vmnd = min_node_distance(grid, VerticalDirection())
+
+    T_profile = IsothermalProfile(param_set, setup.T_ref)
+    δ_χ = @SVector [FT(ii) for ii in 1:ntracers]
+
+    fullmodel = AtmosModel{FT}(
+        AtmosLESConfigType,
+        param_set;
+        orientation = SphericalOrientation(),
+        ref_state = HydrostaticState(T_profile),
+        turbulence = ConstantViscosityWithDivergence(FT(0)),
+        moisture = DryModel(),
+        tracers = NTracers{length(δ_χ), FT}(δ_χ),
+        source = Gravity(),
+        init_state_conservative = setup,
+    )
+    dg = DGModel(
+        fullmodel,
+        grid,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+    Q = init_ode_state(dg, FT(0))
+
+    # The linear model which contains the fast modes
+    # acousticmodel = AtmosAcousticLinearModel(fullmodel)
+    acousticmodel = AtmosAcousticGravityLinearModel(fullmodel)
+
+    vacoustic_dg = DGModel(
+        acousticmodel,
+        grid,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient();
+        direction = VerticalDirection(),
+        state_auxiliary = dg.state_auxiliary,
+    )
+
+    # Advection model is the difference between the fullmodel and acousticmodel.
+    # This will be handled with explicit substepping (time step in between the
+    # vertical and horizontally acoustic models)
+    rem_dg = remainder_DGModel(dg, (vacoustic_dg,))
+
+    # determine the time step for the model components
+    acoustic_speed = soundspeed_air(fullmodel.param_set, FT(setup.T_ref))
+    advection_speed = 1 # What's a reasonable number here?
+
+    vacoustic_dt = vmnd / acoustic_speed
+    remainder_dt = min(min(hmnd, vmnd) / advection_speed, hmnd / acoustic_speed)
+    odesolver = if explicit_solve
+        remainder_dt = 5vacoustic_dt
+
+        nsteps_output = ceil(outputtime / remainder_dt)
+        remainder_dt = outputtime / nsteps_output
+        nsteps = ceil(Int, timeend / remainder_dt)
+        @assert nsteps * remainder_dt ≈ timeend
+
+        vacoustic_solver =
+            LSRK54CarpenterKennedy(vacoustic_dg, Q; dt = vacoustic_dt)
+        rem_solver = MRIGARKERK45aSandu(
+            rem_dg,
+            vacoustic_solver,
+            Q;
+            dt = remainder_dt,
+        )
+
+        rem_solver
+    else
+        vacoustic_dt = 200vacoustic_dt
+        element_size = (setup.domain_height / numelem_vert)
+
+        nsteps_output = ceil(outputtime / vacoustic_dt)
+        vacoustic_dt = outputtime / nsteps_output
+        nsteps = ceil(Int, timeend / vacoustic_dt)
+        @assert nsteps * vacoustic_dt ≈ timeend
+
+        rem_solver = LSRK54CarpenterKennedy(rem_dg, Q; dt = remainder_dt)
+        vacoustic_solver = MRIGARKESDIRK24LSA(
+            vacoustic_dg,
+            LinearBackwardEulerSolver(ManyColumnLU(); isadjustable = false),
+            rem_solver,
+            Q;
+            dt = vacoustic_dt,
+        )
+
+        vacoustic_solver
+    end
+
+
+    filterorder = 18
+    filter = ExponentialFilter(grid, 0, filterorder)
+    cbfilter = EveryXSimulationSteps(1) do
+        Filters.apply!(Q, :, grid, filter, direction = VerticalDirection())
+        nothing
+    end
+
+    eng0 = norm(Q)
+    @info @sprintf(
+        """Starting
+           ArrayType       = %s
+           FT              = %s
+           polynomialorder = %d
+           numelem_horz    = %d
+           numelem_vert    = %d
+           acoustic dt     = %.16e
+           remainder_dt    = %.16e
+           norm(Q₀)        = %.16e
+           """,
+        "$ArrayType",
+        "$FT",
+        polynomialorder,
+        numelem_horz,
+        numelem_vert,
+        vacoustic_dt,
+        remainder_dt,
+        eng0
+    )
+    # Set up the information callback
+    starttime = Ref(now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            runtime = Dates.format(
+                convert(DateTime, now() - starttime[]),
+                dateformat"HH:MM:SS",
+            )
+            @info @sprintf """Update
+                              simtime = %.16e
+                              runtime = %s
+                              norm(Q) = %.16e
+                              """ gettime(odesolver) runtime energy
+        end
+    end
+    callbacks = (cbinfo, cbfilter)
+
+    if output_vtk
+        # create vtk dir
+        vtkdir =
+            "vtk_acousticwave" *
+            "_poly$(polynomialorder)_horz$(numelem_horz)_vert$(numelem_vert)" *
+            "_$(ArrayType)_$(FT)" *
+            "_$(explicit_solve ? "Explicit_Explicit" : "Implicit_Explicit")"
+        mkpath(vtkdir)
+
+        vtkstep = 0
+        # output initial step
+        do_output(mpicomm, vtkdir, vtkstep, dg, Q, fullmodel)
+
+        # setup the output callback
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dg, gettime(odesolver))
+            do_output(mpicomm, vtkdir, vtkstep, dg, Q, fullmodel)
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    solve!(
+        Q,
+        odesolver;
+        numberofsteps = nsteps,
+        adjustfinalstep = false,
+        callbacks = callbacks,
+    )
+
+    # final statistics
+    engf = norm(Q)
+    @info @sprintf """Finished
+    norm(Q)                 = %.16e
+    norm(Q) / norm(Q₀)      = %.16e
+    norm(Q) - norm(Q₀)      = %.16e
+    """ engf engf / eng0 engf - eng0
+    engf
+end
+
+Base.@kwdef struct AcousticWaveSetup{FT}
+    domain_height::FT = 10e3
+    T_ref::FT = 300
+    α::FT = 3
+    γ::FT = 100
+    nv::Int = 1
+end
+
+function (setup::AcousticWaveSetup)(bl, state, aux, coords, t)
+    # callable to set initial conditions
+    FT = eltype(state)
+
+    λ = longitude(bl, aux)
+    φ = latitude(bl, aux)
+    z = altitude(bl, aux)
+
+    β = min(FT(1), setup.α * acos(cos(φ) * cos(λ)))
+    f = (1 + cos(FT(π) * β)) / 2
+    g = sin(setup.nv * FT(π) * z / setup.domain_height)
+    Δp = setup.γ * f * g
+    p = aux.ref_state.p + Δp
+
+    ts = PhaseDry_given_pT(bl.param_set, p, setup.T_ref)
+    q_pt = PhasePartition(ts)
+    e_pot = gravitational_potential(bl.orientation, aux)
+    e_int = internal_energy(ts)
+
+    state.ρ = air_density(ts)
+    state.ρu = SVector{3, FT}(0, 0, 0)
+    state.ρe = state.ρ * (e_int + e_pot)
+
+    state.tracers.ρχ = @SVector [FT(ii) for ii in 1:ntracers]
+    nothing
+end
+
+function do_output(
+    mpicomm,
+    vtkdir,
+    vtkstep,
+    dg,
+    Q,
+    model,
+    testname = "acousticwave",
+)
+    ## name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    auxnames = flattenednames(vars_state_auxiliary(model, eltype(Q)))
+    writevtk(filename, Q, dg, statenames, dg.state_auxiliary, auxnames)
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(pvtuprefix, prefixes, (statenames..., auxnames...))
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+main()

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -183,14 +183,7 @@ function run(
     )
 
     if split_explicit_implicit
-        dg_nonlinear = remainder_DGModel(
-            dg,
-            (dg_linear,),
-            RusanovNumericalFlux(),
-            CentralNumericalFluxSecondOrder(),
-            CentralNumericalFluxGradient();
-            state_auxiliary = dg.state_auxiliary,
-        )
+        dg_nonlinear = remainder_DGModel(dg, (dg_linear,))
     end
 
     timeend = FT(2 * setup.domain_halflength / setup.translation_speed)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -2,7 +2,7 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods: DGModel, init_ode_state
+using ClimateMachine.DGMethods: DGModel, init_ode_state, RemainderModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -19,7 +19,6 @@ using ClimateMachine.Thermodynamics:
 using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
-    RemainderModel,
     NoReferenceState,
     ReferenceState,
     DryModel,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -2,7 +2,8 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods: DGModel, init_ode_state, RemainderModel
+using ClimateMachine.DGMethods:
+    DGModel, init_ode_state, RemainderModel, remainder_DGModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -184,7 +185,7 @@ function run(
     )
 
     if split_explicit_implicit
-        dg_nonlinear = DGModel(
+        dg_nonlinear = remainder_DGModel(
             nonlinear_model,
             grid,
             RusanovNumericalFlux(),

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -2,8 +2,7 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods:
-    DGModel, init_ode_state, RemainderModel, remainder_DGModel
+using ClimateMachine.DGMethods: DGModel, init_ode_state, remainder_DGModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -165,7 +164,6 @@ function run(
     )
 
     linear_model = AtmosAcousticLinearModel(model)
-    nonlinear_model = RemainderModel(model, (linear_model,))
 
     dg = DGModel(
         model,
@@ -186,8 +184,8 @@ function run(
 
     if split_explicit_implicit
         dg_nonlinear = remainder_DGModel(
-            nonlinear_model,
-            grid,
+            dg,
+            (dg_linear,),
             RusanovNumericalFlux(),
             CentralNumericalFluxSecondOrder(),
             CentralNumericalFluxGradient();

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -174,14 +174,7 @@ function run(
         CentralNumericalFluxGradient();
         state_auxiliary = dg.state_auxiliary,
     )
-    slow_dg = remainder_DGModel(
-        dg,
-        (fast_dg,),
-        RusanovNumericalFlux(),
-        CentralNumericalFluxSecondOrder(),
-        CentralNumericalFluxGradient();
-        state_auxiliary = dg.state_auxiliary,
-    )
+    slow_dg = remainder_DGModel(dg, (fast_dg,))
 
     timeend = FT(2 * setup.domain_halflength / setup.translation_speed)
     # determine the slow time step

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -2,7 +2,7 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods: DGModel, init_ode_state
+using ClimateMachine.DGMethods: DGModel, init_ode_state, RemainderModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -19,7 +19,6 @@ using ClimateMachine.Thermodynamics:
 using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
-    RemainderModel,
     NoReferenceState,
     ReferenceState,
     DryModel,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -2,8 +2,7 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods:
-    DGModel, init_ode_state, RemainderModel, remainder_DGModel
+using ClimateMachine.DGMethods: DGModel, init_ode_state, remainder_DGModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -159,8 +158,6 @@ function run(
     )
     # The linear model has the fast time scales
     fast_model = AtmosAcousticLinearModel(model)
-    # The nonlinear model has the slow time scales
-    slow_model = RemainderModel(model, (fast_model,))
 
     dg = DGModel(
         model,
@@ -178,8 +175,8 @@ function run(
         state_auxiliary = dg.state_auxiliary,
     )
     slow_dg = remainder_DGModel(
-        slow_model,
-        grid,
+        dg,
+        (fast_dg,),
         RusanovNumericalFlux(),
         CentralNumericalFluxSecondOrder(),
         CentralNumericalFluxGradient();

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -2,7 +2,8 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods: DGModel, init_ode_state, RemainderModel
+using ClimateMachine.DGMethods:
+    DGModel, init_ode_state, RemainderModel, remainder_DGModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -176,7 +177,7 @@ function run(
         CentralNumericalFluxGradient();
         state_auxiliary = dg.state_auxiliary,
     )
-    slow_dg = DGModel(
+    slow_dg = remainder_DGModel(
         slow_model,
         grid,
         RusanovNumericalFlux(),

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -178,15 +178,7 @@ function run(
         CentralNumericalFluxGradient();
         state_auxiliary = dg.state_auxiliary,
     )
-    fast_dg = remainder_DGModel(
-        dg,
-        (slow_dg,),
-        grid,
-        RusanovNumericalFlux(),
-        CentralNumericalFluxSecondOrder(),
-        CentralNumericalFluxGradient();
-        state_auxiliary = dg.state_auxiliary,
-    )
+    fast_dg = remainder_DGModel(dg, (slow_dg,))
 
     timeend = FT(2 * setup.domain_halflength / setup.translation_speed)
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -2,7 +2,8 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods: DGModel, init_ode_state, RemainderModel
+using ClimateMachine.DGMethods:
+    DGModel, init_ode_state, RemainderModel, remainder_DGModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -172,7 +173,7 @@ function run(
         CentralNumericalFluxSecondOrder(),
         CentralNumericalFluxGradient(),
     )
-    fast_dg = DGModel(
+    fast_dg = remainder_DGModel(
         fast_model,
         grid,
         RusanovNumericalFlux(),

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -2,8 +2,7 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods:
-    DGModel, init_ode_state, RemainderModel, remainder_DGModel
+using ClimateMachine.DGMethods: DGModel, init_ode_state, remainder_DGModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -163,8 +162,6 @@ function run(
     # The linear model has the fast time scales but will be
     # treated implicitly (outer solver)
     slow_model = AtmosAcousticLinearModel(model)
-    # The remainder will be treated explicitly in the inner loop
-    fast_model = RemainderModel(model, (slow_model,))
 
     dg = DGModel(
         model,
@@ -173,16 +170,17 @@ function run(
         CentralNumericalFluxSecondOrder(),
         CentralNumericalFluxGradient(),
     )
-    fast_dg = remainder_DGModel(
-        fast_model,
+    slow_dg = DGModel(
+        slow_model,
         grid,
         RusanovNumericalFlux(),
         CentralNumericalFluxSecondOrder(),
         CentralNumericalFluxGradient();
         state_auxiliary = dg.state_auxiliary,
     )
-    slow_dg = DGModel(
-        slow_model,
+    fast_dg = remainder_DGModel(
+        dg,
+        (slow_dg,),
         grid,
         RusanovNumericalFlux(),
         CentralNumericalFluxSecondOrder(),

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -2,7 +2,7 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods: DGModel, init_ode_state
+using ClimateMachine.DGMethods: DGModel, init_ode_state, RemainderModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -19,7 +19,6 @@ using ClimateMachine.Thermodynamics:
 using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
-    RemainderModel,
     NoReferenceState,
     ReferenceState,
     DryModel,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -179,13 +179,7 @@ function run(
         CentralNumericalFluxGradient();
         state_auxiliary = dg.state_auxiliary,
     )
-    slow_dg = remainder_DGModel(
-        dg,
-        (fast_dg,),
-        RusanovNumericalFlux(),
-        CentralNumericalFluxSecondOrder(),
-        CentralNumericalFluxGradient(),
-    )
+    slow_dg = remainder_DGModel(dg, (fast_dg,))
 
     timeend = FT(2 * setup.domain_halflength / setup.translation_speed)
     # determine the slow time step

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -2,8 +2,7 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods:
-    DGModel, init_ode_state, RemainderModel, remainder_DGModel
+using ClimateMachine.DGMethods: DGModel, init_ode_state, remainder_DGModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -164,7 +163,6 @@ function run(
     # The linear model has the fast time scales
     fast_model = AtmosAcousticLinearModel(model)
     # The nonlinear model has the slow time scales
-    slow_model = RemainderModel(model, (fast_model,))
 
     dg = DGModel(
         model,
@@ -182,12 +180,11 @@ function run(
         state_auxiliary = dg.state_auxiliary,
     )
     slow_dg = remainder_DGModel(
-        slow_model,
-        grid,
+        dg,
+        (fast_dg,),
         RusanovNumericalFlux(),
         CentralNumericalFluxSecondOrder(),
-        CentralNumericalFluxGradient();
-        state_auxiliary = dg.state_auxiliary,
+        CentralNumericalFluxGradient(),
     )
 
     timeend = FT(2 * setup.domain_halflength / setup.translation_speed)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -2,7 +2,7 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods: DGModel, init_ode_state
+using ClimateMachine.DGMethods: DGModel, init_ode_state, RemainderModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -19,7 +19,6 @@ using ClimateMachine.Thermodynamics:
 using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
-    RemainderModel,
     NoReferenceState,
     ReferenceState,
     DryModel,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -2,7 +2,8 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies: BrickTopology
 using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.DGMethods: DGModel, init_ode_state, RemainderModel
+using ClimateMachine.DGMethods:
+    DGModel, init_ode_state, RemainderModel, remainder_DGModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -180,7 +181,7 @@ function run(
         CentralNumericalFluxGradient();
         state_auxiliary = dg.state_auxiliary,
     )
-    slow_dg = DGModel(
+    slow_dg = remainder_DGModel(
         slow_model,
         grid,
         RusanovNumericalFlux(),

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -202,7 +202,14 @@ source!(m::AdvectionDiffusion, _...) = nothing
 
 Wavespeed with respect to vector `nM`
 """
-function wavespeed(m::AdvectionDiffusion, nM, state::Vars, aux::Vars, t::Real)
+function wavespeed(
+    m::AdvectionDiffusion,
+    nM,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
     u = aux.u
     abs(dot(nM, u))
 end

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -107,6 +107,7 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     ρ = state.ρ
     u = aux.u
@@ -389,6 +390,7 @@ function numerical_flux_first_order!(
     state⁺::Vars{S},
     aux⁺::Vars{A},
     t,
+    direction,
 ) where {S, A}
     un⁻ = dot(n, aux⁻.u)
     un⁺ = dot(n, aux⁺.u)

--- a/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
@@ -47,13 +47,7 @@ vars_state_gradient_flux(::HyperDiffusion, FT) = @vars()
 # The hyperdiffusion DG auxiliary variable: D ∇ Δρ
 vars_hyperdiffusive(::HyperDiffusion, FT) = @vars(σ::SVector{3, FT})
 
-function flux_first_order!(
-    m::HyperDiffusion,
-    flux::Grad,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-) end
+function flux_first_order!(m::HyperDiffusion, _...) end
 
 """
     flux_second_order!(m::HyperDiffusion, flux::Grad, state::Vars,

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
@@ -138,7 +138,7 @@ function source!(
     source.ρe = SE_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
 end
 
-function wavespeed(::MMSModel, nM, state::Vars, aux::Vars, t::Real)
+function wavespeed(::MMSModel, nM, state::Vars, aux::Vars, t::Real, direction)
     T = eltype(state)
     γ = T(γ_exact)
     ρinv = 1 / state.ρ

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
@@ -35,6 +35,7 @@ function flux_first_order!(
     state::Vars,
     auxstate::Vars,
     t::Real,
+    direction,
 )
     # preflux
     T = eltype(flux)

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -85,6 +85,7 @@ function flux_first_order!(
     state::Vars,
     auxstate::Vars,
     t::Real,
+    direction,
 )
     vel = auxstate.vel
     flux.q = state.q .* vel
@@ -113,6 +114,7 @@ function numerical_flux_first_order!(
     state⁺::Vars{S},
     aux⁺::Vars{A},
     t,
+    direction,
 ) where {S, A}
     un⁻ = dot(n, aux⁻.vel)
     un⁺ = dot(n, aux⁺.vel)
@@ -138,6 +140,7 @@ function numerical_boundary_flux_first_order!(
     aux⁺::Vars{A},
     bctype,
     t,
+    direction,
     state1⁻::Vars{S},
     aux1⁻::Vars{A},
 ) where {S, A}

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -8,7 +8,7 @@ using ClimateMachine.VTK
 using Logging
 using Printf
 using LinearAlgebra
-using ClimateMachine.DGMethods: DGModel, init_ode_state, courant, RemainderModel
+using ClimateMachine.DGMethods: DGModel, init_ode_state, courant
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -8,7 +8,7 @@ using ClimateMachine.VTK
 using Logging
 using Printf
 using LinearAlgebra
-using ClimateMachine.DGMethods: DGModel, init_ode_state, courant
+using ClimateMachine.DGMethods: DGModel, init_ode_state, courant, RemainderModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -19,7 +19,6 @@ using ClimateMachine.TemperatureProfiles: IsothermalProfile
 using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
-    RemainderModel,
     NoReferenceState,
     ReferenceState,
     DryModel,

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -1,0 +1,525 @@
+using ClimateMachine
+using ClimateMachine.ConfigTypes
+using ClimateMachine.Mesh.Topologies:
+    StackedCubedSphereTopology, cubedshellwarp, grid1d
+using ClimateMachine.Mesh.Grids:
+    DiscontinuousSpectralElementGrid,
+    VerticalDirection,
+    HorizontalDirection,
+    EveryDirection
+using ClimateMachine.DGMethods:
+    DGModel,
+    init_ode_state,
+    remainder_DGModel,
+    wavespeed,
+    number_state_conservative,
+    number_state_auxiliary,
+    vars_state_conservative,
+    vars_state_auxiliary
+using ClimateMachine.VariableTemplates: Vars
+using ClimateMachine.DGMethods.NumericalFluxes:
+    RusanovNumericalFlux,
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxSecondOrder
+using ClimateMachine.Atmos:
+    AtmosModel,
+    SphericalOrientation,
+    DryModel,
+    Vreman,
+    Gravity,
+    HydrostaticState,
+    IsothermalProfile,
+    AtmosAcousticGravityLinearModel
+
+using CLIMAParameters
+using CLIMAParameters.Planet: planet_radius
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using MPI
+using Test
+using StaticArrays
+using LinearAlgebra
+
+using Random
+
+"""
+    main()
+
+Run this test problem
+"""
+function main()
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 5
+    numelem_horz = 10
+    numelem_vert = 5
+
+    @testset "remainder model" begin
+        for FT in (Float64,)# Float32)
+            result = run(
+                mpicomm,
+                polynomialorder,
+                numelem_horz,
+                numelem_vert,
+                ArrayType,
+                FT,
+            )
+        end
+    end
+end
+
+function run(
+    mpicomm,
+    polynomialorder,
+    numelem_horz,
+    numelem_vert,
+    ArrayType,
+    FT,
+)
+
+    # Structure to pass around to setup the simulation
+    setup = RemainderTestSetup{FT}()
+
+    # Create the cubed sphere mesh
+    _planet_radius::FT = planet_radius(param_set)
+    vert_range = grid1d(
+        _planet_radius,
+        FT(_planet_radius + setup.domain_height),
+        nelem = numelem_vert,
+    )
+    topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)
+
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = polynomialorder,
+        meshwarp = cubedshellwarp,
+    )
+    T_profile = IsothermalProfile(param_set, setup.T_ref)
+
+    # This is the base model which defines all the data (all other DGModels
+    # for substepping components will piggy-back off of this models data)
+    fullmodel = AtmosModel{FT}(
+        AtmosLESConfigType,
+        param_set;
+        orientation = SphericalOrientation(),
+        ref_state = HydrostaticState(T_profile),
+        turbulence = Vreman(FT(0.23)),
+        moisture = DryModel(),
+        source = Gravity(),
+        init_state_conservative = setup,
+    )
+    dg = DGModel(
+        fullmodel,
+        grid,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+    Random.seed!(1235)
+    Q = init_ode_state(dg, FT(0); init_on_cpu = true)
+
+    acousticmodel = AtmosAcousticGravityLinearModel(fullmodel)
+
+    acoustic_dg = DGModel(
+        acousticmodel,
+        grid,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient();
+        direction = EveryDirection(),
+        state_auxiliary = dg.state_auxiliary,
+    )
+    vacoustic_dg = DGModel(
+        acousticmodel,
+        grid,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient();
+        direction = VerticalDirection(),
+        state_auxiliary = dg.state_auxiliary,
+    )
+    hacoustic_dg = DGModel(
+        acousticmodel,
+        grid,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient();
+        direction = HorizontalDirection(),
+        state_auxiliary = dg.state_auxiliary,
+    )
+
+    # Create some random data to check the wavespeed function with
+    nM = rand(3)
+    nM /= norm(nM)
+    state_conservative = Vars{vars_state_conservative(dg.balance_law, FT)}(rand(
+        FT,
+        number_state_conservative(dg.balance_law, FT),
+    ))
+    state_auxiliary = Vars{vars_state_auxiliary(dg.balance_law, FT)}(rand(
+        FT,
+        number_state_auxiliary(dg.balance_law, FT),
+    ))
+    full_wavespeed = wavespeed(
+        dg.balance_law,
+        nM,
+        state_conservative,
+        state_auxiliary,
+        FT(0),
+        (EveryDirection(),),
+    )
+    acoustic_wavespeed = wavespeed(
+        acoustic_dg.balance_law,
+        nM,
+        state_conservative,
+        state_auxiliary,
+        FT(0),
+        (EveryDirection(),),
+    )
+
+    # Evaluate the full tendency
+    full_tendency = similar(Q)
+    dg(full_tendency, Q, nothing, 0; increment = false)
+
+    # Evaluate various splittings
+    split_tendency = similar(Q)
+
+    # Check pulling acoustic model out
+    @testset "full acoustic" begin
+        rem_dg = remainder_DGModel(
+            dg,
+            (acoustic_dg,);
+            numerical_flux_first_order = (
+                dg.numerical_flux_first_order,
+                (acoustic_dg.numerical_flux_first_order,),
+            ),
+        )
+        rem_dg(split_tendency, Q, nothing, 0; increment = false)
+        acoustic_dg(split_tendency, Q, nothing, 0; increment = true)
+        A = Array(full_tendency.data)
+        B = Array(split_tendency.data)
+        # Test that we have a fully discrete splitting
+        @test all(isapprox.(
+            A,
+            B,
+            rtol = sqrt(eps(FT)),
+            atol = 10 * sqrt(eps(FT)),
+        ))
+
+        # Test that wavespeeds are split by direction
+        every_wavespeed = full_wavespeed - acoustic_wavespeed
+        horz_wavespeed = -zero(FT)
+        vert_wavespeed = -zero(FT)
+        @test all(
+            every_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(),),
+            ),
+        )
+        @test all(
+            horz_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (HorizontalDirection(),),
+            ),
+        )
+        @test all(
+            vert_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (VerticalDirection(),),
+            ),
+        )
+        @test all(
+            every_wavespeed .+ horz_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(), HorizontalDirection()),
+            ),
+        )
+        @test all(
+            every_wavespeed .+ vert_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(), VerticalDirection()),
+            ),
+        )
+    end
+
+    # Check pulling acoustic model but as two pieces
+    @testset "horizontal and vertical acoustic" begin
+        rem_dg = remainder_DGModel(
+            dg,
+            (hacoustic_dg, vacoustic_dg);
+            numerical_flux_first_order = (
+                dg.numerical_flux_first_order,
+                (
+                    hacoustic_dg.numerical_flux_first_order,
+                    vacoustic_dg.numerical_flux_first_order,
+                ),
+            ),
+        )
+        rem_dg(split_tendency, Q, nothing, 0; increment = false)
+        vacoustic_dg(split_tendency, Q, nothing, 0; increment = true)
+        hacoustic_dg(split_tendency, Q, nothing, 0; increment = true)
+        A = Array(full_tendency.data)
+        B = Array(split_tendency.data)
+        # Test that we have a fully discrete splitting
+        @test all(isapprox.(
+            A,
+            B,
+            rtol = sqrt(eps(FT)),
+            atol = 10 * sqrt(eps(FT)),
+        ))
+
+        # Test that wavespeeds are split by direction
+        every_wavespeed = full_wavespeed
+        horz_wavespeed = -acoustic_wavespeed
+        vert_wavespeed = -acoustic_wavespeed
+        @test all(
+            every_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(),),
+            ),
+        )
+        @test all(
+            horz_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (HorizontalDirection(),),
+            ),
+        )
+        @test all(
+            vert_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (VerticalDirection(),),
+            ),
+        )
+        @test all(
+            every_wavespeed .+ horz_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(), HorizontalDirection()),
+            ),
+        )
+        @test all(
+            every_wavespeed .+ vert_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(), VerticalDirection()),
+            ),
+        )
+    end
+
+    # Check pulling horizontal acoustic model
+    @testset "horizontal acoustic" begin
+        rem_dg = remainder_DGModel(
+            dg,
+            (hacoustic_dg,);
+            numerical_flux_first_order = (
+                dg.numerical_flux_first_order,
+                (hacoustic_dg.numerical_flux_first_order,),
+            ),
+        )
+        rem_dg(split_tendency, Q, nothing, 0; increment = false)
+        hacoustic_dg(split_tendency, Q, nothing, 0; increment = true)
+        A = Array(full_tendency.data)
+        B = Array(split_tendency.data)
+        # Test that we have a fully discrete splitting
+        @test all(isapprox.(
+            A,
+            B,
+            rtol = sqrt(eps(FT)),
+            atol = 10 * sqrt(eps(FT)),
+        ))
+
+        # Test that wavespeeds are split by direction
+        every_wavespeed = full_wavespeed
+        horz_wavespeed = -acoustic_wavespeed
+        vert_wavespeed = -zero(eltype(FT))
+        @test all(
+            every_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(),),
+            ),
+        )
+        @test all(
+            horz_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (HorizontalDirection(),),
+            ),
+        )
+        @test all(
+            vert_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (VerticalDirection(),),
+            ),
+        )
+        @test all(
+            every_wavespeed .+ horz_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(), HorizontalDirection()),
+            ),
+        )
+        @test all(
+            every_wavespeed .+ vert_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(), VerticalDirection()),
+            ),
+        )
+    end
+
+    # Check pulling vertical acoustic model
+    @testset "vertical acoustic" begin
+        rem_dg = remainder_DGModel(
+            dg,
+            (vacoustic_dg,);
+            numerical_flux_first_order = (
+                dg.numerical_flux_first_order,
+                (vacoustic_dg.numerical_flux_first_order,),
+            ),
+        )
+        rem_dg(split_tendency, Q, nothing, 0; increment = false)
+        vacoustic_dg(split_tendency, Q, nothing, 0; increment = true)
+        A = Array(full_tendency.data)
+        B = Array(split_tendency.data)
+        # Test that we have a fully discrete splitting
+        @test all(isapprox.(
+            A,
+            B,
+            rtol = sqrt(eps(FT)),
+            atol = 10 * sqrt(eps(FT)),
+        ))
+
+        # Test that wavespeeds are split by direction
+        every_wavespeed = full_wavespeed
+        horz_wavespeed = -zero(eltype(FT))
+        vert_wavespeed = -acoustic_wavespeed
+        @test all(
+            every_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(),),
+            ),
+        )
+        @test all(
+            horz_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (HorizontalDirection(),),
+            ),
+        )
+        @test all(
+            vert_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (VerticalDirection(),),
+            ),
+        )
+        @test all(
+            every_wavespeed .+ horz_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(), HorizontalDirection()),
+            ),
+        )
+        @test all(
+            every_wavespeed .+ vert_wavespeed .≈ wavespeed(
+                rem_dg.balance_law,
+                nM,
+                state_conservative,
+                state_auxiliary,
+                FT(0),
+                (EveryDirection(), VerticalDirection()),
+            ),
+        )
+    end
+end
+
+Base.@kwdef struct RemainderTestSetup{FT}
+    domain_height::FT = 10e3
+    T_ref::FT = 300
+end
+
+function (setup::RemainderTestSetup)(bl, state, aux, coords, t)
+    FT = eltype(state)
+
+    # Vary around the reference state by 10% and a random velocity field
+    state.ρ = (4 + rand(FT)) / 5 + aux.ref_state.ρ
+    state.ρu = 2 * (@SVector rand(FT, 3)) .- 1
+    state.ρe = (4 + rand(FT)) / 5 + aux.ref_state.ρe
+
+    nothing
+end
+
+main()

--- a/test/Numerics/SystemSolvers/poisson.jl
+++ b/test/Numerics/SystemSolvers/poisson.jl
@@ -48,15 +48,7 @@ vars_state_gradient_flux(::PoissonModel, T) = @vars(∇ϕ::SVector{3, T})
 
 boundary_state!(nf, bl::PoissonModel, _...) = nothing
 
-function flux_first_order!(
-    ::PoissonModel,
-    flux::Grad,
-    state::Vars,
-    state_auxiliary::Vars,
-    t::Real,
-)
-    nothing
-end
+function flux_first_order!(::PoissonModel, _...) end
 
 function flux_second_order!(
     ::PoissonModel,

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -304,6 +304,7 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    _...,
 )
     flux.ρ = state.ρu
 

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -236,13 +236,7 @@ end;
 
 # We have no sources, nor non-diffusive fluxes.
 function source!(m::HeatModel, _...) end;
-function flux_first_order!(
-    m::HeatModel,
-    flux::Grad,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-) end;
+function flux_first_order!(m::HeatModel, _...) end;
 
 # Compute diffusive flux (``F(α, ρcT, t) = -α ∇ρcT`` in the original PDE).
 # Note that:


### PR DESCRIPTION
This PR reworks the remainder model to achieve three things:

- Move Remainder Model Upstream DG Model Level
- Make the Remainder Model a true Discrete Splitting
- Allow Remainder Model to be Involve Models with Different Directions

### Move Remainder Model Upstream DG Model Level

The Remainder model previously existed in the atmos model even though it was not atmos specific. By moving it upstream it will be usable across CLIMA.

### Make the Remainder Model a true Discrete Splitting

Previously the remainder model defined a wave speed in an ad hoc way since it tried to construct a splitting at the physics level, here we seek to create a true discrete splitting so that
```
remainder tendency + subcomponent tendency == main tendency
```
To do this the numerical flux of each subcomponent is needed (since they might all be different). This is enabled by using a tuple of numerical fluxes. 

This was simplified by introducing an outer `DGModel` constructor for `remainder_DGModel`, which allows the user to compose `DGModel`s to construct a remainder based `DGModel` (as opposed to composing `BalanceLaws`)

### Allow Remainder Model to be Involve Models with Different Directions

Previously the remainder model only support the main model and subcomponents being active in the same direction. This extends things so that if the main model is `EveryDirection` the subcomponents can be either `EveryDirection`, `HorizontalDirection`, or `VerticalDirection`. If the main model is either `HorizontalDirection` or `VerticalDirection`, then the subcomponents must match this.

### Remaining limitations

- The subcomponent models must involve only first order terms (no diffusion or hyper-diffusion)
- The subcomponent models must be defined for the full set of states as the main component model.