### PR TITLE
Limit thread block size in Courant number kernels

### DIFF
--- a/src/Numerics/DGmethods/DGmodel.jl
+++ b/src/Numerics/DGmethods/DGmodel.jl
@@ -796,17 +796,20 @@ function courant(
         device = grid.vgeo isa Array ? CPU() : CUDA()
         pointwise_courant = similar(grid.vgeo, Nq^dim, nrealelem)
         event = Event(device)
-        event = Grids.kernel_min_neighbor_distance!(device, (Nq, Nq, Nqk))(
+        event = Grids.kernel_min_neighbor_distance!(
+            device,
+            min(Nq * Nq * Nqk, 1024),
+        )(
             Val(N),
             Val(dim),
             direction,
             pointwise_courant,
             grid.vgeo,
             topology.realelems;
-            ndrange = (nrealelem * Nq, Nq, Nqk),
+            ndrange = (nrealelem * Nq * Nq * Nqk),
             dependencies = (event,),
         )
-        event = kernel_local_courant!(device, Nq * Nq * Nqk)(
+        event = kernel_local_courant!(device, min(Nq * Nq * Nqk, 1024))(
             m,
             Val(dim),
             Val(N),

--- a/src/Numerics/DGmethods/DGmodel_kernels.jl
+++ b/src/Numerics/DGmethods/DGmodel_kernels.jl
@@ -2594,8 +2594,10 @@ end
             MArray{Tuple{num_state_gradient_flux}, FT}(undef)
     end
 
-    e = @index(Group, Linear)
-    n = @index(Local, Linear)
+    I = @index(Global, Linear)
+    e = (I - 1) ÷ Np + 1
+    n = (I - 1) % Np + 1
+
     @inbounds begin
         @unroll for s in 1:num_state_conservative
             local_state_conservative[s] = state_conservative[n, s, e]


### PR DESCRIPTION
# Description

This limits the number of threads in a thread block for two kernels used in Courant number calculation. This allows use of high order polynomials on the GPU, at least without hyperdiffusion. Missed in #1005.

CC
@vchuravy 

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
