### PR TITLE
Refactor thermo profiles, add plots to docs

### DIFF
--- a/docs/src/HowToGuides/Atmos/TemperatureProfiles.md
+++ b/docs/src/HowToGuides/Atmos/TemperatureProfiles.md
@@ -26,8 +26,7 @@ using Plots
 struct EarthParameterSet <: AbstractEarthParameterSet end;
 const param_set = EarthParameterSet();
 FT = Float64;
-include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "Thermodynamics", "profiles.jl"))
-z, e_int, ρ, q_tot, q_pt, T, p, θ_liq_ice = tested_profiles(param_set, 50, FT);
+z = range(FT(0), stop = FT(2.5e4), length = 50);
 
 isothermal = IsothermalProfile(param_set, FT);
 args = isothermal.(Ref(param_set), z)
@@ -53,8 +52,7 @@ using Plots
 struct EarthParameterSet <: AbstractEarthParameterSet end;
 const param_set = EarthParameterSet();
 FT = Float64;
-include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "Thermodynamics", "profiles.jl"))
-z, e_int, ρ, q_tot, q_pt, T, p, θ_liq_ice = tested_profiles(param_set, 50, FT);
+z = range(FT(0), stop = FT(2.5e4), length = 50);
 
 decaying = DecayingTemperatureProfile{FT}(param_set);
 args = decaying.(Ref(param_set), z)
@@ -79,8 +77,7 @@ using Plots
 struct EarthParameterSet <: AbstractEarthParameterSet end;
 const param_set = EarthParameterSet();
 FT = Float64;
-include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "Thermodynamics", "profiles.jl"))
-z, e_int, ρ, q_tot, q_pt, T, p, θ_liq_ice = tested_profiles(param_set, 50, FT);
+z = range(FT(0), stop = FT(2.5e4), length = 50);
 
 dry_adiabatic = DryAdiabaticProfile{FT}(param_set);
 args = dry_adiabatic.(Ref(param_set), z)

--- a/docs/src/HowToGuides/Common/Thermodynamics.md
+++ b/docs/src/HowToGuides/Common/Thermodynamics.md
@@ -138,3 +138,51 @@ thermodynamic state into one of:
  - `PhaseNonEquil` a moist thermodynamic state in thermodynamic
    non-equilibrium, uniquely determined by four independent thermodynamic
    properties
+
+## Tested Profiles
+
+Thermodynamics.jl is tested using a set of profiles specified in `test/Common/Thermodynamics/profiles.jl`.
+
+### Dry Phase
+
+```@example
+using ClimateMachine.Thermodynamics
+using ClimateMachine.TemperatureProfiles
+using CLIMAParameters
+using CLIMAParameters.Planet
+using Plots
+struct EarthParameterSet <: AbstractEarthParameterSet end;
+const param_set = EarthParameterSet();
+FT = Float64;
+include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "Thermodynamics", "profiles.jl"))
+profiles = PhaseDryProfiles(param_set, FT);
+@unpack_fields profiles T ρ z
+p1 = scatter(ρ, z./10^3, xlabel="Density [kg/m^3]", ylabel="z [km]", title="Density");
+p2 = scatter(T, z./10^3, xlabel="Temperature [K]", ylabel="z [km]", title="Temperature");
+plot(p1, p2, layout=(1,2))
+savefig("tested_profiles_dry.svg");
+```
+![](tested_profiles_dry.svg)
+
+### Moist Phase in thermodynamic equilibrium
+
+```@example
+using ClimateMachine.Thermodynamics
+using ClimateMachine.TemperatureProfiles
+using CLIMAParameters
+using CLIMAParameters.Planet
+using Plots
+struct EarthParameterSet <: AbstractEarthParameterSet end;
+const param_set = EarthParameterSet();
+FT = Float64;
+include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "Thermodynamics", "profiles.jl"))
+profiles = PhaseEquilProfiles(param_set, FT);
+@unpack_fields profiles T ρ q_tot z
+p1 = scatter(ρ, z./10^3, xlabel="Density [kg/m^3]", ylabel="z [km]", title="Density");
+p2 = scatter(T, z./10^3, xlabel="Temperature [K]", ylabel="z [km]", title="Temperature");
+p3 = scatter(q_tot*1000, z./10^3, xlabel="Total specific\nhumidity [g/kg]", ylabel="z [km]", title="Total specific\nhumidity");
+plot(p1, p2, p3, layout=(1,3))
+savefig("tested_profiles_virt_temp.svg")
+```
+![](tested_profiles_virt_temp.svg)
+

--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -32,6 +32,7 @@ export air_temperature_from_liquid_ice_pottemp,
     air_temperature_from_liquid_ice_pottemp_given_pressure
 export air_temperature_from_liquid_ice_pottemp_non_linear
 export vapor_specific_humidity
