### PR TITLE
Abstract array device discovery

### DIFF
--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -27,7 +27,7 @@ using .CMBuffers
 cpuify(x::AbstractArray) = convert(Array, x)
 cpuify(x::Real) = x
 
-export MPIStateArray, euclidean_distance, weightedsum
+export MPIStateArray, euclidean_distance, weightedsum, array_device
 
 """
     MPIStateArray{FT, DATN<:AbstractArray{FT,3}, DAI1, DAV,
@@ -460,7 +460,7 @@ function fillsendbuf!(
     Np = size(buf, 1)
     nvar = size(buf, 2)
 
-    event = kernel_fillsendbuf!(device(buf), 256)(
+    event = kernel_fillsendbuf!(array_device(buf), 256)(
         Val(Np),
         Val(nvar),
         sendbuf,
@@ -489,7 +489,7 @@ function transferrecvbuf!(
     Np = size(buf, 1)
     nvar = size(buf, 2)
 
-    event = kernel_transferrecvbuf!(device(buf), 256)(
+    event = kernel_transferrecvbuf!(array_device(buf), 256)(
         Val(Np),
         Val(nvar),
         buf,
@@ -734,20 +734,14 @@ function Base.mapreduce(
     MPI.Allreduce(cpuify(locreduce), max, Q.mpicomm)
 end
 
-
-# `realview` and `device` are helpers that enable
-# testing ODESolvers and LinearSolvers without using MPIStateArrays
-# They could be potentially useful elsewhere and exported but probably need
-# better names, for example `device` is also defined in CUDAdrv
-
-device(::Union{Array, SArray, MArray}) = CPU()
-device(Q::MPIStateArray) = device(Q.data)
+# helpers: `array_device` and `realview`
+array_device(::Union{Array, SArray, MArray}) = CPU()
+array_device(::CuArray) = CUDA()
+array_device(s::SubArray) = array_device(parent(s))
+array_device(Q::MPIStateArray) = array_device(Q.data)
 
 realview(Q::Union{Array, SArray, MArray}) = Q
 realview(Q::MPIStateArray) = Q.realdata
-
-
-device(::CuArray) = CUDA()
 realview(Q::CuArray) = Q
 
 # transform all arguments of `bc` from MPIStateArrays to CuArrays

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -24,6 +24,7 @@ using MPI
 using OrderedCollections
 using Printf
 using StaticArrays
+import KernelAbstractions: CPU
 
 using ClimateMachine
 using ..DGmethods

--- a/src/Diagnostics/atmos_common.jl
+++ b/src/Diagnostics/atmos_common.jl
@@ -21,11 +21,7 @@ function atmos_collect_onetime(mpicomm, dg, Q)
         nvertelem = topology.stacksize
         nhorzelem = div(nrealelem, nvertelem)
 
-        if Array ∈ typeof(Q).parameters
-            localvgeo = grid.vgeo
-        else
-            localvgeo = Array(grid.vgeo)
-        end
+        localvgeo = array_device(Q) isa CPU ? grid.vgeo : Array(grid.vgeo)
 
         AtmosCollected.zvals = zeros(FT, Nqk * nvertelem)
         AtmosCollected.repdvsr = zeros(FT, Nqk * nvertelem)

--- a/src/Diagnostics/atmos_core.jl
+++ b/src/Diagnostics/atmos_core.jl
@@ -160,7 +160,7 @@ function atmos_core_collect(dgngrp::DiagnosticsGroup, currtime)
     nhorzelem = div(nrealelem, nvertelem)
 
     # get needed arrays onto the CPU
-    if Array ∈ typeof(Q).parameters
+    if array_device(Q) isa CPU
         host_state_conservative = Q.realdata
         host_state_auxiliary = dg.state_auxiliary.realdata
         host_vgeo = grid.vgeo

--- a/src/Diagnostics/atmos_default.jl
+++ b/src/Diagnostics/atmos_default.jl
@@ -278,7 +278,7 @@ function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
     nhorzelem = div(nrealelem, nvertelem)
 
     # get needed arrays onto the CPU
-    if Array ∈ typeof(Q).parameters
+    if array_device(Q) isa CPU
         host_state_conservative = Q.realdata
         host_state_auxiliary = dg.state_auxiliary.realdata
         host_vgeo = grid.vgeo

--- a/src/Diagnostics/dump_state_and_aux.jl
+++ b/src/Diagnostics/dump_state_and_aux.jl
@@ -5,7 +5,7 @@ end
 function get_dims(dgngrp)
     if dgngrp.interpol !== nothing
         if dgngrp.interpol isa InterpolationBrick
-            if Array ∈ typeof(dgngrp.interpol.x1g).parameters
+            if array_device(dgngrp.interpol.x1g) isa CPU
                 h_x1g = dgngrp.interpol.x1g
                 h_x2g = dgngrp.interpol.x2g
                 h_x3g = dgngrp.interpol.x3g
@@ -16,7 +16,7 @@ function get_dims(dgngrp)
             end
             dims = OrderedDict("x" => h_x1g, "y" => h_x2g, "z" => h_x3g)
         elseif dgngrp.interpol isa InterpolationCubedSphere
-            if Array ∈ typeof(dgngrp.interpol.rad_grd).parameters
+            if array_device(dgngrp.interpol.rad_grd) isa CPU
                 h_rad_grd = dgngrp.interpol.rad_grd
                 h_lat_grd = dgngrp.interpol.lat_grd
                 h_long_grd = dgngrp.interpol.long_grd

--- a/src/InputOutput/VTK/writevtk.jl
+++ b/src/InputOutput/VTK/writevtk.jl
@@ -1,3 +1,5 @@
+import KernelAbstractions: CPU
+
 using ..Mesh.Grids
 using ..MPIStateArrays
 using ..DGmethods
@@ -16,8 +18,8 @@ number of states in `Q`, i.e., `k = size(Q,2)`.
 """
 function writevtk(prefix, Q::MPIStateArray, dg::DGModel, fieldnames = nothing)
     vgeo = dg.grid.vgeo
