### PR TITLE
Fix docs and remove slurm-tested broken tutorials from docs

### DIFF
--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -20,16 +20,7 @@ if generate_tutorials
     tutorials_dir = joinpath(@__DIR__, "..", "tutorials")
 
     tutorials = [
-        "Atmos" => [
-            "Dry Rayleigh Bernard" => "Atmos/dry_rayleigh_benard.jl",
-            "Dry Idealized GCM" => "Atmos/heldsuarez.jl",
-            "Rising Thermal Bubble" => "Atmos/risingbubble.jl",
-            "Microphysics" => [
-                "Saturation adjustment" =>
-                    "Microphysics/ex_1_saturation_adjustment.jl",
-                "Kessler" => "Microphysics/ex_2_Kessler.jl",
-            ],
-        ],
+        "Atmos" => ["Dry Idealized GCM" => "Atmos/heldsuarez.jl"],
         "Ocean" => [],
         "Land" => ["Heat" => ["Heat Equation" => "Land/Heat/heat_equation.jl"]],
         "Numerics" => [
@@ -38,10 +29,7 @@ if generate_tutorials
                 "Batched Generalized Minimal Residual" =>
                     "Numerics/SystemSolvers/bgmres.jl",
             ],
-            "DG Methods" => [
-                "Topology" => "topo.jl",
-                "Preserving positivity" => "Numerics/DGMethods/nonnegative.jl",
-            ],
+            "DG Methods" => ["Topology" => "topo.jl"],
         ],
         "Diagnostics" => [
             "Debug" => [
@@ -61,15 +49,6 @@ if generate_tutorials
     transform(x) = joinpath(basename(generated_dir), replace(x, ".jl" => ".md"))
     tutorials = transform_second(x -> transform(x), tutorials)
 
-    skip_execute = [
-        "Atmos/dry_rayleigh_benard.jl",               # takes too long
-        "Atmos/risingbubble.jl",                      # broken
-        "Numerics/DGMethods/nonnegative.jl",          # broken
-        "Microphysics/ex_1_saturation_adjustment.jl", # too long
-        "Microphysics/ex_2_Kessler.jl",               # too long
-        "topo.jl",                                    # broken
-    ]
-
     tutorials_jl = map(x -> joinpath(tutorials_dir, x), tutorials_jl)
 
     for tutorial in tutorials_jl
@@ -80,9 +59,7 @@ if generate_tutorials
         code = strip(read(script, String))
         mdpost(str) = replace(str, "@__CODE__" => code)
         Literate.markdown(input, gen_dir, postprocess = mdpost)
-        if !any(occursin.(skip_execute, Ref(input)))
-            Literate.notebook(input, gen_dir, execute = true)
-        end
+        Literate.notebook(input, gen_dir, execute = true)
     end
 
 end

--- a/docs/src/Contributing.md
+++ b/docs/src/Contributing.md
@@ -48,7 +48,7 @@ GitHub](https://github.com/CliMA/ClimateMachine.jl) and check out your copy:
 ```
 $ git clone https://github.com/<username>/ClimateMachine.jl.git
 $ cd ClimateMachine.jl
-$ git remote add upstream https://github.com/CliMA/ClimateMachine.jl.git
+$ git remote add upstream https://github.com/CliMA/ClimateMachine.jl
 ```
 
 Now you have two remote repositories -- `origin`, which is your fork of the
@@ -63,7 +63,7 @@ $ git checkout -b <branchname>
 
 ## Develop your feature
 
-Follow the [coding style](CodingStyle.md) we use. Make sure you add tests
+Follow the [Coding conventions](@ref) we use. Make sure you add tests
 for your code in `test/` and appropriate documentation in the code and/or
 in `docs/`.
 

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -1,3 +1,26 @@
+# # Dry Rayleigh Benard
+
+# ## Problem description
+#
+# 1) Dry Rayleigh Benard Convection (re-entrant channel configuration)
+# 2) Boundaries - `Sides` : Periodic (Default `bctuple` used to identify bot,top walls)
+#                 `Top`   : Prescribed temperature, no-slip
+#                 `Bottom`: Prescribed temperature, no-slip
+# 3) Domain - 250m[horizontal] x 250m[horizontal] x 500m[vertical]
+# 4) Timeend - 100s
+# 5) Mesh Aspect Ratio (Effective resolution) 1:1
+# 6) Random values in initial condition (Requires `init_on_cpu=true` argument)
+# 7) Overrides defaults for
+#               `C_smag`
+#               `Courant_number`
+#               `init_on_cpu`
+#               `ref_state`
+#               `solver_type`
+#               `bc`
+#               `sources`
+# 8) Default settings can be found in src/Driver/Configurations.jl
+
+# ## Loading code
 using Distributions
 using Random
 using StaticArrays
@@ -23,25 +46,7 @@ using CLIMAParameters.Planet: R_d, cp_d, cv_d, grav, MSLP
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-# ------------------- Description ---------------------------------------- #
-# 1) Dry Rayleigh Benard Convection (re-entrant channel configuration)
-# 2) Boundaries - `Sides` : Periodic (Default `bctuple` used to identify bot,top walls)
-#                 `Top`   : Prescribed temperature, no-slip
-#                 `Bottom`: Prescribed temperature, no-slip
-# 3) Domain - 250m[horizontal] x 250m[horizontal] x 500m[vertical]
-# 4) Timeend - 1000s
-# 5) Mesh Aspect Ratio (Effective resolution) 1:1
-# 6) Random values in initial condition (Requires `init_on_cpu=true` argument)
-# 7) Overrides defaults for
-#               `C_smag`
-#               `Courant_number`
-#               `init_on_cpu`
-#               `ref_state`
-#               `solver_type`
-#               `bc`
-#               `sources`
-# 8) Default settings can be found in src/Driver/Configurations.jl
-
+# Convenience struct for sharing data between kernels
 struct DryRayleighBenardConvectionDataConfig{FT}
     xmin::FT
     ymin::FT
@@ -54,6 +59,7 @@ struct DryRayleighBenardConvectionDataConfig{FT}
     T_top::FT
 end
 
+# Define initial condition kernel
 function init_problem!(bl, state, aux, (x, y, z), t)
     dc = bl.data_config
     FT = eltype(state)
@@ -97,9 +103,10 @@ function init_problem!(bl, state, aux, (x, y, z), t)
     state.tracers.ρχ = SVector{1, FT}(ρχ)
 end
 
+# Define problem configuration kernel
 function config_problem(FT, N, resolution, xmax, ymax, zmax)
 
-    # Boundary conditions
+    ## Boundary conditions
     T_bot = FT(299)
 
     _cp_d::FT = cp_d(param_set)
@@ -111,7 +118,7 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
     ntracers = 1
     δ_χ = SVector{ntracers, FT}(1)
 
-    # Turbulence
+    ## Turbulence
     C_smag = FT(0.23)
     data_config = DryRayleighBenardConvectionDataConfig{FT}(
         0,
@@ -125,7 +132,7 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
         FT(T_bot - T_lapse * zmax),
     )
 
-    # Set up the model
+    ## Set up the model
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         param_set;
@@ -146,10 +153,10 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
         data_config = data_config,
     )
 
-    # Set up the time-integrator, using a multirate infinitesimal step
-    # method. The option `splitting_type = ClimateMachine.SlowFastSplitting()`
-    # separates fast-slow modes by splitting away the acoustic waves and
-    # treating them via a sub-stepped explicit method.
+    ## Set up the time-integrator, using a multirate infinitesimal step
+    ## method. The option `splitting_type = ClimateMachine.SlowFastSplitting()`
+    ## separates fast-slow modes by splitting away the acoustic waves and
+    ## treating them via a sub-stepped explicit method.
     ode_solver = ClimateMachine.MISSolverType(;
         splitting_type = ClimateMachine.SlowFastSplitting(),
         mis_method = MIS2,
@@ -172,6 +179,7 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
     return config
 end
 
+# Define diagnostics configuration kernel
 function config_diagnostics(driver_config)
     interval = "10000steps"
     dgngrp = setup_atmos_default_diagnostics(
@@ -182,15 +190,16 @@ function config_diagnostics(driver_config)
     return ClimateMachine.DiagnosticsConfiguration([dgngrp])
 end
 
+# Define main entry point kernel
 function main()
     FT = Float64
-    # DG polynomial order
+    ## DG polynomial order
     N = 4
-    # Domain resolution and size
+    ## Domain resolution and size
     Δh = FT(10)
-    # Time integrator setup
+    ## Time integrator setup
     t0 = FT(0)
-    # Courant number
+    ## Courant number
     CFLmax = FT(20)
     timeend = FT(1000)
     xmax, ymax, zmax = FT(250), FT(250), FT(500)
@@ -208,7 +217,7 @@ function main()
                 Courant_number = CFLmax,
             )
             dgn_config = config_diagnostics(driver_config)
-            # User defined callbacks (TMAR positivity preserving filter)
+            ## User defined callbacks (TMAR positivity preserving filter)
             cbtmarfilter =
                 GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
                     Filters.apply!(
@@ -225,10 +234,11 @@ function main()
                 user_callbacks = (cbtmarfilter,),
                 check_euclidean_distance = true,
             )
-            # result == engf/eng0
+            ## result == engf/eng0
             @test isapprox(result, FT(1); atol = 1.5e-2)
         end
     end
 end
 
+# Run
 main()

--- a/tutorials/Diagnostics/Debug/StateCheck.jl
+++ b/tutorials/Diagnostics/Debug/StateCheck.jl
@@ -1,14 +1,14 @@
 # # State debug statistics
 #
-# This page shows how to use the ```StateCheck``` functions to get basic
-# statistics for nodal values of fields held in ClimateMachine ```MPIStateArray```
-# data structures. The ```StateCheck``` functions can be used to
+# This page shows how to use the `StateCheck` functions to get basic
+# statistics for nodal values of fields held in ClimateMachine `MPIStateArray`
+# data structures. The `StateCheck` functions can be used to
 #
-# 1. Generate statistics on ```MPIStateArray``` holding the state #    of a ClimateMachine experiment.
-# 
+# 1. Generate statistics on `MPIStateArray` holding the state of a ClimateMachine experiment.
+#
 #    and to
 #
-# 2. Compare against saved reference statistics from ClimateMachine ```MPIStateArray```
+# 2. Compare against saved reference statistics from ClimateMachine `MPIStateArray`
 #    variables. This can enable simple automated regression test checks for
 #    detecting unexpected changes introduced into numerical experiments
 #    by code updates.
@@ -22,18 +22,18 @@
 # set of the MPIStateArray type variables of the sort that hold persistent state for
 # ClimateMachine models. We then invoke the call back to show the statistics.
 #
-# In regular use the ```MPIStateArray``` variables will come from model configurations.
-# Here we create a dummy set of ```MPIStateArray``` variables for use in stand alone
+# In regular use the `MPIStateArray` variables will come from model configurations.
+# Here we create a dummy set of `MPIStateArray` variables for use in stand alone
 # examples.
 
 # ### Create a dummy set of MPIStateArrays
 #
-# First we set up two ```MPIStateArray``` variables. This need a few packages to be in placeT,
+# First we set up two `MPIStateArray` variables. This need a few packages to be in placeT,
 # and utilizes some utility functions to create the array and add named
 # persistent state variables.
-# This is usually handled automatically as part of model deefinition in regular
+# This is usually handled automatically as part of model definition in regular
 # ClimateMachine activity.
-# Calling ```ClimateMachine.init()``` includes initializing GPU CUDA and MPI parallel
+# Calling `ClimateMachine.init()` includes initializing GPU CUDA and MPI parallel
 # processing options that match the hardware/software system in use.
 
 # Set up a basic environment
@@ -59,7 +59,7 @@ F2 = @vars begin
 end
 nothing # hide
 
-# Create ```MPIStateArray``` variables with arrays to hold elements of the 
+# Create `MPIStateArray` variables with arrays to hold elements of the
 # vectors and tensors
 Q1 = MPIStateArray{Float32, F1}(
     MPI.COMM_WORLD,
@@ -79,9 +79,9 @@ nothing # hide
 
 # ### Create a call-back
 #
-# Now we can create a ```StateCheck``` call-back, _cb_, tied to the ```MPIStateArray```
-# variables _Q1_ and _Q2_. Each ```MPIStateArray``` in the array
-# of ```MPIStateArray``` variables tracked is paired with a label
+# Now we can create a `StateCheck` call-back, _cb_, tied to the `MPIStateArray`
+# variables _Q1_ and _Q2_. Each `MPIStateArray` in the array
+# of `MPIStateArray` variables tracked is paired with a label
 # to identify it. The call-back is also given a frequency (in time step numbers) and
 # precision for printing summary tables.
 cb = ClimateMachine.StateCheck.sccreate(
@@ -93,13 +93,13 @@ nothing # hide
 
 # ### Invoke the call-back
 #
-# The call-back is of type ```ClimateMachine.GenericCallbacks.EveryXSimulationSteps```
-# and in regular use is designed to be passed to a ClimateMachine timestepping 
+# The call-back is of type `ClimateMachine.GenericCallbacks.EveryXSimulationSteps`
+# and in regular use is designed to be passed to a ClimateMachine timestepping
 # solver e.g.
 typeof(cb)
 
 # Here, for demonstration purposes, we can invoke
-# the call-back after simply initializing the ```MPIStateArray``` fields to a random
+# the call-back after simply initializing the `MPIStateArray` fields to a random
 # set of values e.g.
 Q1.data .= rand(MersenneTwister(0), Float32, size(Q1.data))
 Q2.data .= rand(MersenneTwister(0), Float64, size(Q2.data))
@@ -120,10 +120,10 @@ ClimateMachine.StateCheck.scprintref(cb)
 
 # **Step 2.** Next the array setting program code is executed (see below). At this stage the _parr[]_ array
 # context may be hand edited. The parr[] array sets a target number of decimal places for
-# matching against refence values in _varr[]_. For different experiments and different fields
-# the degree of precision that constitutes failig a regression test may vary. Choosing the
+# matching against reference values in _varr[]_. For different experiments and different fields
+# the degree of precision that constitutes failing a regression test may vary. Choosing the
 # _parr[]_ values requires some sense as to the stability of the particular numerical
-# and physical scenario an experiment represents. In the example below some precision 
+# and physical scenario an experiment represents. In the example below some precision
 # settings have been hand edited from the default of 16 to illustrate the process.
 
 #! format: off
@@ -157,20 +157,20 @@ parr = [
 ]
 #! format: on
 
-# **Step 3.** Finally a call-back stored value can be compared for consistency to with _parr[]_ decimal places 
+# **Step 3.** Finally a call-back stored value can be compared for consistency to with _parr[]_ decimal places
 
 ClimateMachine.StateCheck.scdocheck(cb, (varr, parr))
 nothing # hide
 
 # In this trivial case the match is guaranteed. The function will return _true_ to the calling
-# routine and this can be passed to an ```@test``` block.
+# routine and this can be passed to an `@test` block.
 #
-# However we can modify the refernce test values to
+# However we can modify the reference test values to
 # see the effect of a mismatch e.g.
 varr[1][3] = varr[1][3] * 10.0
 ClimateMachine.StateCheck.scdocheck(cb, (varr, parr))
 nothing # hide
 
 # Here the mis-matching field is highlighted with _N(0)_ indicating that the precision
-# was not met and actual match length was (in this case) 0. If any field fails the test returns false 
-# for use in any egression testing control logic.
+# was not met and actual match length was (in this case) 0. If any field fails the test returns false
+# for use in any regression testing control logic.

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -436,7 +436,7 @@ end;
 
 # This is the main `ClimateMachine` solver invocation. While users do not have
 # access to the time-stepping loop, code may be injected via `user_callbacks`,
-# which is a `Tuple` of [`GenericCallbacks`](@ref).
+# which is a `Tuple` of callbacks in [`GenericCallbacks`](@ref ClimateMachine.GenericCallbacks).
 ClimateMachine.invoke!(solver_config; user_callbacks = (callback,));
 
 # # Post-processing

--- a/tutorials/Numerics/DGMethods/nonnegative.jl
+++ b/tutorials/Numerics/DGMethods/nonnegative.jl
@@ -36,11 +36,10 @@ using ClimateMachine.GenericCallbacks:
     EveryXWallTimeSeconds, EveryXSimulationSteps
 using ClimateMachine.VTK: writevtk, writepvtu
 
+using ClimateMachine
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
 include(joinpath(
-    @__DIR__,
-    "..",
-    "..",
-    "..",
+    clima_dir,
     "test",
     "Numerics",
     "DGMethods",
@@ -63,7 +62,7 @@ function initial_condition!(::SwirlingFlow, state, aux, coord, t)
     x0, y0 = FT(1 // 4), FT(1 // 4)
     τ = 4 * hypot(x - x0, y - y0)
     state.ρ = cosbell(τ, 3)
-end
+end;
 
 has_variable_coefficients(::SwirlingFlow) = true
 function update_velocity_diffusion!(
@@ -81,7 +80,7 @@ function update_velocity_diffusion!(
     u = 2 * sx^2 * sy * cy * ct
     v = -2 * sy^2 * sx * cx * ct
     aux.u = SVector(u, v, 0)
-end
+end;
 
 function do_output(mpicomm, vtkdir, vtkstep, dg, Q, model, testname)
     ## name of the file that this MPI rank will write
@@ -111,7 +110,7 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, model, testname)
 
         @info "Done writing VTK: $pvtuprefix"
     end
-end
+end;
 
 function run(
     mpicomm,
@@ -146,7 +145,7 @@ function run(
 
     initialsumQ = weightedsum(Q)
 
-    # We integrate so that the final solution is equal to the initial solution
+    ## We integrate so that the final solution is equal to the initial solution
     Qe = copy(Q)
 
     rhs! = function (dQdt, Q, ::Nothing, t; increment = false)
@@ -160,16 +159,16 @@ function run(
         Filters.apply!(Q, :, grid, TMARFilter())
     end
 
-    # create output directory on first rank of communicator
+    ## create output directory on first rank of communicator
     if MPI.Comm_rank(mpicomm) == 0
         mkpath(vtkdir)
     end
     MPI.Barrier(mpicomm)
 
     vtkstep = 0
-    # output initial step
+    ## output initial step
     do_output(mpicomm, vtkdir, vtkstep, dg, Q, model, "nonnegative")
-    # setup the output callback
+    ## setup the output callback
     cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
         vtkstep += 1
         minQ, maxQ = minimum(Q), maximum(Q)
@@ -202,7 +201,7 @@ function run(
     L2 error   = %.16e
     sum error  = %.16e
     """ minQ maxQ error sumerror
-end
+end;
 
 let
     ArrayType = ClimateMachine.array_type()
@@ -262,4 +261,4 @@ let
         vtkdir,
         outputtime,
     )
-end
+end;

--- a/tutorials/Numerics/SystemSolvers/bgmres.jl
+++ b/tutorials/Numerics/SystemSolvers/bgmres.jl
@@ -175,9 +175,9 @@ gmres = BatchedGeneralizedMinimalResidual(
     atol = eps(Float64) * 10^2,
     rtol = eps(Float64) * 10^2,
 );
-# ```m``` is the number of gridpoints along a column. As mentioned previously,
-# this is `tup[3]*tup[5]*tup[4]`. The ```n``` term corresponds to the batch size
-# or the number of columns in this case. ```atol``` and ```rtol``` are relative and
+# `m` is the number of gridpoints along a column. As mentioned previously,
+# this is `tup[3]*tup[5]*tup[4]`. The `n` term corresponds to the batch size
+# or the number of columns in this case. `atol` and `rtol` are relative and
 # absolute tolerances
 
 # All the hard work is done, now we just call our linear solver
@@ -197,7 +197,7 @@ columnwise_inverse_linear_operator!(x_exact, b);
 norm(x - x_exact) / norm(x_exact)
 columnwise_linear_operator!(x_exact, x);
 norm(x_exact - b) / norm(b)
-# Which we see are small, given our choice of ```atol``` and ```rtol```.
+# Which we see are small, given our choice of `atol` and `rtol`.
 # The struct also keeps a record of its convergence rate
 # in the residual member. The convergence rate of each column
 # can be visualized via

--- a/tutorials/Numerics/SystemSolvers/cg.jl
+++ b/tutorials/Numerics/SystemSolvers/cg.jl
@@ -56,7 +56,7 @@ linearsolver = ConjugateGradient(b);
 x = ones(typeof(1.0), 3);
 # To solve the linear system we just need to pass to the linearsolve! function
 iters = linearsolve!(linear_operator!, linearsolver, x, b)
-# The variable `x` gets overwitten during the linear solve
+# The variable `x` gets overwritten during the linear solve
 # The norm of the error is
 norm(x - x_exact) / norm(x_exact)
 # The relative norm of the residual is
@@ -136,7 +136,7 @@ function closure_linear_operator!(A, tup)
 end;
 
 # Now that we have this function, we can define a linear system that we will solve columnwise
-# First we define the structure of our array as ```tup``` in a manner that is similar to a stacked brick topology
+# First we define the structure of our array as `tup` in a manner that is similar to a stacked brick topology
 tup = (3, 4, 7, 2, 20, 2);
 # where
 # 1. tup[1] is the number of Gauss–Lobatto points in the x-direction
@@ -191,4 +191,4 @@ iters
 # ## Tips
 # 1. The convergence criteria should be changed, machine precision is too small and the maximum iterations is often too large
 # 2. Use a preconditioner if possible
-# 3. Make sure that the linear system really is symmetric and positive-definite 
+# 3. Make sure that the linear system really is symmetric and positive-definite

--- a/tutorials/topo.jl
+++ b/tutorials/topo.jl
@@ -2,15 +2,7 @@ using MPI
 using ClimateMachine
 using Logging
 using ClimateMachine.Mesh.Topologies
-using ClimateMachine.Mesh.Grids
-using ClimateMachine.DGMethods
-using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.MPIStateArrays
-using ClimateMachine.LowStorageRungeKuttaMethod
-using LinearAlgebra
-using ClimateMachine.GenericCallbacks:
-    EveryXWallTimeSeconds, EveryXSimulationSteps
-using ClimateMachine.ODESolvers
 
 MPI.Initialized() || MPI.Init()
 mpicomm = MPI.COMM_WORLD


### PR DESCRIPTION
# Description

Some of the tutorials do not generate valid markdown. This PR attempts to make them generate valid markdown and removes them from the docs and many take too long to run (#1233). The upside is that all of them are still tested in slurm. We can add these tutorials back into the docs once they've been tested to generate valid markdown and finish in a reasonable amount of time.

Supercedes #1181. Another step towards #1189 !

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