+export condensate, has_condensate
 
 """
     gas_constant_air(param_set, [q::PhasePartition])
@@ -817,6 +818,27 @@ saturation_excess(ts::ThermodynamicState) = saturation_excess(
 )
 
 """
+    condensate(q::PhasePartition{FT})
+    condensate(ts::ThermodynamicState)
+
+Condensate of the phase partition.
+"""
+condensate(q::PhasePartition) = q.liq + q.ice
+condensate(ts::ThermodynamicState) = condensate(PhasePartition(ts))
+
+"""
+    has_condensate(q::PhasePartition{FT})
+    has_condensate(ts::ThermodynamicState)
+
+Bool indicating if condensate exists in the phase
+partition
+"""
+has_condensate(q_c::FT) where {FT} = q_c > eps(FT)
+has_condensate(q::PhasePartition) = has_condensate(condensate(q))
+has_condensate(ts::ThermodynamicState) = has_condensate(PhasePartition(ts))
+
+
+"""
     liquid_fraction(param_set, T, phase_type[, q])
 
 The fraction of condensate that is liquid where
@@ -847,8 +869,8 @@ function liquid_fraction(
     phase_type::Type{<:PhaseNonEquil},
     q::PhasePartition{FT} = q_pt_0(FT),
 ) where {FT <: Real}
-    q_c = q.liq + q.ice     # condensate specific humidity
-    if q_c > eps(FT)
+    q_c = condensate(q)     # condensate specific humidity
+    if has_condensate(q_c)
         return q.liq / q_c
     else
         return liquid_fraction(param_set, T, PhaseEquil, q)

--- a/test/Common/Thermodynamics/profiles.jl
+++ b/test/Common/Thermodynamics/profiles.jl
@@ -6,125 +6,230 @@ thermodynamic _states_ that Thermodynamics is
 tested with in runtests.jl
 =#
 
-
 """
-    fixed_lapse_rate(
-        param_set::AbstractParameterSet,
-        z::FT,
-        T_surface::FT,
-        T_min::FT,
-        ) where {FT <: AbstractFloat}
+    unpack_fields(_struct, syms...)
 
-Fixed lapse rate hydrostatic reference state given
+Unpack struct properties `syms`
+from struct `_struct`
 
- - `param_set` parameter set, used to dispatch planet parameter function calls
- - `z` altitude
- - `T_surface` surface temperature
- - `T_min` minimum temperature
+# Example
+```julia
+julia> struct Foo;a;b;c;end
+
+julia> f = Foo(1,2,3)
+Foo(1, 2, 3)
+
+julia> @unpack_fields f a c; @show a c
+a = 1
+c = 3
+```
 """
-function fixed_lapse_rate(
-    param_set::AbstractParameterSet,
-    z::FT,
-    T_surface::FT,
-    T_min::FT,
-) where {FT <: AbstractFloat}
-    _grav::FT = grav(param_set)
-    _cp_d::FT = cp_d(param_set)
-    _R_d::FT = R_d(param_set)
-    _MSLP::FT = MSLP(param_set)
-    Γ = _grav / _cp_d
-    z_tropopause = (T_surface - T_min) / Γ
-    H_min = _R_d * T_min / _grav
-    T = max(T_surface - Γ * z, T_min)
-    p = _MSLP * (T / T_surface)^(_grav / (_R_d * Γ))
-    T == T_min && (p = p * exp(-(z - z_tropopause) / H_min))
-    ρ = p / (_R_d * T)
-    return T, p, ρ
+macro unpack_fields(_struct, syms...)
+    thunk = Expr(:block)
+    for sym in syms
+        push!(
+            thunk.args,
+            :($(esc(sym)) = getproperty($(esc(_struct)), $(QuoteNode(sym)))),
+        )
+    end
+    push!(thunk.args, nothing)
+    return thunk
 end
 
 """
-    tested_profiles(param_set, n::Int, ::Type{FT})
+    ProfileSet
 
-A range of input arguments to thermodynamic state constructors
-
- - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
- - `z_all` altitude
- - `e_int` internal energy
- - `ρ` (moist-)air density
- - `q_tot` total specific humidity
- - `q_pt` phase partition
- - `T` air temperature
- - `θ_liq_ice` liquid-ice potential temperature
-
-that are tested for convergence in saturation adjustment.
-
-Note that the output vectors are of size ``n*n_RS``, and they
-should span the input arguments to all of the constructors.
+A set of profiles used to test Thermodynamics.
 """
