### PR TITLE
Method dispatch on `liquid_frac` based on thermodynamic state type

### DIFF
--- a/test/Common/MoistThermodynamics/profiles.jl
+++ b/test/Common/MoistThermodynamics/profiles.jl
@@ -100,9 +100,10 @@ function tested_profiles(
     relative_sat = RS
 
     # Additional variables
-    q_sat = q_vap_saturation.(Ref(param_set), T, ρ)
+    phase_type = PhaseEquil # TODO: Verify this!
+    q_sat = q_vap_saturation.(Ref(param_set), T, ρ, Ref(phase_type))
     q_tot = min.(relative_sat .* q_sat, FT(1))
-    q_pt = PhasePartition_equil.(Ref(param_set), T, ρ, q_tot)
+    q_pt = PhasePartition_equil.(Ref(param_set), T, ρ, q_tot, Ref(phase_type))
     e_int = internal_energy.(Ref(param_set), T, q_pt)
     θ_liq_ice = liquid_ice_pottemp.(Ref(param_set), T, ρ, q_pt)
 

--- a/tutorials/Microphysics/KinematicModel.jl
+++ b/tutorials/Microphysics/KinematicModel.jl
@@ -41,6 +41,7 @@ using ClimateMachine.MoistThermodynamics:
     PhasePartition,
     internal_energy,
     q_vap_saturation,
+    relative_humidity,
     TemperatureSHumEquil,
     TemperatureSHumNonEquil,
     air_temperature

--- a/tutorials/Microphysics/ex_1_saturation_adjustment.jl
+++ b/tutorials/Microphysics/ex_1_saturation_adjustment.jl
@@ -96,10 +96,9 @@ function kinematic_model_nodal_update_auxiliary_state!(
     aux.q_liq = pp.liq
     aux.q_ice = pp.ice
 
-    q = PhasePartition(aux.q_tot, aux.q_liq, aux.q_ice)
-    ts_neq = TemperatureSHumNonEquil(param_set, aux.T, state.ρ, q)
-    aux.S = max(0, aux.q_vap / q_vap_saturation(ts_neq) - FT(1)) * FT(100)
-    aux.RH = aux.q_vap / q_vap_saturation(ts_neq) * FT(100)
+    # TODO: add super_saturation method in moist thermo
+    aux.S = max(0, aux.q_vap / q_vap_saturation(ts) - FT(1)) * FT(100)
+    aux.RH = relative_humidity(ts)
 end
 
 function boundary_state!(

--- a/tutorials/Microphysics/ex_2_Kessler.jl
+++ b/tutorials/Microphysics/ex_2_Kessler.jl
@@ -110,8 +110,9 @@ function kinematic_model_nodal_update_auxiliary_state!(
     q = PhasePartition(aux.q_tot, aux.q_liq, aux.q_ice)
     aux.T = air_temperature(param_set, aux.e_int, q)
     ts_neq = TemperatureSHumNonEquil(param_set, aux.T, state.ρ, q)
+    # TODO: add super_saturation method in moist thermo
     aux.S = max(0, aux.q_vap / q_vap_saturation(ts_neq) - FT(1)) * FT(100)
-    aux.RH = aux.q_vap / q_vap_saturation(ts_neq) * FT(100)
+    aux.RH = relative_humidity(ts_neq)
 
     aux.rain_w = terminal_velocity(param_set, aux.q_rai, state.ρ)
 


### PR DESCRIPTION
# Description

Since `liquid_frac` really depends on whether the phase is in equilibrium or not, we need to pass this information down from the constructors. In this PR, `ThermodynamicState`'s are passed down to inform which state is being constructed.

Co-authored by: @kpamnany, @trontrytel and @tapios 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
