### PR TITLE
Driver hotfix: Pass diffusion direction to the slow dg model for multirate methods

### DIFF
--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -146,7 +146,7 @@ function SolverConfiguration(
     end
 
     # default Courant number
-    if Courant_number == nothing
+    if Courant_number === nothing
         if ode_solver_type.solver_method == LSRK144NiegemannDiehlBusch
             Courant_number = FT(1.7)
         elseif ode_solver_type.solver_method == LSRK54CarpenterKennedy
@@ -195,6 +195,7 @@ function SolverConfiguration(
             state_auxiliary = dg.state_auxiliary,
             state_gradient_flux = dg.state_gradient_flux,
             states_higher_order = dg.states_higher_order,
+            diffusion_direction = diffdir,
         )
         slow_solver = ode_solver_type.slow_method(slow_dg, Q; dt = ode_dt)
         fast_dt = ode_dt / ode_solver_type.timestep_ratio


### PR DESCRIPTION
# Description

When the hyperviscosity terms were added a while ago, so was the `diffusion_direction` argument to `DGModel`. This was never taken into account in the driver and was therefore missed. This ensures the diffusion direction argument is passed to the slow solver, which is where we want _all_ diffusion to be handled!

Note sure if this fixes #1047, but it was definitely causing problems when using multirate rate together with hyperviscosity.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
