### PR TITLE
Fix some broken docs

### DIFF
--- a/.github/workflows/Documenter.yaml
+++ b/.github/workflows/Documenter.yaml
@@ -22,7 +22,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install mpich libmpich-dev
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
+        run: |
+          sudo apt install libxt6 libxrender1 libxext6 libgl1-mesa-glx libqt5widgets5
+          julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,7 @@
 Base.HOME_PROJECT[] = abspath(Base.HOME_PROJECT[]) # JuliaLang/julia/pull/28625
 
 using ClimateMachine, Documenter, Literate
+ENV["GKSwstype"] = "100" # https://github.com/jheinen/GR.jl/issues/278#issuecomment-587090846
 
 generated_dir = joinpath(@__DIR__, "src", "generated") # generated files directory
 mkpath(generated_dir)

--- a/docs/src/HowToGuides/Atmos/Microphysics.md
+++ b/docs/src/HowToGuides/Atmos/Microphysics.md
@@ -98,8 +98,9 @@ The default value of ``C_{drag}`` is chosen such that the ``v_t`` is close to th
 using ClimateMachine.Microphysics
 using Plots
 using CLIMAParameters
-abstract type EarthParameterSet <: AbstractParameterSet end
-param_set = EarthParameterSet()
+using CLIMAParameters.Atmos.Microphysics
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
 
 # eq. 5d in Smolarkiewicz and Grabowski 1996
 # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
@@ -172,7 +173,7 @@ using ClimateMachine.Microphysics
 using Plots
 using CLIMAParameters
 struct EarthParameterSet <: AbstractEarthParameterSet end
-param_set = EarthParameterSet()
+const param_set = EarthParameterSet()
 
 # eq. 5b in Smolarkiewicz and Grabowski 1996
 # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
@@ -271,7 +272,7 @@ using ClimateMachine.Microphysics
 using ClimateMachine.MoistThermodynamics
 
 using CLIMAParameters
-using CLIMAParameters.Planet: R_d, planet_radius, grav, MSLP
+using CLIMAParameters.Planet: R_d, planet_radius, grav, MSLP, molmass_ratio
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
@@ -310,7 +311,7 @@ q = PhasePartition(q_tot, q_liq, q_ice)
 R = gas_constant_air(param_set, q)
 ρ = p / R / T
 
-plot(q_rain_range * 1e3,  [conv_q_rai_to_q_vap(q_rai, q, T, p, ρ) for q_rai in q_rain_range], xlabel="q_rain [g/kg]", ylabel="rain evaporation rate [1/s]", title="Rain evaporation", label="ClimateMachine")
+plot(q_rain_range * 1e3,  [conv_q_rai_to_q_vap(param_set, q_rai, q, T, p, ρ) for q_rai in q_rain_range], xlabel="q_rain [g/kg]", ylabel="rain evaporation rate [1/s]", title="Rain evaporation", label="ClimateMachine")
 plot!(q_rain_range * 1e3, [rain_evap_empirical(q_rai, q, T, p, ρ) for q_rai in q_rain_range], label="empirical")
 savefig("rain_evaporation_rate.svg") # hide
 nothing # hide

--- a/docs/src/HowToGuides/Atmos/Model/tracers.md
+++ b/docs/src/HowToGuides/Atmos/Model/tracers.md
@@ -16,7 +16,7 @@ In `tracers.jl`, we define the equation sets governing
 tracer dynamics. Specifically, we address the the equations
 of tracer motion in conservation form,
 
-```@example tracers
+```julia
 export NoTracers, NTracers
 ```
 
@@ -38,9 +38,8 @@ and [`NTracers`](@ref multiple-tracers).
 
 Default stub functions for a generic tracer type are defined here.
 
-```@example tracers
-abstract type TracerModel end
-
+```julia
+abstract type TracerModel <: BalanceLaw end
 
 vars_state_conservative(::TracerModel, FT) = @vars()
 vars_state_gradient(::TracerModel, FT) = @vars()

--- a/docs/src/HowToGuides/Atmos/Model/turbulence.md
+++ b/docs/src/HowToGuides/Atmos/Model/turbulence.md
@@ -21,7 +21,7 @@ are:\
     - `turbulence=Vreman(C_smag)`\
     - `turbulence=AnisoMinDiss(C_poincare)`
 
-```@example turbulence
+```julia
 using DocStringExtensions
 using CLIMAParameters.Atmos.SubgridScale: inv_Pr_turb
 export ConstantViscosityWithDivergence, SmagorinskyLilly, Vreman, AnisoMinDiss
@@ -34,7 +34,7 @@ default functions for the generic turbulence closure
 which will be overloaded with model specific functions. Minimally, overloaded functions for the
 following stubs must be defined for a turbulence model.
 
-```@example turbulence
+```julia
 abstract type TurbulenceClosure end
 
 
@@ -70,7 +70,7 @@ The following may need to be addressed if turbulence models require
 additional state variables or auxiliary variable updates (e.g. TKE
 based models)
 
-```@example turbulence
+```julia
 vars_state_conservative(::TurbulenceClosure, FT) = @vars()
 function atmos_nodal_update_auxiliary_state!(
     ::TurbulenceClosure,
@@ -137,7 +137,7 @@ skew symmetric component (rate-of-rotation) is not currently computed.
 ClimateMachine.Atmos.strain_rate_magnitude
 ```
 
-```@example turbulence
+```julia
 """
     strain_rate_magnitude(S)
 Given the rate-of-strain tensor `S`, computes its magnitude.


### PR DESCRIPTION
# Description

Fixes several broken docs:

 - Microphysics: had missing variables / function arguments
 - RTB/Turbulence/Tracers: switched `@example` to `julia` blocks, since they are split across scope blocks (which breaks), or does not include sufficient code for an example.

 - Fixes the
```
connect: Connection refused
GKS: can't connect to GKS socket application

GKS: Open failed in routine OPEN_WS
GKS: GKS not in proper state. GKS must be either in the state WSOP or WSAC in routine ACTIVATE_WS
```
error by [installing](https://gr-framework.org/julia.html#installation) required libraries as suggested [here](https://github.com/jheinen/GR.jl/issues/278#issuecomment-587101840) and [here](https://github.com/jheinen/GR.jl/issues/278#issuecomment-587090846)

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
