### PR TITLE
Bug fix for v_lat component (interpolation)

### DIFF
--- a/src/Numerics/Mesh/Interpolation.jl
+++ b/src/Numerics/Mesh/Interpolation.jl
@@ -429,8 +429,7 @@ function interpolate_local!(
                 for ik in ikloop
                     vout_ij .= 0.0
                     f2 == 0 ? (ijloop = 1:qm1) : (ijloop = f2:f2)
-                    for ij in ijloop #1:qm1
-
+                    for ij in ijloop
                         vout_ii .= 0.0
 
                         if f1 == 0
@@ -896,7 +895,6 @@ struct InterpolationCubedSphere{
                         push!(longi[el_loc], UInt16(k))
                         offset_d[el_loc + 1] += 1
                     end
-
                 end
             end
         end
@@ -1302,9 +1300,9 @@ function interpolate_local!(
 
         Nel = length(offset) - 1
 
-        vout = zeros(FT, nvars) #FT(0)
-        vout_ii = zeros(FT, nvars) #FT(0)
-        vout_ij = zeros(FT, nvars) #FT(0)
+        vout = zeros(FT, nvars)
+        vout_ii = zeros(FT, nvars)
+        vout_ij = zeros(FT, nvars)
 
 
         for el in 1:Nel # for each element elno
@@ -1547,9 +1545,9 @@ function project_cubed_sphere!(
                 v[i, _ρw] * sind(lat_grd[lati[i]])
 
             @inbounds vlat =
-                -v[i, _ρu] * sind(lat_grd[lati[i]]) * cosd(long_grd[longi[i]])
-            -v[i, _ρv] * sind(lat_grd[lati[i]]) * sind(long_grd[longi[i]]) +
-            v[i, _ρw] * cosd(lat_grd[lati[i]])
+                -v[i, _ρu] * sind(lat_grd[lati[i]]) * cosd(long_grd[longi[i]]) -
+                v[i, _ρv] * sind(lat_grd[lati[i]]) * sind(long_grd[longi[i]]) +
+                v[i, _ρw] * cosd(lat_grd[lati[i]])
 
             @inbounds vlon =
                 -v[i, _ρu] * sind(long_grd[longi[i]]) +
@@ -1611,11 +1609,11 @@ function project_cubed_sphere_CUDA!(
         vlat =
             -v[idx, _ρu] *
             CUDAnative.sin(lat_grd[lati[idx]] * pi / 180.0) *
-            CUDAnative.cos(long_grd[longi[idx]] * pi / 180.0)
-        -v[idx, _ρv] *
-        CUDAnative.sin(lat_grd[lati[idx]] * pi / 180.0) *
-        CUDAnative.sin(long_grd[longi[idx]] * pi / 180.0) +
-        v[idx, _ρw] * CUDAnative.cos(lat_grd[lati[idx]] * pi / 180.0)
+            CUDAnative.cos(long_grd[longi[idx]] * pi / 180.0) -
+            v[idx, _ρv] *
+            CUDAnative.sin(lat_grd[lati[idx]] * pi / 180.0) *
+            CUDAnative.sin(long_grd[longi[idx]] * pi / 180.0) +
+            v[idx, _ρw] * CUDAnative.cos(lat_grd[lati[idx]] * pi / 180.0)
 
         vlon =
             -v[idx, _ρu] * CUDAnative.sin(long_grd[longi[idx]] * pi / 180.0) +

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -387,9 +387,9 @@ function run_cubed_sphere_interpolation_test()
                         fex[i, j, k, _ρ] * cosd(long[i])
 
                     fex[i, j, k, _ρv] =
-                        -fex[i, j, k, _ρ] * sind(lat[j]) * cosd(long[i])
-                    -fex[i, j, k, _ρ] * sind(lat[j]) * sind(long[i]) +
-                    fex[i, j, k, _ρ] * cosd(lat[j])
+                        -fex[i, j, k, _ρ] * sind(lat[j]) * cosd(long[i]) -
+                        fex[i, j, k, _ρ] * sind(lat[j]) * sind(long[i]) +
+                        fex[i, j, k, _ρ] * cosd(lat[j])
 
                     fex[i, j, k, _ρw] =
                         fex[i, j, k, _ρ] * cosd(lat[j]) * cosd(long[i]) +
@@ -407,9 +407,9 @@ function run_cubed_sphere_interpolation_test()
         MPI.Bcast!(err_inf_dom, root, mpicomm)
 
         if FT == Float64
-            toler = 1.0E-7
+            toler = 2.0E-7
         elseif FT == Float32
-            toler = 1.0E-6
+            toler = 2.0E-6
         end
 
         if maximum(err_inf_dom) > toler


### PR DESCRIPTION

Due to a formatting error, bottom lines of a multi-line statement are ignored. This bug is fixed.

# Description

A clear and concise description of the code with usage.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