-function tested_profiles(
-    param_set::AbstractParameterSet,
-    n::Int,
-    ::Type{FT},
-) where {FT}
+struct ProfileSet{FT}
+    z::Array{FT}                        # Altitude
+    T::Array{FT}                        # Temperature
+    p::Array{FT}                        # Pressure
+    RS::Array{FT}                       # Relative humidity
+    e_int::Array{FT}                    # Internal energy
+    ρ::Array{FT}                        # Density
+    θ_liq_ice::Array{FT}                # Potential temperature
+    q_tot::Array{FT}                    # Total specific humidity
+    q_liq::Array{FT}                    # Liquid specific humidity
+    q_ice::Array{FT}                    # Ice specific humidity
+    q_pt::Array{PhasePartition{FT}}     # Phase partition
+    RH::Array{FT}                       # Relative humidity
+    SS::Array{FT}                       # Super saturation
+end
 
-    n_RS1 = 10
-    n_RS2 = 20
+"""
+    input_config(
+        FT;
+        n=50,
+        n_RS1=10,
+        n_RS2=20,
+        T_min=FT(150),
+        T_surface=FT(350)
+    ) where {FT}
+
+Return input arguments to construct profiles
+"""
+function input_config(
+    FT;
+    n = 50,
+    n_RS1 = 10,
+    n_RS2 = 20,
+    T_surface = FT(350),
+    T_min = FT(150),
+)
     n_RS = n_RS1 + n_RS2
     z_range = range(FT(0), stop = FT(2.5e4), length = n)
     relative_sat1 = range(FT(0), stop = FT(1), length = n_RS1)
     relative_sat2 = range(FT(1), stop = FT(1.02), length = n_RS2)
     relative_sat = [relative_sat1..., relative_sat2...]
-    T_min = FT(150)
-    T_surface = FT(350)
+    return z_range, relative_sat, T_surface, T_min
+end
 
-    T = zeros(FT, n, n_RS)
-    p = zeros(FT, n, n_RS)
-    ρ = zeros(FT, n, n_RS)
-    RS = zeros(FT, n, n_RS)
-    z_all = zeros(FT, n, n_RS)
-    for i in eachindex(z_range)
-        for j in eachindex(relative_sat)
-            args = fixed_lapse_rate(param_set, z_range[i], T_surface, T_min)
-            k = CartesianIndex(i, j)
-            z_all[k] = z_range[i]
-            T[k] = args[1]
-            p[k] = args[2]
-            ρ[k] = args[3]
+"""
+    shared_profiles(
+        param_set::AbstractParameterSet,
+        z_range::AbstractArray,
+        relative_sat::AbstractArray,
+        T_surface::FT,
+        T_min::FT,
+    ) where {FT}
+
+Compute profiles shared across `PhaseDry`,
+`PhaseEquil` and `PhaseNonEquil` thermodynamic
+states, including:
+ - `z` altitude
+ - `T_virt` virtual temperature
+ - `p` pressure
+ - `RS` relative saturation
+"""
+function shared_profiles(
+    param_set::AbstractParameterSet,
+    z_range::AbstractArray,
+    relative_sat::AbstractArray,
+    T_surface::FT,
+    T_min::FT,
+) where {FT}
+    n_RS = length(relative_sat)
+    n = length(z_range)
+    T_virt = Array{FT}(undef, n * n_RS)
+    p = Array{FT}(undef, n * n_RS)
+    RS = Array{FT}(undef, n * n_RS)
+    z = Array{FT}(undef, n * n_RS)
+    linear_indices = LinearIndices((1:n, 1:n_RS))
+    profile = DecayingTemperatureProfile{FT}(param_set, T_surface, T_min)
+    for i in linear_indices.indices[1]
+        for j in linear_indices.indices[2]
+            k = linear_indices[i, j]
+            z[k] = z_range[i]
+            T_virt[k], p[k] = profile(param_set, z[k])
             RS[k] = relative_sat[j]
         end
     end
-    T = reshape(T, n * n_RS)
-    p = reshape(p, n * n_RS)
-    ρ = reshape(ρ, n * n_RS)
-    RS = reshape(RS, n * n_RS)
-    relative_sat = RS
+    return z, T_virt, p, RS
+end
+
+####
+#### PhaseDry
+####
+
+"""
+    PhaseDryProfiles(param_set, ::Type{FT})
+
+Returns a `ProfileSet` used to test dry thermodynamic states.
+"""
+function PhaseDryProfiles(
+    param_set::AbstractParameterSet,
+    ::Type{FT},
+) where {FT}
+
+    z_range, relative_sat, T_surface, T_min = input_config(FT)
+    z, T_virt, p, RS =
+        shared_profiles(param_set, z_range, relative_sat, T_surface, T_min)
+    _R_d::FT = R_d(param_set)
+    T = T_virt
+    ρ = p ./ (_R_d .* T)
 
     # Additional variables
