### PR TITLE
Fix README azure badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The Climate Machine is a new Earth system model that leverages recent advances i
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-latest-url]: https://CliMA.github.io/ClimateMachine.jl/latest/
 
-[azure-img]: https://dev.azure.com/climate-machine/ClimateMachine.jl/_apis/build/status/CliMA.ClimateMachine.jl?branchName=master
-[azure-url]: https://dev.azure.com/climate-machine/ClimateMachine.jl/_build/latest?definitionId=5&branchName=master
+[azure-img]: https://dev.azure.com/climate-machine/ClimateMachine.jl/_apis/build/status/azure-ci?branchName=master
+[azure-url]: https://dev.azure.com/climate-machine/ClimateMachine.jl/_build/latest?definitionId=15&branchName=master
 
 [codecov-img]: https://codecov.io/gh/CliMA/ClimateMachine.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/CliMA/ClimateMachine.jl


### PR DESCRIPTION
# Description

This PR fixes the README azure badge links. (this broke when we changed the CI name to `azure-ci`)

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
