### PR TITLE
Add old `.dev/format.jl` capability into `.dev/climaformat.jl`

### DIFF
--- a/.dev/climaformat.jl
+++ b/.dev/climaformat.jl
@@ -37,7 +37,8 @@ help = """
 Usage: climaformat.jl [flags] [FILE/PATH]...
 
 Formats the given julia files using the CLIMA formatting options.  If paths
-are given it will format the julia files in the paths.
+are given it will format the julia files in the paths. Otherwise, it will
+format all changed julia files.
 
     -v, --verbose
         Print the name of the files being formatted with relevant details.
@@ -71,9 +72,15 @@ function parse_opts!(args::Vector{String})
 end
 
 opts = parse_opts!(ARGS)
-if isempty(ARGS) || haskey(opts, :help)
+if haskey(opts, :help)
     write(stdout, help)
     exit(0)
 end
+if isempty(ARGS)
+    filenames = readlines(`git diff --name-only --diff-filter=AM HEAD`)
+    filter!(f -> endswith(f, ".jl"), filenames)
+else
+    filenames = ARGS
+end
 
-format(ARGS; clima_formatter_options..., opts...)
+format(filenames; clima_formatter_options..., opts...)


### PR DESCRIPTION
# Description

This is better for my work flow than the pre-commit hook. @charleskawczynski likes it too.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
