### PR TITLE
Driver update: Solver types for explicit, IMEX, multirate, and MIS methods

### DIFF
--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -191,13 +191,22 @@ function main()
     # Set up driver configuration
     driver_config = config_heldsuarez(FT, poly_order, (n_horz, n_vert))
 
+    ode_solver_type = ClimateMachine.IMEXSolverType(
+        splitting_type = HEVISplitting(),
+        implicit_model = AtmosAcousticGravityLinearModel,
+        implicit_solver = ManyColumnLU,
+        solver_method = ARK2GiraldoKellyConstantinescu,
+    )
+    CFL = FT(0.2)
+
     # Set up experiment
     solver_config = ClimateMachine.SolverConfiguration(
         timestart,
         timeend,
         driver_config,
-        Courant_number = 0.2,
+        Courant_number = CFL,
         init_on_cpu = true,
+        ode_solver_type = ode_solver_type,
         CFL_direction = HorizontalDirection(),
         diffdir = HorizontalDirection(),
     )

--- a/experiments/OceanBoxGCM/homogeneous_box.jl
+++ b/experiments/OceanBoxGCM/homogeneous_box.jl
@@ -59,8 +59,8 @@ function run_homogeneous_box(; imex::Bool = false, BC = nothing)
 
     if imex
         solver_type = ClimateMachine.IMEXSolverType(
-            linear_model = LinearHBModel,
-            linear_solver = ClimateMachine.SystemSolvers.SingleColumnLU,
+            implicit_model = LinearHBModel,
+            implicit_solver = ClimateMachine.SystemSolvers.SingleColumnLU,
         )
         Nᶻ = Int(400)
         Courant_number = 0.1

--- a/experiments/OceanBoxGCM/ocean_gyre.jl
+++ b/experiments/OceanBoxGCM/ocean_gyre.jl
@@ -61,7 +61,7 @@ function run_ocean_gyre(; imex::Bool = false, BC = nothing)
 
     if imex
         solver_type =
