### PR TITLE
Move add of `PackageCompiler` in sys image script

### DIFF
--- a/.dev/systemimage/climate_machine_image.jl
+++ b/.dev/systemimage/climate_machine_image.jl
@@ -21,6 +21,8 @@ climatemachine_pkg = get(ARGS, 2, "false") == "true"
 start_time = time()
 
 using Pkg
+Pkg.add("PackageCompiler")
+
 Pkg.activate(joinpath(@__DIR__, "..", ".."))
 Pkg.instantiate(verbose = true)
 
@@ -37,7 +39,6 @@ else
 end
 
 # use package compiler
-Pkg.add("PackageCompiler")
 using PackageCompiler
 PackageCompiler.create_sysimage(
     pkgs,


### PR DESCRIPTION
By moving the line `Pkg.add("PackageCompiler")` to before activating
`ClimateMachine` we avoid having it get added to `ClimateMachine.jl`s
`Project.toml` and `Manifest.toml`