### PR TITLE
Add domain min to single stack driver info

### DIFF
--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -375,7 +375,8 @@ function SingleStackConfiguration(
 Establishing single stack configuration for %s
     precision        = %s
     polynomial order = %d
-    domain           = %.2f m x%.2f m x%.2f m
+    domain_min       = %.2f m x%.2f m x%.2f m
+    domain_max       = %.2f m x%.2f m x%.2f m
     #vert elems      = %d
     MPI ranks        = %d
     min(Δ_horz)      = %.2f m
@@ -383,6 +384,9 @@ Establishing single stack configuration for %s
         name,
         FT,
         N,
+        xmin,
+        ymin,
+        zmin,
         xmax,
         ymax,
         zmax,


### PR DESCRIPTION
# Description

The land model uses `z_min < 0` and, while we support `z_min < 0` in the configuration, no domain minimum information is printed. This PR adds a print for `domain_min` to the single stack driver, as this will be used in the land and ocean model where `z_min < 0`.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
