### PR TITLE
Fix docs, execute ipynb

### DIFF
--- a/docs/clean_build_folder.jl
+++ b/docs/clean_build_folder.jl
@@ -8,7 +8,6 @@ generated_files = [
     for (root, dirs, files) in Base.Filesystem.walkdir(generated_dir)
     for f in files
 ]
-println("Generated files: $(generated_files)")
 
 filter!(
     x -> any([endswith(x, y) for y in file_extensions_to_remove]),

--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -14,6 +14,16 @@ if generate_tutorials
 
     tutorials_dir = joinpath(@__DIR__, "..", "tutorials")      # julia src files
 
+    non_tutorial_files = ["KinematicModel.jl"]
+    skip_execute = [
+        "heldsuarez.jl",                # broken
+        "dry_rayleigh_benard.jl",       # takes too long
+        "nonnegative.jl",               # takes too long
+        "ex_2_Kessler.jl",              # takes too long
+        "ex_1_saturation_adjustment.jl", # takes too long
+    ]
+
+
     # generate tutorials
     import Literate
 
@@ -24,15 +34,10 @@ if generate_tutorials
     ]
     filter!(x -> endswith(x, ".jl"), tutorials_jl) # only grab .jl files
 
-    filter!(x -> !occursin("topo.jl", x), tutorials_jl)                       # currently broken, TODO: Fix me!
-    filter!(x -> !occursin("dry_rayleigh_benard.jl", x), tutorials_jl)        # currently broken, TODO: Fix me!
-    filter!(x -> !occursin("ex_001_periodic_advection.jl", x), tutorials_jl)  # currently broken, TODO: Fix me!
-    filter!(x -> !occursin("ex_002_solid_body_rotation.jl", x), tutorials_jl) # currently broken, TODO: Fix me!
-    filter!(x -> !occursin("ex_003_acoustic_wave.jl", x), tutorials_jl)       # currently broken, TODO: Fix me!
-    filter!(x -> !occursin("ex_004_nonnegative.jl", x), tutorials_jl)         # currently broken, TODO: Fix me!
-    filter!(x -> !occursin("KinematicModel.jl", x), tutorials_jl)             # currently broken, TODO: Fix me!
-    filter!(x -> !occursin("ex_1_saturation_adjustment.jl", x), tutorials_jl) # currently broken, TODO: Fix me!
-    filter!(x -> !occursin("ex_2_Kessler.jl", x), tutorials_jl)               # currently broken, TODO: Fix me!
+    filter!(
+        x -> !any([occursin(y, x) for y in non_tutorial_files]),
+        tutorials_jl,
+    )
 
     println("Building literate tutorials:")
     for tutorial in tutorials_jl
@@ -47,7 +52,9 @@ if generate_tutorials
         code = strip(read(script, String))
         mdpost(str) = replace(str, "@__CODE__" => code)
         Literate.markdown(input, gen_dir, postprocess = mdpost)
-        # Literate.notebook(input, gen_dir, execute = true)
+        if !any([occursin(y, input) for y in skip_execute])
+            Literate.notebook(input, gen_dir, execute = true)
+        end
     end
 
     # TODO: Should we use AutoPages.jl?

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ using ClimateMachine, Documenter, Literate
 ENV["GKSwstype"] = "100" # https://github.com/jheinen/GR.jl/issues/278#issuecomment-587090846
 
 generated_dir = joinpath(@__DIR__, "src", "generated") # generated files directory
+rm(generated_dir, force = true, recursive = true)
 mkpath(generated_dir)
 
 include("list_of_experiments.jl")        # defines a nested array `experiments`

--- a/docs/src/HowToGuides/Numerics/DGmethods/how_to_make_a_balance_law.md
+++ b/docs/src/HowToGuides/Numerics/DGmethods/how_to_make_a_balance_law.md
@@ -20,7 +20,7 @@ In order to alleviate users from being concerned with the burden of spatial disc
 
 ## Variable name specification methods
 | **Method** | Necessary | Purpose |
