### PR TITLE
Remove LinearTemperatureProfile, switch to DecayingTemperatureProfile

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -64,9 +64,9 @@ version = "0.1.0"
 
 [[CLIMAParameters]]
 deps = ["Test"]
-git-tree-sha1 = "7b80821bffd8702ccc2a712aef804e30b3bd7012"
+git-tree-sha1 = "9c3eae7d6bcabf604d9e4e9cc0802db01357bc37"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
-version = "0.1.3"
+version = "0.1.4"
 
 [[CUDAapi]]
 deps = ["Libdl", "Logging"]
@@ -342,9 +342,9 @@ version = "0.14.0"
 
 [[MPICH_jll]]
 deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
-git-tree-sha1 = "f25a503231b1ca0a93ac6efb07044574354a039d"
+git-tree-sha1 = "4d37f1e07b4e2a74462eebf9ee48c626d15ffdac"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "3.3.2+9"
+version = "3.3.2+10"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
@@ -443,9 +443,9 @@ version = "0.9.12"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "72c3451932513427caffbd8bab15643ad693804b"
+git-tree-sha1 = "f0abb338b4d00306500056a3fd44c221b8473ef2"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.3"
+version = "1.0.4"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
@@ -572,9 +572,9 @@ version = "1.0.1"
 
 [[TimeZones]]
 deps = ["Dates", "EzXML", "Mocking", "Printf", "RecipesBase", "Serialization", "Unicode"]
-git-tree-sha1 = "07af1bd3226d644ca1a3235c93e7d0207ce4536a"
+git-tree-sha1 = "db7bc2051d4c2e5f336409224df81485c00de6cb"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.1.1"
+version = "1.2.0"
 
 [[TimerOutputs]]
 deps = ["Printf"]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -70,9 +70,9 @@ version = "0.1.0"
 
 [[CLIMAParameters]]
 deps = ["Test"]
-git-tree-sha1 = "7b80821bffd8702ccc2a712aef804e30b3bd7012"
+git-tree-sha1 = "9c3eae7d6bcabf604d9e4e9cc0802db01357bc37"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
-version = "0.1.3"
+version = "0.1.4"
 
 [[CUDAapi]]
 deps = ["Libdl", "Logging"]
@@ -134,10 +134,9 @@ uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
 version = "0.12.0"
 
 [[Combinatorics]]
-deps = ["Polynomials"]
-git-tree-sha1 = "8153f2c7cc4446958920242c4caa3dc0e061918f"
+git-tree-sha1 = "08c8b6831dc00bfea825826be0bc8336fc369860"
 uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
-version = "1.0.1"
+version = "1.0.2"
 
 [[CommonSubexpressions]]
 deps = ["Test"]
@@ -147,9 +146,9 @@ version = "0.2.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "b0ae6133d365da2dbc88bc43d997b1b95c9df5f6"
+git-tree-sha1 = "48c20c43e157c6eab6cf88326504ec042b05e456"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.9.1"
+version = "3.10.0"
 
 [[CompilerSupportLibraries_jll]]
 deps = ["Libdl", "Pkg"]
@@ -489,9 +488,9 @@ version = "0.14.0"
 
 [[MPICH_jll]]
 deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
-git-tree-sha1 = "f25a503231b1ca0a93ac6efb07044574354a039d"
+git-tree-sha1 = "4d37f1e07b4e2a74462eebf9ee48c626d15ffdac"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "3.3.2+9"
+version = "3.3.2+10"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
@@ -613,9 +612,9 @@ version = "0.9.12"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "72c3451932513427caffbd8bab15643ad693804b"
+git-tree-sha1 = "f0abb338b4d00306500056a3fd44c221b8473ef2"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.3"
+version = "1.0.4"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
@@ -628,10 +627,10 @@ uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
 version = "2.0.0"
 
 [[PlotUtils]]
-deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport"]
-git-tree-sha1 = "44de63b180da00d30dcfbe467dd62bd3cbc87af0"
+deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
+git-tree-sha1 = "59ec24a0c96c513533e488dff1433df1bd3d6b9f"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.0.2"
+version = "1.0.3"
 
 [[Plots]]
 deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryTypes", "JSON", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
@@ -641,9 +640,9 @@ version = "1.2.4"
 
 [[Polynomials]]
 deps = ["Intervals", "LinearAlgebra", "RecipesBase"]
