### PR TITLE
Add missing sync in vertical volume tendency kernel

### DIFF
--- a/src/Numerics/DGmethods/DGmodel_kernels.jl
+++ b/src/Numerics/DGmethods/DGmodel_kernels.jl
@@ -320,6 +320,9 @@ end
             local_MI[k] = vgeo[ijk, _MI, e]
         end
 
+        # ensure D is loaded
+        @synchronize(dim == 3)
+
         @unroll for k in 1:Nqk
             ijk = i + Nq * ((j - 1) + Nq * (k - 1))
 


### PR DESCRIPTION
# Description

Fixes a possible race condition in the vertical tendency evaluation.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
