### PR TITLE
switch to using new mpiexec interface from MPI.jl

### DIFF
--- a/test/Arrays/runtests.jl
+++ b/test/Arrays/runtests.jl
@@ -2,13 +2,9 @@ using Test
 include(joinpath("..", "testhelpers.jl"))
 
 @testset "MPIStateArrays reductions" begin
-    tests = [
-        (1, "basics.jl")
-        (1, "broadcasting.jl")
-        (1, "reductions.jl")
-        (3, "reductions.jl")
-        (1, "varsindex.jl")
-    ]
-
-    runmpi(tests, @__FILE__)
+    runmpi(joinpath(@__DIR__, "basics.jl"))
+    runmpi(joinpath(@__DIR__, "broadcasting.jl"))
+    runmpi(joinpath(@__DIR__, "reductions.jl"))
+    runmpi(joinpath(@__DIR__, "reductions.jl"), ntasks = 3)
+    runmpi(joinpath(@__DIR__, "varsindex.jl"))
 end

--- a/test/Diagnostics/runtests.jl
+++ b/test/Diagnostics/runtests.jl
@@ -2,7 +2,5 @@ using MPI, Test
 include("../testhelpers.jl")
 
 @testset "Diagnostics" begin
-    tests = [(2, "sin_test.jl")]
-
-    runmpi(tests, @__FILE__)
+    runmpi(joinpath(@__DIR__, "sin_test.jl"), ntasks = 2)
 end

--- a/test/Driver/runtests.jl
+++ b/test/Driver/runtests.jl
@@ -3,13 +3,10 @@ using MPI, Test
 include("../testhelpers.jl")
 
 @testset "Driver" begin
-    tests = [
-        (1, "cr_unit_tests.jl"),
-        (1, "driver_test.jl"),
-        #TODO: these take too long on Azure CI -- need to go in weekly
-        #(1, "mms3.jl --checkpoint-walltime 60 --checkpoint-keep-all"),
-        #(1, "mms3.jl --restart-from-num 3"),
-    ]
+    runmpi(joinpath(@__DIR__, "cr_unit_tests.jl"), ntasks = 1)
+    runmpi(joinpath(@__DIR__, "driver_test.jl"), ntasks = 1)
 
-    runmpi(tests, @__FILE__)
+    #TODO: these take too long on Azure CI -- need to go in weekly
+    # runmpi(`$(joinpath(@__DIR__, mms3.jl)) --checkpoint-walltime 60 --checkpoint-keep-all`; ntasks=1)
+    # runmpi(`$(joinpath(@__DIR__, mms3.jl)) --restart-from-num 3`; ntasks=1)
 end

--- a/test/Numerics/DGmethods/runtests.jl
+++ b/test/Numerics/DGmethods/runtests.jl
@@ -2,18 +2,17 @@ using MPI, Test
 include(joinpath("..", "..", "testhelpers.jl"))
 
 @testset "DGmethods" begin
-    tests = [
-        (1, "vars_test.jl")
-        (1, "integral_test.jl")
-        (1, "integral_test_sphere.jl")
-        (1, "Euler/isentropicvortex.jl")
-        (1, "Euler/isentropicvortex_imex.jl")
-        (1, "Euler/isentropicvortex_multirate.jl")
-        (1, "advection_diffusion/pseudo1D_advection_diffusion.jl")
-        (1, "compressible_Navier_Stokes/ref_state.jl")
-        (1, "horizontal_integral_test.jl")
-        (2, "courant.jl")
-    ]
-
-    runmpi(tests, @__FILE__)
+    runmpi(joinpath(@__DIR__, "vars_test.jl"))
+    runmpi(joinpath(@__DIR__, "integral_test.jl"))
+    runmpi(joinpath(@__DIR__, "integral_test_sphere.jl"))
+    runmpi(joinpath(@__DIR__, "Euler/isentropicvortex.jl"))
+    runmpi(joinpath(@__DIR__, "Euler/isentropicvortex_imex.jl"))
+    runmpi(joinpath(@__DIR__, "Euler/isentropicvortex_multirate.jl"))
+    runmpi(joinpath(
+        @__DIR__,
+        "advection_diffusion/pseudo1D_advection_diffusion.jl",
+    ))
+    runmpi(joinpath(@__DIR__, "compressible_Navier_Stokes/ref_state.jl"))
+    runmpi(joinpath(@__DIR__, "horizontal_integral_test.jl"))
+    runmpi(joinpath(@__DIR__, "courant.jl"), ntasks = 2)
 end

