### PR TITLE
Init shared path prefix from a single rank before run

### DIFF
--- a/experiments/OceanBoxGCM/ocean_gyre.jl
+++ b/experiments/OceanBoxGCM/ocean_gyre.jl
@@ -53,7 +53,6 @@ function run_ocean_gyre(; imex::Bool = false, BC = nothing)
     H = 1000   # m
     dimensions = (Lˣ, Lʸ, H)
 
-    outpdir = "output"
     timestart = FT(0)    # s
     timeout = FT(0.25 * 86400) # s
     timeend = FT(86400) # s
@@ -86,7 +85,6 @@ function run_ocean_gyre(; imex::Bool = false, BC = nothing)
         modeldata = modeldata,
     )
 
-    mkpath(outpdir)
     ClimateMachine.Settings.vtk = "never"
     # vtk_interval = ceil(Int64, timeout / solver_config.dt)
     # ClimateMachine.Settings.vtk = "$(vtk_interval)steps"

--- a/tutorials/Microphysics/ex_1_saturation_adjustment.jl
+++ b/tutorials/Microphysics/ex_1_saturation_adjustment.jl
@@ -210,19 +210,27 @@ function main()
     mpicomm = MPI.COMM_WORLD
 
     # output for paraview
+
+    # initialize base prefix directory from rank 0
+    vtkdir = abspath(joinpath(ClimateMachine.Settings.output_dir, "vtk"))
+    if MPI.Comm_rank(mpicomm) == 0
+        mkpath(vtkdir)
+    end
+    MPI.Barrier(mpicomm)
+
     model = driver_config.bl
     step = [0]
     cbvtk =
         GenericCallbacks.EveryXSimulationSteps(output_freq) do (init = false)
-            mkpath("vtk/")
-            outprefix = @sprintf(
-                "vtk/new_ex_1_mpirank%04d_step%04d",
+            out_dirname = @sprintf(
+                "new_ex_1_mpirank%04d_step%04d",
                 MPI.Comm_rank(mpicomm),
                 step[1]
             )
-            @info "doing VTK output" outprefix
+            out_path_prefix = joinpath(vtkdir, out_dirname)
+            @info "doing VTK output" out_path_prefix
             writevtk(
-                outprefix,
+                out_path_prefix,
                 solver_config.Q,
                 solver_config.dg,
                 flattenednames(vars_state_conservative(model, FT)),

--- a/tutorials/Microphysics/ex_2_Kessler.jl
+++ b/tutorials/Microphysics/ex_2_Kessler.jl
@@ -350,18 +350,26 @@ function main()
         end
 
     # output for paraview
+
+    # initialize base output prefix directory from rank 0
+    vtkdir = abspath(joinpath(ClimateMachine.Settings.output_dir, "vtk"))
+    if MPI.Comm_rank(mpicomm) == 0
+        mkpath(vtkdir)
+    end
+    MPI.Barrier(mpicomm)
+
     step = [0]
     cb_vtk =
         GenericCallbacks.EveryXSimulationSteps(output_freq) do (init = false)
-            mkpath("vtk/")
-            outprefix = @sprintf(
-                "vtk/new_ex_2_mpirank%04d_step%04d",
+            out_dirname = @sprintf(
+                "new_ex_2_mpirank%04d_step%04d",
                 MPI.Comm_rank(mpicomm),
                 step[1]
             )
-            @info "doing VTK output" outprefix
+            out_path_prefix = joinpath(vtkdir, out_dirname)
+            @info "doing VTK output" out_path_prefix
             writevtk(
-                outprefix,
+                out_path_prefix,
                 solver_config.Q,
                 solver_config.dg,
                 flattenednames(vars_state_conservative(model, FT)),

--- a/tutorials/Numerics/DGmethods/nonnegative.jl
+++ b/tutorials/Numerics/DGmethods/nonnegative.jl
@@ -160,7 +160,12 @@ function run(
         Filters.apply!(Q, 1, grid, TMARFilter())
     end
 
-    mkpath(vtkdir)
+    # create output directory on first rank of communicator
+    if MPI.Comm_rank(mpicomm) == 0
+        mkpath(vtkdir)
+    end
+    MPI.Barrier(mpicomm)
+
     vtkstep = 0
     # output initial step
     do_output(mpicomm, vtkdir, vtkstep, dg, Q, model, "nonnegative")
@@ -229,7 +234,8 @@ let
     CFL = 1
     dt = CFL * dx / maxvelocity
 
-    vtkdir = "vtk_nonnegative"
+    vtkdir =
+        abspath(joinpath(ClimateMachine.Settings.output_dir, "vtk_nonnegative"))
     outputtime = 0.0625
     dt = outputtime / ceil(Int64, outputtime / dt)
 


### PR DESCRIPTION
# Description
Only create top-level prefix path on rank 0 of a communicator group to prevent output race conditions.  This doesn't impact unit tests because they are run sequentially, but slurm-ci tests have issues if multiple concurrent tests are scheduled to write to a common prefix.  We'll need to also change slurm-ci so that jobs don't write to a common prefix for test output.

Closes #1114 


<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