-git-tree-sha1 = "19f1b9e3f27702309880b9ccb051287729af7db4"
+git-tree-sha1 = "23b99e32043d2fa4c0d1975ca30e14e00c6ea53b"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
-version = "0.8.0"
+version = "1.0.6"
 
 [[PooledArrays]]
 deps = ["DataAPI"]
@@ -806,9 +805,9 @@ version = "1.0.1"
 
 [[TimeZones]]
 deps = ["Dates", "EzXML", "Mocking", "Printf", "RecipesBase", "Serialization", "Unicode"]
-git-tree-sha1 = "07af1bd3226d644ca1a3235c93e7d0207ce4536a"
+git-tree-sha1 = "db7bc2051d4c2e5f336409224df81485c00de6cb"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.1.1"
+version = "1.2.0"
 
 [[TimerOutputs]]
 deps = ["Printf"]

--- a/docs/src/Theory/Atmos/EDMFEquations.md
+++ b/docs/src/Theory/Atmos/EDMFEquations.md
@@ -1098,16 +1098,3 @@ Bottom boundary
 where additional variable/function definitions are in:
 
  - [BC functions](@ref) $\Gamma_{TKE}$, $\Gamma_{\phi}$, $F_{\eint}$, $\SensibleSurfaceHeatFlux$, $F_{\qt}$, $\LatentSurfaceHeatFlux$.
-
-## Case-specific configurations
-
-| **Case** | **Variable**                 | **Value**                        | **Reference**    |
-|:---------|------------------------------|----------------------------------|------------------|
-| Bomex    | $\BC{p_s}$                   | 1000 [hPa]                       |                  |
-| Bomex    | $\BC{\DM{\qt}}$              | 5 [g/kg]                         |                  |
-| Bomex    | $\BC{\DM{\ThetaLiqIce}}$     | 300 [K]                          |                  |
-| Bomex    | $\BC{\TCV{w}{\qt}}$          | $5.2 \times 10^{-5} [m s^{-1}]$  |                  |
-| Bomex    | $\BC{\TCV{w}{\ThetaLiqIce}}$ | $8 \times 10^{-3} [K m s^{-1}]$  |                  |
-| Soares   | $\BC{\TCV{w}{\qt}}$          | $2.5 \times 10^{-5} [m s^{-1}]$  |                  |
-| Soares   | $\BC{\TCV{w}{\ThetaLiqIce}}$ | $6 \times 10^{-2} [K m s^{-1}]$  |                  |
-|          |                              |                                  |                  |

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -42,11 +42,8 @@ end
 
 function config_heldsuarez(FT, poly_order, resolution)
     # Set up a reference state for linearization of equations
-    T_sfc::FT = 290 # surface temperature of reference state (K)
-    ΔT::FT = 60     # temperature drop between surface and top of atmosphere (K)
-    H_t::FT = 8e3   # height sclae over which temperature drops (m)
-    temp_profile_ref = DecayingTemperatureProfile(T_sfc, ΔT, H_t)
-    ref_state = HydrostaticState(temp_profile_ref, FT(0))
+    temp_profile_ref = DecayingTemperatureProfile{FT}(param_set)
+    ref_state = HydrostaticState(temp_profile_ref)
 
     # Set up a Rayleigh sponge to dampen flow at the top of the domain
     domain_height::FT = 30e3               # distance between surface and top of atmosphere (m)

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -522,7 +522,7 @@ function main()
         check_euclidean_distance = true,
     )
 
-    @test isapprox(result, FT(1); atol = 2e-3)
+    @test isapprox(result, FT(1); atol = 4e-3)
 end
 
 main()

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -252,14 +252,8 @@ end
 
 function config_dycoms(FT, N, resolution, xmax, ymax, zmax)
     # Reference state
