### PR TITLE
Remove broken ref on landing page

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,7 +19,7 @@ features such as droughts, rainfall extremes, and high-impact storms.
 The `ClimateMachine` currently consists of three models for the subcomponents
 of the Earth system:
 
-* [`ClimateMachine.Atmos`](@ref AtmosModel-docs): A model of the fluid
+* `ClimateMachine.Atmos`: A model of the fluid
   mechanics of the atmosphere and its interaction with solar radiation and
   phase changes of water that occur, for example, in clouds.
 


### PR DESCRIPTION
# Description

Removes a broken ref on the landing page.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
