### PR TITLE
fixing broken docs link in README and updating installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Climate Machine is a new Earth system model that leverages recent advances i
 | [![latest][docs-latest-img]][docs-latest-url] | [![azure][azure-img]][azure-url] [![codecov][codecov-img]][codecov-url] |
 
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
-[docs-latest-url]: https://climate-machine.github.io/CLIMA/latest/
+[docs-latest-url]: https://climate-machine.github.io/ClimateMachine.jl/latest/
 
 [azure-img]: https://dev.azure.com/climate-machine/CLIMA/_apis/build/status/climate-machine.CLIMA?branchName=master
 [azure-url]: https://dev.azure.com/climate-machine/CLIMA/_build/latest?definitionId=5&branchName=master

--- a/docs/src/Installation.md
+++ b/docs/src/Installation.md
@@ -2,13 +2,14 @@
 
 Installation of CLIMA can be divided into 3 parts:
 
-1. Installation of Julia (1.3.1)
+1. Installation of Julia (1.4.1)
 2. Installation of MPI
 3. Installation of CLIMA
 
-## Installation of Julia (1.3.1)
+## Installation of Julia (1.4.1)
 
-The Climate Machine (CLIMA) uses the Julia programming language; however, at the current time, certain dependencies are only available on Julia 1.3, so please download the download the appropriate binary for your platform from [Julia's old releases](https://julialang.org/downloads/oldreleases/#v131_dec_30_2019).
+The Climate Machine (CLIMA) uses the Julia programming language and has been tested for the Julia version 1.4.1, which can be downloaded via your package manager or from the [Julia website](https://julialang.org/downloads/#current_stable_release).
+CLIMA has also been tested for Julia version 1.3, which can be found in [Julia's old releases](https://julialang.org/downloads/oldreleases/).
 
 ## Installation of MPI
 


### PR DESCRIPTION
# Description
The docs link was broken in the readme and there is no longer any reason to limit people to 1.3.1 anymore. This PR fixes these issues.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
