### PR TITLE
Rename climate-machine-> CliMA

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ A clear and concise description of the code with usage.
 I have
 
 - [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
-- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
+- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
 - [ ] Updated the documentation to reflect changes from this PR.
 
 <!--- Please leave the following section --->
@@ -16,5 +16,5 @@ I have
 
 - [ ] There are no open pull requests for this already
 - [ ] CLIMA developers with relevant expertise have been assigned to review this submission
-- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
+- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
 - [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)

--- a/.github/pull_request_template.md.bak
+++ b/.github/pull_request_template.md.bak
@@ -4,7 +4,7 @@ Thanks for submitting code to CLIMA, the Climate Machine.
 Before continuing, please be sure you have:
 
 1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
-2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
+2. Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html)
 3. Identified key contributors to review this submission
 -->
 
@@ -18,5 +18,5 @@ A clear and concise description of the code with usage.
 
 - [ ] There are no open PR's for this already
 - [ ] CLIMA developers with relevant expertise have been assigned to review this submission
-- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
+- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
 - [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ The Climate Machine is a new Earth system model that leverages recent advances i
 | **Code Coverage**    | [![codecov][codecov-img]][codecov-url]        |
 | **Bors**             | [![Bors enabled][bors-img]][bors-url]         |
 
-[docs-bld-img]: https://github.com/climate-machine/ClimateMachine.jl/workflows/Documentation/badge.svg
-[docs-bld-url]: https://github.com/climate-machine/ClimateMachine.jl/actions?query=workflow%3ADocumentation
+[docs-bld-img]: https://github.com/CliMA/ClimateMachine.jl/workflows/Documentation/badge.svg
+[docs-bld-url]: https://github.com/CliMA/ClimateMachine.jl/actions?query=workflow%3ADocumentation
 
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
-[docs-latest-url]: https://climate-machine.github.io/ClimateMachine.jl/latest/
+[docs-latest-url]: https://CliMA.github.io/ClimateMachine.jl/latest/
 
-[azure-img]: https://dev.azure.com/climate-machine/ClimateMachine.jl/_apis/build/status/climate-machine.ClimateMachine.jl?branchName=master
-[azure-url]: https://dev.azure.com/climate-machine/ClimateMachine.jl/_build/latest?definitionId=5&branchName=master
+[azure-img]: https://dev.azure.com/CliMA/ClimateMachine.jl/_apis/build/status/CliMA.ClimateMachine.jl?branchName=master
+[azure-url]: https://dev.azure.com/CliMA/ClimateMachine.jl/_build/latest?definitionId=5&branchName=master
 
-[codecov-img]: https://codecov.io/gh/climate-machine/ClimateMachine.jl/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/climate-machine/ClimateMachine.jl
+[codecov-img]: https://codecov.io/gh/CliMA/ClimateMachine.jl/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/CliMA/ClimateMachine.jl
 
 [bors-img]: https://bors.tech/images/badge_small.svg
 [bors-url]: https://app.bors.tech/repositories/11521
 
-For installation instructions and explanations on how to use the Climate Machine, please look at the [Documentation](https://climate-machine.github.io/ClimateMachine.jl/latest/Installation).
+For installation instructions and explanations on how to use the Climate Machine, please look at the [Documentation](https://CliMA.github.io/ClimateMachine.jl/latest/Installation).

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,7 +39,7 @@ format = Documenter.HTML(
     mathengine = mathengine,
     collapselevel = 1,
     # prettyurls = !("local" in ARGS),
-    # canonical = "https://climate-machine.github.io/CLIMA/stable/",
+    # canonical = "https://CliMA.github.io/CLIMA/stable/",
 )
 
 makedocs(
@@ -58,7 +58,7 @@ makedocs(
 include("clean_build_folder.jl")
 
 deploydocs(
-    repo = "github.com/climate-machine/CLIMA.git",
+    repo = "github.com/CliMA/CLIMA.git",
     target = "build",
     push_preview = true,
 )

--- a/docs/src/CodingConventions.md
+++ b/docs/src/CodingConventions.md
@@ -12,7 +12,7 @@ A list of recommended coding conventions.
 
  - Function names should be lowercase, with words separated by underscores as necessary to improve readability.
 
- - Variable names follow the format used in the [VariableList](https://climate-machine.github.io/CLIMA/latest/VariableList.html). In addition, follow CMIP conventions (http://clipc-services.ceda.ac.uk/dreq/) where possible and practicable.
+ - Variable names follow the format used in the [VariableList](https://CliMA.github.io/CLIMA/latest/VariableList.html). In addition, follow CMIP conventions (http://clipc-services.ceda.ac.uk/dreq/) where possible and practicable.
 
  - Make names consistent, distinctive, and meaningful.
 

--- a/docs/src/ExtendingCLIMA/Atmos/Model/risingbubble.md
+++ b/docs/src/ExtendingCLIMA/Atmos/Model/risingbubble.md
@@ -124,7 +124,7 @@ using CLIMA.MoistThermodynamics
 using CLIMA.VariableTemplates
 ```
 
-- Required so we may access planet parameters ([CLIMAParameters](https://climate-machine.github.io/CLIMAParameters.jl/latest/) specific to this problem include the gas constant, specific heats, mean-sea-level pressure, gravity and the Smagorinsky coefficient)
+- Required so we may access planet parameters ([CLIMAParameters](https://CliMA.github.io/CLIMAParameters.jl/latest/) specific to this problem include the gas constant, specific heats, mean-sea-level pressure, gravity and the Smagorinsky coefficient)
 
 ```@example risingbubble
 using CLIMAParameters
@@ -293,7 +293,7 @@ integers corresponding to the tracer index identifier)
 ```
 
 The model coefficient for the turbulence closure is defined via the [CLIMAParameters
-package](https://climate-machine.github.io/CLIMAParameters.jl/latest/)
+package](https://CliMA.github.io/CLIMAParameters.jl/latest/)
 A reference state for the linearisation step is also defined.
 
 ```@example risingbubble
@@ -306,7 +306,7 @@ The fun part! Here we assemble the `AtmosModel`.
 ```@example risingbubble
     #md # !!! note
     #md #     Docs on model subcomponent options can be found here:
-    #md #     - [`param_set`](https://climate-machine.github.io/CLIMAParameters.jl/latest/)
+    #md #     - [`param_set`](https://CliMA.github.io/CLIMAParameters.jl/latest/)
     #md #     - [`turbulence`](@ref Turbulence-Closures-docs)
     #md #     - [`hyperdiffusion`](@ref Hyperdiffusion-docs)
     #md #     - [`source`](@ref atmos-sources)
@@ -437,7 +437,7 @@ can also prescribe command line arguments (docs pending, `Driver.jl`) for simula
 For rapid turnaround, we recommend that you run this experiment on a GPU.
 
 ## [Output Visualisation](@id output-viz)
-See command line output arguments listed [here](https://github.com/climate-machine/CLIMA/wiki/CLIMA-command-line-arguments).
+See command line output arguments listed [here](https://github.com/CliMA/CLIMA/wiki/CLIMA-command-line-arguments).
 For VTK output,
 - [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit/)
 - [Paraview](https://wci.llnl.gov/simulation/computer-codes/visit/)

--- a/docs/src/ExtendingCLIMA/Contributing/CONTRIBUTING.md
+++ b/docs/src/ExtendingCLIMA/Contributing/CONTRIBUTING.md
@@ -16,12 +16,12 @@ We will try to guide you along the process here, but this is by no means an exha
 
 ## Forks and branches
 
-To start contributing, first create your own fork (version of CLIMA) [on GitHub](https://github.com/climate-machine/CLIMA) and check out your copy:
+To start contributing, first create your own fork (version of CLIMA) [on GitHub](https://github.com/CliMA/CLIMA) and check out your copy:
 
 ```
 $ git clone https://github.com/<username>/CLIMA.git
 $ cd CLIMA
-$ git remote add upstream https://github.com/climate-machine/CLIMA.git
+$ git remote add upstream https://github.com/CliMA/CLIMA.git
 ```
 
 This will create two places for you to keep code, one called `origin`, which is your own fork and another called `upstream`, which is CLIMA's main repository.
@@ -66,7 +66,7 @@ This will help us keep the commit history clean on the master branch of CLIMA.
 
 ## Formatting and style
 
-For the most part, we follow the [YASGuide](https://github.com/jrevels/YASGuide) for Julia formatting, with small exceptions covered in the [Coding Conventions](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) section of the documentation.
+For the most part, we follow the [YASGuide](https://github.com/jrevels/YASGuide) for Julia formatting, with small exceptions covered in the [Coding Conventions](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) section of the documentation.
 
 In addition to this, once you are happy with your PR, please apply [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) to all changed files in the repository.
 

--- a/docs/src/ExtendingCLIMA/Numerics/LinearSolvers/IterativeSolvers.md
+++ b/docs/src/ExtendingCLIMA/Numerics/LinearSolvers/IterativeSolvers.md
@@ -1,6 +1,6 @@
 # Contribution Guide for Abstract Iterative Solvers
 
-An abstract iterative solver is a **module** that needs **one struct**, **one constructor**, and **two functions** in order to interface with the rest of [CLIMA](https://github.com/climate-machine). In what follows we will describe in detail the function signatures, return values, and struct properties necessary to build with [CLIMA](https://github.com/climate-machine).
+An abstract iterative solver is a **module** that needs **one struct**, **one constructor**, and **two functions** in order to interface with the rest of [CLIMA](https://github.com/CliMA). In what follows we will describe in detail the function signatures, return values, and struct properties necessary to build with [CLIMA](https://github.com/CliMA).
 
 
 We have the following concrete implementations:

--- a/docs/src/ExtendingCLIMA/Numerics/ODESolvers/Timestepping.md
+++ b/docs/src/ExtendingCLIMA/Numerics/ODESolvers/Timestepping.md
@@ -1,7 +1,7 @@
 # Contribution Guide for Abstract Time-stepping Algorithms
 
 This guide gives a brief overview on how time-stepping methods are
-implemented in [CLIMA](https://github.com/climate-machine), and
+implemented in [CLIMA](https://github.com/CliMA), and
 how one might contribute a new time-stepping method.
 
 Currently, CLIMA supports a variety of time-stepping methods within

--- a/docs/src/Installation.md
+++ b/docs/src/Installation.md
@@ -46,10 +46,10 @@ If you suspect there may be a problem with the Julia MPI package, please [create
 
 ## Installation of CLIMA
 
-As of now, CLIMA is not registered as an official Julia package, so you will need to download [the source](https://github.com/climate-machine/CLIMA.git) with a command, such as:
+As of now, CLIMA is not registered as an official Julia package, so you will need to download [the source](https://github.com/CliMA/CLIMA.git) with a command, such as:
 
 ```
-git clone https://github.com/climate-machine/CLIMA.git
+git clone https://github.com/CliMA/CLIMA.git
 ```
 
 Once on your machine, you will need to run CLIMA with

--- a/experiments/AtmosLES/risingbubble.jl
+++ b/experiments/AtmosLES/risingbubble.jl
@@ -78,7 +78,7 @@ using CLIMA.Mesh.Filters
 using CLIMA.MoistThermodynamics
 # - Required so we may access our variable arrays by a sensible naming convention rather than by numerical array indices.
 using CLIMA.VariableTemplates
-# - Required so we may access planet parameters ([CLIMAParameters](https://climate-machine.github.io/CLIMAParameters.jl/latest/) specific to this problem include the gas constant, specific heats, mean-sea-level pressure, gravity and the Smagorinsky coefficient)
+# - Required so we may access planet parameters ([CLIMAParameters](https://CliMA.github.io/CLIMAParameters.jl/latest/) specific to this problem include the gas constant, specific heats, mean-sea-level pressure, gravity and the Smagorinsky coefficient)
 
 # In CLIMA we use `StaticArrays` for our variable arrays.
 using StaticArrays
@@ -212,7 +212,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
     δ_χ = SVector{ntracers, FT}(1, 2, 3, 4)
 
     # The model coefficient for the turbulence closure is defined via the [CLIMAParameters
-    # package](https://climate-machine.github.io/CLIMAParameters.jl/latest/)
+    # package](https://CliMA.github.io/CLIMAParameters.jl/latest/)
     # A reference state for the linearisation step is also defined.
     ref_state =
         HydrostaticState(DryAdiabaticProfile(typemin(FT), FT(300)), FT(0))
@@ -220,7 +220,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
     # The fun part! Here we assemble the `AtmosModel`.
     #md # !!! note
     #md #     Docs on model subcomponent options can be found here:
-    #md #     - [`param_set`](https://climate-machine.github.io/CLIMAParameters.jl/latest/)
+    #md #     - [`param_set`](https://CliMA.github.io/CLIMAParameters.jl/latest/)
     #md #     - [`turbulence`](@ref Turbulence-Closures-docs)
     #md #     - [`hyperdiffusion`](@ref Hyperdiffusion-docs)
     #md #     - [`source`](@ref atmos-sources)
@@ -324,7 +324,7 @@ end
 # For rapid turnaround, we recommend that you run this experiment on a GPU.
 
 # ## [Output Visualisation](@id output-viz)
-#md # See command line output arguments listed [here](https://github.com/climate-machine/CLIMA/wiki/CLIMA-command-line-arguments).
+#md # See command line output arguments listed [here](https://github.com/CliMA/CLIMA/wiki/CLIMA-command-line-arguments).
 #md # For VTK output,
 #md # - [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit/)
 #md # - [Paraview](https://wci.llnl.gov/simulation/computer-codes/visit/)

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -25,7 +25,7 @@ using CLIMA.Mesh.Filters
 using CLIMA.MoistThermodynamics
 using CLIMA.VariableTemplates
 
-# [CLIMA parameters](https://github.com/climate-machine/CLIMAParameters.jl) are needed to have access to Earth's physical parameters
+# [CLIMA parameters](https://github.com/CliMA/CLIMAParameters.jl) are needed to have access to Earth's physical parameters
 #
 using CLIMAParameters
 using CLIMAParameters.Planet: R_d, day, grav, cp_d, cv_d, planet_radius
@@ -250,7 +250,7 @@ end
 #
 # Choose frequency and resolution of output, and a diagnostics group (dgngrp)
 # which defines output variables. This needs to be defined
-# in [diagnostics](https://climate-machine.github.io/CLIMA/latest/generated/Diagnostics).
+# in [diagnostics](https://CliMA.github.io/CLIMA/latest/generated/Diagnostics).
 interval = "1000steps"
 _planet_radius = FT(planet_radius(param_set))
 info = driver_config.config_info


### PR DESCRIPTION
# Description

Change `climate-machine` to reflect the new organization name.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
