### PR TITLE
Fix reference state definition, add tests

### DIFF
--- a/test/Atmos/TemperatureProfiles/runtests.jl
+++ b/test/Atmos/TemperatureProfiles/runtests.jl
@@ -1,0 +1,57 @@
+using Test
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.Thermodynamics
+using CLIMAParameters
+using CLIMAParameters.Planet
+using ForwardDiff
+
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+@testset "Temperature profiles - DecayingTemperatureProfile" begin
+    for FT in [Float32, Float64]
+        _grav = FT(grav(param_set))
+        _R_d = FT(R_d(param_set))
+        _MSLP = FT(MSLP(param_set))
+
+        z = collect(range(FT(0), stop = FT(25e3), length = 100))
+        n = 7
+        _T_virt_surf_range = collect(range(FT(260), stop = FT(320), length = n))
+        _T_min_ref_range = collect(range(FT(170), stop = FT(230), length = n))
+        _H_t_range = collect(range(FT(6e3), stop = FT(13e3), length = n))
+
+        profiles = []
+        for (_T_virt_surf, _T_min_ref, _H_t) in
+            zip(_T_virt_surf_range, _T_min_ref_range, _H_t_range)
+            profiles = [
+                DecayingTemperatureProfile{FT}(
+                    param_set,
+                    _T_virt_surf,
+                    _T_min_ref,
+                    _H_t,
+                ),
+                DryAdiabaticProfile{FT}(param_set, _T_virt_surf, _T_min_ref),
+                IsothermalProfile(param_set, _T_virt_surf),
+            ]
+
+            for profile in profiles
+                args = profile.(Ref(param_set), z)
+                T_virt = first.(args)
+                p = last.(args)
+
+                mask_z_0 = z .≈ 0
+                @test all(p[mask_z_0] .≈ _MSLP)
+
+                function log_p_over_MSLP(_z)
+                    _, _p = profile(param_set, _z)
+                    return log(_p / _MSLP)
+                end
+                ∇log_p_over_MSLP =
+                    _z -> ForwardDiff.derivative(log_p_over_MSLP, _z)
+                T_rec = -_grav ./ (_R_d .* ∇log_p_over_MSLP.(z))
+                @test all(T_rec .≈ T_virt)
+            end
+        end
+
+    end
+end

--- a/test/Atmos/runtests.jl
+++ b/test/Atmos/runtests.jl
@@ -2,7 +2,7 @@ using Test, Pkg
 
 @testset "Atmos" begin
     all_tests = isempty(ARGS) || "all" in ARGS ? true : false
-    for submodule in ["Parameterizations"]
+    for submodule in ["Parameterizations", "TemperatureProfiles"]
         if all_tests || "$submodule" in ARGS || "Atmos" in ARGS
             include_test(submodule)
         end

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -64,8 +64,8 @@ function main()
     outputtime = 60 * 60
 
     expected_result = Dict()
-    expected_result[Float32] = 9.2987451244544000e+13
-    expected_result[Float64] = 9.2993570967854438e+13
+    expected_result[Float32] = 9.5066030866432000e+13
+    expected_result[Float64] = 9.5073452847149594e+13
 
     for FT in (Float32, Float64)
         result = run(


### PR DESCRIPTION
# Description

 - Fixes reference state definition for `DecayingTemperatureProfile`.
 - Adds tests for hydrostatic balance for all temperature profiles
 - Updates expected solution in `test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl`

Should close #1183

Co-authored with: @tapios 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
