### PR TITLE
Remove generated docs folder in docs/make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ using ClimateMachine, Documenter, Literate
 ENV["GKSwstype"] = "100" # https://github.com/jheinen/GR.jl/issues/278#issuecomment-587090846
 
 generated_dir = joinpath(@__DIR__, "src", "generated") # generated files directory
+rm(generated_dir, force = true, recursive = true)
 mkpath(generated_dir)
 
 include("list_of_experiments.jl")        # defines a nested array `experiments`


### PR DESCRIPTION
# Description

My docs were hanging locally because of some leftover files in `docs/src/generated/` (this folder is not git-tracked). So, this PR removes this folder before building the docs so that others don't fall into this trap.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
