### PR TITLE
Make moist thermo tolerance residual-based

### DIFF
--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -27,6 +27,7 @@ module MoistThermodynamics
 
 using DocStringExtensions
 using RootSolvers
+using RootSolvers: AbstractTolerance
 
 using CLIMAParameters: AbstractParameterSet
 using CLIMAParameters.Planet

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -89,19 +89,25 @@ Moist thermodynamic phase, given
 and, optionally
  - `maxiter` maximum iterations for saturation adjustment
  - `temperature_tol` temperature tolerance for saturation adjustment
- - `sat_adjust` function pointer to particular saturation adjustment function
+ - `sat_adjust` function pointer to particular saturation adjustment method, options include
+    - `saturation_adjustment` uses Newtons method with analytic gradients
+    - `saturation_adjustment_SecantMethod` uses Secant method
 """
 function PhaseEquil(
     param_set::APS,
     e_int::FT,
     ρ::FT,
     q_tot::FT,
-    maxiter::Int = 3,
-    tol::FT = FT(1e-1),
+    maxiter::Int = 6,
+    temperature_tol::FT = FT(1e-1),
     sat_adjust::Function = saturation_adjustment,
 ) where {FT <: Real}
     # TODO: Remove these safety nets, or at least add warnings
     # waiting on fix: github.com/vchuravy/GPUifyLoops.jl/issues/104
+
+    _cv_d = FT(cv_d(param_set))
+    # Convert temperature tolerance to a convergence criterion on internal energy residuals
+    tol = ResidualTolerance(temperature_tol * _cv_d)
     q_tot_safe = clamp(q_tot, FT(0), FT(1))
     T = sat_adjust(param_set, e_int, ρ, q_tot_safe, maxiter, tol)
     return PhaseEquil{FT, typeof(param_set)}(param_set, e_int, ρ, q_tot_safe, T)
@@ -156,7 +162,7 @@ Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
  - `θ_liq_ice` liquid-ice potential temperature
  - `ρ` (moist-)air density
  - `q_tot` total specific humidity
- - `tol` tolerance for saturation adjustment
+ - `temperature_tol` temperature tolerance for saturation adjustment
  - `maxiter` maximum iterations for saturation adjustment
 """
 function LiquidIcePotTempSHumEquil(
@@ -164,9 +170,10 @@ function LiquidIcePotTempSHumEquil(
     θ_liq_ice::FT,
     ρ::FT,
     q_tot::FT,
-    maxiter::Int = 30,
-    tol::FT = FT(1e-1),
+    maxiter::Int = 36,
+    temperature_tol::FT = FT(1e-1),
 ) where {FT <: Real}
+    tol = ResidualTolerance(temperature_tol)
     T = saturation_adjustment_q_tot_θ_liq_ice(
         param_set,
         θ_liq_ice,
@@ -189,7 +196,7 @@ Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
  - `θ_liq_ice` liquid-ice potential temperature
  - `p` pressure
  - `q_tot` total specific humidity
- - `tol` tolerance for saturation adjustment
+ - `temperature_tol` temperature tolerance for saturation adjustment
  - `maxiter` maximum iterations for saturation adjustment
 """
 function LiquidIcePotTempSHumEquil_given_pressure(
@@ -198,8 +205,9 @@ function LiquidIcePotTempSHumEquil_given_pressure(
     p::FT,
     q_tot::FT,
     maxiter::Int = 30,
-    tol::FT = FT(1e-1),
+    temperature_tol::FT = FT(1e-1),
 ) where {FT <: Real}
+    tol = ResidualTolerance(temperature_tol)
     T = saturation_adjustment_q_tot_θ_liq_ice_given_pressure(
         param_set,
         θ_liq_ice,
@@ -280,7 +288,7 @@ Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
  - `ρ` (moist-)air density
  - `q_pt` phase partition
 and, optionally
- - `tol` tolerance for non-linear equation solve
+ - `potential_temperature_tol` potential temperature for non-linear equation solve
  - `maxiter` maximum iterations for non-linear equation solve
 """
 function LiquidIcePotTempSHumNonEquil(
@@ -288,9 +296,10 @@ function LiquidIcePotTempSHumNonEquil(
     θ_liq_ice::FT,
     ρ::FT,
     q_pt::PhasePartition{FT},
-    maxiter::Int = 5,
-    tol::FT = FT(1e-1),
+    maxiter::Int = 10,
+    potential_temperature_tol::FT = FT(1e-2),
 ) where {FT <: Real}
+    tol = ResidualTolerance(potential_temperature_tol)
     T = air_temperature_from_liquid_ice_pottemp_non_linear(
         param_set,
         θ_liq_ice,

--- a/test/Common/MoistThermodynamics/profiles.jl
+++ b/test/Common/MoistThermodynamics/profiles.jl
@@ -15,7 +15,12 @@ tested with in runtests.jl
         T_min::FT,
         ) where {FT <: AbstractFloat}
 
-Fixed lapse rate hydrostatic reference state
+Fixed lapse rate hydrostatic reference state given
+
+ - `param_set` parameter set, used to dispatch planet parameter function calls
+ - `z` altitude
+ - `T_surface` surface temperature
+ - `T_min` minimum temperature
 """
 function fixed_lapse_rate(
     param_set::AbstractParameterSet,


### PR DESCRIPTION
# Description

Changes Moist Thermo's saturation adjustment tolerance to accept the residual tolerance and not the solution tolerance.

 - Some of the tolerances in moist thermo's test suite need to be reviewed

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
