### PR TITLE
fix format, add formatter to bors

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -1,6 +1,13 @@
 name: JuliaFormatter
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+      - trying
+      - staging
+    tags: '*'
+  pull_request:
 
 jobs:
   format:

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,8 @@
 status = [
   "azure-ci",
   "ci/slurmci",
-  "docs-build"
+  "docs-build",
+  "format"
 ]
 delete_merged_branches = true
 timeout_sec = 86400

--- a/src/Numerics/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
@@ -191,7 +191,7 @@ Exact choice of coefficients from wikipedia page for Heun's method :)
 function SSPRK22Heuns(F, Q::AT; dt = 0, t0 = 0) where {AT <: AbstractArray}
     T = eltype(Q)
     RT = real(T)
-    RKA = [RT(1) RT(0); RT(1//2) RT(1//2)]
+    RKA = [RT(1) RT(0); RT(1 // 2) RT(1 // 2)]
     RKB = [RT(1), RT(1 // 2)]
     RKC = [RT(0), RT(1)]
     StrongStabilityPreservingRungeKutta(F, RKA, RKB, RKC, Q; dt = dt, t0 = t0)


### PR DESCRIPTION
# Description

#1136 introduced a formatter error. This fixes it and adds the formatter to the bors checklist.


<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)