### PR TITLE
DCMIP Test Case: Non-orographic gravity waves on a small planet

### DIFF
--- a/experiments/AtmosGCM/dcmip-3-1.jl
+++ b/experiments/AtmosGCM/dcmip-3-1.jl
@@ -1,0 +1,209 @@
+#!/usr/bin/env julia --project
+using ClimateMachine
+ClimateMachine.init()
+using ClimateMachine.Atmos
+using ClimateMachine.ConfigTypes
+using ClimateMachine.Diagnostics
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.ODESolvers
+using ClimateMachine.SystemSolvers: ManyColumnLU
+using ClimateMachine.Mesh.Filters
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.Thermodynamics:
+    air_temperature, internal_energy, air_pressure
+using ClimateMachine.VariableTemplates
+
+using Distributions: Uniform
+using LinearAlgebra
+using StaticArrays
+using Random: rand
+using Test
+
+using CLIMAParameters
+using CLIMAParameters.Planet: R_d, day, grav, cp_d, cv_d, planet_radius, Omega, kappa_d
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+import CLIMAParameters
+CLIMAParameters.planet.Omega(::EarthParameterSet) = 0.0
+CLIMAParameters.planet.planet_radius(::EarthParameterSet) = 6.371 * 10^6 / 125
+
+struct dcmip31DataConfig{FT}
+    T_ref::FT
+end
+
+function init_dcmip31!(bl, state, aux, coords, t)
+    FT = eltype(state)
+
+    ϕ = latitude(bl, aux)
+    λ = longitude(bl, aux)
+    z = altitude(bl, aux)
+
+    # initial velocity profile
+    u_0 = FT(20)
+    u = u_0 * cos(ϕ)
+    v = FT(0)
+    w = FT(0)
+
+    # surface temperature
+    _grav = FT(grav(bl.param_set))
+    _N = FT(0.01)
+    _cp = FT(cp_d(bl.param_set))
+    _Ω = FT(Omega(bl.param_set))
+    _a = FT(planet_radius(bl.param_set))
+    G = _grav^2 / (_N^2 * _cp)
+    T_eq = FT(300)
+    T_s = G  + (T_eq - G) * exp( -(u_0 * _N^2) / (4 * _grav^2) * (u_0 + 2 * _Ω *_a)* (cos(2ϕ) - 1))
+
+    # background temperature
+    T_b = G * (1 - exp((_N^2 / _grav)*z)) + T_s * exp((_N^2 / _grav)*z)
+
+    # surface pressure
+    p_eq = FT(100000)  # Pa
+    _R_d = FT(R_d(bl.param_set))
+    _kappa = FT(kappa_d(bl.param_set))
+    p_s = p_eq * exp( u_0 / (4 * G * _R_d) * (u_0 + 2 * _Ω *_a)* (cos(2ϕ) - 1)) * (T_s / T_eq)^(1/_kappa)
+
+    # unperturbed pressure field
+    p = p_s * (G / T_s * exp(-_N^2/_grav * z) + 1 - G/T_s)^(1/_kappa)
+
+    # Background potential temperature
+    θ_b = T_s * ( p_eq / p_s )^(_kappa) * exp(_N^2/_grav * z)
+
+    # density
+    ρ = p / (_R_d * T_b)
+
+    # potential temperature perturbation
+    Δθ = FT(1.0)
+    d = FT(5000)
+    λ_c = 2*FT(π)/3
+    ϕ_c = 0
+    r = _a * acos(sin(ϕ_c)*sin(ϕ) + cos(ϕ_c)*cos(ϕ)*cos(λ - λ_c))
+    s = d^2 / (d^2 + r^2)
+    L_z = FT(20000)
+    θ' = Δθ * s * sin(2*FT(π) z / L_z)
+
+    # Temperature perturbation
+    T' = θ' * (p / p_eq)^(_kappa)
+
+    e_pot = gravitational_potential(bl.orientation, aux)
+    e_kin = FT(0.5)*u^2
+
+    state.ρ = ρ
+    state.ρu = ρ * SVector{3, FT}(u, v, w)
+    state.ρe = ρ * total_energy(bl.param_set, e_kin, e_pot, T_b + T')
+
+    nothing
+end
+
+function config_dcmip31(FT, poly_order, resolution)
+    # Set up a reference state for linearization of equations
+    temp_profile_ref = DecayingTemperatureProfile{FT}(param_set)
+    ref_state = HydrostaticState(temp_profile_ref)
+
+    domain_height::FT = 10e3               # distance between surface and top of atmosphere (m)
+
+    # Set up the atmosphere model
+    exp_name = "DCMIP Case 3-1"
+
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        param_set;
+        ref_state = ref_state,
+        turbulence = ConstantViscosityWithDivergence(FT(0.0)),
+        moisture = DryModel(),
+        source = (Gravity(),),
+        init_state_conservative = init_dcmip31!,
+    )
+
+    config = ClimateMachine.AtmosGCMConfiguration(
+        exp_name,
+        poly_order,
+        resolution,
+        domain_height,
+        param_set,
+        init_dcmip31!;
+        model = model,
+    )
+
+    return config
+end
+
+function config_diagnostics(FT, driver_config)
+    interval = "40000steps" # chosen to allow a single diagnostics collection
+
+    _planet_radius = FT(planet_radius(param_set))
+
+    info = driver_config.config_info
+    boundaries = [
+        FT(-90.0) FT(-180.0) _planet_radius
+        FT(90.0) FT(180.0) FT(_planet_radius + info.domain_height)
+    ]
+    resolution = (FT(10), FT(10), FT(1000)) # in (deg, deg, m)
+    interpol = ClimateMachine.InterpolationConfiguration(
+        driver_config,
+        boundaries,
+        resolution,
+    )
+
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosGCMConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+
+    return ClimateMachine.DiagnosticsConfiguration([dgngrp])
+end
+
+function main()
+    # Driver configuration parameters
+    FT = Float64                             # floating type precision
+    poly_order = 5                           # discontinuous Galerkin polynomial order
+    n_horz = 5                               # horizontal element number
+    n_vert = 5                               # vertical element number
+    timestart = FT(0)                        # start time (s)
+    timeend = FT(3600)                       # end time (s)
+
+    # Set up driver configuration
+    driver_config = config_heldsuarez(FT, poly_order, (n_horz, n_vert))
+
+    # Set up experiment
+    CFL = FT(0.2)
+    solver_config = ClimateMachine.SolverConfiguration(
+        timestart,
+        timeend,
+        driver_config,
+        Courant_number = CFL,
+        init_on_cpu = true,
+        CFL_direction = HorizontalDirection(),
+        diffdir = HorizontalDirection(),
+    )
+
+    # Set up diagnostics
+    dgn_config = config_diagnostics(FT, driver_config)
+
+    # Set up user-defined callbacks
+    filterorder = 10
+    filter = ExponentialFilter(solver_config.dg.grid, 0, filterorder)
+    cbfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            1:size(solver_config.Q, 2),
+            solver_config.dg.grid,
+            filter,
+        )
+        nothing
+    end
+
+    # Run the model
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (cbfilter,),
+        check_euclidean_distance = true,
+    )
+end
+
+main()

