### PR TITLE
Refactor columnwise LU code

### DIFF
--- a/test/Numerics/LinearSolvers/bandedsystem.jl
+++ b/test/Numerics/LinearSolvers/bandedsystem.jl
@@ -152,7 +152,7 @@ let
                     Q.data .= dQ1.data
 
                     vdg(dQ1, Q, nothing, 0; increment = false)
-                    banded_matrix_vector_product!(vdg, A_banded, dQ2, Q)
+                    banded_matrix_vector_product!(A_banded, dQ2, Q)
                     @test all(isapprox.(
                         Array(dQ1.realdata),
                         Array(dQ2.realdata),
@@ -181,7 +181,7 @@ let
                     Q.data .= dQ1.data
 
                     op!(dQ1, Q)
-                    banded_matrix_vector_product!(vdg, A_banded, dQ2, Q)
+                    banded_matrix_vector_product!(A_banded, dQ2, Q)
                     @test all(isapprox.(
                         Array(dQ1.realdata),
                         Array(dQ2.realdata),


### PR DESCRIPTION
This refactors the LU columnwise linear solver code. The main idea is to have  a single
function where the various size parameters of the matrix have to be specified and to avoid having to
pass `DGmodel` around. Since those parameters have to known statically for GPU performance they are stored in type domain, which has the benefit of simplifying many kernel calls.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
