### PR TITLE
Add TicToc timing for diagnostics

### DIFF
--- a/src/InputOutput/VTK/VTK.jl
+++ b/src/InputOutput/VTK/VTK.jl
@@ -6,8 +6,4 @@ include("writemesh.jl")
 include("writevtk.jl")
 include("writepvtu.jl")
 
-function __init__()
-    tictoc()
-end
-
 end

--- a/src/InputOutput/VTK/writepvtu.jl
+++ b/src/InputOutput/VTK/writepvtu.jl
@@ -7,44 +7,52 @@ Write a pvtu file with the prefix 'pvtuprefix' for the collection of vtk files
 given by 'vtkprefixes' using names  of fields 'fieldnames'
 """
 function writepvtu(pvtuprefix, vtkprefixes, fieldnames)
-  @tic writepvtu
-  open(pvtuprefix*".pvtu", "w") do pvtufile
-    write(pvtufile,
-          """
-          <?xml version="1.0"?>
-          <VTKFile type="PUnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
-            <PUnstructuredGrid GhostLevel="0">
-              <PPoints>
-                <PDataArray type="Float64" Name="Position" NumberOfComponents="3" format="binary"/>
-              </PPoints>
-              <PPointData>
-          """)
-
-    for name in fieldnames
-      write(pvtufile,
+    open(pvtuprefix * ".pvtu", "w") do pvtufile
+        write(
+            pvtufile,
             """
-                  <PDataArray type="Float64" Name="$name" format="binary"/>
-            """)
+            <?xml version="1.0"?>
+            <VTKFile type="PUnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+              <PUnstructuredGrid GhostLevel="0">
+                <PPoints>
+                  <PDataArray type="Float64" Name="Position" NumberOfComponents="3" format="binary"/>
+                </PPoints>
+                <PPointData>
+            """,
+        )
+
+        for name in fieldnames
+            write(
+                pvtufile,
+                """
+                      <PDataArray type="Float64" Name="$name" format="binary"/>
+                """,
+            )
+        end
+
+        write(
+            pvtufile,
+            """
+                </PPointData>
+            """,
+        )
+
+        for name in vtkprefixes
+            write(
+                pvtufile,
+                """
+                    <Piece Source="$name.vtu"/>
+                """,
+            )
+        end
+
+        write(
+            pvtufile,
+            """
+              </PUnstructuredGrid>
+            </VTKFile>
+            """,
+        )
     end
-
-    write(pvtufile,
-          """
-              </PPointData>
-          """)
-
-    for name in vtkprefixes
-      write(pvtufile,
-          """
-              <Piece Source="$name.vtu"/>
-          """)
-    end
-
-    write(pvtufile,
-        """
-          </PUnstructuredGrid>
-        </VTKFile>
-        """)
-  end
-  @toc writepvtu
-  return nothing
+    return nothing
 end

--- a/src/InputOutput/VTK/writevtk.jl
+++ b/src/InputOutput/VTK/writevtk.jl
@@ -15,12 +15,10 @@ number of states in `Q`, i.e., `k = size(Q,2)`.
 
 """
 function writevtk(prefix, Q::MPIStateArray, dg::DGModel, fieldnames = nothing)
-    @tic writevtk_Q
     vgeo = dg.grid.vgeo
     host_array = Array ∈ typeof(Q).parameters
     (h_vgeo, h_Q) = host_array ? (vgeo, Q.data) : (Array(vgeo), Array(Q))
     writevtk_helper(prefix, h_vgeo, h_Q, dg.grid, fieldnames)
-    @toc writevtk_Q
     return nothing
 end
 
@@ -50,7 +48,6 @@ function writevtk(
     state_auxiliary,
     auxfieldnames,
 )
-    @tic writevtk_Q_aux
     vgeo = dg.grid.vgeo
     host_array = Array ∈ typeof(Q).parameters
     (h_vgeo, h_Q, h_aux) = host_array ? (vgeo, Q.data, state_auxiliary.data) :
@@ -64,7 +61,6 @@ function writevtk(
         h_aux,
         auxfieldnames,
     )
-    @toc writevtk_Q_aux
     return nothing
 end
 

--- a/src/Utilities/Callbacks/Callbacks.jl
+++ b/src/Utilities/Callbacks/Callbacks.jl
@@ -18,6 +18,7 @@ using ..Diagnostics
 using ..GenericCallbacks
 using ..MPIStateArrays
 using ..ODESolvers
+using ..TicToc
 using ..VariableTemplates
 using ..VTK
 using ..Mesh.Grids: HorizontalDirection, VerticalDirection
@@ -90,6 +91,7 @@ function diagnostics(
                 CB_constructor(diagnostics_opt, solver_config, dgngrp.interval)
             cb_constr === nothing && continue
             fn = cb_constr() do (init = false)
+                @tic diagnostics
                 currtime = ODESolvers.gettime(solver_config.solver)
                 @info @sprintf(
                     """
@@ -100,6 +102,7 @@ Diagnostics: %s
                     string(currtime),
                 )
                 dgngrp(currtime, init = init)
+                @toc diagnostics
                 nothing
             end
             dgncbs = (dgncbs..., fn)
@@ -128,6 +131,7 @@ function vtk(vtk_opt, solver_config, output_dir)
         FT = eltype(Q)
 
         cb_vtk = cb_constr() do (init = false)
+            @tic vtk
             vprefix = @sprintf(
                 "%s_mpirank%04d_num%04d",
                 solver_config.name,
@@ -160,6 +164,7 @@ function vtk(vtk_opt, solver_config, output_dir)
             end
 
             vtknum[] += 1
+            @toc vtk
             nothing
         end
         return cb_vtk
@@ -407,6 +412,10 @@ function CB_constructor(interval::String, solver_config, default = nothing)
         )
         return nothing
     end
+end
+
+function __init__()
+    tictoc()
 end
 
 end # module


### PR DESCRIPTION
# Description

And rework how VTK timing is done.

`export TICTOC_PRINT_RESULTS=1` before running CLIMA to see timing information.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
