### PR TITLE
Add support for NTuple types in VariableTemplates

### DIFF
--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -267,4 +267,22 @@ end
     expr
 end
 
+
+@inline function Base.getindex(
+    v::Vars{NTuple{N, T}, A, offset},
+    i,
+) where {N, T, A, offset}
+    # 1 <= i <= N
+    array = parent(v)
+    return Vars{T, A, offset + (i - 1) * varsize(T)}(array)
+end
+@inline function Base.getindex(
+    v::Grad{NTuple{N, T}, A, offset},
+    i,
+) where {N, T, A, offset}
+    # 1 <= i <= N
+    array = parent(v)
+    return Grad{T, A, offset + (i - 1) * varsize(T)}(array)
+end
+
 end # module

--- a/src/Utilities/VariableTemplates/var_names.jl
+++ b/src/Utilities/VariableTemplates/var_names.jl
@@ -1,5 +1,9 @@
 export flattenednames
 
+flattenednames(nt::Type{NTuple{N, T}}; prefix = "") where {N, T} =
+    Iterators.flatten([
+        flattenednames(T; prefix = "$(prefix)[$i]") for i in 1:N
+    ]) |> collect
 flattenednames(::Type{NamedTuple{(), Tuple{}}}; prefix = "") = ()
 flattenednames(::Type{T}; prefix = "") where {T <: Real} = (prefix,)
 flattenednames(::Type{T}; prefix = "") where {T <: SVector} =

--- a/test/Utilities/VariableTemplates/ntuple_type.jl
+++ b/test/Utilities/VariableTemplates/ntuple_type.jl
@@ -1,0 +1,91 @@
+using Test, StaticArrays
+using ClimateMachine.VariableTemplates
+
+@testset "NTuple type" begin
+
+    struct SingleType{FT} end
+    struct NTupleType{FT} end
+    Base.@kwdef struct Container{FT, N}
+        ntuple_type::NTuple{N, NTupleType{FT}} =
+            ntuple(i -> NTupleType{FT}(), N)
+        single_type::SingleType{FT} = SingleType{FT}()
+    end
+
+    vars_state(m::NTupleType, FT) = @vars(a::FT, b::SVector{3, FT})
+    vars_state(m::NTuple{N, NTupleType}, FT) where {N} =
+        Tuple{ntuple(i -> vars_state(m[i], FT), N)...}
+    vars_state(::SingleType, FT) = @vars(a::FT)
+
+    function vars_state(m::Container, FT)
+        @vars(
+            single_type::vars_state(m.single_type, FT),
+            ntuple_type::vars_state(m.ntuple_type, FT)
+        )
+    end
+
+    FT = Float32
+    N = 5
+    container = Container{FT, N}()
+    st = vars_state(container, FT)
+    num_state = varsize(vars_state(container, FT))
+
+    # Vars
+    local_state = MArray{Tuple{num_state}, FT}(undef)
+    fill!(local_state, 0)
+    v = Vars{st}(local_state)
+    v.single_type.a = 2
+    @test v.single_type.a == 2
+    v.ntuple_type[1].a = 2
+    @test v.ntuple_type[1].a == 2
+    v.ntuple_type[2].b = SVector(FT(1), FT(2), FT(3))
+    @test v.ntuple_type[2].b == SVector(FT(1), FT(2), FT(3))
+    @test v.ntuple_type[1].b == SVector(FT(0), FT(0), FT(0))
+    v.ntuple_type[3].a = 3
+    @test v.ntuple_type[3].a == 3
+    v.ntuple_type[N].a = 3
+    @test v.ntuple_type[N].a == 3
+
+    # Grad
+    local_state = MArray{Tuple{3, num_state}, FT}(undef)
+    fill!(local_state, 0)
+    v = Grad{st}(local_state)
+    v.single_type.a = SVector(2, 2, 2)
+    @test v.single_type.a == SVector(2, 2, 2)
+    v.ntuple_type[1].a = SVector(1, 2, 3)
+    @test v.ntuple_type[1].a == SVector(1, 2, 3)
+
+    v.ntuple_type[2].b = SArray{Tuple{3, 3}, FT}([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    @test v.ntuple_type[2].b ==
+          SArray{Tuple{3, 3}, FT}([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    @test v.ntuple_type[3].b ==
+          SArray{Tuple{3, 3}, FT}([0, 0, 0, 0, 0, 0, 0, 0, 0])
+    @test v.ntuple_type[1].b ==
+          SArray{Tuple{3, 3}, FT}([0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+    # flattenednames
+    fn = flattenednames(st)
+    @test fn == [
+        "single_type.a",
+        "ntuple_type[1].a",
+        "ntuple_type[1].b[1]",
+        "ntuple_type[1].b[2]",
+        "ntuple_type[1].b[3]",
+        "ntuple_type[2].a",
+        "ntuple_type[2].b[1]",
+        "ntuple_type[2].b[2]",
+        "ntuple_type[2].b[3]",
+        "ntuple_type[3].a",
+        "ntuple_type[3].b[1]",
+        "ntuple_type[3].b[2]",
+        "ntuple_type[3].b[3]",
+        "ntuple_type[4].a",
+        "ntuple_type[4].b[1]",
+        "ntuple_type[4].b[2]",
+        "ntuple_type[4].b[3]",
+        "ntuple_type[5].a",
+        "ntuple_type[5].b[1]",
+        "ntuple_type[5].b[2]",
+        "ntuple_type[5].b[3]",
+    ]
+
+end

--- a/test/Utilities/VariableTemplates/runtests.jl
+++ b/test/Utilities/VariableTemplates/runtests.jl
@@ -97,3 +97,4 @@ sg = similar(g)
 ]
 
 include("varsindex.jl")
+include("ntuple_type.jl")


### PR DESCRIPTION
# Description

This PR allows for `VariableTemplates` to work with `NTuple` types. Example:

```julia
  struct SingleType{FT} end
  struct NTupleType{FT} end
  Base.@kwdef struct Container{FT, N}
      ntuple_type::NTuple{N,NTupleType{FT}} = ntuple(i->NTupleType{FT}(), N)
      single_type::SingleType{FT} = SingleType{FT}()
  end

  vars_state(m::NTupleType, FT) = @vars(a::FT, b::SVector{3,FT})
  vars_state(m::NTuple{N,NTupleType}, FT) where {N} = Tuple{ntuple(i->vars_state(m[i], FT), N)...}
  vars_state(::SingleType, FT) = @vars(a::FT)

  function vars_state(m::Container, FT)
      @vars(single_type::vars_state(m.single_type, FT),
            ntuple_type::vars_state(m.ntuple_type, FT)
            );
  end
```

This also provides support for `flattenednames`. This is needed for the EDMF model, which will have multiple updrafts.

Co-Authored by @simonbyrne. Thanks for helping with this! 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
