### PR TITLE
Remove call to `update_auxiliary_state!` in driver

### DIFF
--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -134,7 +134,6 @@ function SolverConfiguration(
         @info @sprintf("Initializing %s", driver_config.name,)
         Q = init_ode_state(dg, FT(0), init_args...; init_on_cpu = init_on_cpu)
     end
-    update_auxiliary_state!(dg, bl, Q, FT(0), dg.grid.topology.realelems)
 
     # default Courant number
     # TODO: Think about revising this or drop it entirely.


### PR DESCRIPTION
# Description

At the moment, users cannot visualize the results of what is computed in `init_state_auxiliary!`, this PR fixes this by removing the call to `update_auxiliary_state!` in the solver configuration.

Step towards fixing #1213

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
