### PR TITLE
Diagnostics and VTK fixes+adjustments

### DIFF
--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -114,9 +114,8 @@ end
 function (dgngrp::DiagnosticsGroup)(currtime; init = false, fini = false)
     if init
         dgngrp.init(dgngrp, currtime)
-    else
-        dgngrp.collect(dgngrp, currtime)
     end
+    dgngrp.collect(dgngrp, currtime)
     if fini
         dgngrp.fini(dgngrp, currtime)
     end

--- a/src/Diagnostics/atmos_core.jl
+++ b/src/Diagnostics/atmos_core.jl
@@ -13,10 +13,12 @@ Initialize the 'AtmosCore' diagnostics group.
 function atmos_core_init(dgngrp::DiagnosticsGroup, currtime)
     dg = Settings.dg
     bl = dg.balance_law
-    if isa(bl.moisture, DryModel)
+    # FIXME properly
+    if !isa(bl.moisture, EquilMoist)
         @warn """
-            Diagnostics ($dgngrp.name): cannot be used with `DryModel`
+            Diagnostics $(dgngrp.name): can only be used with the `EquilMoist` moisture model
             """
+        return nothing
     end
 
     atmos_collect_onetime(Settings.mpicomm, Settings.dg, Settings.Q)
@@ -133,10 +135,12 @@ Perform a global grid traversal to compute various diagnostics.
 function atmos_core_collect(dgngrp::DiagnosticsGroup, currtime)
     dg = Settings.dg
     bl = dg.balance_law
-    if isa(bl.moisture, DryModel)
+    # FIXME properly
+    if !isa(bl.moisture, EquilMoist)
         @warn """
-            Diagnostics $(dgngrp.name): cannot be used with `DryModel`
+            Diagnostics $(dgngrp.name): can only be used with the `EquilMoist` moisture model
             """
+        return nothing
     end
 
     mpicomm = Settings.mpicomm

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -160,7 +160,7 @@ function parse_commandline(custom_settings)
         action = :store_true
     end
 
-    if custom_settings !== nothing
+    if !isnothing(custom_settings)
         import_settings!(s, custom_settings)
     end
 
@@ -334,12 +334,12 @@ function invoke!(
         solver_config,
         user_info_callback,
     )
-    if cb_updates !== nothing
+    if !isnothing(cb_updates)
         callbacks = (callbacks..., cb_updates)
     end
 
     # diagnostics callback(s)
-    if Settings.diagnostics !== "never" && diagnostics_config !== nothing
+    if Settings.diagnostics != "never" && !isnothing(diagnostics_config)
         dgn_starttime = replace(string(now()), ":" => ".")
         Diagnostics.init(mpicomm, dg, Q, dgn_starttime, Settings.output_dir)
 
@@ -354,7 +354,7 @@ function invoke!(
 
     # vtk callback
     cb_vtk = Callbacks.vtk(Settings.vtk, solver_config, Settings.output_dir)
-    if cb_vtk !== nothing
+    if !isnothing(cb_vtk)
         callbacks = (callbacks..., cb_vtk)
     end
 
@@ -364,7 +364,7 @@ function invoke!(
         Settings.array_type,
         mpicomm,
     )
-    if cb_mtd !== nothing
+    if !isnothing(cb_mtd)
         callbacks = (callbacks..., cb_mtd)
     end
 
@@ -373,7 +373,7 @@ function invoke!(
         Settings.monitor_courant_numbers,
         solver_config,
     )
-    if cb_mcn !== nothing
+    if !isnothing(cb_mcn)
         callbacks = (callbacks..., cb_mcn)
     end
 
@@ -384,7 +384,7 @@ function invoke!(
         solver_config,
         Settings.checkpoint_dir,
     )
-    if cb_checkpoint !== nothing
+    if !isnothing(cb_checkpoint)
         callbacks = (callbacks..., cb_checkpoint)
     end
 
@@ -430,12 +430,15 @@ Starting %s
     end
 
     # fini diagnostics groups
-    if Settings.diagnostics !== "never" && diagnostics_config !== nothing
+    if Settings.diagnostics != "never" && !isnothing(diagnostics_config)
         currtime = ODESolvers.gettime(solver)
         for dgngrp in diagnostics_config.groups
             dgngrp(currtime, fini = true)
         end
     end
+
+    # fini VTK
+    !isnothing(cb_vtk) && cb_vtk()
 
     engf = norm(Q)
     @info @sprintf(


### PR DESCRIPTION
# Description

- Don't try and compute `cld_*` diagnostics in `DryModel`s. 🙄 
- Run diagnostics collection at `t0` apart from the specified intervals (like VTK does).
- Run VTK collection at `timeend` apart from the specified intervals (like diagnostics does).

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