-    T_min = FT(289)
-    T_s = FT(290.4)
-    _grav = FT(grav(param_set))
-    _cp_d = FT(cp_d(param_set))
-    Γ_lapse = _grav / _cp_d
-    T = LinearTemperatureProfile(T_min, T_s, Γ_lapse)
-    rel_hum = FT(0)
-    ref_state = HydrostaticState(T, rel_hum)
+    T_profile = DecayingTemperatureProfile{FT}(param_set)
+    ref_state = HydrostaticState(T_profile)
 
     # Radiation model
     κ = FT(85)

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -128,14 +128,7 @@ function AtmosModel{FT}(
     ::Type{AtmosLESConfigType},
     param_set::AbstractParameterSet;
     orientation::O = FlatOrientation(),
-    ref_state::RS = HydrostaticState(
-        LinearTemperatureProfile(
-            FT(200),
-            FT(280),
-            FT(grav(param_set)) / FT(cp_d(param_set)),
-        ),
-        FT(0),
-    ),
+    ref_state::RS = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),),
     turbulence::T = SmagorinskyLilly{FT}(0.21),
     hyperdiffusion::HD = NoHyperDiffusion(),
     moisture::M = EquilMoist{FT}(),
@@ -172,14 +165,7 @@ function AtmosModel{FT}(
     ::Type{AtmosGCMConfigType},
     param_set::AbstractParameterSet;
     orientation::O = SphericalOrientation(),
-    ref_state::RS = HydrostaticState(
-        LinearTemperatureProfile(
-            FT(200),
-            FT(280),
-            FT(grav(param_set)) / FT(cp_d(param_set)),
-        ),
-        FT(0),
-    ),
+    ref_state::RS = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),),
     turbulence::T = SmagorinskyLilly{FT}(C_smag(param_set)),
     hyperdiffusion::HD = NoHyperDiffusion(),
     moisture::M = EquilMoist{FT}(),

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -89,9 +89,9 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
     )
 
     # Set up the model
+    T_profile = DryAdiabaticProfile{FT}(param_set)
     C_smag = FT(0.23)
-    ref_state =
-        HydrostaticState(DryAdiabaticProfile(typemin(FT), FT(300)), FT(0))
+    ref_state = HydrostaticState(T_profile)
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         param_set;

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -67,8 +67,9 @@ function main()
     dt = FT(600)
 
     setup = AcousticWaveSetup{FT}()
+    T_profile = IsothermalProfile(param_set, setup.T_ref)
     orientation = SphericalOrientation()