-|:-----|:-|:----|
+|:-----|:--|:----|
 | [`vars_state_conservative`](@ref)         | **YES** |  specify the names of the variables in the conservative state vector, typically mass, momentum, and various tracers. |
 | [`vars_state_auxiliary`](@ref)           | **YES** |  specify the names of any variables required for the balance law that aren't related to derivatives of the state variables (e.g. spatial coordinates or various integrals) or those needed to solve expensive auxiliary equations (e.g., temperature via a non-linear equation solve)     |
 | [`vars_state_gradient`](@ref)         | **YES** |  specify the names of the gradients of functions of the conservative state variables. used to represent values before **and** after differentiation |
@@ -65,7 +65,7 @@ In order to alleviate users from being concerned with the burden of spatial disc
 
 While `Y` can be thought of a column vector (each _row_ of which corresponds to each state variable and its prognostic equation), the _second_ function argument inside these methods behave as dictionaries, for example:
 
-```
+```julia
 struct MyModel <: BalanceLaw end
 
 function vars_state_conservative(m::MyModel, FT)

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -100,7 +100,7 @@ end
 
 function config_problem(FT, N, resolution, xmax, ymax, zmax)
 
-    # Boundary conditions
+    ## Boundary conditions
     T_bot = FT(299)
 
     _cp_d::FT = cp_d(param_set)
@@ -112,7 +112,7 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
     ntracers = 1
     δ_χ = SVector{ntracers, FT}(1)
 
-    # Turbulence
+    ## Turbulence
     C_smag = FT(0.23)
     data_config = DryRayleighBenardConvectionDataConfig{FT}(
         0,
@@ -126,7 +126,7 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
         FT(T_bot - T_lapse * zmax),
     )
 
-    # Set up the model
+    ## Set up the model
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         param_set;
@@ -177,13 +177,13 @@ end
 
 function main()
     FT = Float64
-    # DG polynomial order
+    ## DG polynomial order
     N = 4
-    # Domain resolution and size
+    ## Domain resolution and size
     Δh = FT(10)
-    # Time integrator setup
+    ## Time integrator setup
     t0 = FT(0)
-    # Courant number
+    ## Courant number
     CFLmax = FT(5)
     timeend = FT(1000)
     xmax, ymax, zmax = FT(250), FT(250), FT(500)
@@ -201,7 +201,7 @@ function main()
                 Courant_number = CFLmax,
             )
             dgn_config = config_diagnostics(driver_config)
-            # User defined callbacks (TMAR positivity preserving filter)
+            ## User defined callbacks (TMAR positivity preserving filter)
             cbtmarfilter =
                 GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
                     Filters.apply!(
@@ -218,7 +218,7 @@ function main()
                 user_callbacks = (cbtmarfilter,),
                 check_euclidean_distance = true,
             )
-            # result == engf/eng0
+            ## result == engf/eng0
             @test isapprox(result, FT(1); atol = 1.5e-2)
         end
     end

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -38,7 +38,7 @@ nothing # hide
 # Construct the Held-Suarez forcing function
 # We can view this as part the right-hand-side of our governing equations. It
 # forces the total energy field in a way that the resulting steady-state velocity
