### PR TITLE
Fix ref state docs

### DIFF
--- a/docs/src/GettingStarted/Atmos.md
+++ b/docs/src/GettingStarted/Atmos.md
@@ -1,7 +1,7 @@
 # Atmosphere model configurations
 
 The struct `AtmosModel` defines a specific subtype of a balance law
-(i.e. conservation equations) specific to atmospheric modelling. A
+(i.e. conservation equations) specific to atmospheric modeling. A
 complete description of a `model` is provided by the fields listed
 below. In this implementation of the `AtmosModel` we concern ourselves
 with the conservative form of the compressible equations of moist fluid
@@ -15,14 +15,7 @@ possible options for each subcomponent.
     ::Type{AtmosLESConfigType},
     param_set::AbstractParameterSet;
     orientation::O = FlatOrientation(),
-    ref_state::RS = HydrostaticState(
-        LinearTemperatureProfile(
-            FT(200),
-            FT(280),
-            FT(grav(param_set)) / FT(cp_d(param_set)),
-        ),
-        FT(0),
-    ),
+    ref_state::RS = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),)
     turbulence::T = SmagorinskyLilly{FT}(0.21),
     hyperdiffusion::HD = NoHyperDiffusion(),
     moisture::M = EquilMoist{FT}(),
@@ -52,14 +45,7 @@ possible options for each subcomponent.
     ::Type{AtmosGCMConfigType},
     param_set::AbstractParameterSet;
     orientation::O = SphericalOrientation(),
-    ref_state::RS = HydrostaticState(
-        LinearTemperatureProfile(
-            FT(200),
-            FT(280),
-            FT(grav(param_set)) / FT(cp_d(param_set)),
-        ),
-        FT(0),
-    ),
+    ref_state::RS = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),)
     turbulence::T = SmagorinskyLilly{FT}(C_smag(param_set)),
     hyperdiffusion::HD = NoHyperDiffusion(),
     moisture::M = EquilMoist{FT}(),


### PR DESCRIPTION
# Description

Removing `LinearTemperatureProfile ` from docs.  This was missed in #1057.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