-    phase_type = PhaseEquil # TODO: Verify this!
-    q_sat = q_vap_saturation.(Ref(param_set), T, ρ, Ref(phase_type))
-    q_tot = min.(relative_sat .* q_sat, FT(1))
+    phase_type = PhaseDry
+    q_tot = zeros(FT, length(RS))
     q_pt = PhasePartition_equil.(Ref(param_set), T, ρ, q_tot, Ref(phase_type))
     e_int = internal_energy.(Ref(param_set), T, q_pt)
     θ_liq_ice = liquid_ice_pottemp.(Ref(param_set), T, ρ, q_pt)
-
-    # Sort by altitude (for visualization):
-    # TODO: Refactor, by avoiding phase partition copy, once
-    # https://github.com/JuliaLang/julia/pull/33515 merges
     q_liq = getproperty.(q_pt, :liq)
     q_ice = getproperty.(q_pt, :ice)
-    args = [z_all, e_int, ρ, q_tot, q_liq, q_ice, T, p, θ_liq_ice]
-    args = collect(zip(args...))
-    sort!(args)
-    z_all = getindex.(args, 1)
-    e_int = getindex.(args, 2)
-    ρ = getindex.(args, 3)
-    q_tot = getindex.(args, 4)
-    q_liq = getindex.(args, 5)
-    q_ice = getindex.(args, 6)
-    T = getindex.(args, 7)
-    p = getindex.(args, 8)
-    θ_liq_ice = getindex.(args, 9)
-    q_pt = PhasePartition.(q_tot, q_liq, q_ice)
-    args = [z_all, e_int, ρ, q_tot, q_pt, T, p, θ_liq_ice]
-    return args
+    RH = relative_humidity.(Ref(param_set), T, p, e_int, Ref(phase_type), q_pt)
+
+    # TODO: Update this once a super saturation method exists
+    # SS = super_saturation.(Ref(param_set), T, p, e_int, Ref(phase_type), q_pt)
+    SS = zeros(FT, length(RH))
+
+    return ProfileSet(
+        z,
+        T,
+        p,
+        RS,
+        e_int,
+        ρ,
+        θ_liq_ice,
+        q_tot,
+        q_liq,
+        q_ice,
+        q_pt,
+        RH,
+        SS,
+    )
+end
+
+####
+#### PhaseEquil
+####
+
+"""
+    PhaseEquilProfiles(param_set, ::Type{FT})
+
+Returns a `ProfileSet` used to test moist states in thermodynamic equilibrium.
+"""
+function PhaseEquilProfiles(
+    param_set::AbstractParameterSet,
+    ::Type{FT},
+) where {FT}
+
+    z_range, relative_sat, T_surface, T_min = input_config(FT)
+
+    z, T_virt, p, RS =
+        shared_profiles(param_set, z_range, relative_sat, T_surface, T_min)
+    _R_d::FT = R_d(param_set)
+    T = T_virt
+    ρ = p ./ (_R_d .* T)
+
+    # Additional variables
+    phase_type = PhaseEquil
+    q_sat = q_vap_saturation.(Ref(param_set), T, ρ, Ref(phase_type))
+    q_tot = min.(RS .* q_sat, FT(1))
+    q_pt = PhasePartition_equil.(Ref(param_set), T, ρ, q_tot, Ref(phase_type))
+    e_int = internal_energy.(Ref(param_set), T, q_pt)
+    θ_liq_ice = liquid_ice_pottemp.(Ref(param_set), T, ρ, q_pt)
+    q_liq = getproperty.(q_pt, :liq)
+    q_ice = getproperty.(q_pt, :ice)
+    RH = relative_humidity.(Ref(param_set), T, p, e_int, Ref(phase_type), q_pt)
+
+    # TODO: Update this once a super saturation method exists
+    # SS = super_saturation.(Ref(param_set), T, p, e_int, Ref(phase_type), q_pt)
+    SS = zeros(FT, length(RH))
+
+    return ProfileSet(
+        z,
+        T,
+        p,
+        RS,
+        e_int,
+        ρ,
+        θ_liq_ice,
+        q_tot,
+        q_liq,
+        q_ice,
+        q_pt,
+        RH,
+        SS,
+    )
 end


### PR DESCRIPTION
# Description

 - Refactors thermodynamic profiles
    - Adds a struct to hold fields, which can be re-used for dry, equilibrium moist, and non-equilibrium moist profiles
    - Adds `has_condensate` and `condensate` convenience methods to ensure consistent tolerances between different `liquid_fraction` behaviors
    - Use `DecayingTemperatureProfile` to test thermodynamics
 - Adds plots of thermodynamic profiles to docs

This PR should be non-behavior changing and will take some of the weight off of #1050.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