-# and temperature fields of the simluation resemble those of an idealized dry
+# and temperature fields of the simulation resemble those of an idealized dry
 # planet.
 function held_suarez_forcing!(
     balance_law,
@@ -87,8 +87,8 @@ function held_suarez_forcing!(
     φ = latitude(balance_law.orientation, aux)
     p = air_pressure(balance_law.param_set, T, ρ)
 
-    ##TODO: replace _p0 with dynamic surfce pressure in Δσ calculations to account
-    #for topography, but leave unchanged for calculations of σ involved in T_equil
+    ## TODO: replace _p0 with dynamic surface pressure in Δσ calculations to account
+    ## for topography, but leave unchanged for calculations of σ involved in T_equil
     _p0 = 1.01325e5
     σ = p / _p0
     exner_p = σ^(_R_d / _cp_d)
@@ -107,10 +107,10 @@ end
 nothing # hide
 
 # ## Set initial condition
-# When using ClimateMachine, we need to define a function that sets the intial state of our
+# When using ClimateMachine, we need to define a function that sets the initial state of our
 # model run. In our case, we use the reference state of the simulation (defined
 # below) and add a little bit of noise. Note that the initial states includes a
-# zero initial velocity field. 
+# zero initial velocity field.
 function init_heldsuarez!(balance_law, state, aux, coordinates, time)
     FT = eltype(state)
 
@@ -138,17 +138,17 @@ FT = Float32
 nothing # hide
 
 # ## Setup model configuration
-# Now that we have definied our forcing and initialization functions, and have
-# initialized ClimateMachine, we can set up the model. 
-# 
+# Now that we have defined our forcing and initialization functions, and have
+# initialized ClimateMachine, we can set up the model.
+#
 # ## Set up a reference state
 # We start by setting up a
 # reference state. This is simply a vector field that we subtract from the
 # solutions to the governing equations to both improve numerical stability of the
 # implicit time stepper and enable faster model spin-up. The reference state
-# assumes hydrostatic balance and ideal gas law, with a pressure $p_r(z)$ and 
+# assumes hydrostatic balance and ideal gas law, with a pressure $p_r(z)$ and
 # density $\rho_r(z)$ that only depend on altitude $z$ and are in hydrostatic balance
-# with each other. 
+# with each other.
 # In this example, the reference temperature field smoothly transitions from a
 # linearly decaying profile near the surface to a constant temperature profile at the top
 # of the domain.
@@ -182,7 +182,7 @@ nothing # hide
 
 # ## Instantiate the model
 # The Held Suarez setup was designed to produce an equilibrated state
-# that is comparable to the zonal mean of the Earth’s atmosphere. 
+# that is comparable to the zonal mean of the Earth’s atmosphere.
 model = AtmosModel{FT}(
     AtmosGCMConfigType,
     param_set;
@@ -191,12 +191,12 @@ model = AtmosModel{FT}(
     hyperdiffusion = hyperdiffusion_model,
     moisture = DryModel(),
     source = (Gravity(), Coriolis(), held_suarez_forcing!, sponge),
-    init_state = init_heldsuarez!,
+    init_state_conservative = init_heldsuarez!,
 )
 nothing # hide
 # This concludes the setup of the physical model!
 
-# ## Set up the driver 
+# ## Set up the driver
 # We just need to set up a few parameters that define the resolution of the
 # discontinuous Galerkin method and how long we want to run our model setup for.
 poly_order = 5                        ## discontinuous Galerkin polynomial order

--- a/tutorials/Microphysics/KinematicModel.jl
+++ b/tutorials/Microphysics/KinematicModel.jl
@@ -1,20 +1,20 @@
-# The set-up was designed for the
-# 8th International Cloud Modelling Workshop
-# (ICMW, Muhlbauer et al., 2013, case 1, doi:10.1175/BAMS-D-12-00188.1)
-#
-# See chapter 2 in Arabas et al 2015 for setup details:
-#@Article{gmd-8-1677-2015,
-#AUTHOR = {Arabas, S. and Jaruga, A. and Pawlowska, H. and Grabowski, W. W.},
-#TITLE = {libcloudph++ 1.0: a single-moment bulk, double-moment bulk,
-#         and particle-based warm-rain microphysics library in C++},
-#JOURNAL = {Geoscientific Model Development},
-#VOLUME = {8},
-#YEAR = {2015},
-#NUMBER = {6},
-#PAGES = {1677--1707},
-#URL = {https://www.geosci-model-dev.net/8/1677/2015/},
-#DOI = {10.5194/gmd-8-1677-2015}
-#}
+##  The set-up was designed for the
+##  8th International Cloud Modelling Workshop
+##  (ICMW, Muhlbauer et al., 2013, case 1, doi:10.1175/BAMS-D-12-00188.1)
+##
+##  See chapter 2 in Arabas et al 2015 for setup details:
+## @Article{gmd-8-1677-2015,
+## AUTHOR = {Arabas, S. and Jaruga, A. and Pawlowska, H. and Grabowski, W. W.},
+## TITLE = {libcloudph++ 1.0: a single-moment bulk, double-moment bulk,
+##          and particle-based warm-rain microphysics library in C++},
+## JOURNAL = {Geoscientific Model Development},
+## VOLUME = {8},
+## YEAR = {2015},
+## NUMBER = {6},
+## PAGES = {1677--1707},
+## URL = {https://www.geosci-model-dev.net/8/1677/2015/},
+## DOI = {10.5194/gmd-8-1677-2015}
+## }
 
 using Dates
 using DocStringExtensions
@@ -141,12 +141,12 @@ function init_state_auxiliary!(
     _cp_d::FT = cp_d(m.param_set)
     _grav::FT = grav(m.param_set)
 
-    # TODO - should R_d and cp_d here be R_m and cp_m?
+    ## TODO - should R_d and cp_d here be R_m and cp_m?
     R_m, cp_m, cv_m, γ = gas_constants(m.param_set, PhasePartition(dc.qt_0))
 
-    # Pressure profile assuming hydrostatic and constant θ and qt profiles.
-    # It is done this way to be consistent with Arabas paper.
-    # It's not necessarily the best way to initialize with our model variables.
+    ## Pressure profile assuming hydrostatic and constant θ and qt profiles.
+    ## It is done this way to be consistent with Arabas paper.
+    ## It's not necessarily the best way to initialize with our model variables.
     p =
         dc.p_1000 *
         (
@@ -231,7 +231,7 @@ function config_kinematic_eddy(
     qt_0,
     z_0,
 )
-    # Choose explicit solver
+    ## Choose explicit solver
     ode_solver = ClimateMachine.ExplicitSolverType(
         solver_method = LSRK144NiegemannDiehlBusch,
     )
@@ -248,7 +248,7 @@ function config_kinematic_eddy(
         FT(z_0),
     )
 
-    # Set up the model
+    ## Set up the model
     model = KinematicModel{FT}(
         AtmosLESConfigType,
         param_set;

--- a/tutorials/Microphysics/ex_1_saturation_adjustment.jl
+++ b/tutorials/Microphysics/ex_1_saturation_adjustment.jl
@@ -1,4 +1,6 @@
-include("KinematicModel.jl")
+using ClimateMachine
+const clima_dir = dirname(dirname(pathof(ClimateMachine)))
+include(joinpath(clima_dir, "tutorials", "Microphysics", "KinematicModel.jl"))
 
 function vars_state_conservative(m::KinematicModel, FT)
     @vars begin
@@ -11,10 +13,10 @@ end
 
 function vars_state_auxiliary(m::KinematicModel, FT)
     @vars begin
-        # defined in init_state_auxiliary
+        ## defined in init_state_auxiliary
         p::FT
         z::FT
-        # defined in update_aux
+        ## defined in update_aux
         u::FT
         w::FT
         q_tot::FT
@@ -38,17 +40,17 @@ function init_kinematic_eddy!(eddy_model, state, aux, (x, y, z), t)
 
     dc = eddy_model.data_config
 
-    # density
+    ## density
     q_pt_0 = PhasePartition(dc.qt_0)
     R_m, cp_m, cv_m, γ = gas_constants(param_set, q_pt_0)
     T::FT = dc.θ_0 * (aux.p / dc.p_1000)^(R_m / cp_m)
     ρ::FT = aux.p / R_m / T
     state.ρ = ρ
 
-    # moisture
+    ## moisture
     state.ρq_tot = ρ * dc.qt_0
 
-    # velocity (derivative of streamfunction)
+    ## velocity (derivative of streamfunction)
     ρu::FT =
         dc.wmax * dc.xmax / dc.zmax *
         cos(π * z / dc.zmax) *
@@ -58,7 +60,7 @@ function init_kinematic_eddy!(eddy_model, state, aux, (x, y, z), t)
     u::FT = ρu / ρ
     w::FT = ρw / ρ
 
-    # energy
+    ## energy
     e_kin::FT = 1 // 2 * (u^2 + w^2)
     e_pot::FT = _grav * z
     e_int::FT = internal_energy(param_set, T, q_pt_0)
@@ -87,7 +89,7 @@ function kinematic_model_nodal_update_auxiliary_state!(
     aux.e_pot = _grav * aux.z
     aux.e_int = aux.e_tot - aux.e_kin - aux.e_pot
 
-    # saturation adjustment happens here
+    ## saturation adjustment happens here
     ts = PhaseEquil(param_set, aux.e_int, state.ρ, aux.q_tot)
     pp = PhasePartition(ts)
 
@@ -139,38 +141,38 @@ end
 )
     FT = eltype(state)
 
-    # advect moisture ...
+    ## advect moisture ...
     flux.ρq_tot = SVector(
         state.ρu[1] * state.ρq_tot / state.ρ,
         FT(0),
         state.ρu[3] * state.ρq_tot / state.ρ,
     )
-    # ... energy ...
+    ## ... energy ...
     flux.ρe = SVector(
         state.ρu[1] / state.ρ * (state.ρe + aux.p),
         FT(0),
         state.ρu[3] / state.ρ * (state.ρe + aux.p),
     )
-    # ... and don't advect momentum (kinematic setup)
+    ## ... and don't advect momentum (kinematic setup)
 end
 
 source!(::KinematicModel, _...) = nothing
 
 function main()
-    # Working precision
+    ## Working precision
     FT = Float64
-    # DG polynomial order
+    ## DG polynomial order
     N = 4
-    # Domain resolution and size
+    ## Domain resolution and size
     Δx = FT(20)
     Δy = FT(1)
     Δz = FT(20)
     resolution = (Δx, Δy, Δz)
-    # Domain extents
+    ## Domain extents
     xmax = 1500
     ymax = 10
     zmax = 1500
-    # initial configuration
+    ## initial configuration
     wmax = FT(0.6)  # max velocity of the eddy  [m/s]
     θ_0 = FT(289) # init. theta value (const) [K]
     p_0 = FT(101500) # surface pressure [Pa]
@@ -178,7 +180,7 @@ function main()
     qt_0 = FT(7.5 * 1e-3) # init. total water specific humidity (const) [kg/kg]
     z_0 = FT(0) # surface height
 
-    # time stepping
+    ## time stepping
     t_ini = FT(0)
     t_end = FT(60 * 30)
     dt = 40
@@ -204,12 +206,12 @@ function main()
         driver_config;
         ode_dt = dt,
         init_on_cpu = true,
-        #Courant_number = CFL,
+        ## Courant_number = CFL,
     )
 
     mpicomm = MPI.COMM_WORLD
 
-    # output for paraview
+    ## output for paraview
     model = driver_config.bl
     step = [0]
     cbvtk =
@@ -233,31 +235,31 @@ function main()
             nothing
         end
 
-    # get aux variables indices for testing
+    ## get aux variables indices for testing
     q_tot_ind = varsindex(vars_state_auxiliary(model, FT), :q_tot)
     q_vap_ind = varsindex(vars_state_auxiliary(model, FT), :q_vap)
     q_liq_ind = varsindex(vars_state_auxiliary(model, FT), :q_liq)
     q_ice_ind = varsindex(vars_state_auxiliary(model, FT), :q_ice)
     S_ind = varsindex(vars_state_auxiliary(model, FT), :S)
 
-    # call solve! function for time-integrator
+    ## call solve! function for time-integrator
     result = ClimateMachine.invoke!(
         solver_config;
         user_callbacks = (cbvtk,),
         check_euclidean_distance = true,
     )
 
-    # no supersaturation
+    ## no supersaturation
     max_S = maximum(abs.(solver_config.dg.state_auxiliary[:, S_ind, :]))
     @test isequal(max_S, FT(0))
 
-    # qt is conserved
+    ## qt is conserved
     max_q_tot = maximum(abs.(solver_config.dg.state_auxiliary[:, q_tot_ind, :]))
     min_q_tot = minimum(abs.(solver_config.dg.state_auxiliary[:, q_tot_ind, :]))
     @test isapprox(max_q_tot, qt_0; rtol = 1e-3)
     @test isapprox(min_q_tot, qt_0; rtol = 1e-3)
 
-    # q_vap + q_liq = q_tot
+    ## q_vap + q_liq = q_tot
     max_water_diff = maximum(abs.(
         solver_config.dg.state_auxiliary[:, q_tot_ind, :] .-
         solver_config.dg.state_auxiliary[:, q_vap_ind, :] .-
@@ -265,11 +267,11 @@ function main()
     ))
     @test isequal(max_water_diff, FT(0))
 
-    # no ice
+    ## no ice
     max_q_ice = maximum(abs.(solver_config.dg.state_auxiliary[:, q_ice_ind, :]))
     @test isequal(max_q_ice, FT(0))
 
-    # q_liq ∈ reference range
+    ## q_liq ∈ reference range
     max_q_liq = max(solver_config.dg.state_auxiliary[:, q_liq_ind, :]...)
     min_q_liq = min(solver_config.dg.state_auxiliary[:, q_liq_ind, :]...)
     @test max_q_liq < FT(1e-3)

--- a/tutorials/Numerics/DGmethods/nonnegative.jl
+++ b/tutorials/Numerics/DGmethods/nonnegative.jl
@@ -1,21 +1,21 @@
-# This tutorial uses the TMAR Filter from
-#
-#    @article{doi:10.1175/MWR-D-16-0220.1,
-#      author = {Light, Devin and Durran, Dale},
-#      title = {Preserving Nonnegativity in Discontinuous Galerkin
-#               Approximations to Scalar Transport via Truncation and Mass
-#               Aware Rescaling (TMAR)},
-#      journal = {Monthly Weather Review},
-#      volume = {144},
-#      number = {12},
-#      pages = {4771-4786},
-#      year = {2016},
-#      doi = {10.1175/MWR-D-16-0220.1},
-#    }
-#
-# to reproduce the tutorial in section 4b.  It is a shear swirling
-# flow deformation of a transported quantity from LeVeque 1996.  The exact
-# solution at the final time is the same as the initial condition.
+## This tutorial uses the TMAR Filter from
+##
+##    @article{doi:10.1175/MWR-D-16-0220.1,
+##      author = {Light, Devin and Durran, Dale},
+##      title = {Preserving Nonnegativity in Discontinuous Galerkin
+##               Approximations to Scalar Transport via Truncation and Mass
+##               Aware Rescaling (TMAR)},
+##      journal = {Monthly Weather Review},
+##      volume = {144},
+##      number = {12},
+##      pages = {4771-4786},
+##      year = {2016},
+##      doi = {10.1175/MWR-D-16-0220.1},
+##    }
+##
+## to reproduce the tutorial in section 4b.  It is a shear swirling
+## flow deformation of a transported quantity from LeVeque 1996.  The exact
+## solution at the final time is the same as the initial condition.
 
 using MPI
 using Test
@@ -36,11 +36,10 @@ using ClimateMachine.GenericCallbacks:
     EveryXWallTimeSeconds, EveryXSimulationSteps
 using ClimateMachine.VTK: writevtk, writepvtu
 
+
+const clima_dir = dirname(dirname(pathof(ClimateMachine)))
 include(joinpath(
-    @__DIR__,
-    "..",
-    "..",
-    "..",
+    clima_dir,
     "test",
     "Numerics",
     "DGmethods",
@@ -146,7 +145,7 @@ function run(
 
     initialsumQ = weightedsum(Q)
 
-    # We integrate so that the final solution is equal to the initial solution
+    ## We integrate so that the final solution is equal to the initial solution
     Qe = copy(Q)
 
     rhs! = function (dQdt, Q, ::Nothing, t; increment = false)
@@ -162,9 +161,9 @@ function run(
 
     mkpath(vtkdir)
     vtkstep = 0
-    # output initial step
+    ## output initial step
     do_output(mpicomm, vtkdir, vtkstep, dg, Q, model, "nonnegative")
-    # setup the output callback
+    ## setup the output callback
     cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
         vtkstep += 1
         minQ, maxQ = minimum(Q), maximum(Q)

--- a/tutorials/Numerics/LinearSolvers/cg.jl
+++ b/tutorials/Numerics/LinearSolvers/cg.jl
@@ -3,7 +3,7 @@
 # At the end you should be able to
 # 1. Use Conjugate Gradient to solve a linear system
 # 2. Know when to not use it
-# 3. Contruct a column-wise linear solver with Conjugate Gradient
+# 3. Construct a column-wise linear solver with Conjugate Gradient
 
 # ## What is it?
 # Conjugate Gradient is an iterative method for solving special kinds of linear systems:
@@ -56,7 +56,7 @@ linearsolver = ConjugateGradient(b);
 x = ones(typeof(1.0), 3);
 # To solve the linear system we just need to pass to the linearsolve! function
 iters = linearsolve!(linear_operator!, linearsolver, x, b)
-# The variable `x` gets overwitten during the linear solve
+# The variable `x` gets overwritten during the linear solve
 # The norm of the error is
 norm(x - x_exact) / norm(x_exact)
 # The relative norm of the residual is
@@ -103,7 +103,7 @@ linearsolver = ConjugateGradient(b, max_iter = 100);
 x = ones(typeof(1.0), 3);
 # To (not) solve the linear system we just need to pass to the linearsolve! function
 iters = linearsolve!(linear_operator!, linearsolver, x, b)
-# The variable `x` gets overwitten during the linear solve
+# The variable `x` gets overwritten during the linear solve
 # The norm of the error is
 norm(x - x_exact) / norm(x_exact)
 # The relative norm of the residual is
@@ -191,4 +191,4 @@ iters
 # ## Tips
 # 1. The convergence criteria should be changed, machine precision is too small and the maximum iterations is often too large
 # 2. Use a preconditioner if possible
-# 3. Make sure that the linear system really is symmetric and positive-definite 
+# 3. Make sure that the linear system really is symmetric and positive-definite

--- a/tutorials/topo.jl
+++ b/tutorials/topo.jl
@@ -6,7 +6,6 @@ using ClimateMachine.Mesh.Grids
 using ClimateMachine.DGmethods
 using ClimateMachine.DGmethods.NumericalFluxes
 using ClimateMachine.MPIStateArrays
-using ClimateMachine.LowStorageRungeKuttaMethod
 using LinearAlgebra
 using ClimateMachine.GenericCallbacks:
     EveryXWallTimeSeconds, EveryXSimulationSteps


### PR DESCRIPTION
# Description

 - Fixes broken docs, both in `docs/` and in `tutorials/`
 - Turns back on `Literate.notebook(input, gen_dir, execute = true)`
 - This will allow us to include figures in our Literate tutorials (figs are not generated unless the ipynb executes).
 - Removes `println("Generated files: $(generated_files)")`, since this is very noisy when the ipynb executes.

Fixes ipynb execution for the following tutorials:
 - `topo.jl`
 - `nonnegative.jl`
 - `ex_1_saturation_adjustment.jl`
 - `ex_2_Kessler.jl`

I ran into problems with
 - `heldsuarez` (breaks)
 - `dry_rayleigh_benard` (takes too long, ~1 hr)

As a general note, it might be nice to add a `@test`s in the docs and, if/when we set `strict = true` in `docs/make.jl`, then these tutorials will hopefully never go stale.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
