### PR TITLE
Add filter targets and filter perturbations in Held-Suarez

### DIFF
--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -245,9 +245,10 @@ function main()
     cbfilter = GenericCallbacks.EveryXSimulationSteps(1) do
         Filters.apply!(
             solver_config.Q,
-            1:size(solver_config.Q, 2),
+            AtmosFilterPerturbations(driver_config.bl),
             solver_config.dg.grid,
             filter,
+            state_auxiliary = solver_config.dg.state_auxiliary,
         )
         nothing
     end

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -513,7 +513,12 @@ function main()
     dgn_config = config_diagnostics(driver_config)
 
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
-        Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())
+        Filters.apply!(
+            solver_config.Q,
+            ("moisture.ρq_tot",),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
         nothing
     end
 

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -383,7 +383,12 @@ function main()
     dgn_config = config_diagnostics(driver_config)
 
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
-        Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())
+        Filters.apply!(
+            solver_config.Q,
+            ("moisture.ρq_tot",),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
         nothing
     end
 

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -155,7 +155,12 @@ function main()
     dgn_config = config_diagnostics(driver_config)
 
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
-        Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())
+        Filters.apply!(
+            solver_config.Q,
+            ("moisture.ρq_tot",),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
         nothing
     end
 

--- a/experiments/AtmosLES/taylor-green.jl
+++ b/experiments/AtmosLES/taylor-green.jl
@@ -206,11 +206,6 @@ function main()
     )
     dgn_config = config_diagnostics(driver_config)
 
