### PR TITLE
bump existing github actions to use julia 1.4

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.3
+          version: 1.4
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()

--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        julia-version: ['1.3']
+        julia-version: ['1.4']
         project: ['ClimateMachine.jl']
 
     steps:

--- a/.github/workflows/Documenter.yaml
+++ b/.github/workflows/Documenter.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.3
+          version: 1.4
       - name: Install dependencies
         run: |
           sudo apt install libxt6 libxrender1 libxext6 libgl1-mesa-glx libqt5widgets5

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -12,7 +12,7 @@ jobs:
     - run: git fetch origin
     - uses: julia-actions/setup-julia@latest
       with:
-        version: 1.3
+        version: 1.4
     - name: Apply JuliaFormatter
       run: |
         julia --project=.dev .dev/climaformat.jl .

--- a/docs/src/GettingStarted/Installation.md
+++ b/docs/src/GettingStarted/Installation.md
@@ -2,8 +2,7 @@
 
 ## Install Julia
 
-The Climate Machine (CLIMA) uses the Julia programming language and has been tested for the Julia version 1.4.1, which can be downloaded via your package manager or from the [Julia website](https://julialang.org/downloads/#current_stable_release).
-CLIMA has also been tested for Julia version 1.3, which can be found in [Julia's old releases](https://julialang.org/downloads/oldreleases/).
+The Climate Machine (CLIMA) uses the Julia programming language and has been tested for the latest Julia release version 1.4, which can be downloaded via your package manager or from the [Julia website](https://julialang.org/downloads/#current_stable_release).
 
 ## Install MPI (optional)
 


### PR DESCRIPTION
# Description

Port the last of the CI checks to use 1.4, closes #1061 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