--- a/test/Numerics/LinearSolvers/runtests.jl
+++ b/test/Numerics/LinearSolvers/runtests.jl
@@ -4,11 +4,8 @@ include(joinpath("..", "..", "testhelpers.jl"))
 include("iterativesolvers.jl")
 
 @testset "Linear Solvers Poisson" begin
-    tests = [
-        (1, "columnwiselu.jl"),
-        (1, "poisson.jl"),
-        (1, "bandedsystem.jl"),
-        (1, "cg.jl"),
-    ]
-    runmpi(tests, @__FILE__)
+    runmpi(joinpath(@__DIR__, "columnwiselu.jl"))
+    runmpi(joinpath(@__DIR__, "poisson.jl"))
+    runmpi(joinpath(@__DIR__, "bandedsystem.jl"))
+    runmpi(joinpath(@__DIR__, "cg.jl"))
 end

--- a/test/Numerics/Mesh/runtests.jl
+++ b/test/Numerics/Mesh/runtests.jl
@@ -24,18 +24,13 @@ MPI.Initialized() && MPI.Finalize()
 Base.GC.gc()
 
 @testset "MPI Jobs" begin
-
-    tests = [
-        (3, "mpi_centroid.jl")
-        (2, "mpi_connect_ell.jl")
-        (3, "interpolation.jl")
-        (3, "mpi_connect.jl")
-        (3, "mpi_connect_stacked.jl")
-        (2, "mpi_connect_stacked_3d.jl")
-        (3, "mpi_getpartition.jl")
-        (3, "mpi_partition.jl")
-        (1, "mpi_sortcolumns.jl")
-    ]
-
-    runmpi(tests, @__FILE__)
+    runmpi(joinpath(@__DIR__, "mpi_centroid.jl"), ntasks = 3)
+    runmpi(joinpath(@__DIR__, "mpi_connect_ell.jl"), ntasks = 2)
+    runmpi(joinpath(@__DIR__, "interpolation.jl"), ntasks = 3)
+    runmpi(joinpath(@__DIR__, "mpi_connect.jl"), ntasks = 3)
+    runmpi(joinpath(@__DIR__, "mpi_connect_stacked.jl"), ntasks = 3)
+    runmpi(joinpath(@__DIR__, "mpi_connect_stacked_3d.jl"), ntasks = 2)
+    runmpi(joinpath(@__DIR__, "mpi_getpartition.jl"), ntasks = 3)
+    runmpi(joinpath(@__DIR__, "mpi_partition.jl"), ntasks = 3)
+    runmpi(joinpath(@__DIR__, "mpi_sortcolumns.jl"), ntasks = 1)
 end

--- a/test/Numerics/ODESolvers/runtests.jl
+++ b/test/Numerics/ODESolvers/runtests.jl
@@ -2,6 +2,6 @@ using Test, MPI
 include(joinpath("..", "..", "testhelpers.jl"))
 
 @testset "ODE Solvers" begin
-    tests = [(1, "ode_tests_basic.jl"), (1, "genericcb_tests.jl")]
-    runmpi(tests, @__FILE__)
+    runmpi(joinpath(@__DIR__, "ode_tests_basic.jl"))
+    runmpi(joinpath(@__DIR__, "genericcb_tests.jl"))
 end

--- a/test/Ocean/runtests.jl
+++ b/test/Ocean/runtests.jl
@@ -2,11 +2,7 @@ using MPI, Test
 include("../testhelpers.jl")
 
 @testset "Ocean" begin
-    tests = [
-        (1, "HydrostaticBoussinesq/test_divergence_free.jl"),
-        (1, "HydrostaticBoussinesq/test_ocean_gyre.jl"),
-        # (1,"shallow_water/GyreDriver.jl"),
-    ]
-
-    runmpi(tests, @__FILE__)
+    runmpi(joinpath(@__DIR__, "HydrostaticBoussinesq/test_divergence_free.jl"))
+    runmpi(joinpath(@__DIR__, "HydrostaticBoussinesq/test_ocean_gyre.jl"))
+    # runmpi(joinpath(@__DIR__,"shallow_water/GyreDriver.jl"))
 end


### PR DESCRIPTION
# Description

Simplify the runmpi function

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)