-            ClimateMachine.IMEXSolverType(linear_model = LinearHBModel)
+            ClimateMachine.IMEXSolverType(implicit_model = LinearHBModel)
     else
         solver_type = ClimateMachine.ExplicitSolverType(
             solver_method = LSRK144NiegemannDiehlBusch,

--- a/src/Driver/SolverTypes/ExplicitSolverType.jl
+++ b/src/Driver/SolverTypes/ExplicitSolverType.jl
@@ -1,0 +1,65 @@
+
+export ExplicitSolverType
+
+"""
+# Description
+    ExplicitSolverType(;
+        solver_method = LSRK54CarpenterKennedy,
+    )
+
+This solver type constructs an ODE solver using an explicit
+Runge-Kutta method.
+
+# Arguments
+- `solver_method` (Function): Function defining the explicit
+    Runge-Kutta solver.
+    Default: `LSRK54CarpenterKennedy`
+"""
+struct ExplicitSolverType <: AbstractSolverType
+    # Function for an explicit Runge-Kutta method
+    solver_method::Function
+
+    function ExplicitSolverType(; solver_method = LSRK54CarpenterKennedy)
+
+        return new(solver_method)
+    end
+end
+
+"""
+    getdtmodel(ode_solver::AbstractSolverType, bl)
+
+A function which returns a model representing the dynamics
+with the most restrictive time-stepping requirements.
+"""
+function getdtmodel(::ExplicitSolverType, bl)
+    # For explicit methods, the entire model itself
+    # contributes to the total stability of the time-integrator
+    return bl
+end
+
+"""
+# Description
+    function solversetup(
+        ode_solver::ExplicitSolverType,
+        dg,
+        Q,
+        dt,
+        t0,
+        diffusion_direction,
+    )
+
+Creates an explicit ODE solver.
+"""
+function solversetup(
+    ode_solver::ExplicitSolverType,
+    dg,
+    Q,
+    dt,
+    t0,
+    diffusion_direction,
+)
+
+    solver = ode_solver.solver_method(dg, Q; dt = dt, t0 = t0)
+
+    return solver
+end

--- a/src/Driver/SolverTypes/IMEXSolverType.jl
+++ b/src/Driver/SolverTypes/IMEXSolverType.jl
@@ -1,0 +1,172 @@
+
+export IMEXSolverType
+
+"""
+# Description
+    IMEXSolverType(;
+        splitting_type = HEVISplitting(),
+        implicit_model = AtmosAcousticGravityLinearModel,
+        implicit_solver = ManyColumnLU,
+        implicit_solver_adjustable = false,
+        solver_method = ARK2GiraldoKellyConstantinescu,
+        solver_storage_variant = LowStorageVariant(),
+    )
+
+This solver type constructs a solver for ODEs with the
+additively-partitioned form:
+
+```math
+  \\dot{Q} = [l(Q, t)] + [f(Q, t) - l(Q, t)]
+```
+
+where `Q` is the state, `f` is the full tendency and `l` is the chosen
+implicit operator.
+
+# Arguments
+- `splitting_type` (DiscreteSplittingType): The type of discrete
+    splitting to apply to the right-hand side.
+    Default: `HEVISplitting()`
+- `implicit_model` (Type): The model describing dynamics to be
+    treated implicitly.
+    Default: `AtmosAcousticGravityLinearModel`
+- `implicit_solver` (Type): A solver for inverting the
+    implicit system of equations.
+    Default: `ManyColumnLU`
+- `implicit_solver_adjustable` (Bool): A flag identifying whether
+    or not the `implicit_solver` can be updated as the time-step
+    size changes.
+    Default: `false`
+- `solver_method` (Function): Function defining the particular additive
+    Runge-Kutta method to be used for the IMEX method.
+    Default: `ARK2GiraldoKellyConstantinescu`
+- `solver_storage_variant` (Type): Storage type for the additive
+    Runge-Kutta method.
+    Default: `LowStorageVariant()`
+
+### References
+    @article{giraldo2013implicit,
+      title={Implicit-explicit formulations of a three-dimensional
+             nonhydrostatic unified model of the atmosphere ({NUMA})},
+      author={Giraldo, Francis X and Kelly, James F and Constantinescu, Emil M},
+      journal={SIAM Journal on Scientific Computing},
+      volume={35},
+      number={5},
+      pages={B1162--B1194},
+      year={2013},
+      publisher={SIAM}
+    }
+"""
+struct IMEXSolverType{DS, ST} <: AbstractSolverType
+    # The type of discrete splitting to apply to the right-hand side
+    splitting_type::DS
+    # The implicit model
+    implicit_model::Type
+    # Choice of implicit solver
+    implicit_solver::Type
+    # Can the implicit solver be updated with changing dt?
+    implicit_solver_adjustable::Bool
+    # Function for the IMEX method
+    solver_method::Function
+    # Storage type for the ARK scheme
+    solver_storage_variant::ST
+
+    function IMEXSolverType(;
+        splitting_type = HEVISplitting(),
+        implicit_model = AtmosAcousticGravityLinearModel,
+        implicit_solver = ManyColumnLU,
+        implicit_solver_adjustable = false,
+        solver_method = ARK2GiraldoKellyConstantinescu,
+        solver_storage_variant = LowStorageVariant(),
+    )
+
+        DS = typeof(splitting_type)
+        ST = typeof(solver_storage_variant)
+
+        return new{DS, ST}(
+            splitting_type,
+            implicit_model,
+            implicit_solver,
+            implicit_solver_adjustable,
+            solver_method,
+            solver_storage_variant,
+        )
+    end
+end
+
+"""
+    getdtmodel(ode_solver::IMEXSolverType, bl)
+
+A function which returns a model representing the dynamics
+with the most restrictive time-stepping requirements.
+"""
+function getdtmodel(ode_solver::IMEXSolverType, bl)
+    # Most restrictive dynamics are treated implicitly
+    return ode_solver.implicit_model(bl)
+end
+
+"""
+# Description
+    solversetup(
+        ode_solver::IMEXSolverType{HEVISplitting},
+        dg,
+        Q,
+        dt,
+        t0,
+        diffusion_direction,
+    )
+
+Creates an ODE solver using a HEVI-type time-integration
+scheme. All horizontal acoustic waves are treated explicitly,
+while the 1-D vertical problem is treated implicitly. All
+other dynamics (advection, diffusion) is treated explicitly
+in the additive Runge-Kutta method.
+
+# Comments:
+Currently, the only HEVI-type splitting ClimateMachine can currently
+do only involves splitting the acoustic processes; it is not currently
+possible to perform more fine-grained separation of tendencies
+(for example, including vertical advection or diffusion in the 1-D implicit problem)
+"""
+function solversetup(
+    ode_solver::IMEXSolverType{HEVISplitting},
+    dg,
+    Q,
+    dt,
+    t0,
+    diffusion_direction,
+)
+
+    # All we need to do is create a DGModel for the
+    # vertical acoustic waves (determined from the `implicit_model`)
+    vdg = DGModel(
+        ode_solver.implicit_model(dg.balance_law),
+        dg.grid,
+        dg.numerical_flux_first_order,
+        dg.numerical_flux_second_order,
+        dg.numerical_flux_gradient,
+        state_auxiliary = dg.state_auxiliary,
+        state_gradient_flux = dg.state_gradient_flux,
+        states_higher_order = dg.states_higher_order,
+        direction = VerticalDirection(),
+    )
+
+    solver = ode_solver.solver_method(
+        dg,
+        vdg,
+        LinearBackwardEulerSolver(
+            ode_solver.implicit_solver();
+            isadjustable = ode_solver.implicit_solver_adjustable,
+        ),
+        Q;
+        dt = dt,
+        t0 = t0,
+        # NOTE: This needs to be `false` since the ARK method will
+        # evaluate the explicit part using the RemainderModel
+        # (Difference between full DG model (dg) and the
+        # DG model associated with the 1-D implicit problem (vdg))
+        split_explicit_implicit = false,
+        variant = ode_solver.solver_storage_variant,
+    )
+
+    return solver
+end

--- a/src/Driver/SolverTypes/MISSolverType.jl
+++ b/src/Driver/SolverTypes/MISSolverType.jl
@@ -1,0 +1,166 @@
+
+export MISSolverType
+
+"""
+# Description
+    MISSolverType(;
+        splitting_type = SlowFastSplitting(),
+        fast_model = AtmosAcousticGravityLinearModel,
+        mis_method = MIS2,
+        fast_method = LSRK54CarpenterKennedy,
+        nsubsteps = 50,
+    )
+
+This solver type constructs an ODE solver using a generalization
+of the split-explicit Runge-Kutta method. Known as the Multirate
+Infinitesimal Step (MIS) method, this solver solves ODEs with
+the partitioned form:
+
+```math
+    \\dot{Q} = f_fast(Q, t) + f_slow(Q, t)
+```
+
+where the right-hand-side functions `f_fast` and `f_slow` denote
+fast and slow dynamics respectively, depending on the state `Q`.
+
+# Arguments
+- `splitting_type` (DiscreteSplittingType): The type of discrete
+    splitting to apply to the right-hand side.
+    Default: `SlowFastSplitting()`
+- `fast_model` (Type): The model describing fast dynamics.
+    Default: `AtmosAcousticGravityLinearModel`
+- `mis_method` (Function): Function defining the particular MIS
+    method to be used.
+    Default: `MIS2`
+- `fast_method` (Function): Function defining the fast solver.
+    Default: `LSRK54CarpenterKennedy`
+- `nsubsteps` (Int): Integer denoting the total number of times
+    to substep the fast process.
+    Default: `50`
+
+### References
+    @article{KnothWensch2014,
+        title={Generalized split-explicit Runge--Kutta methods for
+            the compressible Euler equations},
+        author={Knoth, Oswald and Wensch, Joerg},
+        journal={Monthly Weather Review},
+        volume={142},
+        number={5},
+        pages={2067--2081},
+        year={2014}
+    }
+"""
+struct MISSolverType{DS} <: AbstractSolverType
+    # The type of discrete splitting to apply to the right-hand side
+    splitting_type::DS
+    # The model describing fast dynamics
+    fast_model::Type
+    # Main MIS function
+    mis_method::Function
+    # Fast RK solver
+    fast_method::Function
+    # Substepping parameter for the fast processes
+    nsubsteps::Int
+
+    function MISSolverType(;
+        splitting_type = SlowFastSplitting(),
+        fast_model = AtmosAcousticGravityLinearModel,
+        mis_method = MIS2,
+        fast_method = LSRK54CarpenterKennedy,
+        nsubsteps = 50,
+    )
+
+        DS = typeof(splitting_type)
+
+        return new{DS}(
+            splitting_type,
+            fast_model,
+            mis_method,
+            fast_method,
+            nsubsteps,
+        )
+    end
+end
+
+"""
+    getdtmodel(ode_solver::MISSolverType, bl)
+
+A function which returns a model representing the dynamics
+with the most restrictive time-stepping requirements.
+"""
+function getdtmodel(ode_solver::MISSolverType, bl)
+    # Most restrictive dynamics are part of the fast model
+    return ode_solver.fast_model(bl)
+end
+
+"""
+# Description
+    function solversetup(
+        ode_solver::MISSolverType{SlowFastSplitting},
+        dg,
+        Q,
+        dt,
+        t0,
+        diffusion_direction,
+    )
+
+Creates an ODE solver for the partition slow-fast ODE
+using an MIS method with explicit time-integration.
+The splitting of the fast (acoustic and gravity waves)
+dynamics is done in _all_ spatial directions.
+"""
+function solversetup(
+    ode_solver::MISSolverType{SlowFastSplitting},
+    dg,
+    Q,
+    dt,
+    t0,
+    diffusion_direction,
+)
+
+    # Extract fast model and define a DG model
+    # for the fast processes (acoustic/gravity waves
+    # in all spatial directions)
+    fast_model = ode_solver.fast_model(dg.balance_law)
+    fast_dg = DGModel(
+        fast_model,
+        dg.grid,
+        dg.numerical_flux_first_order,
+        dg.numerical_flux_second_order,
+        dg.numerical_flux_gradient,
+        state_auxiliary = dg.state_auxiliary,
+        state_gradient_flux = dg.state_gradient_flux,
+        states_higher_order = dg.states_higher_order,
+        direction = EveryDirection(),
+    )
+
+    # Using the RemainderModel, we subtract away the
+    # fast processes and define a DG model for the
+    # slower processes (advection and diffusion)
+    slow_model = RemainderModel(dg.balance_law, (fast_model,))
+    slow_dg = DGModel(
+        slow_model,
+        dg.grid,
+        dg.numerical_flux_first_order,
+        dg.numerical_flux_second_order,
+        dg.numerical_flux_gradient,
+        state_auxiliary = dg.state_auxiliary,
+        state_gradient_flux = dg.state_gradient_flux,
+        states_higher_order = dg.states_higher_order,
+        # Ensure diffusion direction is passed to the correct
+        # DG model
+        diffusion_direction = diffusion_direction,
+    )
+
+    solver = ode_solver.mis_method(
+        slow_dg,
+        fast_dg,
+        ode_solver.fast_method,
+        ode_solver.nsubsteps,
+        Q;
+        dt = dt,
+        t0 = t0,
+    )
+
+    return solver
+end

--- a/src/Driver/SolverTypes/MultirateSolverType.jl
+++ b/src/Driver/SolverTypes/MultirateSolverType.jl
@@ -1,0 +1,351 @@
+
+export MultirateSolverType
+
+"""
+# Description
+    MultirateSolverType(;
+        splitting_type = SlowFastSplitting(),
+        fast_model = AtmosAcousticGravityLinearModel,
+        implicit_solver = ManyColumnLU,
+        implicit_solver_adjustable = false,
+        slow_method = LSRK54CarpenterKennedy,
+        fast_method = LSRK54CarpenterKennedy,
+        timestep_ratio = 100,
+    )
+
+This solver type constructs an ODE solver using a standard multirate
+Runge-Kutta implementation. This solver computes solutions to ODEs with
+the partitioned form:
+
+```math
+    \\dot{Q} = f_fast(Q, t) + f_slow(Q, t)
+```
+
+where the right-hand-side functions `f_fast` and `f_slow` denote
+fast and slow dynamics respectively, depending on the state `Q`.
+
+# Arguments
+- `splitting_type` (DiscreteSplittingType): The type of discrete
+    splitting to apply to the right-hand side.
+    Default: `SlowFastSplitting()`
+- `fast_model` (Type): The model describing fast dynamics.
+    Default: `AtmosAcousticGravityLinearModel`
+- `implicit_solver` (Type): An implicit solver for inverting the
+    implicit system of equations (if using `HEVISplitting()`).
+    Default: `ManyColumnLU`
+- `implicit_solver_adjustable` (Bool): A flag identifying whether
+    or not the `implicit_solver` can be updated as the time-step
+    size changes. This is particularly important when using
+    an implicit solver within a multirate scheme.
+    Default: `false`
+- `slow_method` (Function): Function defining the particular explicit
+    Runge-Kutta method to be used for the slow processes.
+    Default: `LSRK54CarpenterKennedy`
+- `fast_method` (Function): Function defining the fast solver.
+    Depending on the choice of `splitting_type`, this can be
+    an explicit Runge Kutta method or a 1-D IMEX (additive Runge-Kutta)
+    method.
+    Default: `LSRK54CarpenterKennedy`
+- `timestep_ratio` (Int): Integer denoting the ratio between the slow
+    and fast time-step sizes.
+    Default: `100`
+
+### References
+    @article{SchlegelKnothArnoldWolke2012,
+        title={Implementation of multirate time integration methods for air
+            pollution modelling},
+        author={Schlegel, M and Knoth, O and Arnold, M and Wolke, R},
+        journal={Geoscientific Model Development},
+        volume={5},
+        number={6},
+        pages={1395--1405},
+        year={2012},
+        publisher={Copernicus GmbH}
+    }
+"""
+struct MultirateSolverType{DS} <: AbstractSolverType
+    # The type of discrete splitting to apply to the right-hand side
+    splitting_type::DS
+    # The model describing fast dynamics
+    fast_model::Type
+    # Choice of implicit solver
+    implicit_solver::Type
+    # Can the implicit solver be updated with changing dt?
+    implicit_solver_adjustable::Bool
+    # RK method for evaluating the slow processes
+    slow_method::Function
+    # RK method for evaluating the fast processes
+    fast_method::Function
+    # The ratio between slow and fast time-step sizes
+    timestep_ratio::Int
+
+    function MultirateSolverType(;
+        splitting_type = SlowFastSplitting(),
+        fast_model = AtmosAcousticGravityLinearModel,
+        implicit_solver = ManyColumnLU,
+        implicit_solver_adjustable = false,
+        slow_method = LSRK54CarpenterKennedy,
+        fast_method = LSRK54CarpenterKennedy,
+        timestep_ratio = 100,
+    )
+
+        DS = typeof(splitting_type)
+
+        return new{DS}(
+            splitting_type,
+            fast_model,
+            implicit_solver,
+            implicit_solver_adjustable,
+            slow_method,
+            fast_method,
+            timestep_ratio,
+        )
+    end
+end
+
+"""
+    getdtmodel(ode_solver::MultirateSolverType, bl)
+
+A function which returns a model representing the dynamics
+with the most restrictive time-stepping requirements.
+"""
+function getdtmodel(ode_solver::MultirateSolverType, bl)
+    # Most restrictive dynamics are part of the fast model
+    return ode_solver.fast_model(bl)
+end
+
+"""
+# Description
+    function solversetup(
+        ode_solver::MultirateSolverType{SlowFastSplitting},
+        dg,
+        Q,
+        dt,
+        t0,
+        diffusion_direction,
+    )
+
+Creates an ODE solver for the partition slow-fast ODE
+using a multirate method with explicit time-integration.
+The splitting of the fast (acoustic and gravity waves)
+dynamics is done in _all_ spatial directions. Examples
+of a similar implementations include the following
+references.
+
+### References
+    @article{SchlegelKnothArnoldWolke2012,
+        title={Implementation of multirate time integration methods for air
+            pollution modelling},
+        author={Schlegel, M and Knoth, O and Arnold, M and Wolke, R},
+        journal={Geoscientific Model Development},
+        volume={5},
+        number={6},
+        pages={1395--1405},
+        year={2012},
+        publisher={Copernicus GmbH}
+    }
+
+    @article{Schlegel_2009,
+        doi = {10.1016/j.cam.2008.08.009},
+        year = {2009},
+        month = {apr},
+        publisher = {Elsevier {BV}},
+        volume = {226},
+        number = {2},
+        pages = {345--357},
+        author = {Martin Schlegel and Oswald Knoth and Martin Arnold and Ralf Wolke},
+        title = {Multirate Runge-Kutta schemes for advection equations},
+        journal = {Journal of Computational and Applied Mathematics}
+    }
+"""
+function solversetup(
+    ode_solver::MultirateSolverType{SlowFastSplitting},
+    dg,
+    Q,
+    dt,
+    t0,
+    diffusion_direction,
+)
+
+    # Extract fast model and define a DG model
+    # for the fast processes (acoustic/gravity waves
+    # in all spatial directions)
+    fast_model = ode_solver.fast_model(dg.balance_law)
+    fast_dg = DGModel(
+        fast_model,
+        dg.grid,
+        dg.numerical_flux_first_order,
+        dg.numerical_flux_second_order,
+        dg.numerical_flux_gradient,
+        state_auxiliary = dg.state_auxiliary,
+        state_gradient_flux = dg.state_gradient_flux,
+        states_higher_order = dg.states_higher_order,
+        direction = EveryDirection(),
+    )
+
+    # Using the RemainderModel, we subtract away the
+    # fast processes and define a DG model for the
+    # slower processes (advection and diffusion)
+    slow_model = RemainderModel(dg.balance_law, (fast_model,))
+    slow_dg = DGModel(
+        slow_model,
+        dg.grid,
+        dg.numerical_flux_first_order,
+        dg.numerical_flux_second_order,
+        dg.numerical_flux_gradient,
+        state_auxiliary = dg.state_auxiliary,
+        state_gradient_flux = dg.state_gradient_flux,
+        states_higher_order = dg.states_higher_order,
+        # Ensure diffusion direction is passed to the correct
+        # DG model
+        diffusion_direction = diffusion_direction,
+    )
+
+    slow_solver = ode_solver.slow_method(slow_dg, Q; dt = dt)
+    fast_dt = dt / ode_solver.timestep_ratio
+    fast_solver = ode_solver.fast_method(fast_dg, Q; dt = fast_dt)
+
+    solver = MultirateRungeKutta((slow_solver, fast_solver), t0 = t0)
+
+    return solver
+end
+
+"""
+# Description
+    solversetup(
+        ode_solver::MultirateSolverType{HEVISplitting},
+        dg,
+        Q,
+        dt,
+        t0,
+        diffusion_direction,
+    )
+
+Creates an ODE solver for the partition slow-fast ODE
+using a multirate method with HEVI time-integration.
+The splitting of the fast (acoustic and gravity waves)
+dynamics is performed by splitting the fast model
+into horizontal and vertical directions. All horizontal
+acoustic waves are treated explicitly, while the 1-D
+vertical problem is treated implicitly. The HEVI-splitting
+of the acoustic waves is handled using an IMEX additive
+Runge-Kutta method in the fast (inner-most) solver.
+
+Examples of similar multirate-HEVI approaches include
+the following references.
+
+### References
+    @article{doms2011description,
+        title={A Description of the Nonhydrostatic Regional COSMO model.
+            Part I: Dynamics and Numerics},
+        author={Doms, G{\"u}nther and Baldauf, M},
+        journal={Deutscher Wetterdienst, Offenbach},
+        year={2011}
+    }
+
+    @article{Tomita_2008,
+        doi = {10.1137/070692273},
+        year = {2008},
+        month = {jan},
+        publisher = {Society for Industrial and Applied Mathematics ({SIAM})},
+        volume = {30},
+        number = {6},
+        pages = {2755--2776},
+        author = {Hirofumi Tomita and Koji Goto and Masaki Satoh},
+        title = {A New Approach to Atmospheric General Circulation Model:
+            Global Cloud Resolving Model {NICAM} and its Computational Performance},
+        journal = {{SIAM} Journal on Scientific Computing}
+    }
+
+# Comments:
+Currently, the only HEVI-type splitting ClimateMachine can currently
+do only involves splitting the acoustic processes; it is not currently
+possible to perform more fine-grained separation of tendencies
+(for example, including vertical advection or diffusion in the 1-D implicit problem)
+"""
+function solversetup(
+    ode_solver::MultirateSolverType{HEVISplitting},
+    dg,
+    Q,
+    dt,
+    t0,
+    diffusion_direction,
+)
+
+    # Extract fast model and define a DG model
+    # for the fast processes
+    fast_model = ode_solver.fast_model(dg.balance_law)
+
+    # Full DG model for the acoustic waves in all directions
+    acoustic_dg_full = DGModel(
+        fast_model,
+        dg.grid,
+        dg.numerical_flux_first_order,
+        dg.numerical_flux_second_order,
+        dg.numerical_flux_gradient,
+        state_auxiliary = dg.state_auxiliary,
+        state_gradient_flux = dg.state_gradient_flux,
+        states_higher_order = dg.states_higher_order,
+        direction = EveryDirection(),
+    )
+
+    # DG model for the vertical acoustic waves only
+    acoustic_dg_vert = DGModel(
+        fast_model,
+        dg.grid,
+        dg.numerical_flux_first_order,
+        dg.numerical_flux_second_order,
+        dg.numerical_flux_gradient,
+        state_auxiliary = dg.state_auxiliary,
+        state_gradient_flux = dg.state_gradient_flux,
+        states_higher_order = dg.states_higher_order,
+        direction = VerticalDirection(),
+    )
+
+    # Compute fast time-step size from target ratio
+    fast_dt = dt / ode_solver.timestep_ratio
+
+    # Fast solver for the acoustic/gravity waves using
+    # a HEVI-type splitting and a 1-D IMEX method
+    fast_solver = ode_solver.fast_method(
+        acoustic_dg_full,
+        acoustic_dg_vert,
+        LinearBackwardEulerSolver(
+            ode_solver.implicit_solver();
+            isadjustable = ode_solver.implicit_solver_adjustable,
+        ),
+        Q;
+        dt = fast_dt,
+        t0 = t0,
+        # NOTE: This needs to be `false` since the ARK method will
+        # evaluate the explicit part using the RemainderModel
+        # (Difference between acoustic_dg_full and acoustic_dg_vert)
+        split_explicit_implicit = false,
+        # NOTE: Do we want to support more variants?
+        variant = LowStorageVariant(),
+    )
+
+    # Finally, we subtract away the
+    # fast processes and define a DG model for the
+    # slower processes (advection and diffusion)
+    slow_model = RemainderModel(dg.balance_law, (fast_model,))
+    slow_dg = DGModel(
+        slow_model,
+        dg.grid,
+        dg.numerical_flux_first_order,
+        dg.numerical_flux_second_order,
+        dg.numerical_flux_gradient,
+        state_auxiliary = dg.state_auxiliary,
+        state_gradient_flux = dg.state_gradient_flux,
+        states_higher_order = dg.states_higher_order,
+        # Ensure diffusion direction is passed to the correct
+        # DG model
+        diffusion_direction = diffusion_direction,
+    )
+
+    slow_solver = ode_solver.slow_method(slow_dg, Q; dt = dt, t0 = t0)
+
+    solver = MultirateRungeKutta((slow_solver, fast_solver), t0 = t0)
+
+    return solver
+end

--- a/src/Driver/SolverTypes/SolverTypes.jl
+++ b/src/Driver/SolverTypes/SolverTypes.jl
@@ -1,0 +1,86 @@
+
+export AbstractSolverType
+export DiscreteSplittingType, HEVISplitting
+
+"""
+    AbstractSolverType
+
+This is an abstract type representing a generic solver. By
+a "solver," we mean an ODE solver together with any potential
+implicit solver (linear solvers).
+"""
+abstract type AbstractSolverType end
+
+"""
+    DiscreteSplittingType
+
+This is an abstract type representing a temporal splitting
+in the discrete equations. For example, HEVI
+(horizontally explicit, vertically implicit) type methods.
+"""
+abstract type DiscreteSplittingType end
+
+"""
+    SlowFastSplitting
+
+The tendency is treated using a standard slow-fast splitting,
+where the fast processes are purely related to acoustic/gravity
+waves (ideal for a typical multirate or MIS method).
+This splitting does not take into account the geometric
+direction (vertical vs horizontal).
+"""
+struct SlowFastSplitting <: DiscreteSplittingType end
+
+"""
+    HEVISplitting
+
+HEVI (horizontally explicit, vertically implicit) type method,
+where vertical acoustic waves are treated implicitly. All other
+dynamics are treated explicitly.
+
+Note: Can potentially imagine several different types of
+HEVI splittings (for example, include vertical momentum and/or
+diffusion)
+"""
+struct HEVISplitting <: DiscreteSplittingType end
+
+"""
+    getdtmodel(ode_solver::AbstractSolverType, bl)
+
+A function which returns a model representing the dynamics
+with the most restrictive time-stepping requirements.
+"""
+getdtmodel(ode_solver::AbstractSolverType, bl) =
+    throw(MethodError(solversetup, (ode_solver, bl)),)
+
+"""
+    solversetup(
+        ode_solver::AbstractSolverType,
+        dg,
+        Q,
+        dt,
+        t0,
+        diffusion_direction,
+    )
+
+A function which returns a configured ODE solver.
+"""
+solversetup(
+    ode_solver::AbstractSolverType,
+    dg,
+    Q,
+    dt,
+    t0,
+    diffusion_direction,
+) = throw(MethodError(
+    solversetup,
+    (ode_solver, dg, Q, dt, t0, diffusion_direction),
+))
+
+include("ExplicitSolverType.jl")
+include("IMEXSolverType.jl")
+include("MultirateSolverType.jl")
+include("MISSolverType.jl")
+
+DefaultSolverType = IMEXSolverType
+export DefaultSolverType

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -12,54 +12,6 @@
 using CLIMAParameters
 using CLIMAParameters.Planet: planet_radius
 
-abstract type AbstractSolverType end
-
-struct ExplicitSolverType <: AbstractSolverType
-    solver_method::Function
-    ExplicitSolverType(; solver_method = LSRK54CarpenterKennedy) =
-        new(solver_method)
-end
-
-struct IMEXSolverType <: AbstractSolverType
-    linear_model::Type
-    linear_solver::Type
-    solver_method::Function
-    function IMEXSolverType(;
-        # FIXME: this is Atmos-specific
-        linear_model = AtmosAcousticGravityLinearModel,
-        linear_solver = ManyColumnLU,
-        solver_method = ARK2GiraldoKellyConstantinescu,
-    )
-        return new(linear_model, linear_solver, solver_method)
-    end
-end
-
-struct MultirateSolverType <: AbstractSolverType
-    linear_model::Type
-    solver_method::Type
-    slow_method::Function
-    fast_method::Function
-    timestep_ratio::Int
-    function MultirateSolverType(;
-        # FIXME: this is Atmos-specific
-        linear_model = AtmosAcousticGravityLinearModel,
-        solver_method = MultirateRungeKutta,
-        slow_method = LSRK54CarpenterKennedy,
-        fast_method = LSRK54CarpenterKennedy,
-        timestep_ratio = 100,
-    )
-        return new(
-            linear_model,
-            solver_method,
-            slow_method,
-            fast_method,
-            timestep_ratio,
-        )
-    end
-end
-
-DefaultSolverType = IMEXSolverType
-
 abstract type ConfigSpecificInfo end
 struct AtmosLESSpecificInfo <: ConfigSpecificInfo end
 struct AtmosGCMSpecificInfo{FT} <: ConfigSpecificInfo
@@ -69,6 +21,8 @@ struct AtmosGCMSpecificInfo{FT} <: ConfigSpecificInfo
 end
 struct OceanBoxGCMSpecificInfo <: ConfigSpecificInfo end
 struct SingleStackSpecificInfo <: ConfigSpecificInfo end
+
+include("SolverTypes/SolverTypes.jl")
 
 """
     ClimateMachine.DriverConfiguration
@@ -158,7 +112,10 @@ function AtmosLESConfiguration(
     ymin = zero(FT),
     zmin = zero(FT),
     array_type = ClimateMachine.array_type(),
-    solver_type = IMEXSolverType(linear_solver = SingleColumnLU),
+    solver_type = IMEXSolverType(
+        implicit_solver = SingleColumnLU,
+        implicit_solver_adjustable = false,
+    ),
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         param_set;

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -136,21 +136,18 @@ function SolverConfiguration(
     end
     update_auxiliary_state!(dg, bl, Q, FT(0), dg.grid.topology.realelems)
 
-    # create the linear model for IMEX and Multirate solvers
-    linmodel = nothing
-    if isa(ode_solver_type, ExplicitSolverType)
-        dtmodel = bl
-    else
-        linmodel = ode_solver_type.linear_model(bl)
-        dtmodel = linmodel
-    end
-
     # default Courant number
+    # TODO: Think about revising this or drop it entirely.
+    # This is difficult to determine/approximate
+    # for MIS and general multirate methods.
     if Courant_number === nothing
-        if ode_solver_type.solver_method == LSRK144NiegemannDiehlBusch
-            Courant_number = FT(1.7)
-        elseif ode_solver_type.solver_method == LSRK54CarpenterKennedy
-            Courant_number = FT(0.3)
+        if isa(ode_solver_type, ExplicitSolverType)
+            if ode_solver_type.solver_method == LSRK144NiegemannDiehlBusch
+                Courant_number = FT(1.7)
+            else
+                @assert ode_solver_type.solver_method == LSRK54CarpenterKennedy
+                Courant_number = FT(0.3)
+            end
         else
             Courant_number = FT(0.5)
         end
@@ -159,6 +156,7 @@ function SolverConfiguration(
     # initial Δt specified or computed
     simtime = FT(0) # TODO: needs to be more general to account for restart:
     if ode_dt === nothing
+        dtmodel = getdtmodel(ode_solver_type, bl)
         ode_dt = ClimateMachine.DGMethods.calculate_dt(
             dg,
             dtmodel,
@@ -172,60 +170,7 @@ function SolverConfiguration(
     timeend_dt_adjust && (ode_dt = timeend / numberofsteps)
 
     # create the solver
-    if isa(ode_solver_type, ExplicitSolverType)
-        solver = ode_solver_type.solver_method(dg, Q; dt = ode_dt, t0 = t0)
-    elseif isa(ode_solver_type, MultirateSolverType)
-        fast_dg = DGModel(
-            linmodel,
-            grid,
-            numerical_flux_first_order,
-            numerical_flux_second_order,
-            numerical_flux_gradient,
-            state_auxiliary = dg.state_auxiliary,
-            state_gradient_flux = dg.state_gradient_flux,
-            states_higher_order = dg.states_higher_order,
-        )
-        slow_model = RemainderModel(bl, (linmodel,))
-        slow_dg = DGModel(
-            slow_model,
-            grid,
-            numerical_flux_first_order,
-            numerical_flux_second_order,
-            numerical_flux_gradient,
-            state_auxiliary = dg.state_auxiliary,
-            state_gradient_flux = dg.state_gradient_flux,
-            states_higher_order = dg.states_higher_order,
-            diffusion_direction = diffdir,
-        )
-        slow_solver = ode_solver_type.slow_method(slow_dg, Q; dt = ode_dt)
-        fast_dt = ode_dt / ode_solver_type.timestep_ratio
-        fast_solver = ode_solver_type.fast_method(fast_dg, Q; dt = fast_dt)
-        solver =
-            ode_solver_type.solver_method((slow_solver, fast_solver), t0 = t0)
-    else # solver_type === IMEXSolverType
-        vdg = DGModel(
-            linmodel,
-            grid,
-            numerical_flux_first_order,
-            numerical_flux_second_order,
-            numerical_flux_gradient,
-            state_auxiliary = dg.state_auxiliary,
-            state_gradient_flux = dg.state_gradient_flux,
-            states_higher_order = dg.states_higher_order,
-            direction = VerticalDirection(),
-        )
-        solver = ode_solver_type.solver_method(
-            dg,
-            vdg,
-            LinearBackwardEulerSolver(
-                ode_solver_type.linear_solver();
-                isadjustable = false,
-            ),
-            Q;
-            dt = ode_dt,
-            t0 = t0,
-        )
-    end
+    solver = solversetup(ode_solver_type, dg, Q, ode_dt, t0, diffdir)
 
     @toc SolverConfiguration
 

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -81,9 +81,9 @@ end
 
 function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
 
-    # Choose explicit solver
+    # Choose explicit multirate solver
     ode_solver = ClimateMachine.MultirateSolverType(
-        linear_model = AtmosAcousticGravityLinearModel,
+        fast_model = AtmosAcousticGravityLinearModel,
         slow_method = LSRK144NiegemannDiehlBusch,
         fast_method = LSRK144NiegemannDiehlBusch,
         timestep_ratio = 10,

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -69,6 +69,11 @@ function main()
     # Timestep size (s)
     dt = FT(600)
 
+    ode_solver = ClimateMachine.MISSolverType(;
+        splitting_type = ClimateMachine.SlowFastSplitting(),
+        nsubsteps = 20,
+    )
+
     setup = AcousticWaveSetup{FT}()
     T_profile = IsothermalProfile(param_set, setup.T_ref)
     orientation = SphericalOrientation()
@@ -92,6 +97,7 @@ function main()
         setup.domain_height,
         param_set,
         setup;
+        solver_type = ode_solver,
         model = model,
     )
     solver_config = ClimateMachine.SolverConfiguration(

--- a/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
@@ -57,8 +57,8 @@ function test_divergence_free(; imex::Bool = false, BC = nothing)
 
     if imex
         solver_type = ClimateMachine.IMEXSolverType(
-            linear_model = LinearHBModel,
-            linear_solver = ClimateMachine.SystemSolvers.SingleColumnLU,
+            implicit_model = LinearHBModel,
+            implicit_solver = ClimateMachine.SystemSolvers.SingleColumnLU,
         )
         Courant_number = 0.1
     else

--- a/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
@@ -56,7 +56,7 @@ function test_ocean_gyre(; imex::Bool = false, BC = nothing, Δt = 60)
 
     if imex
         solver_type =
-            ClimateMachine.IMEXSolverType(linear_model = LinearHBModel)
+            ClimateMachine.IMEXSolverType(implicit_model = LinearHBModel)
         Courant_number = 0.1
     else
         solver_type = ClimateMachine.ExplicitSolverType(

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -146,11 +146,15 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
         data_config = data_config,
     )
 
-    ode_solver = ClimateMachine.MultirateSolverType(
-        linear_model = AtmosAcousticGravityLinearModel,
-        slow_method = LSRK144NiegemannDiehlBusch,
+    # Set up the time-integrator, using a multirate infinitesimal step
+    # method. The option `splitting_type = ClimateMachine.SlowFastSplitting()`
+    # separates fast-slow modes by splitting away the acoustic waves and
+    # treating them via a sub-stepped explicit method.
+    ode_solver = ClimateMachine.MISSolverType(;
+        splitting_type = ClimateMachine.SlowFastSplitting(),
+        mis_method = MIS2,
         fast_method = LSRK144NiegemannDiehlBusch,
-        timestep_ratio = 10,
+        nsubsteps = 10,
     )
 
     config = ClimateMachine.AtmosLESConfiguration(
@@ -187,7 +191,7 @@ function main()
     # Time integrator setup
     t0 = FT(0)
     # Courant number
-    CFLmax = FT(5)
+    CFLmax = FT(20)
     timeend = FT(1000)
     xmax, ymax, zmax = FT(250), FT(250), FT(500)
 

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -221,12 +221,25 @@ driver_config = ClimateMachine.AtmosGCMConfiguration(
     model = model,
 );
 
-# The next lines set up the time stepper.
+# The next lines set up the time stepper. Since the resolution
+# in the vertical is much finer than in the horizontal,
+# the 'stiff' parts of the PDE will be in the vertical.
+# Setting `splitting_type = HEVISplitting()` will treat
+# vertical acoustic waves implicitly, while all other dynamics
+# are treated explicitly.
+ode_solver_type = ClimateMachine.IMEXSolverType(
+    splitting_type = HEVISplitting(),
+    implicit_model = AtmosAcousticGravityLinearModel,
+    implicit_solver = ManyColumnLU,
+    solver_method = ARK2GiraldoKellyConstantinescu,
+)
+
 solver_config = ClimateMachine.SolverConfiguration(
     timestart,
     timeend,
     driver_config,
     Courant_number = FT(0.2),
+    ode_solver_type = ode_solver_type,
     init_on_cpu = true,
     CFL_direction = HorizontalDirection(),
     diffdir = HorizontalDirection(),

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -218,7 +218,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
     # the ode_solver above can be replaced with 
     # 
     # `ode_solver = ClimateMachine.MultirateSolverType(
-    #    linear_model = AtmosAcousticGravityLinearModel,
+    #    fast_model = AtmosAcousticGravityLinearModel,
     #    slow_method = LSRK144NiegemannDiehlBusch,
     #    fast_method = LSRK144NiegemannDiehlBusch,
     #    timestep_ratio = 10,


### PR DESCRIPTION
# Description

This PR does the following:

- It moves current time-stepping solver types into their own self-contained directory, but with the intention of being used specifically with the driver. The rationale behind this: the stream of `if elseif elseif elseif...` is not sustainable in the long term and one can EASILY imagine this getting way out of hand when adding more time-stepping wrappers.
- I've added discrete splitting types to be used with the solver types: (1): `SlowFastSplitting()` which is designed to be simple splitting of fast (acoustic in all directions) and slow (everything else). And (2): `HEVISplitting()` - this splitting will split the acoustic part into horizontal and vertical parts. The vertical part is implicitly treated while all other tendencies are explicit.
- It extends the current multirate solver type to now support IMEX fast solvers. This is done by specifying `splitting_type = `HEVISplitting()` and passing an IMEX ARK method as the fast solver.
- I've also added a new solver type for the Multirate Infinitesimal Step methods in Clima (A generalization of split-explicit RK methods). At the moment, it only supports purely explicit integration by setting `splitting_type =SlowFastSplitting()`

If anyone sees something strange or thinks it can be done in a better (more Julian?) way, I'd be very keen to learn! Also, I struggled with thinking of designing a set of unit tests for this. One idea is to purposefully use these solver types in the unit tests in `test/Driver` (I've started this).

If others have better ideas, I'd appreciate the feedback.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
