### PR TITLE
Revert PR #1142

### DIFF
--- a/src/Ocean/HydrostaticBoussinesq/SimpleBoxProblem.jl
+++ b/src/Ocean/HydrostaticBoussinesq/SimpleBoxProblem.jl
@@ -48,6 +48,11 @@ function ocean_init_aux!(m::HBModel, p::AbstractSimpleBoxProblem, A, geom)
     FT = eltype(A)
     @inbounds A.y = geom.coord[2]
 
+    # needed for proper CFL condition calculation
+    A.w = 0
+    A.pkin = 0
+    A.wz0 = 0
+
     return nothing
 end
 


### PR DESCRIPTION
# Description

Turns out these zero initializations are needed for the initial CFL condition calculations, so I'm reverting #1142 

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
