### PR TITLE
Moves temperature profiles to separate module

### DIFF
--- a/docs/list_of_how_to_guides.jl
+++ b/docs/list_of_how_to_guides.jl
@@ -4,6 +4,7 @@
 
 how_to_guides = Any[
     "Common" => Any["MoistThermodynamics" => "HowToGuides/Common/MoistThermodynamics.md",],
+    "Atmos" => Any["TemperatureProfiles" => "HowToGuides/Atmos/TemperatureProfiles.md",],
     "Ocean" => Any[
     # "Home" => "HowToGuides/Ocean/index.md"
     ],

--- a/docs/src/HowToGuides/Atmos/TemperatureProfiles.md
+++ b/docs/src/HowToGuides/Atmos/TemperatureProfiles.md
@@ -1,0 +1,103 @@
+# Atmospheric temperature profiles
+
+```@meta
+CurrentModule = ClimateMachine.TemperatureProfiles
+```
+
+Several temperature profiles are available in ClimateMachine.jl. Here, we plot each profile.
+
+## Usage
+
+Using a profile involves passing two arguments:
+
+ - `param_set` a parameter set, from [CLIMAParameters.jl](https://github.com/CliMA/CLIMAParameters.jl)
+ - `z` altitude
+
+to one of the temperature profile constructors.
+
+### IsothermalProfile
+
+```@example
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.MoistThermodynamics
+using CLIMAParameters
+using CLIMAParameters.Planet
+using Plots
+struct EarthParameterSet <: AbstractEarthParameterSet end;
+const param_set = EarthParameterSet();
+FT = Float64;
+include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "MoistThermodynamics", "profiles.jl"))
+z, e_int, ρ, q_tot, q_pt, T, p, θ_liq_ice = tested_profiles(param_set, 50, FT);
+
+isothermal = IsothermalProfile(param_set, FT);
+args = isothermal.(Ref(param_set), z)
+T = first.(args)
+p = last.(args)
+
+p1 = plot(T, z./10^3, xlabel="Temperature [K]");
+p2 = plot(p./10^3, z./10^3, xlabel="Pressure [kPa]");
+plot(p1, p2, layout=(1,2), title="Isothermal", ylabel="z [km]")
+savefig("isothermal.svg")
+```
+![](isothermal.svg)
+
+
+### DecayingTemperatureProfile
+
+```@example
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.MoistThermodynamics
+using CLIMAParameters
+using CLIMAParameters.Planet
+using Plots
+struct EarthParameterSet <: AbstractEarthParameterSet end;
+const param_set = EarthParameterSet();
+FT = Float64;
+include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "MoistThermodynamics", "profiles.jl"))
+z, e_int, ρ, q_tot, q_pt, T, p, θ_liq_ice = tested_profiles(param_set, 50, FT);
+
+decaying = DecayingTemperatureProfile{FT}(param_set);
+args = decaying.(Ref(param_set), z)
+T = first.(args)
+p = last.(args)
+
+p1 = plot(T, z./10^3, xlabel="Temperature [K]");
+p2 = plot(p./10^3, z./10^3, xlabel="Pressure [kPa]");
+plot(p1, p2, layout=(1,2), ylabel="z [km]", title="Decaying")
+savefig("decaying.svg")
+```
+![](decaying.svg)
+
+### DryAdiabaticProfile
+
+```@example
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.MoistThermodynamics
+using CLIMAParameters
+using CLIMAParameters.Planet
+using Plots
+struct EarthParameterSet <: AbstractEarthParameterSet end;
+const param_set = EarthParameterSet();
+FT = Float64;
+include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "MoistThermodynamics", "profiles.jl"))
+z, e_int, ρ, q_tot, q_pt, T, p, θ_liq_ice = tested_profiles(param_set, 50, FT);
+
+dry_adiabatic = DryAdiabaticProfile{FT}(param_set);
+args = dry_adiabatic.(Ref(param_set), z)
+T = first.(args)
+p = last.(args)
+θ_dry = dry_pottemp_given_pressure.(Ref(param_set), T, p)
+
+p1 = plot(T, z./10^3, xlabel="Temperature [K]");
+p2 = plot(p./10^3, z./10^3, xlabel="Pressure [kPa]");
+p3 = plot(θ_dry, z./10^3, xlabel="Potential temperature [K]");
+plot(p1, p2, p3, layout=(1,3), ylabel="z [km]", title="Dry adiabatic")
+savefig("dry_adiabatic.svg")
+```
+![](dry_adiabatic.svg)
+
+
+## Extending
+
+Additional constructors, or additional profiles can be added to this module by adding a struct, containing parameters needed to construct the profile, and a [functor](https://discourse.julialang.org/t/how-are-functors-useful/24110) to call the profile with a parameter set and altitude.
+

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -9,6 +9,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.ColumnwiseLUSolver: ManyColumnLU
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.Mesh.Grids
+using ClimateMachine.TemperatureProfiles
 using ClimateMachine.MoistThermodynamics:
     air_temperature, internal_energy, air_pressure
 using ClimateMachine.VariableTemplates

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -9,6 +9,7 @@ using ClimateMachine.DGmethods.NumericalFluxes
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
+using ClimateMachine.TemperatureProfiles
 using ClimateMachine.MoistThermodynamics
 using ClimateMachine.VariableTemplates
 

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -11,6 +11,7 @@ using LinearAlgebra, StaticArrays
 using ..ConfigTypes
 using ..VariableTemplates
 using ..MoistThermodynamics
+using ..TemperatureProfiles
 import ..MoistThermodynamics: internal_energy
 using ..MPIStateArrays: MPIStateArray
 using ..Mesh.Grids:

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -1,10 +1,7 @@
 ### Reference state
 using DocStringExtensions
-export NoReferenceState,
-    HydrostaticState,
-    IsothermalProfile,
-    DecayingTemperatureProfile,
-    DryAdiabaticProfile
+using ..TemperatureProfiles
+export NoReferenceState, HydrostaticState
 
 using CLIMAParameters.Planet: R_d, MSLP, cp_d, grav, T_surf_ref, T_min_ref
 
@@ -15,19 +12,6 @@ Reference state, for example, used as initial
 condition or for linearization.
 """
 abstract type ReferenceState end
-
-"""
-    TemperatureProfile
-
-Specifies the temperature or virtual temperature profile for a reference state.
-
-Instances of this type are required to be callable objects with the following signature
-
-    T,p = (::TemperatureProfile)(orientation::Orientation, aux::Vars)
-
-where `T` is the temperature or virtual temperature (in K), and `p` is the pressure (in Pa).
-"""
-abstract type TemperatureProfile{FT <: AbstractFloat} end
 
 vars_state_conservative(m::ReferenceState, FT) = @vars()
 vars_state_gradient(m::ReferenceState, FT) = @vars()
@@ -46,8 +30,6 @@ atmos_init_aux!(
 No reference state used
 """
 struct NoReferenceState <: ReferenceState end
-
-
 
 """
     HydrostaticState{P,T} <: ReferenceState
@@ -77,8 +59,8 @@ function atmos_init_aux!(
     aux::Vars,
     geom::LocalGeometry,
 ) where {P, F}
-    T_virt, p =
-        m.virtual_temperature_profile(atmos.orientation, atmos.param_set, aux)
+    z = altitude(atmos, aux)
+    T_virt, p = m.virtual_temperature_profile(atmos.param_set, z)
     FT = eltype(aux)
     _R_d::FT = R_d(atmos.param_set)
 
@@ -102,133 +84,6 @@ function atmos_init_aux!(
     e_pot = gravitational_potential(atmos.orientation, aux)
     aux.ref_state.ρe = ρ * total_energy(atmos.param_set, e_kin, e_pot, T, q_pt)
 end
-
-
-"""
-    IsothermalProfile(param_set, T_virt)
-
-A uniform virtual temperature profile, which is implemented
-as a special case of [`DecayingTemperatureProfile`](@ref).
-"""
-IsothermalProfile(param_set::AbstractParameterSet, T_virt::FT) where {FT} =
-    DecayingTemperatureProfile{FT}(param_set, T_virt, T_virt)
-
-"""
-    DryAdiabaticProfile{FT} <: TemperatureProfile{FT}
-
-
-A temperature profile that has uniform dry potential temperature `θ`
-
-# Fields
-
-$(DocStringExtensions.FIELDS)
-"""
-struct DryAdiabaticProfile{FT} <: TemperatureProfile{FT}
-    "Surface temperature (K)"
-    T_surface::FT
-    "Minimum temperature (K)"
-    T_min_ref::FT
-    function DryAdiabaticProfile{FT}(
-        param_set::AbstractParameterSet,
-        T_surface::FT = FT(T_surf_ref(param_set)),
-        _T_min_ref::FT = FT(T_min_ref(param_set)),
-    ) where {FT <: AbstractFloat}
-        return new{FT}(T_surface, _T_min_ref)
-    end
-end
-
-"""
-    (profile::DryAdiabaticProfile)(
-        orientation::Orientation,
-        param_set::AbstractParameterSet,
-        aux::Vars,
-    )
-
-Returns dry adiabatic temperature and pressure profiles
-with zero relative humidity. The temperature is truncated
-to be greater than or equal to `profile.T_min_ref`.
-"""
-function (profile::DryAdiabaticProfile)(
-    orientation::Orientation,
-    param_set::AbstractParameterSet,
-    aux::Vars,
-)
-    FT = eltype(aux)
-    _R_d::FT = R_d(param_set)
-    _cp_d::FT = cp_d(param_set)
-    _grav::FT = grav(param_set)
-    _MSLP::FT = MSLP(param_set)
-
-    z = altitude(orientation, param_set, aux)
-
-    # Temperature
-    Γ = _grav / _cp_d
-    T = max(profile.T_surface - Γ * z, profile.T_min_ref)
-
-    # Pressure
-    p = _MSLP * (T / profile.T_surface)^(_grav / (_R_d * Γ))
-    if T == profile.T_min_ref
-        z_top = (profile.T_surface - profile.T_min_ref) / Γ
-        H_min = _R_d * profile.T_min_ref / _grav
-        p *= exp(-(z - z_top) / H_min)
-    end
-    return (T, p)
-end
-
-"""
-    DecayingTemperatureProfile{F} <: TemperatureProfile{FT}
-
-A virtual temperature profile that decays smoothly with height `z`, from
-`T_virt_surf` to `T_min_ref` over a height scale `H_t`. The default height
-scale `H_t` is the density scale height evaluated with `T_virt_surf`.
-
-```math
-T_{\\text{v}}(z) = \\max(T_{\\text{v, sfc}} − (T_{\\text{v, sfc}} - T_{\\text{v, min}}) \\tanh(z/H_{\\text{t}})
-```
-
-# Fields
-
-$(DocStringExtensions.FIELDS)
-"""
-struct DecayingTemperatureProfile{FT} <: TemperatureProfile{FT}
-    "Virtual temperature at surface (K)"
-    T_virt_surf::FT
-    "Minimum virtual temperature at the top of the atmosphere (K)"
-    T_min_ref::FT
-    "Height scale over which virtual temperature drops (m)"
-    H_t::FT
-    function DecayingTemperatureProfile{FT}(
-        param_set::AbstractParameterSet,
-        _T_virt_surf::FT = FT(T_surf_ref(param_set)),
-        _T_min_ref::FT = FT(T_min_ref(param_set)),
-        H_t::FT = FT(R_d(param_set)) * FT(T_surf_ref(param_set)) /
-                  FT(grav(param_set)),
-    ) where {FT <: AbstractFloat}
-        return new{FT}(_T_virt_surf, _T_min_ref, H_t)
-    end
-end
-
-
-function (profile::DecayingTemperatureProfile)(
-    orientation::Orientation,
-    param_set::AbstractParameterSet,
-    aux::Vars,
-)
-    z = altitude(orientation, param_set, aux)
-    ΔTv = profile.T_virt_surf - profile.T_min_ref
-    Tv = profile.T_virt_surf - ΔTv * tanh(z / profile.H_t)
-    FT = typeof(z)
-    _R_d::FT = R_d(param_set)
-    _grav::FT = grav(param_set)
-    _MSLP::FT = MSLP(param_set)
-
-    ΔTv′ = ΔTv / profile.T_virt_surf
-    p = -z - profile.H_t * ΔTv′ * log(cosh(z / profile.H_t) - atanh(ΔTv′))
-    p /= profile.H_t * (1 - ΔTv′^2)
-    p = _MSLP * exp(p)
-    return (Tv, p)
-end
-
 
 """
     relative_humidity(hs::HydrostaticState{P,FT})

--- a/src/Atmos/TemperatureProfiles/TemperatureProfiles.jl
+++ b/src/Atmos/TemperatureProfiles/TemperatureProfiles.jl
@@ -1,0 +1,152 @@
+module TemperatureProfiles
+
+using DocStringExtensions
+
+export TemperatureProfile,
+    IsothermalProfile, DecayingTemperatureProfile, DryAdiabaticProfile
+
+using CLIMAParameters: AbstractParameterSet
+using CLIMAParameters.Planet: R_d, MSLP, cp_d, grav, T_surf_ref, T_min_ref
+
+"""
+    TemperatureProfile
+
+Specifies the temperature or virtual temperature profile for a reference state.
+
+Instances of this type are required to be callable objects with the following signature
+
+    T,p = (::TemperatureProfile)(param_set::AbstractParameterSet, z::FT) where {FT<:AbstractFloat}
+
+where `T` is the temperature or virtual temperature (in K), and `p` is the pressure (in Pa).
+"""
+abstract type TemperatureProfile{FT <: AbstractFloat} end
+
+"""
+    IsothermalProfile(param_set, T_virt)
+    IsothermalProfile(param_set, ::Type{FT<:AbstractFloat})
+
+A uniform virtual temperature profile, which is implemented
+as a special case of [`DecayingTemperatureProfile`](@ref).
+"""
+IsothermalProfile(param_set::AbstractParameterSet, T_virt::FT) where {FT} =
+    DecayingTemperatureProfile{FT}(param_set, T_virt, T_virt)
+
+function IsothermalProfile(
+    param_set::AbstractParameterSet,
+    ::Type{FT},
+) where {FT}
+    T_virt = FT(T_surf_ref(param_set))
+    return DecayingTemperatureProfile{FT}(param_set, T_virt, T_virt)
+end
+
+"""
+    DryAdiabaticProfile{FT} <: TemperatureProfile{FT}
+
+
+A temperature profile that has uniform dry potential temperature `θ`
+
+# Fields
+
+$(DocStringExtensions.FIELDS)
+"""
+struct DryAdiabaticProfile{FT} <: TemperatureProfile{FT}
+    "Surface temperature (K)"
+    T_surface::FT
+    "Minimum temperature (K)"
+    T_min_ref::FT
+    function DryAdiabaticProfile{FT}(
+        param_set::AbstractParameterSet,
+        T_surface::FT = FT(T_surf_ref(param_set)),
+        _T_min_ref::FT = FT(T_min_ref(param_set)),
+    ) where {FT <: AbstractFloat}
+        return new{FT}(T_surface, _T_min_ref)
+    end
+end
+
+"""
+    (profile::DryAdiabaticProfile)(
+        param_set::AbstractParameterSet,
+        z::FT,
+    ) where {FT<:AbstractFloat}
+
+Returns dry adiabatic temperature and pressure profiles
+with zero relative humidity. The temperature is truncated
+to be greater than or equal to `profile.T_min_ref`.
+"""
+function (profile::DryAdiabaticProfile)(
+    param_set::AbstractParameterSet,
+    z::FT,
+) where {FT <: AbstractFloat}
+
+    _R_d::FT = R_d(param_set)
+    _cp_d::FT = cp_d(param_set)
+    _grav::FT = grav(param_set)
+    _MSLP::FT = MSLP(param_set)
+
+    # Temperature
+    Γ = _grav / _cp_d
+    T = max(profile.T_surface - Γ * z, profile.T_min_ref)
+
+    # Pressure
+    p = _MSLP * (T / profile.T_surface)^(_grav / (_R_d * Γ))
+    if T == profile.T_min_ref
+        z_top = (profile.T_surface - profile.T_min_ref) / Γ
+        H_min = _R_d * profile.T_min_ref / _grav
+        p *= exp(-(z - z_top) / H_min)
+    end
+    return (T, p)
+end
+
+"""
+    DecayingTemperatureProfile{F} <: TemperatureProfile{FT}
+
+A virtual temperature profile that decays smoothly with height `z`, from
+`T_virt_surf` to `T_min_ref` over a height scale `H_t`. The default height
+scale `H_t` is the density scale height evaluated with `T_virt_surf`.
+
+```math
+T_{\\text{v}}(z) = \\max(T_{\\text{v, sfc}} − (T_{\\text{v, sfc}} - T_{\\text{v, min}}) \\tanh(z/H_{\\text{t}})
+```
+
+# Fields
+
+$(DocStringExtensions.FIELDS)
+"""
+struct DecayingTemperatureProfile{FT} <: TemperatureProfile{FT}
+    "Virtual temperature at surface (K)"
+    T_virt_surf::FT
+    "Minimum virtual temperature at the top of the atmosphere (K)"
+    T_min_ref::FT
+    "Height scale over which virtual temperature drops (m)"
+    H_t::FT
+    function DecayingTemperatureProfile{FT}(
+        param_set::AbstractParameterSet,
+        _T_virt_surf::FT = FT(T_surf_ref(param_set)),
+        _T_min_ref::FT = FT(T_min_ref(param_set)),
+        H_t::FT = FT(R_d(param_set)) * FT(T_surf_ref(param_set)) /
+                  FT(grav(param_set)),
+    ) where {FT <: AbstractFloat}
+        return new{FT}(_T_virt_surf, _T_min_ref, H_t)
+    end
+end
+
+
+function (profile::DecayingTemperatureProfile)(
+    param_set::AbstractParameterSet,
+    z::FT,
+) where {FT <: AbstractFloat}
+
+    ΔTv = profile.T_virt_surf - profile.T_min_ref
+    Tv = profile.T_virt_surf - ΔTv * tanh(z / profile.H_t)
+    _R_d::FT = R_d(param_set)
+    _grav::FT = grav(param_set)
+    _MSLP::FT = MSLP(param_set)
+
+    ΔTv′ = ΔTv / profile.T_virt_surf
+    p = -z - profile.H_t * ΔTv′ * log(cosh(z / profile.H_t) - atanh(ΔTv′))
+    p /= profile.H_t * (1 - ΔTv′^2)
+    p = _MSLP * exp(p)
+    return (Tv, p)
+end
+
+end

--- a/src/ClimateMachine.jl
+++ b/src/ClimateMachine.jl
@@ -11,6 +11,7 @@ include(joinpath("InputOutput", "Writers", "Writers.jl"))
 include(joinpath("Common", "ConfigTypes", "ConfigTypes.jl"))
 include(joinpath("Utilities", "VariableTemplates", "VariableTemplates.jl"))
 include(joinpath("Common", "MoistThermodynamics", "MoistThermodynamics.jl"))
+include(joinpath("Atmos", "TemperatureProfiles", "TemperatureProfiles.jl"))
 include(joinpath(
     "Atmos",
     "Parameterizations",

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -11,6 +11,7 @@ using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
+using ClimateMachine.TemperatureProfiles
 using ClimateMachine.MoistThermodynamics
 using ClimateMachine.VariableTemplates
 

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -3,6 +3,7 @@ ClimateMachine.init()
 using ClimateMachine.Atmos
 using ClimateMachine.Checkpoint
 using ClimateMachine.ConfigTypes
+using ClimateMachine.TemperatureProfiles
 using ClimateMachine.MoistThermodynamics
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Grids

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -6,6 +6,7 @@ ClimateMachine.init()
 using ClimateMachine.Atmos
 using ClimateMachine.ConfigTypes
 using ClimateMachine.MoistThermodynamics
+using ClimateMachine.TemperatureProfiles
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Grids
 using ClimateMachine.ODESolvers

--- a/test/Numerics/DGmethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGmethods/Euler/acousticwave_1d_imex.jl
@@ -22,6 +22,7 @@ using ClimateMachine.MoistThermodynamics:
     internal_energy,
     PhaseDry_given_pT,
     PhasePartition
+using ClimateMachine.TemperatureProfiles: IsothermalProfile
 using ClimateMachine.Atmos:
     AtmosModel,
     SphericalOrientation,
@@ -33,7 +34,6 @@ using ClimateMachine.Atmos:
     vars_state_auxiliary,
     Gravity,
     HydrostaticState,
-    IsothermalProfile,
     AtmosAcousticGravityLinearModel,
     altitude,
     latitude,

--- a/test/Numerics/DGmethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGmethods/compressible_Navier_Stokes/density_current_model.jl
@@ -13,6 +13,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.Atmos
 using ClimateMachine.VariableTemplates
+using ClimateMachine.TemperatureProfiles
 using ClimateMachine.MoistThermodynamics
 using LinearAlgebra
 using StaticArrays

--- a/test/Numerics/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/Numerics/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -10,6 +10,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.Atmos
 using ClimateMachine.VariableTemplates
+using ClimateMachine.TemperatureProfiles
 using ClimateMachine.MoistThermodynamics
 using LinearAlgebra
 using StaticArrays

--- a/test/Numerics/DGmethods/courant.jl
+++ b/test/Numerics/DGmethods/courant.jl
@@ -14,6 +14,7 @@ using ClimateMachine.DGmethods.NumericalFluxes:
     CentralNumericalFluxGradient,
     CentralNumericalFluxSecondOrder
 using ClimateMachine.Courant
+using ClimateMachine.TemperatureProfiles: IsothermalProfile
 using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
@@ -26,7 +27,6 @@ using ClimateMachine.Atmos:
     NoPrecipitation,
     Gravity,
     HydrostaticState,
-    IsothermalProfile,
     ConstantViscosityWithDivergence,
     vars_state_conservative,
     soundspeed

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -24,6 +24,7 @@ using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.Mesh.Filters
+using ClimateMachine.TemperatureProfiles
 using ClimateMachine.MoistThermodynamics
 using ClimateMachine.VariableTemplates
 

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -88,6 +88,8 @@ using ClimateMachine.ODESolvers
 # - Required for utility of spatial filtering functions (e.g. positivity
 #   preservation)
 using ClimateMachine.Mesh.Filters
+# - Required so functions for computation of temperature profiles.
+using ClimateMachine.TemperatureProfiles
 # - Required so functions for computation of moist thermodynamic quantities is
 #   enabled.
 using ClimateMachine.MoistThermodynamics


### PR DESCRIPTION
# Description

This PR pulls the `TemperatureProfile`'s out of the AtmosModel into its own module. This makes plotting in the docs not require using `VariableTemplates`. Also, we may share these profiles in the thermo test suite. This also adds plots of each profile in the docs.

I'm agnostic as to where this module and the corresponding docs should go. @kpamnany and @simonbyrne feel free to make suggestions!

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