-    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
-        Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())
-        nothing
-    end
-    # information.
     result = ClimateMachine.invoke!(
         solver_config;
         diagnostics_config = dgn_config,

--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -27,7 +27,7 @@ using .CMBuffers
 cpuify(x::AbstractArray) = convert(Array, x)
 cpuify(x::Real) = x
 
-export MPIStateArray, euclidean_distance, weightedsum, array_device
+export MPIStateArray, euclidean_distance, weightedsum, array_device, vars
 
 """
     MPIStateArray{FT, DATN<:AbstractArray{FT,3}, DAI1, DAV,
@@ -154,6 +154,7 @@ end
 
 Base.fill!(Q::MPIStateArray, x) = fill!(Q.data, x)
 
+vars(Q::MPIStateArray{FT, V}) where {FT, V} = V
 function Base.getproperty(Q::MPIStateArray{FT, V}, sym::Symbol) where {FT, V}
     if sym ∈ V.names
         varrange = varsindex(V, sym)

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -316,6 +316,7 @@ include("boundaryconditions.jl")
 include("linear.jl")
 include("remainder.jl")
 include("courant.jl")
+include("filters.jl")
 
 @doc """
     flux_first_order!(

--- a/src/Atmos/Model/filters.jl
+++ b/src/Atmos/Model/filters.jl
@@ -1,0 +1,39 @@
+export AtmosFilterPerturbations
+
+import ..Mesh.Filters:
+    AbstractFilterTarget,
+    vars_state_filtered,
+    compute_filter_argument!,
+    compute_filter_result!
+
+struct AtmosFilterPerturbations{M} <: AbstractFilterTarget
+    atmos::M
+end
+
+vars_state_filtered(target::AtmosFilterPerturbations, FT) =
+    vars_state_conservative(target.atmos, FT)
+
+function compute_filter_argument!(
+    ::AtmosFilterPerturbations,
+    filter_state::Vars,
+    state::Vars,
+    aux::Vars,
+)
+    # copy the whole state
+    parent(filter_state) .= parent(state)
+    # remove reference state
+    filter_state.ρ -= aux.ref_state.ρ
+    filter_state.ρe -= aux.ref_state.ρe
+end
+function compute_filter_result!(
+    ::AtmosFilterPerturbations,
+    state::Vars,
+    filter_state::Vars,
+    aux::Vars,
+)
+    # copy the whole filter state
+    parent(state) .= parent(filter_state)
+    # add reference state
+    state.ρ += aux.ref_state.ρ
+    state.ρe += aux.ref_state.ρe
+end

--- a/src/Numerics/Mesh/Filters.jl
+++ b/src/Numerics/Mesh/Filters.jl
@@ -1,14 +1,101 @@
 module Filters
 
 using LinearAlgebra, GaussQuadrature, KernelAbstractions
+using KernelAbstractions.Extras: @unroll
+using StaticArrays
 using ..Grids
 using ..Grids: Direction, EveryDirection, HorizontalDirection, VerticalDirection
+
+using ...MPIStateArrays
+using ...VariableTemplates: @vars, varsize, Vars, varsindices
 
 export AbstractSpectralFilter, AbstractFilter
 export ExponentialFilter, CutoffFilter, TMARFilter
 
 abstract type AbstractFilter end
 abstract type AbstractSpectralFilter <: AbstractFilter end
+
+"""
+    AbstractFilterTarget
+
+An abstract type representing variables that the filter
+will act on
+"""
+abstract type AbstractFilterTarget end
+
+"""
+    vars_state_filtered(::AbstractFilterTarget, FT)
+
+A tuple of symbols containing variables that the filter
+will act on given a float type `FT`
+"""
+function vars_state_filtered end
+
+"""
+    compute_filter_argument!(::AbstractFilterTarget,
+                             state_filter::Vars,
+                             state::Vars,
+                             state_auxiliary::Vars)
+
+Compute filter argument `state_filter` based on `state`
+and `state_auxiliary`
+"""
+function compute_filter_argument! end
+"""
+    compute_filter_result!(::AbstractFilterTarget,
+                           state::Vars,
+                           state_filter::Vars,
+                           state_auxiliary::Vars)
+
+Compute filter result `state` based on the filtered state
+`state_filter` and `state_auxiliary`
+"""
+function compute_filter_result! end
+
+number_state_filtered(t::AbstractFilterTarget, FT) =
+    varsize(vars_state_filtered(t, FT))
+
+"""
+    FilterIndices(I)
+
+Filter variables based on their indices `I` where `I` can
+be a range or a list of indices
+
+## Examples
+```julia
+FiltersIndices(1:3)
+FiltersIndices(1, 3, 5)
+```
+"""
+struct FilterIndices{I} <: AbstractFilterTarget
+    FilterIndices(I::Integer...) = new{I}()
+    FilterIndices(I::AbstractRange) = new{I}()
+end
+vars_state_filtered(::FilterIndices{I}, FT) where {I} =
+    @vars(_::SVector{length(I), FT})
+
+function compute_filter_argument!(
+    ::FilterIndices{I},
+    filter_state::Vars,
+    state::Vars,
+    aux::Vars,
+) where {I}
+    @unroll for s in 1:length(I)
+        @inbounds parent(filter_state)[s] = parent(state)[I[s]]
+    end
+end
+
+function compute_filter_result!(
+    ::FilterIndices{I},
+    state::Vars,
+    filter_state::Vars,
+    aux::Vars,
+) where {I}
+    @unroll for s in 1:length(I)
+        @inbounds parent(state)[I[s]] = parent(filter_state)[s]
+    end
+end
+
 
 """
     spectral_filter_matrix(r, Nc, σ)
@@ -130,29 +217,32 @@ where `grid` is the associated `DiscontinuousSpectralElementGrid`.
 struct TMARFilter <: AbstractFilter end
 
 """
-    apply!(Q, states, grid::DiscontinuousSpectralElementGrid,
-           filter::AbstractSpectralFilter,
-           direction::Direction = EveryDirection())
+    apply!(Q, target, grid::DiscontinuousSpectralElementGrid,
+           filter::AbstractSpectralFilter;
+           direction::Direction = EveryDirection(),
+           state_auxiliary = nothing)
 
-Applies `filter` to the `states` of `Q`.
+Applies `filter` to `Q` given a `grid` and a custom `target`.
 
 The `direction` argument controls if the filter is applied in the horizontal
 and/or vertical directions. It is assumed that the trailing dimension on the
 reference element is the vertical dimension and the rest are horizontal.
+
+If the target requires auxiliary state to compute its argument or results
+this state should be provided in `state_auxiliary`.
 """
 function apply!(
     Q,
-    states,
+    target::AbstractFilterTarget,
     grid::DiscontinuousSpectralElementGrid,
-    filter::AbstractSpectralFilter,
+    filter::AbstractSpectralFilter;
     direction::Direction = EveryDirection(),
+    state_auxiliary = nothing,
 )
     topology = grid.topology
 
     dim = dimensionality(grid)
     N = polynomialorder(grid)
-
-    nstate = size(Q, 2)
 
     filtermatrix = filter.filter
     device = typeof(Q.data) <: Array ? CPU() : CUDA()
@@ -167,26 +257,33 @@ function apply!(
     event = kernel_apply_filter!(device, (Nq, Nq, Nqk))(
         Val(dim),
         Val(N),
-        Val(nstate),
-        Val(direction),
+        Val(vars(Q)),
+        Val(isnothing(state_auxiliary) ? nothing : vars(state_auxiliary)),
+        direction,
         Q.data,
-        Val(states),
+        isnothing(state_auxiliary) ? nothing : state_auxiliary.data,
+        target,
         filtermatrix,
-        topology.realelems;
         ndrange = (nrealelem * Nq, Nq, Nqk),
         dependencies = (event,),
     )
     wait(device, event)
 end
 
-"""
-    apply!(Q, states, grid::DiscontinuousSpectralElementGrid, ::TMARFilter)
 
-Applies the truncation and mass aware rescaling to `states` of `Q`.  This
-rescaling keeps the states nonegative while keeping the element average
-the same.
 """
-function apply!(Q, states, grid::DiscontinuousSpectralElementGrid, ::TMARFilter)
+    apply!(Q, target, grid::DiscontinuousSpectralElementGrid, ::TMARFilter)
+
+Applies the truncation and mass aware rescaling to `Q` given a
+`grid` and a custom `target`. This rescaling keeps
+the states nonegative while keeping the element average the same.
+"""
+function apply!(
+    Q,
+    target::AbstractFilterTarget,
+    grid::DiscontinuousSpectralElementGrid,
+    ::TMARFilter,
+)
     topology = grid.topology
 
     device = typeof(Q.data) <: Array ? CPU() : CUDA()
@@ -205,25 +302,76 @@ function apply!(Q, states, grid::DiscontinuousSpectralElementGrid, ::TMARFilter)
         Val(dim),
         Val(N),
         Q.data,
-        Val(states),
+        target,
         grid.vgeo,
-        topology.realelems;
         dependencies = (event,),
     )
     wait(device, event)
 end
 
-using ..Mesh.Grids: EveryDirection, VerticalDirection, HorizontalDirection
-using KernelAbstractions.Extras: @unroll
+"""
+    apply!(Q, indices, grid::DiscontinuousSpectralElementGrid, filter; kwargs)
+
+Applies `filter` to the states of `Q` specified by `indices`, which
+can be either a tuple or a range.
+
+# Examples
+```julia
+Filters.apply!(Q, :, grid, TMARFilter())
+Filters.apply!(Q, (1, 3), grid, CutoffFilter(grid); direction=VerticalDirection())
+```
+"""
+function apply!(
+    Q,
+    indices::Union{Colon, AbstractRange, Tuple{Vararg{Integer}}},
+    grid::DiscontinuousSpectralElementGrid,
+    filter::AbstractFilter;
+    kwargs...,
+)
+    if indices isa Colon
+        indices = 1:size(Q, 2)
+    end
+    apply!(Q, FilterIndices(indices...), grid, filter; kwargs...)
+end
+
+"""
+    apply!(Q, vars, grid::DiscontinuousSpectralElementGrid, filter; kwargs)
+
+Applies `filter` to the states of `Q` specified by `vars`.
+The variable names `vars` can be a tuple of symbols or strings.
+
+# Examples
+```julia
+Filters.apply!(Q, (:ρ, :ρe), grid, TMARFilter())
+Filters.apply!(Q, ("moisture.ρq_tot",), grid, CutoffFilter(grid);
+               direction=VerticalDirection())
+```
+"""
+function apply!(
+    Q,
+    vs::Tuple,
+    grid::DiscontinuousSpectralElementGrid,
+    filter::AbstractFilter;
+    kwargs...,
+)
+    apply!(
+        Q,
+        FilterIndices(varsindices(vars(Q), vs)...),
+        grid,
+        filter;
+        kwargs...,
+    )
+end
 
 const _M = Grids._M
 
 @doc """
-    kernel_apply_filter!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{direction},
-                      Q, ::Val{states}, filtermatrix,
-                      elems) where {dim, N, nstate, states, direction}
+    kernel_apply_filter!(::Val{dim}, ::Val{N}, direction,
+                         Q, state_auxiliary, target, filtermatrix
+                        ) where {dim, N}
 
-Computational kernel: Applies the `filtermatrix` to the `states` of `Q`.
+Computational kernel: Applies the `filtermatrix` to `Q` given a
+custom target `target`.
 
 The `direction` argument is used to control if the filter is applied in the
 horizontal and/or vertical reference directions.
@@ -231,13 +379,14 @@ horizontal and/or vertical reference directions.
 @kernel function kernel_apply_filter!(
     ::Val{dim},
     ::Val{N},
-    ::Val{nstate},
-    ::Val{direction},
+    ::Val{vars_Q},
+    ::Val{vars_state_auxiliary},
+    direction,
     Q,
-    ::Val{states},
+    state_auxiliary,
+    target::AbstractFilterTarget,
     filtermatrix,
-    elems,
-) where {dim, N, nstate, direction, states}
+) where {dim, N, vars_Q, vars_state_auxiliary}
     @uniform begin
         FT = eltype(Q)
 
@@ -257,27 +406,54 @@ horizontal and/or vertical reference directions.
             filterinξ3 = dim == 2 ? false : true
         end
 
-        nfilterstates = length(states)
+        nstates = varsize(vars_Q)
+        nfilterstates = number_state_filtered(target, FT)
+        nfilteraux =
+            isnothing(state_auxiliary) ? 0 : varsize(vars_state_auxiliary)
+
+        # ugly workaround around problems with @private
+        # hopefully will be soon fixed in KA
+        l_Q2 = MVector{nstates, FT}(undef)
+        l_Qfiltered2 = MVector{nfilterstates, FT}(undef)
     end
 
     s_filter = @localmem FT (Nq, Nq)
     s_Q = @localmem FT (Nq, Nq, Nqk, nfilterstates)
+    l_Q = @private FT (nstates,)
     l_Qfiltered = @private FT (nfilterstates,)
+    l_aux = @private FT (nfilteraux,)
 
     e = @index(Group, Linear)
     i, j, k = @index(Local, NTuple)
 
     @inbounds begin
+        ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+
         s_filter[i, j] = filtermatrix[i, j]
+
+        @unroll for s in 1:nstates
+            l_Q[s] = Q[ijk, s, e]
+        end
+
+        @unroll for s in 1:nfilteraux
+            l_aux[s] = state_auxiliary[ijk, s, e]
+        end
+
+        fill!(l_Qfiltered2, -zero(FT))
+
+        compute_filter_argument!(
+            target,
+            Vars{vars_state_filtered(target, FT)}(l_Qfiltered2),
+            Vars{vars_Q}(l_Q[:]),
+            Vars{vars_state_auxiliary}(l_aux[:]),
+        )
 
         @unroll for fs in 1:nfilterstates
             l_Qfiltered[fs] = zero(FT)
         end
 
-        ijk = i + Nq * ((j - 1) + Nq * (k - 1))
-
         @unroll for fs in 1:nfilterstates
-            s_Q[i, j, k, fs] = Q[ijk, states[fs], e]
+            s_Q[i, j, k, fs] = l_Qfiltered2[fs]
         end
 
         if filterinξ1
@@ -323,10 +499,21 @@ horizontal and/or vertical reference directions.
             end
         end
 
+        @unroll for s in 1:nstates
+            l_Q2[s] = l_Q[s]
+        end
+
+        compute_filter_result!(
+            target,
+            Vars{vars_Q}(l_Q2),
+            Vars{vars_state_filtered(target, FT)}(l_Qfiltered[:]),
+            Vars{vars_state_auxiliary}(l_aux[:]),
+        )
+
         # Store result
         ijk = i + Nq * ((j - 1) + Nq * (k - 1))
-        @unroll for fs in 1:nfilterstates
-            Q[ijk, states[fs], e] = l_Qfiltered[fs]
+        @unroll for s in 1:nstates
+            Q[ijk, s, e] = l_Q2[s]
         end
 
         @synchronize
@@ -338,17 +525,16 @@ end
     ::Val{dim},
     ::Val{N},
     Q,
-    ::Val{filterstates},
+    target::FilterIndices{I},
     vgeo,
-    elems,
-) where {nreduce, dim, N, filterstates}
+) where {nreduce, dim, N, I}
     @uniform begin
         FT = eltype(Q)
 
         Nq = N + 1
         Nqj = dim == 2 ? 1 : Nq
 
-        nfilterstates = length(filterstates)
+        nfilterstates = number_state_filtered(target, FT)
         nelemperblock = 1
     end
 
@@ -367,7 +553,7 @@ end
             ijk = i + Nq * ((j - 1) + Nqj * (k - 1))
 
             @unroll for sf in 1:nfilterstates
-                s = filterstates[sf]
+                s = I[sf]
                 l_Q[sf, k] = Q[ijk, s, e]
             end
 
@@ -413,7 +599,7 @@ end
 
             r = qs_average > 0 ? qs_average / qs_clipped_average : zero(FT)
 
-            s = filterstates[sf]
+            s = I[sf]
             @unroll for k in 1:Nq
                 ijk = i + Nq * ((j - 1) + Nqj * (k - 1))
 

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -585,14 +585,10 @@ function update_auxiliary_state!(
     if elems == dg.grid.topology.realelems
         # required to ensure that after integration velocity field is divergence free
         vert_filter = MD.vert_filter
-        index_u =
-            tuple(collect(varsindex(vars_state_conservative(m, FT), :u))...)
-        apply!(Q, index_u, dg.grid, vert_filter, VerticalDirection())
+        apply!(Q, (:u,), dg.grid, vert_filter, direction = VerticalDirection())
 
         exp_filter = MD.exp_filter
-        index_θ =
-            tuple(collect(varsindex(vars_state_conservative(m, FT), :θ))...)
-        apply!(Q, index_θ, dg.grid, exp_filter, VerticalDirection())
+        apply!(Q, (:θ,), dg.grid, exp_filter, direction = VerticalDirection())
     end
 
     return true

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -174,7 +174,7 @@ function run(
     filterorder = 18
     filter = ExponentialFilter(grid, 0, filterorder)
     cbfilter = EveryXSimulationSteps(1) do
-        Filters.apply!(Q, 1:size(Q, 2), grid, filter, VerticalDirection())
+        Filters.apply!(Q, :, grid, filter, direction = VerticalDirection())
         nothing
     end
 

--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -121,10 +121,8 @@ filtered(::VerticalDirection, dim, x, y, z) =
 filtered(::HorizontalDirection, dim, x, y, z) =
     (dim == 2) ? l2(x) * l3(y) + l3(x) : l2(x) * l3(y) + l3(x) + l2(y)
 
-ClimateMachine.DGMethods.vars_state_conservative(
-    ::FilterTestModel{4},
-    FT,
-) where {N} = @vars(q1::FT, q2::FT, q3::FT, q4::FT)
+ClimateMachine.DGMethods.vars_state_conservative(::FilterTestModel{4}, FT) =
+    @vars(q1::FT, q2::FT, q3::FT, q4::FT)
 function ClimateMachine.DGMethods.init_state_conservative!(
     ::FilterTestModel{4},
     state::Vars,
@@ -175,8 +173,9 @@ end
 
                 filter = ClimateMachine.Mesh.Filters.CutoffFilter(grid, 2)
 
+                model = FilterTestModel{4}()
                 dg = ClimateMachine.DGMethods.DGModel(
-                    FilterTestModel{4}(),
+                    model,
                     grid,
                     nothing,
                     nothing,
@@ -184,22 +183,27 @@ end
                     state_gradient_flux = nothing,
                 )
 
-                Q = ClimateMachine.DGMethods.init_ode_state(dg, nothing, dim)
+                @testset for target in ((1, 3), (:q1, :q3))
+                    Q = ClimateMachine.DGMethods.init_ode_state(
+                        dg,
+                        nothing,
+                        dim,
+                    )
+                    ClimateMachine.Mesh.Filters.apply!(
+                        Q,
+                        target,
+                        grid,
+                        filter,
+                        direction = direction(),
+                    )
 
-                ClimateMachine.Mesh.Filters.apply!(
-                    Q,
-                    (1, 3),
-                    grid,
-                    filter,
-                    direction(),
-                )
-
-                P = ClimateMachine.DGMethods.init_ode_state(
-                    dg,
-                    direction(),
-                    dim,
-                )
-                @test Array(Q.data) ≈ Array(P.data)
+                    P = ClimateMachine.DGMethods.init_ode_state(
+                        dg,
+                        direction(),
+                        dim,
+                    )
+                    @test Array(Q.data) ≈ Array(P.data)
+                end
             end
         end
     end
@@ -240,8 +244,9 @@ end
                 polynomialorder = N,
             )
 
+            model = FilterTestModel{1}()
             dg = ClimateMachine.DGMethods.DGModel(
-                FilterTestModel{1}(),
+                model,
                 grid,
                 nothing,
                 nothing,
@@ -249,22 +254,24 @@ end
                 state_gradient_flux = nothing,
             )
 
-            Q = ClimateMachine.DGMethods.init_ode_state(dg)
+            @testset for target in ((1,), (:q,), :)
+                Q = ClimateMachine.DGMethods.init_ode_state(dg)
 
-            initialsumQ = weightedsum(Q)
-            @test minimum(Q.realdata) < 0
+                initialsumQ = weightedsum(Q)
+                @test minimum(Q.realdata) < 0
 
-            ClimateMachine.Mesh.Filters.apply!(
-                Q,
-                1,
-                grid,
-                ClimateMachine.Mesh.Filters.TMARFilter(),
-            )
+                ClimateMachine.Mesh.Filters.apply!(
+                    Q,
+                    target,
+                    grid,
+                    ClimateMachine.Mesh.Filters.TMARFilter(),
+                )
 
-            sumQ = weightedsum(Q)
+                sumQ = weightedsum(Q)
 
-            @test minimum(Q.realdata) >= 0
-            @test isapprox(initialsumQ, sumQ; rtol = 10 * eps(FT))
+                @test minimum(Q.realdata) >= 0
+                @test isapprox(initialsumQ, sumQ; rtol = 10 * eps(FT))
+            end
         end
     end
 end

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -213,7 +213,7 @@ function main()
                 GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
                     Filters.apply!(
                         solver_config.Q,
-                        6,
+                        ("moisture.ρq_tot",),
                         solver_config.dg.grid,
                         TMARFilter(),
                     )

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -254,7 +254,7 @@ filter = ExponentialFilter(solver_config.dg.grid, 0, filterorder)
 cbfilter = GenericCallbacks.EveryXSimulationSteps(1) do
     Filters.apply!(
         solver_config.Q,
-        1:size(solver_config.Q, 2),
+        AtmosFilterPerturbations(model),
         solver_config.dg.grid,
         filter,
     )

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -86,9 +86,6 @@ using ClimateMachine.GenericCallbacks
 # - Required so we load the appropriate functions for the time-integration
 #   component. Contains ODESolver methods.
 using ClimateMachine.ODESolvers
-# - Required for utility of spatial filtering functions (e.g. positivity
-#   preservation)
-using ClimateMachine.Mesh.Filters
 # - Required so functions for computation of temperature profiles.
 using ClimateMachine.TemperatureProfiles
 # - Required so functions for computation of moist thermodynamic quantities is
@@ -339,18 +336,12 @@ function main()
     )
     dgn_config = config_diagnostics(driver_config)
 
-    # User defined filter (TMAR positivity preserving filter)
-    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
-        Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())
-        nothing
-    end
-
     # Invoke solver (calls `solve!` function for time-integrator), pass the driver, solver and diagnostic config
     # information.
     result = ClimateMachine.invoke!(
         solver_config;
         diagnostics_config = dgn_config,
-        user_callbacks = (cbtmarfilter,),
+        user_callbacks = (),
         check_euclidean_distance = true,
     )
 

--- a/tutorials/Microphysics/ex_2_Kessler.jl
+++ b/tutorials/Microphysics/ex_2_Kessler.jl
@@ -341,7 +341,7 @@ function main()
         GenericCallbacks.EveryXSimulationSteps(filter_freq) do (init = false)
             Filters.apply!(
                 solver_config.Q,
-                (ρq_liq_ind[1], ρq_ice_ind[1], ρq_rai_ind[1]),
+                (:ρq_liq, :ρq_ice, :ρq_rai),
                 solver_config.dg.grid,
                 TMARFilter(),
             )

--- a/tutorials/Numerics/DGMethods/nonnegative.jl
+++ b/tutorials/Numerics/DGMethods/nonnegative.jl
@@ -150,14 +150,14 @@ function run(
     Qe = copy(Q)
 
     rhs! = function (dQdt, Q, ::Nothing, t; increment = false)
-        Filters.apply!(Q, 1, grid, TMARFilter())
+        Filters.apply!(Q, :, grid, TMARFilter())
         dg(dQdt, Q, nothing, t; increment = false)
     end
 
     odesolver = SSPRK33ShuOsher(rhs!, Q; dt = dt, t0 = 0)
 
     cbTMAR = EveryXSimulationSteps(1) do
-        Filters.apply!(Q, 1, grid, TMARFilter())
+        Filters.apply!(Q, :, grid, TMARFilter())
     end
 
     # create output directory on first rank of communicator


### PR DESCRIPTION
# Description

This adds hooks to modify filtered variables before application of the filter, which is
needed for filtering only the perturbations from the reference state.

Closes #1161

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
