### PR TITLE
Add disable_custom_logger option to Driver

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,10 @@ Base.HOME_PROJECT[] = abspath(Base.HOME_PROJECT[]) # JuliaLang/julia/pull/28625
 
 using ClimateMachine, Documenter, Literate
 
-ENV["GKSwstype"] = "100" # https://github.com/jheinen/GR.jl/issues/278#issuecomment-587090846
+# https://github.com/jheinen/GR.jl/issues/278#issuecomment-587090846
+ENV["GKSwstype"] = "100"
+# avoid problems with Documenter/Literate when using `global_logger()`
+ENV["CLIMATEMACHINE_SETTINGS_DISABLE_CUSTOM_LOGGER"] = true
 
 generated_dir = joinpath(@__DIR__, "src", "generated") # generated files directory
 rm(generated_dir, force = true, recursive = true)

--- a/src/Numerics/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
@@ -191,7 +191,7 @@ Exact choice of coefficients from wikipedia page for Heun's method :)
 function SSPRK22Heuns(F, Q::AT; dt = 0, t0 = 0) where {AT <: AbstractArray}
     T = eltype(Q)
     RT = real(T)
-    RKA = [RT(1) RT(0); RT(1//2) RT(1//2)]
+    RKA = [RT(1) RT(0); RT(1 // 2) RT(1 // 2)]
     RKB = [RT(1), RT(1 // 2)]
     RKC = [RT(0), RT(1)]
     StrongStabilityPreservingRungeKutta(F, RKA, RKB, RKC, Q; dt = dt, t0 = t0)


### PR DESCRIPTION
# Description

The logger is not playing nice with Documenter.jl and Literate.jl (we're seeing `Base.IOError("stream is closed or unusable", 0)` exceptions). This PR fixes this issue by disabling the logger for tutorials.

 - Adds a check for `ENV["DISABLE_CUSTOM_LOGGER"]` in `init` in `Driver.jl`
 - Sets `ENV["DISABLE_CUSTOM_LOGGER"] = "OFF"` in `docs/make.jl`

Closes #1190

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