--- a/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
@@ -49,7 +49,7 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
     _p_eq::FT = MSLP(bl.param_set)
 
     N::FT = 0.01
-    u_0::FT = 20
+    u_0::FT = 0.0 # 20
     G::FT = _grav^2 / N^2 / _cp
     T_eq::FT = 300
     Δθ::FT = 1.0
@@ -158,7 +158,7 @@ function config_diagnostics(FT, driver_config)
         resolution,
     )
 
-    dgngrp = setup_dump_state_and_aux_diagnostics(
+    dgngrp = setup_atmos_default_diagnostics(
         AtmosGCMConfigType(),
         interval,
         driver_config.name,

--- a/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
@@ -46,7 +46,8 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
     _kappa::FT = kappa_d(bl.param_set)
 
     N::FT = 0.01
-    u_0::FT = 20
+    #u_0::FT = 20
+    u_0::FT = 0
     G::FT = _grav^2 / N^2 / _cp
     T_eq::FT = 300
     p_eq::FT = 1e5
@@ -71,7 +72,7 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
     p::FT = p_s * (G / T_s * exp( -N^2 / _grav * z ) + 1 - G / T_s)^(1/_kappa)
 
     # background potential temperature
-    θ_b::FT = T_s * (p_eq / p_s)^_kappa * exp( N^2 / _grav * z)
+    θ_b::FT = T_s * (p_eq / p_s)^_kappa * exp( N^2 / _grav * z )
 
     # potential temperature perturbation
     r::FT = _a * acos( sin(φ_c) * sin(φ) + cos(φ_c) * cos(φ) * cos(λ - λ_c) )
@@ -129,7 +130,7 @@ function config_nonhydrostatic_gravity_wave(FT, poly_order, resolution)
         domain_height,
         param_set,
         init_nonhydrostatic_gravity_wave!;
-        solver_type = ode_solver,
+    #    solver_type = ode_solver,
         model = model,
     )
 
@@ -167,8 +168,8 @@ function main()
     # Driver configuration parameters
     FT = Float64                             # floating type precision
     poly_order = 5                           # discontinuous Galerkin polynomial order
-    n_horz = 5                               # horizontal element number
-    n_vert = 10                              # vertical element number
+    n_horz = 7                               # horizontal element number
+    n_vert = 5                               # vertical element number
     timestart = FT(0)                        # start time (s)
     timeend = FT(3600)                       # end time (s)
 
@@ -176,13 +177,13 @@ function main()
     driver_config = config_nonhydrostatic_gravity_wave(FT, poly_order, (n_horz, n_vert))
 
     # Set up experiment
-    CFL = FT(0.8)
+    CFL = FT(0.4)
     solver_config = ClimateMachine.SolverConfiguration(
         timestart,
         timeend,
         driver_config,
         Courant_number = CFL,
-        CFL_direction = EveryDirection(),
+        CFL_direction = HorizontalDirection(),
     )
 
     # Set up diagnostics

--- a/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
@@ -47,8 +47,7 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
     _kappa::FT = kappa_d(bl.param_set)
 
     N::FT = 0.01
-    #u_0::FT = 20
-    u_0::FT = 0
+    u_0::FT = 20
     G::FT = _grav^2 / N^2 / _cp
     T_eq::FT = 300
     p_eq::FT = 1e5
@@ -96,6 +95,7 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
     state.ρ = ρ
     state.ρu = ρ * u_cart 
     state.ρe = ρ * total_energy(bl.param_set, e_kin, e_pot, T)
+    aux.θ₀ = θ_b
 
     nothing
 end
@@ -155,7 +155,7 @@ function config_diagnostics(FT, driver_config)
         resolution,
     )
 
