### PR TITLE
Update Atmos.md to add small warning about reference state use-cases

### DIFF
--- a/docs/src/GettingStarted/Atmos.md
+++ b/docs/src/GettingStarted/Atmos.md
@@ -34,6 +34,15 @@ possible options for each subcomponent.
     configurations.  Equation sets are written in vector-invariant form and
     solved in Cartesian coordinates.  The component `orientation` determines
     whether the problem is solved in a `box (LES)` or a `sphere (GCM)`)
+    
+!!! warning
+
+    The above defaults do not consider any potential interaction with the time stepping
+    components. The user must take appropriate care when setting up the driver configurations.
+    The default hydrostatic reference state may not be suitable to any initial conditions and 
+    it recommended to use a reference state corresponding to the initial condition's background.
+    It is also recommended to use the NoReferenceState type when using a single rate explicit 
+    time stepper.
 
 
 ### [GCM Configuration](@id GCMConfig)(with defaults)


### PR DESCRIPTION
# Description

Documentation change for reference state see issue #1169 

<!--- Please fill out the following section --->

I have added a brief warning to the documentation for driver configuration defaults. This seeks to warn new users about the necessity to adjust from the default reference state setting based on the solver or initial conditions used.

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
