### PR TITLE
Add instructions for creating custom system image

### DIFF
--- a/.dev/systemimage/climate_machine_image.jl
+++ b/.dev/systemimage/climate_machine_image.jl
@@ -1,0 +1,33 @@
+#!/usr/bin/env julia
+#
+# Called with no arguments will create the system image
+#     ClimateMachine.so
+# in the `@__DIR__` directory.
+#
+# Called with a single argument the system image will be placed in the path
+# specified by the argument (relative to the callers path)
+sysimage_path =
+    isempty(ARGS) ? joinpath(@__DIR__, "ClimateMachine.so") : ARGS[1]
+
+using Pkg
+Pkg.add("PackageCompiler")
+using PackageCompiler
+Pkg.activate(joinpath(@__DIR__, "..", ".."))
+Pkg.instantiate()
+pkgs = Pkg.installed()
+delete!(pkgs, "Pkg")
+
+PackageCompiler.create_sysimage(
+    [Symbol(s) for s in keys(pkgs)];
+    sysimage_path = sysimage_path,
+    precompile_execution_file = joinpath(
+        @__DIR__,
+        "..",
+        "..",
+        "test",
+        "Numerics",
+        "DGmethods",
+        "Euler",
+        "isentropicvortex.jl",
+    ),
+)

--- a/.dev/systemimage/climate_machine_image.jl
+++ b/.dev/systemimage/climate_machine_image.jl
@@ -17,17 +17,22 @@ Pkg.instantiate()
 pkgs = Pkg.installed()
 delete!(pkgs, "Pkg")
 
-PackageCompiler.create_sysimage(
-    [Symbol(s) for s in keys(pkgs)];
-    sysimage_path = sysimage_path,
-    precompile_execution_file = joinpath(
-        @__DIR__,
-        "..",
-        "..",
-        "test",
-        "Numerics",
-        "DGmethods",
-        "Euler",
-        "isentropicvortex.jl",
-    ),
-)
+# "TF_BUILD" is check to see if we are running on Azure for CI
+if !haskey(ENV, "TF_BUILD")
+    PackageCompiler.create_sysimage(
+        [Symbol(s) for s in keys(pkgs)];
+        sysimage_path = sysimage_path,
+        precompile_execution_file = joinpath(
+            @__DIR__,
+            "..",
+            "..",
+            "test",
+            "Numerics",
+            "DGmethods",
+            "Euler",
+            "isentropicvortex.jl",
+        ),
+    )
+else
+    return true
+end

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ src/**/Manifest.toml
 *.jpg
 *.jpeg
 *.svg
+
+# Julia System Images
+*.so

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
       ./julia-$(JULIA_VERSION)/bin/julia -e 'using InteractiveUtils; versioninfo()'
       ./julia-$(JULIA_VERSION)/bin/julia --project=@. -e 'using Pkg; Pkg.instantiate()'
       ./julia-$(JULIA_VERSION)/bin/julia --project=@. -e 'using Pkg; Pkg.test()'
+      ./julia-$(JULIA_VERSION)/bin/julia -e 'using Test; @testset "system image" begin;@test include(".dev/systemimage/climate_machine_image.jl"); end;'
     displayName: 'Run the tests'
     continueOnError: true
 
@@ -58,6 +59,7 @@ jobs:
       ./julia-$(JULIA_VERSION)/bin/julia -e 'using InteractiveUtils; versioninfo()'
       ./julia-$(JULIA_VERSION)/bin/julia --project=@. -e 'using Pkg; Pkg.instantiate()'
       ./julia-$(JULIA_VERSION)/bin/julia --project=@. -e 'using Pkg; Pkg.test()'
+      ./julia-$(JULIA_VERSION)/bin/julia -e 'using Test; @testset "system image" begin;@test include(".dev/systemimage/climate_machine_image.jl"); end;'
     env:
       MPICH_INTERFACE_HOSTNAME: localhost
     displayName: 'Run the tests'
