### PR TITLE
Fix bug in `get_vars_from_element_stack` and sign in heat eq tutorial

### DIFF
--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -78,7 +78,7 @@ end
         Q::MPIStateArray,
         vars;
         vrange::UnitRange = 1:size(Q, 3),
-        exclude::Vector{String} = [],
+        exclude::Vector{String} = String[],
     ) where {T, dim, N}
         exclude = [],
     )
@@ -93,7 +93,7 @@ function get_vars_from_element_stack(
     Q::MPIStateArray,
     vars;
     vrange::UnitRange = 1:size(Q, 3),
-    exclude::Vector{String} = [],
+    exclude::Vector{String} = String[],
 ) where {T, dim, N}
     Nq = N + 1
     return [

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -230,7 +230,7 @@ function compute_gradient_flux!(
     aux::Vars,
     t::Real,
 )
-    diffusive.α∇ρcT = m.α * ∇transform.ρcT
+    diffusive.α∇ρcT = -m.α * ∇transform.ρcT
 end;
 
 # We have no sources, nor non-diffusive fluxes.
@@ -256,12 +256,12 @@ function flux_second_order!(
     aux::Vars,
     t::Real,
 )
-    flux.ρcT -= diffusive.α∇ρcT
+    flux.ρcT += diffusive.α∇ρcT
 end;
 
 # ### Boundary conditions
 
-# Second-order terms in our equations, ``∇⋅(G)`` where ``G = α∇ρcT``, are
+# Second-order terms in our equations, ``∇⋅(F)`` where ``F = -α∇ρcT``, are
 # internally reformulated to first-order unknowns.
 # Boundary conditions must be specified for all unknowns, both first-order and
 # second-order unknowns which have been reformulated.
@@ -305,7 +305,7 @@ function boundary_state!(
     if bctype == 1 # bottom
         state⁺.ρcT = m.ρc * m.T_bottom
     elseif bctype == 2 # top
-        diff⁺.α∇ρcT = -n⁻ * m.flux_top
+        diff⁺.α∇ρcT = n⁻ * m.flux_top
     end
 end;
 


### PR DESCRIPTION
# Description

This PR fixes some signs in the second-order fluxes, and fixes a small bug in `get_vars_from_element_stack`.

Thanks for catching the bug in `get_vars_from_element_stack` @ilopezgp! And thanks for fixing @kpamnany!

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