-    host_array = Array ∈ typeof(Q).parameters
-    (h_vgeo, h_Q) = host_array ? (vgeo, Q.data) : (Array(vgeo), Array(Q))
+    device = array_device(Q)
+    (h_vgeo, h_Q) = device isa CPU ? (vgeo, Q.data) : (Array(vgeo), Array(Q))
     writevtk_helper(prefix, h_vgeo, h_Q, dg.grid, fieldnames)
     return nothing
 end
@@ -49,8 +51,9 @@ function writevtk(
     auxfieldnames,
 )
     vgeo = dg.grid.vgeo
-    host_array = Array ∈ typeof(Q).parameters
-    (h_vgeo, h_Q, h_aux) = host_array ? (vgeo, Q.data, state_auxiliary.data) :
+    device = array_device(Q)
+    (h_vgeo, h_Q, h_aux) =
+        device isa CPU ? (vgeo, Q.data, state_auxiliary.data) :
         (Array(vgeo), Array(Q), Array(state_auxiliary))
     writevtk_helper(
         prefix,

--- a/src/Numerics/DGmethods/DGmodel.jl
+++ b/src/Numerics/DGmethods/DGmodel.jl
@@ -51,7 +51,7 @@ function (dg::DGModel)(
 )
 
     balance_law = dg.balance_law
-    device = typeof(state_conservative.data) <: Array ? CPU() : CUDA()
+    device = array_device(state_conservative)
 
     grid = dg.grid
     topology = grid.topology
@@ -626,7 +626,7 @@ function indefinite_stack_integral!(
     elems::UnitRange = dg.grid.topology.elems,
 )
 
-    device = typeof(state_conservative.data) <: Array ? CPU() : CUDA()
+    device = array_device(state_conservative)
 
     grid = dg.grid
     topology = grid.topology
@@ -669,7 +669,7 @@ function reverse_indefinite_stack_integral!(
     elems::UnitRange = dg.grid.topology.elems,
 )
 
-    device = typeof(state_auxiliary.data) <: Array ? CPU() : CUDA()
+    device = array_device(state_auxiliary)
 
     grid = dg.grid
     topology = grid.topology
@@ -710,7 +710,7 @@ function nodal_update_auxiliary_state!(
     elems::UnitRange = dg.grid.topology.realelems;
     diffusive = false,
 )
-    device = typeof(state_conservative.data) <: Array ? CPU() : CUDA()
+    device = array_device(state_conservative)
 
     grid = dg.grid
     topology = grid.topology
@@ -793,7 +793,7 @@ function courant(
         dim = dimensionality(grid)
         Nq = N + 1
         Nqk = dim == 2 ? 1 : Nq
-        device = grid.vgeo isa Array ? CPU() : CUDA()
+        device = array_device(grid.vgeo)
         pointwise_courant = similar(grid.vgeo, Nq^dim, nrealelem)
         event = Event(device)
         event = Grids.kernel_min_neighbor_distance!(
@@ -842,8 +842,7 @@ function copy_stack_field_down!(
     fldout,
     elems = topology.elems,
 )
-
-    device = typeof(state_auxiliary.data) <: Array ? CPU() : CUDA()
+    device = array_device(state_auxiliary)
 
     grid = dg.grid
     topology = grid.topology

--- a/src/Numerics/DGmethods/balance_law.jl
+++ b/src/Numerics/DGmethods/balance_law.jl
@@ -75,7 +75,7 @@ function create_auxiliary_state(balance_law, grid)
     dim = dimensionality(grid)
     polyorder = polynomialorder(grid)
     vgeo = grid.vgeo
-    device = typeof(state_auxiliary.data) <: Array ? CPU() : CUDA()
+    device = array_device(state_auxiliary)
     nrealelem = length(topology.realelems)
     event = Event(device)
     event = kernel_init_state_auxiliary!(device, min(Np, 1024), Np * nrealelem)(

--- a/src/Numerics/LinearSolvers/BatchedGeneralizedMinimalResidualSolver.jl
+++ b/src/Numerics/LinearSolvers/BatchedGeneralizedMinimalResidualSolver.jl
@@ -309,11 +309,10 @@ function LS.doiteration!(
     args...,
 )
     # Get device and groupsize information
-    if isa(gmres.b, Array)
-        device = CPU()
+    device = array_device(gmres.b)
+    if isa(device, CPU)
         groupsize = Threads.nthreads()
-    else
-        device = CUDA()
+    else # isa(device, CUDA)
         groupsize = 256
     end
 

--- a/src/Numerics/LinearSolvers/ColumnwiseLUSolver.jl
+++ b/src/Numerics/LinearSolvers/ColumnwiseLUSolver.jl
@@ -107,8 +107,6 @@ function LS.linearsolve!(
     Qrhs,
     args...,
 )
-    device = typeof(Q.data) <: Array ? CPU() : CUDA()
-
     A = clu.A
     Q .= Qrhs
 
@@ -121,7 +119,7 @@ end
 
 """
 function band_lu!(A)
-    device = typeof(A.data) <: Array ? CPU() : CUDA()
+    device = array_device(A.data)
 
     nstate = num_state(A)
     Nq = polynomialorder(A) + 1
@@ -151,7 +149,7 @@ function band_lu!(A)
 end
 
 function band_forward!(Q, A)
-    device = typeof(Q.data) <: Array ? CPU() : CUDA()
+    device = array_device(Q)
 
     Nq = polynomialorder(A) + 1
     Nqj = dimensionality(A) == 2 ? 1 : Nq
@@ -168,7 +166,7 @@ function band_forward!(Q, A)
 end
 
 function band_back!(Q, A)
-    device = typeof(Q.data) <: Array ? CPU() : CUDA()
+    device = array_device(Q)
 
     Nq = polynomialorder(A) + 1
     Nqj = dimensionality(A) == 2 ? 1 : Nq
@@ -274,7 +272,7 @@ function banded_matrix(
     @assert typeof(dg.direction) <: VerticalDirection
 
     FT = eltype(Q.data)
-    device = typeof(Q.data) <: Array ? CPU() : CUDA()
+    device = array_device(Q)
 
     nstate = number_state_conservative(bl, FT)
     N = polynomialorder(grid)
@@ -376,7 +374,7 @@ created using the `banded_matrix` function.
 This function is primarily for testing purposes.
 """
 function banded_matrix_vector_product!(A, dQ::MPIStateArray, Q::MPIStateArray)
-    device = typeof(Q.data) <: Array ? CPU() : CUDA()
+    device = array_device(Q)
 
     Nq = polynomialorder(A) + 1
     Nqj = dimensionality(A) == 2 ? 1 : Nq

--- a/src/Numerics/LinearSolvers/GeneralizedConjugateResidualSolver.jl
+++ b/src/Numerics/LinearSolvers/GeneralizedConjugateResidualSolver.jl
@@ -4,7 +4,7 @@ export GeneralizedConjugateResidual
 
 using ..LinearSolvers
 const LS = LinearSolvers
-using ..MPIStateArrays: device, realview
+using ..MPIStateArrays: array_device, realview
 
 using LinearAlgebra
 using LazyArrays
@@ -156,8 +156,8 @@ function LS.doiteration!(
         groupsize = 256
         T = eltype(alpha)
 
-        event = Event(device(Q))
-        event = LS.linearcombination!(device(Q), groupsize)(
+        event = Event(array_device(Q))
+        event = LS.linearcombination!(array_device(Q), groupsize)(
             rv_nextp,
             (one(T), alpha[1:k]...),
             (rv_residual, rv_p[1:k]...),
@@ -166,7 +166,7 @@ function LS.doiteration!(
             dependencies = (event,),
         )
 
-        event = LS.linearcombination!(device(Q), groupsize)(
+        event = LS.linearcombination!(array_device(Q), groupsize)(
             rv_L_nextp,
             (one(T), alpha[1:k]...),
             (rv_L_residual, rv_L_p[1:k]...),
@@ -174,7 +174,7 @@ function LS.doiteration!(
             ndrange = length(rv_nextp),
             dependencies = (event,),
         )
-        wait(device(Q), event)
+        wait(array_device(Q), event)
     end
 
     (false, K, residual_norm)

--- a/src/Numerics/LinearSolvers/GeneralizedMinimalResidualSolver.jl
+++ b/src/Numerics/LinearSolvers/GeneralizedMinimalResidualSolver.jl
@@ -4,7 +4,7 @@ export GeneralizedMinimalResidual
 
 using ..LinearSolvers
 const LS = LinearSolvers
-using ..MPIStateArrays: device, realview
+using ..MPIStateArrays: array_device, realview
 
 using LinearAlgebra
 using LazyArrays
@@ -160,8 +160,8 @@ function LS.doiteration!(
     rv_Q = realview(Q)
     rv_krylov_basis = realview.(krylov_basis)
     groupsize = 256
-    event = Event(device(Q))
-    event = LS.linearcombination!(device(Q), groupsize)(
+    event = Event(array_device(Q))
+    event = LS.linearcombination!(array_device(Q), groupsize)(
         rv_Q,
         y,
         rv_krylov_basis,
@@ -169,7 +169,7 @@ function LS.doiteration!(
         ndrange = length(rv_Q),
         dependencies = (event,),
     )
-    wait(device(Q), event)
+    wait(array_device(Q), event)
 
     # if not converged restart
     converged || LS.initialize!(linearoperator!, Q, Qrhs, solver, args...)

--- a/src/Numerics/ODESolvers/AdditiveRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/AdditiveRungeKuttaMethod.jl
@@ -225,8 +225,8 @@ function dostep!(
 
         # this kernel also initializes Qstages[istage] with an initial guess
         # for the linear solver
-        event = Event(device(Q))
-        event = stage_update!(device(Q), groupsize)(
+        event = Event(array_device(Q))
+        event = stage_update!(array_device(Q), groupsize)(
             variant,
             rv_Q,
             rv_Qstages,
@@ -243,7 +243,7 @@ function dostep!(
             ndrange = length(rv_Q),
             dependencies = (event,),
         )
-        wait(device(Q), event)
+        wait(array_device(Q), event)
 
         # solves
         # Qs = Qhat + dt * RKA_implicit[istage, istage] * rhs_implicit!(Qs)
@@ -261,8 +261,8 @@ function dostep!(
     end
 
     # compose the final solution
-    event = Event(device(Q))
-    event = solution_update!(device(Q), groupsize)(
+    event = Event(array_device(Q))
+    event = solution_update!(array_device(Q), groupsize)(
         variant,
         rv_Q,
         rv_Lstages,
@@ -277,7 +277,7 @@ function dostep!(
         ndrange = length(rv_Q),
         dependencies = (event,),
     )
-    wait(device(Q), event)
+    wait(array_device(Q), event)
 end
 
 function dostep!(
@@ -320,8 +320,8 @@ function dostep!(
 
 
         # this kernel also initializes Qtt for the linear solver
-        event = Event(device(Q))
-        event = stage_update!(device(Q), groupsize)(
+        event = Event(array_device(Q))
+        event = stage_update!(array_device(Q), groupsize)(
             variant,
             rv_Q,
             rv_Qstages,
@@ -338,7 +338,7 @@ function dostep!(
             ndrange = length(rv_Q),
             dependencies = (event,),
         )
-        wait(device(Q), event)
+        wait(array_device(Q), event)
 
         # solves
         # Q_tt = Qhat + dt * RKA_implicit[istage, istage] * rhs_implicit!(Q_tt)
@@ -365,8 +365,8 @@ function dostep!(
     end
 
     # compose the final solution
-    event = Event(device(Q))
-    event = solution_update!(device(Q), groupsize)(
+    event = Event(array_device(Q))
+    event = solution_update!(array_device(Q), groupsize)(
         variant,
         rv_Q,
         rv_Rstages,
@@ -379,7 +379,7 @@ function dostep!(
         ndrange = length(rv_Q),
         dependencies = (event,),
     )
-    wait(device(Q), event)
+    wait(array_device(Q), event)
 end
 
 @kernel function stage_update!(

--- a/src/Numerics/ODESolvers/LowStorageRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/LowStorageRungeKuttaMethod.jl
@@ -98,8 +98,8 @@ function dostep!(
             slow_scaling = in_slow_scaling
         end
         # update solution and scale RHS
-        event = Event(device(Q))
-        event = update!(device(Q), groupsize)(
+        event = Event(array_device(Q))
+        event = update!(array_device(Q), groupsize)(
             rv_dQ,
             rv_Q,
             RKA[s % length(RKA) + 1],
@@ -111,7 +111,7 @@ function dostep!(
             ndrange = length(rv_Q),
             dependencies = (event,),
         )
-        wait(device(Q), event)
+        wait(array_device(Q), event)
     end
 end
 
@@ -158,8 +158,8 @@ function dostep!(Q, lsrk::LowStorageRungeKutta2N, mrip::MRIParam, time::Real)
 
         # update solution and scale RHS
         τ = (stage_time - mrip.ts) / mrip.Δts
-        event = Event(device(Q))
-        event = lsrk_mri_update!(device(Q), groupsize)(
+        event = Event(array_device(Q))
+        event = lsrk_mri_update!(array_device(Q), groupsize)(
             rv_dQ,
             rv_Q,
             RKA[s % length(RKA) + 1],
@@ -171,7 +171,7 @@ function dostep!(Q, lsrk::LowStorageRungeKutta2N, mrip::MRIParam, time::Real)
             ndrange = length(rv_Q),
             dependencies = (event,),
         )
-        wait(device(Q), event)
+        wait(array_device(Q), event)
     end
 end
 

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalGARKDecoupledImplicit.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalGARKDecoupledImplicit.jl
@@ -204,8 +204,8 @@ function dostep!(Q, mrigark::MRIGARKDecoupledImplicit, param, time::Real)
         # (Divide by k arises from the integration γ_{ij}(τ) in Sandu (2019);
         # see Equation (2.2b) and Definition 2.2
         γs = ntuple(k -> ntuple(j -> dt * Γs[k][2s, j] / k, s), NΓ)
-        event = Event(device(Q))
-        event = mri_create_Qhat!(device(Q), groupsize)(
+        event = Event(array_device(Q))
+        event = mri_create_Qhat!(array_device(Q), groupsize)(
             realview(Qhat),
             realview(Q),
             γs,
@@ -213,7 +213,7 @@ function dostep!(Q, mrigark::MRIGARKDecoupledImplicit, param, time::Real)
             ndrange = length(realview(Q)),
             dependencies = (event,),
         )
-        wait(device(Q), event)
+        wait(array_device(Q), event)
 
         # Solve: Q = Qhat + α fslow(Q, stage_end_time)
         α = dt * Γs[1][2s, s + 1]

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalGARKExplicit.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalGARKExplicit.jl
@@ -179,8 +179,8 @@ function dostep!(Q, mrigark::MRIGARKExplicit, param, time::Real)
         if param isa MRIParam
             # fraction of the step slower stage increment we are on
             τ = (ts - param.ts) / param.Δts
-            event = Event(device(Q))
-            event = mri_update_rate!(device(Q), groupsize)(
+            event = Event(array_device(Q))
+            event = mri_update_rate!(array_device(Q), groupsize)(
                 realview(Rs[s]),
                 τ,
                 param.γs,
@@ -188,7 +188,7 @@ function dostep!(Q, mrigark::MRIGARKExplicit, param, time::Real)
                 ndrange = length(realview(Rs[s])),
                 dependencies = (event,),
             )
-            wait(device(Q), event)
+            wait(array_device(Q), event)
         end
 
         γs = ntuple(k -> ntuple(j -> Γs[k][s, j], s), NΓ)

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalStepMethod.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalStepMethod.jl
@@ -172,8 +172,8 @@ function dostep!(Q, mis::MultirateInfinitesimalStep, p, time)
         slowrhs!(fYnj[i - 1], Q, p, time + c[i - 1] * dt, increment = false)
 
         groupsize = 256
-        event = Event(device(Q))
-        event = update!(device(Q), groupsize)(
+        event = Event(array_device(Q))
+        event = update!(array_device(Q), groupsize)(
             realview(Q),
             realview(offset),
             Val(i),
@@ -188,7 +188,7 @@ function dostep!(Q, mis::MultirateInfinitesimalStep, p, time)
             ndrange = length(realview(Q)),
             dependencies = (event,),
         )
-        wait(device(Q), event)
+        wait(array_device(Q), event)
 
         fastrhs!.a = time + c̃[i] * dt
         fastrhs!.b = (c[i] - c̃[i]) / d[i]

--- a/src/Numerics/ODESolvers/MultirateRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/MultirateRungeKuttaMethod.jl
@@ -111,8 +111,8 @@ function dostep!(
                 slow_scaling = in_slow_scaling
             end
             # update solution and scale RHS
-            event = Event(device(Q))
-            event = update!(device(Q), groupsize)(
+            event = Event(array_device(Q))
+            event = update!(array_device(Q), groupsize)(
                 slow_rv_dQ,
                 in_slow_rv_dQ,
                 in_slow_δ,
@@ -120,7 +120,7 @@ function dostep!(
                 ndrange = length(realview(Q)),
                 dependencies = (event,),
             )
-            wait(device(Q), event)
+            wait(array_device(Q), event)
         end
 
         # Fractional time for slow stage

--- a/src/Numerics/ODESolvers/ODESolvers.jl
+++ b/src/Numerics/ODESolvers/ODESolvers.jl
@@ -9,7 +9,7 @@ using KernelAbstractions
 using KernelAbstractions.Extras: @unroll
 using StaticArrays
 using ..LinearSolvers
-using ..MPIStateArrays: device, realview
+using ..MPIStateArrays: array_device, realview
 
 export solve!, updatedt!, gettime
 

--- a/src/Numerics/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
@@ -105,8 +105,8 @@ function dostep!(
         if s == length(RKB)
             slow_scaling = in_slow_scaling
         end
-        event = Event(device(Q))
-        event = update!(device(Q), groupsize)(
+        event = Event(array_device(Q))
+        event = update!(array_device(Q), groupsize)(
             rv_Rstage,
             rv_Q,
             rv_Qstage,
@@ -120,7 +120,7 @@ function dostep!(
             ndrange = length(rv_Q),
             dependencies = (event,),
         )
-        wait(device(Q), event)
+        wait(array_device(Q), event)
     end
     rv_Q .= rv_Qstage
 end

--- a/src/Utilities/Checkpoint/Checkpoint.jl
+++ b/src/Utilities/Checkpoint/Checkpoint.jl
@@ -5,8 +5,10 @@ export write_checkpoint, rm_checkpoint, read_checkpoint
 using JLD2
 using MPI
 using Printf
+import KernelAbstractions: CPU
 
 using ..ODESolvers
+import ..MPIStateArrays: array_device
 
 """
     write_checkpoint(solver_config, checkpoint_dir, name, mpicomm, num)
@@ -38,7 +40,7 @@ Checkpoint
 
     dg = solver_config.dg
     Q = solver_config.Q
-    if Array ∈ typeof(Q).parameters
+    if array_device(Q) isa CPU
         h_Q = Q.realdata
         h_aux = dg.state_auxiliary.realdata
     else

--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -4,6 +4,7 @@ export get_vars_from_nodal_stack, get_vars_from_element_stack
 
 using OrderedCollections
 using StaticArrays
+import KernelAbstractions: CPU
 
 using ..DGmethods
 using ..DGmethods.Grids
@@ -45,7 +46,7 @@ function get_vars_from_nodal_stack(
     Nq = N + 1
     Nqk = dimensionality(grid) == 2 ? 1 : Nq
     nvertelem = grid.topology.stacksize
-    host_Q = Array ∈ typeof(Q).parameters ? Q.realdata : Array(Q.realdata)
+    host_Q = array_device(Q) isa CPU ? Q.realdata : Array(Q.realdata)
 
     # set up the dictionary to be returned
     var_names = flattenednames(vars)

--- a/test/Arrays/mpi_comm.jl
+++ b/test/Arrays/mpi_comm.jl
@@ -6,8 +6,6 @@ using ClimateMachine.Mesh.BrickMesh
 using Pkg
 using KernelAbstractions
 
-device(A) = typeof(A) <: Array ? CPU() : CUDA()
-
 ClimateMachine.init()
 const ArrayType = ClimateMachine.array_type()
 const comm = MPI.COMM_WORLD
@@ -145,10 +143,10 @@ function main()
         reshape((crank * 1000) .+ shift .+ (1:(9 * numreal)), 9, numreal)
     copyto!(A.data, Q)
 
-    event = Event(device(A.data))
+    event = Event(array_device(A))
     event = MPIStateArrays.begin_ghost_exchange!(A; dependencies = event)
     event = MPIStateArrays.end_ghost_exchange!(A; dependencies = event)
-    wait(device(A.data), event)
+    wait(array_device(A), event)
 
     Q = Array(A.data)
     @test all(expectedghostdata .== Q[:, 1, :][:][vmaprecv])

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -1,3 +1,9 @@
+using MPI
+using Printf
+using StaticArrays
+using Test
+import KernelAbstractions: CPU
+
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
@@ -8,15 +14,11 @@ using ClimateMachine.MoistThermodynamics
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Grids
 using ClimateMachine.ODESolvers
+import ClimateMachine.MPIStateArrays: array_device
 
 using CLIMAParameters
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
-
-using MPI
-using Printf
-using StaticArrays
-using Test
 
 Base.@kwdef struct AcousticWaveSetup{FT}
     domain_height::FT = 10e3
@@ -148,7 +150,7 @@ function main()
 
         dg = solver_config.dg
         Q = solver_config.Q
-        if Array ∈ typeof(Q).parameters
+        if array_device(Q) isa CPU
             h_Q = Q.realdata
             h_aux = dg.state_auxiliary.realdata
         else

--- a/test/Numerics/DGmethods/horizontal_integral_test.jl
+++ b/test/Numerics/DGmethods/horizontal_integral_test.jl
@@ -4,6 +4,8 @@ using Logging
 using Printf
 using LinearAlgebra
 using Test
+import KernelAbstractions: CPU
+
 using ClimateMachine
 using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
@@ -48,8 +50,7 @@ function run_test1(mpicomm, dim, Ne, N, FT, ArrayType)
     Nq = N + 1
     Nqk = dimensionality(grid) == 2 ? 1 : Nq
     vgeo = grid.vgeo
-    host_array = Array ∈ typeof(vgeo).parameters
-    localvgeo = host_array ? vgeo : Array(vgeo)
+    localvgeo = array_device(vgeo) isa CPU ? vgeo : Array(vgeo)
 
     S = zeros(Nqk)
     S1 = zeros(Nqk)
@@ -113,8 +114,7 @@ function run_test2(mpicomm, dim, Ne, N, FT, ArrayType)
     Nq = N + 1
     Nqk = dimensionality(grid) == 2 ? 1 : Nq
     vgeo = grid.vgeo
-    host_array = Array ∈ typeof(vgeo).parameters
-    localvgeo = host_array ? vgeo : Array(vgeo)
+    localvgeo = array_device(vgeo) isa CPU ? vgeo : Array(vgeo)
 
     S = zeros(Nqk)
     S1 = zeros(Nqk)
@@ -175,8 +175,7 @@ function run_test3(mpicomm, dim, Ne, N, FT, ArrayType)
         Nq = N + 1
         Nqk = dimensionality(grid) == 2 ? 1 : Nq
         vgeo = grid.vgeo
-        host_array = Array ∈ typeof(vgeo).parameters
-        localvgeo = host_array ? vgeo : Array(vgeo)
+        localvgeo = array_device(vgeo) isa CPU ? vgeo : Array(vgeo)
 
         topology = grid.topology
         nvertelem = topology.stacksize
@@ -230,8 +229,7 @@ function run_test4(mpicomm, dim, Ne, N, FT, ArrayType)
     nrealelem = length(topl.realelems)
     Nq = N + 1
     vgeo = grid.vgeo
-    host_array = Array ∈ typeof(vgeo).parameters
-    localvgeo = host_array ? vgeo : Array(vgeo)
+    localvgeo = array_device(vgeo) isa CPU ? vgeo : Array(vgeo)
 
     S = zeros(Nq)
 
@@ -280,8 +278,7 @@ function run_test5(mpicomm, dim, Ne, N, FT, ArrayType)
     nrealelem = length(topl.realelems)
     Nq = N + 1
     vgeo = grid.vgeo
-    host_array = Array ∈ typeof(vgeo).parameters
-    localvgeo = host_array ? vgeo : Array(vgeo)
+    localvgeo = array_device(vgeo) isa CPU ? vgeo : Array(vgeo)
 
     S = zeros(Nq)
     J = zeros(Nq)

--- a/test/Numerics/LinearSolvers/cg.jl
+++ b/test/Numerics/LinearSolvers/cg.jl
@@ -16,7 +16,6 @@ let
     ClimateMachine.init()
     mpicomm = MPI.COMM_WORLD
     ArrayType = ClimateMachine.array_type()
-    device = ArrayType == Array ? CPU() : CUDA()
     n = 100
     T = Float64
     A = rand(n, n)

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -235,7 +235,6 @@ end #function run_brick_interpolation_test
 function run_cubed_sphere_interpolation_test()
     for FT in (Float32, Float64) #Float32 #Float64
         DA = ClimateMachine.array_type()
-        device = ClimateMachine.array_type() <: Array ? CPU() : CUDA()
         mpicomm = MPI.COMM_WORLD
         root = 0
         pid = MPI.Comm_rank(mpicomm)
@@ -300,7 +299,6 @@ function run_cubed_sphere_interpolation_test()
 
         Q = init_ode_state(dg, FT(0))
 
-        device = typeof(Q.data) <: Array ? CPU() : CUDA()
         #------------------------------
         x1 = @view grid.vgeo[:, _x, :]
         x2 = @view grid.vgeo[:, _y, :]

--- a/test/Numerics/Mesh/mpi_connect_sphere.jl
+++ b/test/Numerics/Mesh/mpi_connect_sphere.jl
@@ -5,8 +5,6 @@ using ClimateMachine.Mesh.Grids
 using ClimateMachine.MPIStateArrays
 using KernelAbstractions
 
-device(A) = typeof(A) <: Array ? CPU() : CUDA()
-
 function main()
     FT = Float64
     Nhorz = 3
@@ -91,10 +89,10 @@ function main()
         topology.realelems,
     ]
 
-    event = Event(device(x1x2x3.data))
+    event = Event(array_device(x1x2x3))
     event = MPIStateArrays.begin_ghost_exchange!(x1x2x3, dependencies = event)
     event = MPIStateArrays.end_ghost_exchange!(x1x2x3, dependencies = event)
-    wait(device(x1x2x3.data), event)
+    wait(array_device(x1x2x3), event)
 
     # Check x1x2x3 matches after
     x1 = @view x1x2x3.data[:, 1, :]

--- a/test/Numerics/ODESolvers/ode_tests_convergence.jl
+++ b/test/Numerics/ODESolvers/ode_tests_convergence.jl
@@ -3,7 +3,7 @@ using ClimateMachine
 using StaticArrays
 using LinearAlgebra
 using KernelAbstractions
-using ClimateMachine.MPIStateArrays: device
+using ClimateMachine.MPIStateArrays: array_device
 
 include("ode_tests_common.jl")
 
@@ -612,8 +612,8 @@ const ArrayType = ClimateMachine.array_type()
                             Ω[1, 1] * gf + Ω[1, 2] * gs - ω * sin(ω * t) / 2yf
                     end
                 end
-                event = Event(device(Q))
-                event = knl!(device(Q), 1)(
+                event = Event(array_device(Q))
+                event = knl!(array_device(Q), 1)(
                     dQ,
                     Q,
                     t,
@@ -621,7 +621,7 @@ const ArrayType = ClimateMachine.array_type()
                     ndrange = 1,
                     dependencies = (event,),
                 )
-                wait(device(Q), event)
+                wait(array_device(Q), event)
             end
 
 
@@ -636,8 +636,8 @@ const ArrayType = ClimateMachine.array_type()
                         dQ[2] += Ω[2, 1] * gf + Ω[2, 2] * gs - sin(t) / 2ys
                     end
                 end
-                event = Event(device(Q))
-                event = knl!(device(Q), 1)(
+                event = Event(array_device(Q))
+                event = knl!(array_device(Q), 1)(
                     dQ,
                     Q,
                     t,
@@ -645,7 +645,7 @@ const ArrayType = ClimateMachine.array_type()
                     ndrange = 1,
                     dependencies = (event,),
                 )
-                wait(device(Q), event)
+                wait(array_device(Q), event)
             end
 
             struct ODETestConvNonLinBE <: AbstractBackwardEulerSolver end
@@ -666,8 +666,8 @@ const ArrayType = ClimateMachine.array_type()
                         Q[2] = (-b + sqrt(b^2 - 4 * a * c)) / (2a)
                     end
                 end
-                event = Event(device(Q))
-                event = knl!(device(Q), 1)(
+                event = Event(array_device(Q))
+                event = knl!(array_device(Q), 1)(
                     Q,
                     Qhat,
                     α,
@@ -676,7 +676,7 @@ const ArrayType = ClimateMachine.array_type()
                     ndrange = 1,
                     dependencies = (event,),
                 )
-                wait(device(Q), event)
+                wait(array_device(Q), event)
             end
 
             exactsolution(t) =
@@ -807,8 +807,8 @@ const ArrayType = ClimateMachine.array_type()
                         dQ[1] += Ω[1, :]' * g - ω1 * sin(ω1 * t) / 2y1
                     end
                 end
-                event = Event(device(Q))
-                event = knl!(device(Q), 1)(
+                event = Event(array_device(Q))
+                event = knl!(array_device(Q), 1)(
                     dQ,
                     Q,
                     t,
@@ -816,7 +816,7 @@ const ArrayType = ClimateMachine.array_type()
                     ndrange = 1,
                     dependencies = (event,),
                 )
-                wait(device(Q), event)
+                wait(array_device(Q), event)
             end
             function rhs2!(dQ, Q, param, t; increment)
                 @kernel function knl!(dQ, Q, t, increment)
@@ -831,8 +831,8 @@ const ArrayType = ClimateMachine.array_type()
                         dQ[2] += Ω[2, :]' * g - ω2 * sin(ω2 * t) / 2y2
                     end
                 end
-                event = Event(device(Q))
-                event = knl!(device(Q), 1)(
+                event = Event(array_device(Q))
+                event = knl!(array_device(Q), 1)(
                     dQ,
                     Q,
                     t,
@@ -840,7 +840,7 @@ const ArrayType = ClimateMachine.array_type()
                     ndrange = 1,
                     dependencies = (event,),
                 )
-                wait(device(Q), event)
+                wait(array_device(Q), event)
             end
             function rhs3!(dQ, Q, param, t; increment)
                 @kernel function knl!(dQ, Q, t, increment)
@@ -855,8 +855,8 @@ const ArrayType = ClimateMachine.array_type()
                         dQ[3] += Ω[3, :]' * g - ω3 * sin(ω3 * t) / 2y3
                     end
                 end
-                event = Event(device(Q))
-                event = knl!(device(Q), 1)(
+                event = Event(array_device(Q))
+                event = knl!(array_device(Q), 1)(
                     dQ,
                     Q,
                     t,
@@ -864,7 +864,7 @@ const ArrayType = ClimateMachine.array_type()
                     ndrange = 1,
                     dependencies = (event,),
                 )
-                wait(device(Q), event)
+                wait(array_device(Q), event)
             end
             struct ODETestConvNonLinBE3Rate <: AbstractBackwardEulerSolver end
             ODESolvers.Δt_is_adjustable(::ODETestConvNonLinBE3Rate) = true
@@ -890,8 +890,8 @@ const ArrayType = ClimateMachine.array_type()
                         Q[3] = (-b + sqrt(b^2 - 4 * a * c)) / (2a)
                     end
                 end
-                event = Event(device(Q))
-                event = knl!(device(Q), 1)(
+                event = Event(array_device(Q))
+                event = knl!(array_device(Q), 1)(
                     Q,
                     Qhat,
                     α,
@@ -900,7 +900,7 @@ const ArrayType = ClimateMachine.array_type()
                     ndrange = 1,
                     dependencies = (event,),
                 )
-                wait(device(Q), event)
+                wait(array_device(Q), event)
             end
 
             exactsolution(t) = ArrayType([


### PR DESCRIPTION
# Description

Expand and export `MPIStateArray`s `device()` as `array_device()`. This simplifies adding types such as `SubArray`, as produced by `view()`, which we're using in diagnostics.

Replace all occurrences of:
```
device = typeof(x) <: Array ? CPU() : CUDA()
```
and similar with:
```
device = array_device(x)
```

And:
```
host_array = Array ∈ typeof(Q).parameters
```
and similar with:
```
array_device(Q) isa CPU
```
Exceptions are where `using MPIStateArrays` would violate modularity:
- `src/Arrays/CMBuffers.jl` -- defines its own `device()`
- `src/Numerics/Mesh/Filters.jl` -- tests `Q.data`
- `src/Numerics/Mesh/Grids.jl` -- tests `grid.vgeo`

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
