### PR TITLE
Add varsindices

### DIFF
--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -1,9 +1,26 @@
 module VariableTemplates
 
-export varsize, Vars, Grad, @vars, varsindex
+export varsize, Vars, Grad, @vars, varsindex, varsindices
 
 using StaticArrays
 
+"""
+    varsindex(S, p::Symbol, [sp::Symbol...])
+
+Return a range of indices corresponding to the property `p` and
+(optionally) its subproperties `sp` based on the template type `S`.
+
+# Examples
+```julia-repl
+julia> S = @vars(x::Float64, y::Float64)
+julia> varsindex(S, :y)
+2:2
+
+julia> S = @vars(x::Float64, y::@vars(α::Float64, β::SVector{3, Float64}))
+julia> varsindex(S, :y, :β)
+3:5
+```
+"""
 function varsindex(::Type{S}, insym::Symbol) where {S <: NamedTuple}
     offset = 0
     for varsym in fieldnames(S)
@@ -30,6 +47,42 @@ function varsindex(::Type{S}, insym::Symbol) where {S <: NamedTuple}
     end
     error("symbol '$insym' not found")
 end
+Base.@propagate_inbounds function varsindex(
+    ::Type{S},
+    sym::Symbol,
+    rest::Symbol...,
+) where {S <: NamedTuple}
+    varsindex(S, sym)[varsindex(fieldtype(S, sym), rest...)]
+end
+
+"""
+    varsindices(S, ps::Tuple)
+    varsindices(S, ps...)
+
+Return a tuple of indices corresponding to the properties
+specified by `ps` based on the template type `S`. Properties
+can be specified using either symbols or strings.
+
+# Examples
+```julia-repl
+julia> S = @vars(x::Float64, y::Float64, z::Float64)
+julia> varsindices(S, (:x, :z))
+(1, 3)
+
+julia> S = @vars(x::Float64, y::@vars(α::Float64, β::SVector{3, Float64}))
+julia> varsindices(S, "x", "y.β")
+(1, 3, 4, 5)
+```
+"""
+function varsindices(::Type{S}, vars::Tuple) where {S <: NamedTuple}
+    indices = Int[]
+    for var in vars
+        splitvar = split(string(var), '.')
+        append!(indices, collect(varsindex(S, map(Symbol, splitvar)...)))
+    end
+    Tuple(indices)
+end
+varsindices(::Type{S}, vars...) where {S <: NamedTuple} = varsindices(S, vars)
 
 """
     varsize(S)

--- a/test/Utilities/VariableTemplates/varsindex.jl
+++ b/test/Utilities/VariableTemplates/varsindex.jl
@@ -1,5 +1,5 @@
 using Test, StaticArrays
-using ClimateMachine.VariableTemplates: varsindex, @vars
+using ClimateMachine.VariableTemplates: varsindex, @vars, varsindices
 using StaticArrays
 
 struct MoistureModel{FT} end
@@ -35,9 +35,23 @@ end
     moist = varsindex(vars_state(m, FT), :moisture)
     @test 6:13 === moist
 
-    # To get the specific onnes we need something like
+    # To get the specific ones we can do
+    @test 6:6 === varsindex(vars_state(m, FT), :moisture, :ρq_tot)
+    @test 7:11 === varsindex(vars_state(m, FT), :moisture, :ρq_x)
+    @test 12:12 === varsindex(vars_state(m, FT), :moisture, :ρq_liq)
+    @test 13:13 === varsindex(vars_state(m, FT), :moisture, :ρq_vap)
+    # or
     @test 6:6 === moist[varsindex(vars_state(m.moisture, FT), :ρq_tot)]
     @test 7:11 === moist[varsindex(vars_state(m.moisture, FT), :ρq_x)]
     @test 12:12 === moist[varsindex(vars_state(m.moisture, FT), :ρq_liq)]
     @test 13:13 === moist[varsindex(vars_state(m.moisture, FT), :ρq_vap)]
+
+    @test (1,) === varsindices(vars_state(m, FT), :ρ)
+    @test (2, 3, 4) === varsindices(vars_state(m, FT), :ρu)
+    @test (1, 5) === varsindices(vars_state(m, FT), :ρ, :ρe)
+    @test (12,) === varsindices(vars_state(m, FT), :(moisture.ρq_liq))
+    let
+        vars = ("ρe", "moisture.ρq_x", "moisture.ρq_vap")
+        @test (5, 7, 8, 9, 10, 11, 13) === varsindices(vars_state(m, FT), vars)
+    end
 end


### PR DESCRIPTION
# Description

This PR:
- Adds `varsindices`, a refactored version of the indexing functionality needed
  in #1182 moved to `VariableTemplates` for general use
- Adds mulit-argument method of `varsindex` for getting indices of submodel variables

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