@@ -88,4 +90,5 @@ jobs:
       C:\julia-$(JULIA_VERSION)\bin\julia.exe -e 'using InteractiveUtils; versioninfo()'
       C:\julia-$(JULIA_VERSION)\bin\julia.exe --project=@. -e 'using Pkg; Pkg.instantiate()'
       C:\julia-$(JULIA_VERSION)\bin\julia.exe --project=@. -e 'using Pkg; Pkg.test()'
+      C:\julia-$(JULIA_VERSION)\bin\julia.exe -e 'using Test; @testset "system image" begin;@test include(".dev/systemimage/climate_machine_image.jl"); end;'
     displayName: 'Run the tests'

--- a/docs/src/HowToGuides/Contributing/CONTRIBUTING.md
+++ b/docs/src/HowToGuides/Contributing/CONTRIBUTING.md
@@ -107,7 +107,12 @@ See `man 5 githooks` for more information about git hooks.
 
 ### Precompiling the JuliaFormatter
 
-To speed up the formatter and the githook, a custom system image can be built with the [`PackageCompiler`]. That said, the following [drawback] from the `PackageCompiler` repository should be noted:
+To speed up the formatter and the githook, a custom system image can be built
+with the [`PackageCompiler`](https://github.com/JuliaLang/PackageCompiler.jl).
+That said, the following
+[drawback](https://julialang.github.io/PackageCompiler.jl/dev/sysimages/#Drawbacks-to-custom-sysimages-1)
+from the `PackageCompiler` repository should
+be noted:
 
 > It should be clearly stated that there are some drawbacks to using a custom
 > sysimage, thereby sidestepping the standard Julia package precompilation
@@ -158,6 +163,3 @@ If you are a collaborator and want to test and merge in the same step, use `bors
 
 Most PRs should include tests and these will be reviewed as part of the code review process on GitHub.
 Add your tests in the `test/` directory.
-
-[`PackageCompiler`]: https://github.com/JuliaLang/PackageCompiler.jl
-[drawback]: https://julialang.github.io/PackageCompiler.jl/dev/sysimages/#Drawbacks-to-custom-sysimages-1

--- a/docs/src/HowToGuides/Contributing/CONTRIBUTING.md
+++ b/docs/src/HowToGuides/Contributing/CONTRIBUTING.md
@@ -1,22 +1,30 @@
 # Contributing
 
-ClimateMachine encourages Pull Requests (PRs) and contributions.
-The easiest way to contribute is by running code and letting us know what's wrong by creating issues.
-In the case that you can specifically pinpoint the issue within the code, please consider submitting a PR with these changes.
+ClimateMachine encourages Pull Requests (PRs) and contributions.  The easiest
+way to contribute is by running code and letting us know what's wrong by
+creating issues.  In the case that you can specifically pinpoint the issue
+within the code, please consider submitting a PR with these changes.
 
-To contribute, we assume that you already have a basic understanding of git and version control as all tools are accessible on Github; however, we will discuss the general workflow for submitting code for review to ClimateMachine.
+To contribute, we assume that you already have a basic understanding of git and
+version control as all tools are accessible on Github; however, we will discuss
+the general workflow for submitting code for review to ClimateMachine.
 
-If you are unfamiliar with git and version control, please consider reading the following guides:
+If you are unfamiliar with git and version control, please consider reading the
+following guides:
 
-- [Atlassian (bitbucket) git tutorials. A set of tips and tricks for getting started with git](https://www.atlassian.com/git/tutorials)
-- [GitHub's git tutorials. A set of resources from GitHub to learn git](https://try.github.io/)
+- [Atlassian (bitbucket) git tutorials. A set of tips and tricks for getting
+  started with git](https://www.atlassian.com/git/tutorials)
+- [GitHub's git tutorials. A set of resources from GitHub to learn
+  git](https://try.github.io/)
 
-There are a bunch of other guides available as well.
-We will try to guide you along the process here, but this is by no means an exhaustive set of everything you will need to know when using git and version control.
+There are a bunch of other guides available as well.  We will try to guide you
+along the process here, but this is by no means an exhaustive set of everything
+you will need to know when using git and version control.
 
 ## Forks and branches
 
-To start contributing, first create your own fork (version of ClimateMachine) [on GitHub](https://github.com/CliMA/ClimateMachine.jl) and check out your copy:
+To start contributing, first create your own fork (version of ClimateMachine)
+[on GitHub](https://github.com/CliMA/ClimateMachine.jl) and check out your copy:
 
 ```
 $ git clone https://github.com/<username>/ClimateMachine.jl.git
@@ -24,14 +32,17 @@ $ cd ClimateMachine.jl
 $ git remote add upstream https://github.com/CliMA/ClimateMachine.jl.git
 ```
 
-This will create two places for you to keep code, one called `origin`, which is your own fork and another called `upstream`, which is ClimateMachine's main repository.
+This will create two places for you to keep code, one called `origin`, which is
+your own fork and another called `upstream`, which is ClimateMachine's main
+repository.
 
 From there, it is important to create a *feature branch* for your project:
 
 ```
 $ git checkout -b <branchname>
 ```
-Creating a feature branch allows you to more easily reconcile your code with the master branch on ClimateMachine.
+Creating a feature branch allows you to more easily reconcile your code with the
+master branch on ClimateMachine.
 
 ### Basic git interactions
 
@@ -43,36 +54,52 @@ $ git config --global user.email "j.climate.developer@eg.com"
 ```
 
 From there, we need to begin saving different versions of code.
-This is done by creating `commits`, which are save states for all code within the git repository.
+This is done by creating `commits`, which are save states for all code within
+the git repository.
 The basic workflow for creating changes to ClimateMachine is the following:
 
-1. `git status` will show you any changes in your current code from the last commit
+1. `git status` will show you any changes in your current code from the last
+   commit
 2. `git add <FILE>` will add any files you want to commit into a staging area
 3. `git commit` will store any staged files into a commit.
-4. `git push origin <branchname>` will then push all the changes to `origin`, which is a nickname for your fork on GitHub.
-5. When you are happy with all the code on your branch, go to GitHub and click the button to create a pull request with all the changes against ClimateMachine's master branch.
+4. `git push origin <branchname>` will then push all the changes to `origin`,
+   which is a nickname for your fork on GitHub.
+5. When you are happy with all the code on your branch, go to GitHub and click
+   the button to create a pull request with all the changes against
+   ClimateMachine's master branch.
 
 ### Squash and Rebase
 
-Before merging with ClimateMachine, use `git rebase` (not `git merge`) to sync your work  with the current master.
+Before merging with ClimateMachine, use `git rebase` (not `git merge`) to sync
+your work  with the current master.
 
 ```
 $ git fetch upstream
 $ git rebase upstream/master
 ```
 
-Once the PR is ready for review (or in the process of review), be sure to [squash your commits](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#squash-your-changes).
-This will help us keep the commit history clean on the master branch of ClimateMachine.
+Once the PR is ready for review (or in the process of review), be sure to
+[squash your
+commits](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#squash-your-changes).
+This will help us keep the commit history clean on the master branch of
+ClimateMachine.
 
 ## Formatting and style
 
-For the most part, we follow the [YASGuide](https://github.com/jrevels/YASGuide) for Julia formatting, with small exceptions covered in the [Coding Conventions](https://CliMA.github.io/ClimateMachine.jl/latest/CodingConventions.html) section of the documentation.
+For the most part, we follow the [YASGuide](https://github.com/jrevels/YASGuide)
+for Julia formatting, with small exceptions covered in the [Coding
+Conventions](https://CliMA.github.io/ClimateMachine.jl/latest/CodingConventions.html)
+section of the documentation.
 
-In addition to this, once you are happy with your PR, please apply [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) to all changed files in the repository.
+In addition to this, once you are happy with your PR, please apply
+[JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) to all changed
+files in the repository.
 
 ### Formatting utility
 
-A convenience utility is located at `.dev/climaformat.jl` that will format the julia files in the given path. For example, from the top-level ClimateMachine directory
+A convenience utility is located at `.dev/climaformat.jl` that will format the
+julia files in the given path. For example, from the top-level ClimateMachine
+directory
 ```
 julia .dev/climaformat.jl src/ClimateMachine.jl
 ```
@@ -84,13 +111,20 @@ will format all of ClimateMachine's julia files.
 
 ### Formatting githook
 
-A `pre-commit` script that can be placed in `$GIT_DIR/hooks/*` which will prevent commits of incorrectly formatted julia code.  It will also provide commands that can be run to format the code correctly.
+A `pre-commit` script that can be placed in `$GIT_DIR/hooks/*` which will
+prevent commits of incorrectly formatted julia code.  It will also provide
+commands that can be run to format the code correctly.
 
-One may tell git about the script with (from the top-level directory of a clone of ClimateMachine)
+One may tell git about the script with (from the top-level directory of a clone
+of ClimateMachine)
 ```
 ln -s ../../.dev/hooks/pre-commit .git/hooks
 ```
-and then when `git commit` is run an error message will be given for julia files that are staged to be committed that are not formatted according to ClimateMachine's standard.  With this, when I try to commit changes to `src/Arrays/MPIStateArrays.jl` that are not formatted correctly I get the following error message.
+and then when `git commit` is run an error message will be given for julia files
+that are staged to be committed that are not formatted according to
+ClimateMachine's standard.  With this, when I try to commit changes to
+`src/Arrays/MPIStateArrays.jl` that are not formatted correctly I get the
+following error message.
 
 ```
 ❯ git commit                                                                                                           │
@@ -111,8 +145,7 @@ To speed up the formatter and the githook, a custom system image can be built
 with the [`PackageCompiler`](https://github.com/JuliaLang/PackageCompiler.jl).
 That said, the following
 [drawback](https://julialang.github.io/PackageCompiler.jl/dev/sysimages/#Drawbacks-to-custom-sysimages-1)
-from the `PackageCompiler` repository should
-be noted:
+from the `PackageCompiler` repository should be noted:
 
 > It should be clearly stated that there are some drawbacks to using a custom
 > sysimage, thereby sidestepping the standard Julia package precompilation
@@ -124,7 +157,8 @@ be noted:
 > that needs a specific version of a package, but you have another one compiled
 > into the sysimage.
 
-The `PackageCompiler` compiler can be used with the `JuliaFormatter` using the following commands (from a top-level directory of a clone of ClimateMachine)
+The `PackageCompiler` compiler can be used with the `JuliaFormatter` using the
+following commands (from a top-level directory of a clone of ClimateMachine)
 ```
 $ julia -q
 julia> using Pkg
@@ -135,7 +169,8 @@ julia> using PackageCompiler
 julia> PackageCompiler.create_sysimage(:JuliaFormatter; precompile_execution_file=joinpath(@__DIR__, ".dev/precompile.jl"), replace_default=true)
 ```
 
-If you cannot (or do want to) modify the default system image, instead the following commands can be used
+If you cannot (or do want to) modify the default system image, instead the
+following commands can be used
 ```
 $ julia -q
 julia> using Pkg
@@ -144,22 +179,29 @@ julia> using PackageCompiler
 julia> Pkg.activate(joinpath(@__DIR__,".dev"))
 julia> PackageCompiler.create_sysimage(:JuliaFormatter; precompile_execution_file=joinpath(@__DIR__, ".dev/precompile.jl"), sysimage_path=joinpath(@__DIR__, ".git/hooks/JuliaFormatterSysimage.so"))
 ```
-In this case hook `pre-commit.sysimage` should be used. That is, one can use the following linking command (from the top-level directory of a clone of ClimateMachine)
+In this case hook `pre-commit.sysimage` should be used. That is, one can use the
+following linking command (from the top-level directory of a clone of
+ClimateMachine)
 ```
 ln -s ../../.dev/hooks/pre-commit.sysimage .git/hooks/pre-commit
 ```
-Note: By putting the system image in `.git/hooks` it will be protected from calls to `git clean -x`
+Note: By putting the system image in `.git/hooks` it will be protected from
+calls to `git clean -x`
 
 ## Bors and CI
 
-All commits that end up in the ClimateMachine repository must pass Continuous Integration (CI).
-When a PR is updated, it will automatically be run on Microsoft Azure for Linux, Windows, and MacOS; however, because ClimateMachine is heterogeneous and must also run on GPU hardware, we also manually launch CI with Bors.
+All commits that end up in the ClimateMachine repository must pass Continuous
+Integration (CI).  When a PR is updated, it will automatically be run on
+Microsoft Azure for Linux, Windows, and MacOS; however, because ClimateMachine
+is heterogeneous and must also run on GPU hardware, we also manually launch CI
+with Bors.
 
-To test to see if all bors CI will pass, please type `bors try` in a separate comment in the PR.
-After this, if you are a collaborator you can merge the commit with `bors merge`.
-If you are a collaborator and want to test and merge in the same step, use `bors r+`.
+To test to see if all bors CI will pass, please type `bors try` in a separate
+comment in the PR.  After this, if you are a collaborator you can merge the
+commit with `bors merge`.  If you are a collaborator and want to test and merge
+in the same step, use `bors r+`.
 
 ### Tests
 
-Most PRs should include tests and these will be reviewed as part of the code review process on GitHub.
-Add your tests in the `test/` directory.
+Most PRs should include tests and these will be reviewed as part of the code
+review process on GitHub.  Add your tests in the `test/` directory.

--- a/docs/src/HowToGuides/Contributing/CONTRIBUTING.md
+++ b/docs/src/HowToGuides/Contributing/CONTRIBUTING.md
@@ -204,4 +204,31 @@ in the same step, use `bors r+`.
 ### Tests
 
 Most PRs should include tests and these will be reviewed as part of the code
-review process on GitHub.  Add your tests in the `test/` directory.
+review process on github.  Add your tests in the `test/` directory.
+
+### Building a system image
+
+ClimateMachine has a number of dependencies which can lead to a significant startup time,
+for example the call
+```
+julia --project experiments/AtmosLES/dycoms.jl --help
+```
+can take 30 seconds or more to execute. By using a custom system image this can
+be reduced to 3 seconds.
+
+A reasonable system image for ClimateMachine can be built use the julia program
+`.dev/systemimage/climate_machine_image.jl`. With no arguments this program will
+create the system image `.dev/systemimage/ClimateMachine.so`. With an argument,
+the image will be created using the path specified by the argument.
+
+Once the image is created, the image can be used using the `-J` argument to
+`julia`, namely:
+```
+julia -J.dev/systemimage/ClimateMachine.so --project experiments/AtmosLES/dycoms.jl --help
+```
+
+!!! note
+
+    If the ClimateMachine `Project.toml` or `Manifest.toml` changes the system
+    image MUST be recompiled. This is because the custom system image has a
+    "locked" version of the packages and their dependencies.


### PR DESCRIPTION
CLIMA startup times are long, which can make iterative development and
debugging difficult / painful. This adds a process for creating a custom
system image which drastically reduces initialization time.

|                      command                      |  no image |  with image |
|---------------------------------------------------|-----------|-------------|
| experiments/AtmosLES/dycoms.jl --help             |   31.44s  |       2.5s  |
| experiments/AtmosLES/dycoms.jl                    |  244.03s  |    138.64s  |
| test/Numerics/DGmethods/Euler/isentropicvortex.jl |  229.62s  |    144.19s  |

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
