### PR TITLE
Use reference state moisture in Atmos linear model

### DIFF
--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -58,7 +58,7 @@ end
         state.ρ,
         state.ρe,
         ρe_pot,
-        state.moisture.ρq_tot,
+        aux.ref_state.ρq_tot,
     )
 end
 


### PR DESCRIPTION
The reference state moisture is used in the linear model to avoid needing
the moisture variables in the state vector.  This enables the
removal of the moist variables from the linear model state.
   
Co-authored-by: Jeremy E Kozdon <jekozdon@nps.edu>