-    dgngrp = setup_atmos_default_diagnostics(
+    dgngrp = setup_dump_state_and_aux_diagnostics(
         AtmosGCMConfigType(),
         interval,
         driver_config.name,

--- a/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
@@ -28,6 +28,8 @@ const param_set = EarthParameterSet()
 import CLIMAParameters
 CLIMAParameters.Planet.Omega(::EarthParameterSet) = 0.0
 CLIMAParameters.Planet.planet_radius(::EarthParameterSet) = 6.371e6 / 125.0
+CLIMAParameters.Planet.MSLP(::EarthParameterSet) = 1e5
+
 
 function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
     FT = eltype(state)
@@ -156,7 +158,7 @@ function config_diagnostics(FT, driver_config)
         resolution,
     )
 
-    dgngrp = setup_atmos_default_diagnostics(
+    dgngrp = setup_dump_state_and_aux_diagnostics(
         AtmosGCMConfigType(),
         interval,
         driver_config.name,

--- a/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
@@ -79,7 +79,7 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
     p::FT = p_s * (G / T_s * exp(-N^2 / _grav * z) + 1 - G / T_s)^(1 / _kappa)
 
     # background potential temperature
-    θ_b::FT = T_s * (p_eq / p_s)^_kappa * exp(N^2 / _grav * z)
+    θ_b::FT = T_b * (p_eq / p)^_kappa
 
     # potential temperature perturbation
     r::FT = _a * acos(sin(φ_c) * sin(φ) + cos(φ_c) * cos(φ) * cos(λ - λ_c))
@@ -93,7 +93,7 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
     T::FT = T_b + T′
 
     # density
-    ρ = air_density(bl.param_set, T, p)
+    ρ = air_density(bl.param_set, T_b, p)
 
     # potential & kinetic energy
     e_pot = gravitational_potential(bl.orientation, aux)
@@ -103,6 +103,7 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
     state.ρu = ρ * u_cart
     state.ρe = ρ * total_energy(bl.param_set, e_kin, e_pot, T)
     aux.θ₀ = θ_b
+    aux.θ′ = θ′
 
     nothing
 end

--- a/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
@@ -1,6 +1,7 @@
 #!/usr/bin/env julia --project
 using ClimateMachine
-ClimateMachine.init()
+ClimateMachine.cli()
+
 using ClimateMachine.Atmos
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics

--- a/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
@@ -60,8 +60,9 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
 
     # initial velocity profile (we need to transform the vector into the Cartesian
     # coordinate system)
-    u = u_0 * cos(φ)
-    u_init = SVector{3, FT}(-sin(λ) * u, cos(λ) * u, 0)
+    u_sphere = SVector{3, FT}(u_0 * cos(φ), 0, 0)
+    u_init = sphr_to_cart_vec(bl.orientation, u_sphere, aux)
+    #u_init = SVector{3, FT}(-sin(λ) * u, cos(λ) * u, 0)
 
     # background temperature
     T_s::FT =

--- a/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
@@ -61,7 +61,7 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
     # initial velocity profile (we need to transform the vector into the Cartesian
     # coordinate system)
     u = u_0 * cos(φ)
-    u_init = SVector{3, FT}(-sin(λ)*u, cos(λ)*u, 0)
+    u_init = SVector{3, FT}(-sin(λ) * u, cos(λ) * u, 0)
 
     # background temperature
     T_s::FT =

--- a/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic-gravity-wave.jl
@@ -60,9 +60,8 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
 
     # initial velocity profile (we need to transform the vector into the Cartesian
     # coordinate system)
-    trafo = SMatrix{3, 3, FT, 9}(0, 0, 0, 0, 0, 0, -sin(λ), cos(λ), 0)
-    u_sphere = SVector{3, FT}(u_0 * cos(φ), 0, 0)
-    u_cart = trafo * u_sphere
+    u = u_0 * cos(φ)
+    u_init = SVector{3, FT}(-sin(λ)*u, cos(λ)*u, 0)
 
     # background temperature
     T_s::FT =
@@ -97,10 +96,10 @@ function init_nonhydrostatic_gravity_wave!(bl, state, aux, coords, t)
 
     # potential & kinetic energy
     e_pot = gravitational_potential(bl.orientation, aux)
-    e_kin::FT = 0.5 * sum(abs2.(u_cart))
+    e_kin::FT = 0.5 * sum(abs2.(u_init))
 
     state.ρ = ρ
-    state.ρu = ρ * u_cart
+    state.ρu = ρ * u_init
     state.ρe = ρ * total_energy(bl.param_set, e_kin, e_pot, T)
     aux.θ₀ = θ_b
     aux.θ′ = θ′

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -278,6 +278,7 @@ function vars_state_auxiliary(m::AtmosModel, FT)
         ∫dnz::vars_reverse_integrals(m, FT)
         coord::SVector{3, FT}
         θ₀::FT
+        θ′::FT
         orientation::vars_state_auxiliary(m.orientation, FT)
         ref_state::vars_state_auxiliary(m.ref_state, FT)
         turbulence::vars_state_auxiliary(m.turbulence, FT)
@@ -571,6 +572,7 @@ Store Cartesian coordinate information in `aux.coord`.
 function init_state_auxiliary!(m::AtmosModel, aux::Vars, geom::LocalGeometry)
     aux.coord = geom.coord
     aux.θ₀ = eltype(aux)(0.0)
+    aux.θ′ = eltype(aux)(0.0)
     atmos_init_aux!(m.orientation, m, aux, geom)
     atmos_init_aux!(m.ref_state, m, aux, geom)
     atmos_init_aux!(m.turbulence, m, aux, geom)

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -277,6 +277,7 @@ function vars_state_auxiliary(m::AtmosModel, FT)
         ∫dz::vars_integrals(m, FT)
         ∫dnz::vars_reverse_integrals(m, FT)
         coord::SVector{3, FT}
+        θ₀::FT
         orientation::vars_state_auxiliary(m.orientation, FT)
         ref_state::vars_state_auxiliary(m.ref_state, FT)
         turbulence::vars_state_auxiliary(m.turbulence, FT)
@@ -569,6 +570,7 @@ Store Cartesian coordinate information in `aux.coord`.
 """ init_state_auxiliary!
 function init_state_auxiliary!(m::AtmosModel, aux::Vars, geom::LocalGeometry)
     aux.coord = geom.coord
+    aux.θ₀ = eltype(aux)(0.0)
     atmos_init_aux!(m.orientation, m, aux, geom)
     atmos_init_aux!(m.ref_state, m, aux, geom)
     atmos_init_aux!(m.turbulence, m, aux, geom)

--- a/src/Atmos/Model/orientation.jl
+++ b/src/Atmos/Model/orientation.jl
@@ -117,9 +117,9 @@ function sphr_to_cart_vec(
     vec::AbstractVector,
     aux::Vars,
 )
-    FT = eltype(state)
+    FT = eltype(aux)
     lat = latitude(orientation, aux)
-    long = longitute(orientation, aux)
+    lon = longitude(orientation, aux)
 
     slat, clat = sin(lat), cos(lat)
     slon, clon = sin(lon), cos(lon)
@@ -143,9 +143,9 @@ function cart_to_sphr_vec(
     vec::AbstractVector,
     aux::Vars,
 )
-    FT = eltype(state)
+    FT = eltype(aux)
     lat = latitude(orientation, aux)
-    long = longitute(orientation, aux)
+    lon = longitude(orientation, aux)
 
     slat, clat = sin(lat), cos(lat)
     slon, clon = sin(lon), cos(lon)

--- a/src/Atmos/Model/orientation.jl
+++ b/src/Atmos/Model/orientation.jl
@@ -7,7 +7,9 @@ export vertical_unit_vector,
     longitude,
     gravitational_potential,
     projection_normal,
-    projection_tangential
+    projection_tangential,
+    sphr_to_cart_vec,
+    cart_to_sphr_vec
 
 abstract type Orientation end
 
@@ -105,6 +107,57 @@ latitude(orientation::SphericalOrientation, aux::Vars) =
 longitude(orientation::SphericalOrientation, aux::Vars) =
     @inbounds atan(aux.coord[2], aux.coord[1])
 
+"""
+    sphr_to_cart_vec(orientation::SphericalOrientation, state::Vars, aux::Vars)
+
+Projects a vector defined based on unit vectors in spherical coordinates to cartesian unit vectors.
+"""
+function sphr_to_cart_vec(
+    orientation::SphericalOrientation,
+    vec::AbstractVector,
+    aux::Vars,
+)
+    FT = eltype(state)
+    lat = latitude(orientation, aux)
+    long = longitute(orientation, aux)
+
+    slat, clat = sin(lat), cos(lat)
+    slon, clon = sin(lon), cos(lon)
+
+    u = MVector{3, FT}(
+        -slon * vec[1] - slat * clon * vec[2] + clat * clon * vec[3],
+        clon * vec[1] - slat * slon * vec[2] + clat * slon * vec[3],
+        clat * vec[2] + slat * vec[3],
+    )
+
+    return u
+end
+
+"""
+    cart_to_sphr_vec(orientation::SphericalOrientation, state::Vars, aux::Vars)
+
+Projects a vector defined based on unit vectors in cartesian coordinates to a spherical unit vectors.
+"""
+function cart_to_sphr_vec(
+    orientation::SphericalOrientation,
+    vec::AbstractVector,
+    aux::Vars,
+)
+    FT = eltype(state)
+    lat = latitude(orientation, aux)
+    long = longitute(orientation, aux)
+
+    slat, clat = sin(lat), cos(lat)
+    slon, clon = sin(lon), cos(lon)
+
+    u = MVector{3, FT}(
+        -slon * vec[1] + clon * vec[2],
+        -slat * clon * vec[1] - slat * slon * vec[2] + clat * vec[3],
+        clat * clon * vec[1] + clat * slon * vec[2] + slat * vec[3],
+    )
+
+    return u
+end
 
 """
     FlatOrientation <: Orientation

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -1441,6 +1441,9 @@ end
         @unroll for s in 1:num_state_conservative
             state[n, s, e] = l_state[s]
         end
+        @unroll for s in 1:num_state_auxiliary
+            state_auxiliary[n, s, e] = local_state_auxiliary[s]
+        end
     end
 end
 


### PR DESCRIPTION
# Description

This PR is a result of a productive programming session between myself, @bischtob, @akshaysridhar, and @charleskawczynski. This adds a non-hydrostatic gravity wave test featured in the 2012 Dynamical Core Model Intercomparison Project (DCMIP): https://www.earthsystemcog.org/projects/dcmip-2012/test_cases

This test is a fairly simple GCM test, which is targeting the dynamical core specifically (no moisture, physics, radiation). It's a well-known test and a good one to have!

Currently in a "draft" phase, but will go ahead and post this here for comments!

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
