### PR TITLE
1) Revert BOMEX to use IMEX timestepper

### DIFF
--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -419,7 +419,7 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax)
     )
 
     # Choose default IMEX solver
-    ode_solver_type = ClimateMachine.IMEXSolverType();
+    ode_solver_type = ClimateMachine.IMEXSolverType()
 
     # Assemble model components
     model = AtmosModel{FT}(
@@ -514,21 +514,21 @@ function main()
     Q = solver_config.Q
     # Volume geometry information
     vgeo = driver_config.grid.vgeo
-    M = vgeo[:,Grids._M,:]
+    M = vgeo[:, Grids._M, :]
     # Unpack prognostic vars
     ρ₀ = Q.ρ
     ρe₀ = Q.ρe
     # DG variable sums
-    Σρ₀ = sum(ρ₀ .* M) 
+    Σρ₀ = sum(ρ₀ .* M)
     Σρe₀ = sum(ρe₀ .* M)
     cb_check_cons =
         GenericCallbacks.EveryXSimulationSteps(3000) do (init = false)
             Q = solver_config.Q
-            δρ =(sum(Q.ρ .* M) - Σρ₀) / Σρ₀
-            δρe =(sum(Q.ρe .* M) .- Σρe₀) ./ Σρe₀
+            δρ = (sum(Q.ρ .* M) - Σρ₀) / Σρ₀
+            δρe = (sum(Q.ρe .* M) .- Σρe₀) ./ Σρe₀
             @show (abs(δρ))
             @show (abs(δρe))
-            @test (abs(δρ)  <= 0.0001)
+            @test (abs(δρ) <= 0.0001)
             @test (abs(δρe) <= 0.0025)
             nothing
         end


### PR DESCRIPTION
Rolls back BOMEX driver to use 1D-IMEX method.	
```modified:   experiments/AtmosLES/bomex.jl```
While pending issues with MRRK interactions with physics and boundaries are addressed, this is the stable solution. 

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
