### PR TITLE
fixed restart minor bug

### DIFF
--- a/src/Numerics/DGmethods/DGmodel.jl
+++ b/src/Numerics/DGmethods/DGmodel.jl
@@ -578,7 +578,7 @@ function restart_ode_state(dg::DGModel, state_data; init_on_cpu = false)
     bl = dg.balance_law
     grid = dg.grid
 
-    state = create_state(bl, grid)
+    state = create_conservative_state(bl, grid)
     state .= state_data
 
     device = arraytype(dg.grid) <: Array ? CPU() : CUDA()


### PR DESCRIPTION
# Description

This is a fix for the restart functionality, the create_state function would cause an exit with an error saying the function does not exist, I've replaced it with create_conservative_state and restarting works again.

@simonbyrne @kpamnany @akshaysridhar 