-    ref_state = HydrostaticState(IsothermalProfile(setup.T_ref), FT(0))
+    ref_state = HydrostaticState(T_profile)
     turbulence = ConstantViscosityWithDivergence(FT(0))
     model = AtmosModel{FT}(
         AtmosGCMConfigType,

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -67,8 +67,9 @@ function main()
     dt = FT(600)
 
     setup = AcousticWaveSetup{FT}()
+    T_profile = IsothermalProfile(param_set, setup.T_ref)
     orientation = SphericalOrientation()
-    ref_state = HydrostaticState(IsothermalProfile(setup.T_ref), FT(0))
+    ref_state = HydrostaticState(T_profile)
     turbulence = ConstantViscosityWithDivergence(FT(0))
     model = AtmosModel{FT}(
         AtmosGCMConfigType,

--- a/test/Numerics/DGmethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGmethods/Euler/acousticwave_1d_imex.jl
@@ -65,8 +65,8 @@ function main()
     outputtime = 60 * 60
 
     expected_result = Dict()
-    expected_result[Float32] = 9.5064378310656000e+13
-    expected_result[Float64] = 9.5073452847081828e+13
+    expected_result[Float32] = 9.2987451244544000e+13
+    expected_result[Float64] = 9.2993570967854438e+13
 
     for FT in (Float32, Float64)
         result = run(
@@ -112,11 +112,13 @@ function run(
         meshwarp = cubedshellwarp,
     )
 
+    T_profile = IsothermalProfile(param_set, setup.T_ref)
+
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         param_set;
         orientation = SphericalOrientation(),
-        ref_state = HydrostaticState(IsothermalProfile(setup.T_ref), FT(0)),
+        ref_state = HydrostaticState(T_profile),
         turbulence = ConstantViscosityWithDivergence(FT(0)),
         moisture = DryModel(),
         source = Gravity(),

--- a/test/Numerics/DGmethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGmethods/compressible_Navier_Stokes/density_current_model.jl
@@ -127,13 +127,11 @@ function run(
     )
     # -------------- Define model ---------------------------------- #
     source = Gravity()
+    T_profile = DryAdiabaticProfile{FT}(param_set)
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         param_set;
-        ref_state = HydrostaticState(
-            DryAdiabaticProfile(typemin(FT), FT(300)),
-            FT(0),
-        ),
+        ref_state = HydrostaticState(T_profile),
         turbulence = AnisoMinDiss{FT}(1),
         source = source,
         init_state_conservative = Initialise_Density_Current!,

--- a/test/Numerics/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/Numerics/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -45,12 +45,12 @@ function run1(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
         polynomialorder = N,
     )
 
-    T_s = 320.0
-    RH = 0.01
+    T_s = FT(290)
+    T_profile = IsothermalProfile(param_set, T_s)
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         param_set;
-        ref_state = HydrostaticState(IsothermalProfile(T_s), RH),
+        ref_state = HydrostaticState(T_profile),
         init_state_conservative = init_state_conservative!,
     )
 
@@ -84,15 +84,11 @@ function run2(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
         polynomialorder = N,
     )
 
-    T_min, T_s, Γ = FT(290), FT(320), FT(6.5 * 10^-3)
-    RH = 0.01
+    T_profile = DecayingTemperatureProfile{FT}(param_set)
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         param_set;
-        ref_state = HydrostaticState(
-            LinearTemperatureProfile(T_min, T_s, Γ),
-            RH,
-        ),
+        ref_state = HydrostaticState(T_profile),
         init_state_conservative = init_state_conservative!,
     )
 

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -40,7 +40,7 @@ nothing # hide
 # Construct the Held-Suarez forcing function. We can view this as part the
 # right-hand-side of our governing equations. It forces the total energy field
 # in a way that the resulting steady-state velocity and temperature fields of
-# the simluation resemble those of an idealized dry planet.
+# the simulation resemble those of an idealized dry planet.
 function held_suarez_forcing!(
     balance_law,
     source,
@@ -88,7 +88,7 @@ function held_suarez_forcing!(
     φ = latitude(balance_law.orientation, aux)
     p = air_pressure(balance_law.param_set, T, ρ)
 
-    ##TODO: replace _p0 with dynamic surfce pressure in Δσ calculations to
+    ##TODO: replace _p0 with dynamic surface pressure in Δσ calculations to
     #account for topography, but leave unchanged for calculations of σ involved
     #in T_equil
     _p0 = 1.01325e5
@@ -109,10 +109,10 @@ end
 nothing # hide
 
 # ## Set initial condition
-# When using ClimateMachine, we need to define a function that sets the intial
+# When using ClimateMachine, we need to define a function that sets the initial
 # state of our model run. In our case, we use the reference state of the
 # simulation (defined below) and add a little bit of noise. Note that the
-# initial states includes a zero initial velocity field. 
+# initial states includes a zero initial velocity field.
 function init_heldsuarez!(balance_law, state, aux, coordinates, time)
     FT = eltype(state)
 
@@ -141,25 +141,22 @@ FT = Float32
 nothing # hide
 
 # ## Setup model configuration
-# Now that we have definied our forcing and initialization functions, and have
-# initialized ClimateMachine, we can set up the model. 
-# 
+# Now that we have defined our forcing and initialization functions, and have
+# initialized ClimateMachine, we can set up the model.
+#
 # ## Set up a reference state
 # We start by setting up a reference state. This is simply a vector field that
 # we subtract from the solutions to the governing equations to both improve
 # numerical stability of the implicit time stepper and enable faster model
 # spin-up. The reference state assumes hydrostatic balance and ideal gas law,
 # with a pressure $p_r(z)$ and density $\rho_r(z)$ that only depend on altitude
-# $z$ and are in hydrostatic balance with each other. 
+# $z$ and are in hydrostatic balance with each other.
 #
 # In this example, the reference temperature field smoothly transitions from a
 # linearly decaying profile near the surface to a constant temperature profile
 # at the top of the domain.
-T_surface = FT(290) ## surface temperature (K)
-ΔT = FT(60)  ## temperature drop between surface and top of atmosphere (K)
-H_t = FT(8e3) ## height scale over which temperature drops (m)
-temp_profile_ref = DecayingTemperatureProfile(T_surface, ΔT, H_t)
-ref_state = HydrostaticState(temp_profile_ref, FT(0))
+temp_profile_ref = DecayingTemperatureProfile{FT}(param_set)
+ref_state = HydrostaticState(temp_profile_ref)
 nothing # hide
 
 # ## Set up a Rayleigh sponge layer
@@ -185,7 +182,7 @@ nothing # hide
 
 # ## Instantiate the model
 # The Held Suarez setup was designed to produce an equilibrated state that is
-# comparable to the zonal mean of the Earth’s atmosphere. 
+# comparable to the zonal mean of the Earth’s atmosphere.
 model = AtmosModel{FT}(
     AtmosGCMConfigType,
     param_set;
@@ -199,7 +196,7 @@ model = AtmosModel{FT}(
 nothing # hide
 # This concludes the setup of the physical model!
 
-# ## Set up the driver 
+# ## Set up the driver
 # We just need to set up a few parameters that define the resolution of the
 # discontinuous Galerkin method and for how long we want to run our model
 # setup.

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -129,7 +129,6 @@ const param_set = EarthParameterSet()
 #md #     - `state.ρ` = Scalar quantity for initial density profile
 #md #     - `state.ρu`= 3-component vector for initial momentum profile
 #md #     - `state.ρe`= Scalar quantity for initial total-energy profile
-#md #     - `state.moisture.ρq_tot` = Scalar quantity for the total specific
 #md #       humidity
 #md #     - `state.tracers.ρχ` = Vector of four tracers (here, for demonstration
 #md #       only; we can interpret these as dye injections for visualisation
@@ -152,7 +151,9 @@ function init_risingbubble!(bl, state, aux, (x, y, z), t)
     zc::FT = 1000
     r = sqrt((x - xc)^2 + (y - yc)^2 + (z - zc)^2)
     rc::FT = 500
-    θ_ref::FT = 300
+    # TODO: clean this up, or add convenience function:
+    # This is configured in the reference hydrostatic state
+    θ_ref::FT = bl.ref_state.virtual_temperature_profile.T_surface
     Δθ::FT = 0
 
     # Compute temperature difference over bubble region
@@ -164,9 +165,9 @@ function init_risingbubble!(bl, state, aux, (x, y, z), t)
     θ = θ_ref + Δθ                                      # potential temperature
     π_exner = FT(1) - _grav / (c_p * θ) * z             # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas)      # density
-    q_tot = FT(0)                                       # total specific humidity
-    ts = LiquidIcePotTempSHumEquil(bl.param_set, θ, ρ, q_tot) # thermodynamic state
-    q_pt = PhasePartition(ts)                           # phase partition
+    T = θ * π_exner
+    e_int = internal_energy(bl.param_set, T)
+    ts = PhaseDry(bl.param_set, e_int, ρ)
     ρu = SVector(FT(0), FT(0), FT(0))                   # momentum
     #State (prognostic) variable assignment
     e_kin = FT(0)                                       # kinetic energy
@@ -190,7 +191,6 @@ function init_risingbubble!(bl, state, aux, (x, y, z), t)
     state.ρ = ρ
     state.ρu = ρu
     state.ρe = ρe_tot
-    state.moisture.ρq_tot = ρ * q_pt.tot
     state.tracers.ρχ = ρχ
 end
 
@@ -225,8 +225,10 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
     # [CLIMAParameters
     # package](https://CliMA.github.io/CLIMAParameters.jl/latest/) A reference
     # state for the linearisation step is also defined.
-    ref_state =
-        HydrostaticState(DryAdiabaticProfile(typemin(FT), FT(300)), FT(0))
+    T_surface = FT(300)
+    T_min_ref = FT(0)
+    T_profile = DryAdiabaticProfile{FT}(param_set, T_surface, T_min_ref)
+    ref_state = HydrostaticState(T_profile)
 
     # The fun part! Here we assemble the `AtmosModel`.
     #md # !!! note
@@ -243,6 +245,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
         AtmosLESConfigType,                           # Flow in a box, requires the AtmosLESConfigType
         param_set;                                    # Parameter set corresponding to earth parameters
         turbulence = SmagorinskyLilly(_C_smag),       # Turbulence closure model
+        moisture = DryModel(),                        # Exclude moisture variables
         hyperdiffusion = StandardHyperDiffusion(60),  # Hyperdiffusion (4th order) model
         source = (Gravity(),),                        # Gravity is the only source term here
         tracers = NTracers{ntracers, FT}(δ_χ),        # Tracer model with diffusivity coefficients


### PR DESCRIPTION
# Description

 - Removes `LinearTemperatureProfile` and replaces its use with `DecayingTemperatureProfile`

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
