### PR TITLE
Reverse sign of gradient flux states in HB Model

### DIFF
--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -251,10 +251,10 @@ this computation is done pointwise at each nodal point
     t,
 )
     ν = viscosity_tensor(m)
-    D.ν∇u = ν * G.∇u
+    D.ν∇u = -ν * G.∇u
 
     κ = diffusivity_tensor(m, G.∇θ[3])
-    D.κ∇θ = κ * G.∇θ
+    D.κ∇θ = -κ * G.∇θ
 
     return nothing
 end
@@ -479,8 +479,8 @@ this computation is done pointwise at each nodal point
     A::Vars,
     t::Real,
 )
-    F.u -= D.ν∇u
-    F.θ -= D.κ∇θ
+    F.u += D.ν∇u
+    F.θ += D.κ∇θ
 
     return nothing
 end
@@ -620,8 +620,8 @@ function update_auxiliary_state_gradient!(
     function f!(m::HBModel, Q, A, D, t)
         @inbounds begin
             ν = viscosity_tensor(m)
-            ∇u = ν \ D.ν∇u
-            A.w = -(∇u[1, 1] + ∇u[2, 2])
+            ∇u = ν \ D.ν∇u # minus sign included in gradient flux
+            A.w = (∇u[1, 1] + ∇u[2, 2])
         end
 
         return nothing

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -95,10 +95,10 @@ this computation is done pointwise at each nodal point
     t,
 )
     ν = viscosity_tensor(lm.ocean)
-    D.ν∇u = ν * G.∇u
+    D.ν∇u = -ν * G.∇u
 
     κ = diffusivity_tensor(lm.ocean, G.∇θ[3])
-    D.κ∇θ = κ * G.∇θ
+    D.κ∇θ = -κ * G.∇θ
 
     return nothing
 end
@@ -130,8 +130,8 @@ this computation is done pointwise at each nodal point
     A::Vars,
     t::Real,
 )
-    F.u -= D.ν∇u
-    F.θ -= D.κ∇θ
+    F.u += D.ν∇u
+    F.θ += D.κ∇θ
 
     return nothing
 end

--- a/src/Ocean/HydrostaticBoussinesq/SimpleBoxProblem.jl
+++ b/src/Ocean/HydrostaticBoussinesq/SimpleBoxProblem.jl
@@ -123,7 +123,7 @@ jet stream like windstress
 - `y`: y-coordinate in the box
 """
 @inline kinematic_stress(p::HomogeneousBox, y, ρ) =
-    -(p.τₒ / ρ) * cos(y * π / p.Lʸ)
+    (p.τₒ / ρ) * cos(y * π / p.Lʸ)
 
 ##########################
 # Homogenous wind stress #
@@ -199,7 +199,7 @@ jet stream like windstress
 - `p`: problem object to dispatch on and get additional parameters
 - `y`: y-coordinate in the box
 """
-@inline kinematic_stress(p::OceanGyre, y, ρ) = -(p.τₒ / ρ) * cos(y * π / p.Lʸ)
+@inline kinematic_stress(p::OceanGyre, y, ρ) = (p.τₒ / ρ) * cos(y * π / p.Lʸ)
 
 """
     temperature_flux(::OceanGyre)
@@ -213,5 +213,5 @@ cool-warm north-south linear temperature gradient
 """
 @inline function temperature_flux(p::OceanGyre, y, θ)
     θʳ = p.θᴱ * (1 - y / p.Lʸ)
-    return p.λʳ * (θʳ - θ)
+    return p.λʳ * (θ - θʳ)
 end


### PR DESCRIPTION
# Description

Makes things make more physical sense and imposing boundary conditions easier.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
