### PR TITLE
factor out refstate contributions from AtmosAcousticGravityLinearModel

### DIFF
--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -214,7 +214,11 @@ function flux_first_order!(
         state,
         aux,
     )
-    flux.ρu += pL * I
+    if lm.atmos.ref_state isa HydrostaticState
+        flux.ρu += (pL - aux.ref_state.p) * I
+    else
+        flux.ρu += pL * I
+    end
     flux.ρe = ((ref.ρe + ref.p) / ref.ρ) * state.ρu
     nothing
 end
@@ -229,7 +233,11 @@ function source!(
 )
     if direction isa VerticalDirection || direction isa EveryDirection
         ∇Φ = ∇gravitational_potential(lm.atmos.orientation, aux)
-        source.ρu -= state.ρ * ∇Φ
+        if lm.atmos.ref_state isa HydrostaticState
+            source.ρu -= (state.ρ - aux.ref_state.ρ) * ∇Φ
+        else
+            source.ρu -= state.ρ * ∇Φ
+        end
     end
     nothing
 end


### PR DESCRIPTION
# Description

This applies the same factoring we do for the AtmosModel to the AtmosAcousticGravityLinearModel, which should significant reduce the numerical error in both this and the RemainderModel.

Should we do the same thing for the AtmosAcousticLinearModel? There the benefits are not as clear.

cc: @akshaysridhar @thomasgibson @bischtob 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
