### PR TITLE
Diagnostics group for perturbations from reference state

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -39,6 +39,7 @@ ClimateMachine.Atmos.Rain
 ClimateMachine.Atmos.RemainderModel
 ClimateMachine.Atmos.HydrostaticState
 ClimateMachine.Atmos.InitStateBC
+ClimateMachine.Atmos.ReferenceState
 ClimateMachine.Atmos.NoReferenceState
 ```
 

--- a/docs/src/APIs/Diagnostics/Diagnostics.md
+++ b/docs/src/APIs/Diagnostics/Diagnostics.md
@@ -23,8 +23,9 @@ Diagnostics.Vorticity
 ### Methods
 
 ```@docs
-Diagnostics.setup_dump_state_diagnostics
-Diagnostics.setup_atmos_core_diagnostics
-Diagnostics.setup_dump_aux_diagnostics
 Diagnostics.setup_atmos_default_diagnostics
+Diagnostics.setup_atmos_core_diagnostics
+Diagnostics.setup_atmos_refstate_perturbations
+Diagnostics.setup_dump_state_diagnostics
+Diagnostics.setup_dump_aux_diagnostics
 ```

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -201,7 +201,14 @@ function config_diagnostics(FT, driver_config)
         interpol = interpol,
     )
 
-    return ClimateMachine.DiagnosticsConfiguration([dgngrp])
+    pdgngrp = setup_atmos_refstate_perturbations(
+        AtmosGCMConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+
+    return ClimateMachine.DiagnosticsConfiguration([dgngrp, pdgngrp])
 end
 
 function main()

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -1,7 +1,7 @@
 ### Reference state
 using DocStringExtensions
 using ..TemperatureProfiles
-export NoReferenceState, HydrostaticState
+export ReferenceState, NoReferenceState, HydrostaticState
 
 using CLIMAParameters.Planet: R_d, MSLP, cp_d, grav, T_surf_ref, T_min_ref
 

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -8,6 +8,7 @@ module Diagnostics
 export DiagnosticsGroup,
     setup_atmos_default_diagnostics,
     setup_atmos_core_diagnostics,
+    setup_atmos_refstate_perturbations,
     setup_dump_state_diagnostics,
     setup_dump_aux_diagnostics
 

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -133,6 +133,11 @@ Initialize the GCM default diagnostics group, establishing the output file's
 dimensions and variables.
 """
 function atmos_gcm_default_init(dgngrp::DiagnosticsGroup, currtime)
+    atmos = Settings.dg.balance_law
+    FT = eltype(Settings.Q)
+    mpicomm = Settings.mpicomm
+    mpirank = MPI.Comm_rank(mpicomm)
+
     if !(dgngrp.interpol isa InterpolationCubedSphere)
         @warn """
             Diagnostics ($dgngrp.name): currently requires `InterpolationCubedSphere`!
@@ -140,45 +145,38 @@ function atmos_gcm_default_init(dgngrp::DiagnosticsGroup, currtime)
         return nothing
     end
 
-    FT = eltype(Settings.Q)
-    atmos = Settings.dg.balance_law
+    if mpirank == 0
+        # get dimensions for the interpolated grid
+        dims = dimensions(dgngrp.interpol)
 
-    # get dimensions for the interpolated grid
-    dims = dimensions(dgngrp.interpol)
-
-    # adjust the level dimension for `planet_radius`
-    level_val = dims["level"]
-    dims["level"] =
-        (level_val[1] .- FT(planet_radius(Settings.param_set)), level_val[2])
-
-    # set up the variables we're going to be writing
-    vars = OrderedDict()
-    varnames = map(
-        s -> startswith(s, "moisture.") ? s[10:end] : s,
-        flattenednames(vars_atmos_gcm_default_simple_3d(atmos, FT)),
-    )
-    for varname in varnames
-        var = Variables[varname]
-        vars[varname] = (
-            tuple(collect(keys(dims))...),
-            FT,
-            OrderedDict(
-                "units" => var.units,
-                "long_name" => var.long,
-                "standard_name" => var.standard,
-            ),
+        # adjust the level dimension for `planet_radius`
+        level_val = dims["level"]
+        dims["level"] = (
+            level_val[1] .- FT(planet_radius(Settings.param_set)),
+            level_val[2],
         )
-    end
 
-    # create the output file
-    dprefix = @sprintf(
-        "%s_%s_%s",
-        dgngrp.out_prefix,
-        dgngrp.name,
-        Settings.starttime,
-    )
-    dfilename = joinpath(Settings.output_dir, dprefix)
-    init_data(dgngrp.writer, dfilename, dims, vars)
+        # set up the variables we're going to be writing
+        vars = OrderedDict()
+        varnames = map(
+            s -> startswith(s, "moisture.") ? s[10:end] : s,
+            flattenednames(vars_atmos_gcm_default_simple_3d(atmos, FT)),
+        )
+        for varname in varnames
+            var = Variables[varname]
+            vars[varname] = (tuple(collect(keys(dims))...), FT, var.attrib)
+        end
+
+        # create the output file
+        dprefix = @sprintf(
+            "%s_%s_%s",
+            dgngrp.out_prefix,
+            dgngrp.name,
+            Settings.starttime,
+        )
+        dfilename = joinpath(Settings.output_dir, dprefix)
+        init_data(dgngrp.writer, dfilename, dims, vars)
+    end
 
     return nothing
 end
@@ -198,11 +196,11 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
         return nothing
     end
 
-    mpicomm = Settings.mpicomm
     dg = Settings.dg
-    Q = Settings.Q
-    mpirank = MPI.Comm_rank(mpicomm)
     atmos = dg.balance_law
+    Q = Settings.Q
+    mpicomm = Settings.mpicomm
+    mpirank = MPI.Comm_rank(mpicomm)
     grid = dg.grid
     topology = grid.topology
     N = polynomialorder(grid)
@@ -235,11 +233,11 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
     # Compute thermo variables
     thermo_array = Array{FT}(undef, npoints, num_thermo(atmos, FT), nrealelem)
     @visitQ nhorzelem nvertelem Nqk Nq begin
-        state_conservative = extract_state_conservative(dg, state_data, ijk, e)
-        state_auxiliary = extract_state_auxiliary(dg, aux_data, ijk, e)
+        state = extract_state_conservative(dg, state_data, ijk, e)
+        aux = extract_state_auxiliary(dg, aux_data, ijk, e)
 
         thermo = thermo_vars(atmos, view(thermo_array, ijk, :, e))
-        compute_thermo!(atmos, state_conservative, state_auxiliary, thermo)
+        compute_thermo!(atmos, state, aux, thermo)
     end
 
     # Interpolate the state, thermo and dyn vars to sphere (u and vorticity

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -43,41 +43,35 @@ atmos_les_default_simple_vars(m, array) =
 
 function atmos_les_default_simple_sums!(
     atmos::AtmosModel,
-    state_conservative,
-    state_gradient_flux,
-    state_auxiliary,
+    state,
+    gradflux,
+    aux,
     thermo,
     currtime,
     MH,
     sums,
 )
-    sums.u += MH * state_conservative.ρu[1]
-    sums.v += MH * state_conservative.ρu[2]
-    sums.w += MH * state_conservative.ρu[3]
-    sums.avg_rho += MH * state_conservative.ρ
-    sums.rho += MH * state_conservative.ρ * state_conservative.ρ
-    sums.temp += MH * thermo.temp * state_conservative.ρ
-    sums.pres += MH * thermo.pres * state_conservative.ρ
-    sums.thd += MH * thermo.θ_dry * state_conservative.ρ
-    sums.et += MH * state_conservative.ρe
-    sums.ei += MH * thermo.e_int * state_conservative.ρ
-    sums.ht += MH * thermo.h_tot * state_conservative.ρ
-    sums.hi += MH * thermo.h_int * state_conservative.ρ
+    sums.u += MH * state.ρu[1]
+    sums.v += MH * state.ρu[2]
+    sums.w += MH * state.ρu[3]
+    sums.avg_rho += MH * state.ρ
+    sums.rho += MH * state.ρ * state.ρ
+    sums.temp += MH * thermo.temp * state.ρ
+    sums.pres += MH * thermo.pres * state.ρ
+    sums.thd += MH * thermo.θ_dry * state.ρ
+    sums.et += MH * state.ρe
+    sums.ei += MH * thermo.e_int * state.ρ
+    sums.ht += MH * thermo.h_tot * state.ρ
+    sums.hi += MH * thermo.h_int * state.ρ
 
-    ν, D_t, _ = turbulence_tensors(
-        atmos,
-        state_conservative,
-        state_gradient_flux,
-        state_auxiliary,
-        currtime,
-    )
-    d_h_tot = -D_t .* state_gradient_flux.∇h_tot
-    sums.w_ht_sgs += MH * d_h_tot[end] * state_conservative.ρ
+    ν, D_t, _ = turbulence_tensors(atmos, state, gradflux, aux, currtime)
+    d_h_tot = -D_t .* gradflux.∇h_tot
+    sums.w_ht_sgs += MH * d_h_tot[end] * state.ρ
 
     atmos_les_default_simple_sums!(
         atmos.moisture,
-        state_conservative,
-        state_gradient_flux,
+        state,
+        gradflux,
         thermo,
         MH,
         D_t,
@@ -88,8 +82,8 @@ function atmos_les_default_simple_sums!(
 end
 function atmos_les_default_simple_sums!(
     ::MoistureModel,
-    state_conservative,
-    state_gradient_flux,
+    state,
+    gradflux,
     thermo,
     MH,
     D_t,
@@ -99,20 +93,20 @@ function atmos_les_default_simple_sums!(
 end
 function atmos_les_default_simple_sums!(
     moist::EquilMoist,
-    state_conservative,
-    state_gradient_flux,
+    state,
+    gradflux,
     thermo,
     MH,
     D_t,
     sums,
 )
-    sums.moisture.qt += MH * state_conservative.moisture.ρq_tot
-    sums.moisture.ql += MH * thermo.moisture.q_liq * state_conservative.ρ
-    sums.moisture.qv += MH * thermo.moisture.q_vap * state_conservative.ρ
-    sums.moisture.thv += MH * thermo.moisture.θ_vir * state_conservative.ρ
-    sums.moisture.thl += MH * thermo.moisture.θ_liq_ice * state_conservative.ρ
-    d_q_tot = (-D_t) .* state_gradient_flux.moisture.∇q_tot
-    sums.moisture.w_qt_sgs += MH * d_q_tot[end] * state_conservative.ρ
+    sums.moisture.qt += MH * state.moisture.ρq_tot
+    sums.moisture.ql += MH * thermo.moisture.q_liq * state.ρ
+    sums.moisture.qv += MH * thermo.moisture.q_vap * state.ρ
+    sums.moisture.thv += MH * thermo.moisture.θ_vir * state.ρ
+    sums.moisture.thl += MH * thermo.moisture.θ_liq_ice * state.ρ
+    d_q_tot = (-D_t) .* gradflux.moisture.∇q_tot
+    sums.moisture.w_qt_sgs += MH * d_q_tot[end] * state.ρ
 
     return nothing
 end
@@ -157,43 +151,38 @@ atmos_les_default_ho_vars(m, array) =
 
 function atmos_les_default_ho_sums!(
     atmos::AtmosModel,
-    state_conservative,
+    state,
     thermo,
     MH,
     ha,
     sums,
 )
-    u = state_conservative.ρu[1] / state_conservative.ρ
+    u = state.ρu[1] / state.ρ
     u′ = u - ha.u
-    v = state_conservative.ρu[2] / state_conservative.ρ
+    v = state.ρu[2] / state.ρ
     v′ = v - ha.v
-    w = state_conservative.ρu[3] / state_conservative.ρ
+    w = state.ρu[3] / state.ρ
     w′ = w - ha.w
     e_int′ = thermo.e_int - ha.ei
     θ_dry′ = thermo.θ_dry - ha.thd
 
-    sums.var_u += MH * u′^2 * state_conservative.ρ
-    sums.var_v += MH * v′^2 * state_conservative.ρ
-    sums.var_w += MH * w′^2 * state_conservative.ρ
-    sums.w3 += MH * w′^3 * state_conservative.ρ
+    sums.var_u += MH * u′^2 * state.ρ
+    sums.var_v += MH * v′^2 * state.ρ
+    sums.var_w += MH * w′^2 * state.ρ
+    sums.w3 += MH * w′^3 * state.ρ
     sums.tke +=
-        0.5 * (
-            MH * u′^2 * state_conservative.ρ +
-            MH * v′^2 * state_conservative.ρ +
-            MH * w′^2 * state_conservative.ρ
-        )
-    sums.var_ei += MH * e_int′^2 * state_conservative.ρ
+        0.5 * (MH * u′^2 * state.ρ + MH * v′^2 * state.ρ + MH * w′^2 * state.ρ)
+    sums.var_ei += MH * e_int′^2 * state.ρ
 
-    sums.cov_w_u += MH * w′ * u′ * state_conservative.ρ
-    sums.cov_w_v += MH * w′ * v′ * state_conservative.ρ
-    sums.cov_w_rho +=
-        MH * w′ * (state_conservative.ρ - ha.avg_rho) * state_conservative.ρ
-    sums.cov_w_thd += MH * w′ * θ_dry′ * state_conservative.ρ
-    sums.cov_w_ei += MH * w′ * e_int′ * state_conservative.ρ
+    sums.cov_w_u += MH * w′ * u′ * state.ρ
+    sums.cov_w_v += MH * w′ * v′ * state.ρ
+    sums.cov_w_rho += MH * w′ * (state.ρ - ha.avg_rho) * state.ρ
+    sums.cov_w_thd += MH * w′ * θ_dry′ * state.ρ
+    sums.cov_w_ei += MH * w′ * e_int′ * state.ρ
 
     atmos_les_default_ho_sums!(
         atmos.moisture,
-        state_conservative,
+        state,
         thermo,
         MH,
         ha,
@@ -206,7 +195,7 @@ function atmos_les_default_ho_sums!(
 end
 function atmos_les_default_ho_sums!(
     ::MoistureModel,
-    state_conservative,
+    state,
     thermo,
     MH,
     ha,
@@ -218,7 +207,7 @@ function atmos_les_default_ho_sums!(
 end
 function atmos_les_default_ho_sums!(
     moist::EquilMoist,
-    state_conservative,
+    state,
     thermo,
     MH,
     ha,
@@ -226,23 +215,23 @@ function atmos_les_default_ho_sums!(
     e_int′,
     sums,
 )
-    q_tot = state_conservative.moisture.ρq_tot / state_conservative.ρ
+    q_tot = state.moisture.ρq_tot / state.ρ
     q_tot′ = q_tot - ha.moisture.qt
     q_liq′ = thermo.moisture.q_liq - ha.moisture.ql
     q_vap′ = thermo.moisture.q_vap - ha.moisture.qv
     θ_vir′ = thermo.moisture.θ_vir - ha.moisture.thv
     θ_liq_ice′ = thermo.moisture.θ_liq_ice - ha.moisture.thl
 
-    sums.moisture.var_qt += MH * q_tot′^2 * state_conservative.ρ
-    sums.moisture.var_thl += MH * θ_liq_ice′^2 * state_conservative.ρ
+    sums.moisture.var_qt += MH * q_tot′^2 * state.ρ
+    sums.moisture.var_thl += MH * θ_liq_ice′^2 * state.ρ
 
-    sums.moisture.cov_w_qt += MH * w′ * q_tot′ * state_conservative.ρ
-    sums.moisture.cov_w_ql += MH * w′ * q_liq′ * state_conservative.ρ
-    sums.moisture.cov_w_qv += MH * w′ * q_vap′ * state_conservative.ρ
-    sums.moisture.cov_w_thv += MH * w′ * θ_vir′ * state_conservative.ρ
-    sums.moisture.cov_w_thl += MH * w′ * θ_liq_ice′ * state_conservative.ρ
-    sums.moisture.cov_qt_thl += MH * q_tot′ * θ_liq_ice′ * state_conservative.ρ
-    sums.moisture.cov_qt_ei += MH * q_tot′ * e_int′ * state_conservative.ρ
+    sums.moisture.cov_w_qt += MH * w′ * q_tot′ * state.ρ
+    sums.moisture.cov_w_ql += MH * w′ * q_liq′ * state.ρ
+    sums.moisture.cov_w_qv += MH * w′ * q_vap′ * state.ρ
+    sums.moisture.cov_w_thv += MH * w′ * θ_vir′ * state.ρ
+    sums.moisture.cov_w_thl += MH * w′ * θ_liq_ice′ * state.ρ
+    sums.moisture.cov_qt_thl += MH * q_tot′ * θ_liq_ice′ * state.ρ
+    sums.moisture.cov_qt_ei += MH * q_tot′ * e_int′ * state.ρ
 
     return nothing
 end
@@ -253,41 +242,45 @@ end
 Initialize the 'AtmosLESDefault' diagnostics group.
 """
 function atmos_les_default_init(dgngrp::DiagnosticsGroup, currtime)
-    atmos_collect_onetime(Settings.mpicomm, Settings.dg, Settings.Q)
-
-    FT = eltype(Settings.Q)
     atmos = Settings.dg.balance_law
+    FT = eltype(Settings.Q)
+    mpicomm = Settings.mpicomm
+    mpirank = MPI.Comm_rank(mpicomm)
 
-    dims = OrderedDict("z" => (AtmosCollected.zvals, Dict()))
+    atmos_collect_onetime(mpicomm, Settings.dg, Settings.Q)
 
-    # set up the variables we're going to be writing
-    vars = OrderedDict()
-    varnames = map(
-        s -> startswith(s, "moisture.") ? s[10:end] : s,
-        flattenednames(vars_atmos_les_default_simple(atmos, FT)),
-    )
-    ho_varnames = map(
-        s -> startswith(s, "moisture.") ? s[10:end] : s,
-        flattenednames(vars_atmos_les_default_ho(atmos, FT)),
-    )
-    append!(varnames, ho_varnames)
-    for varname in varnames
-        vars[varname] = (("z",), FT, Dict())
+    if mpirank == 0
+        dims = OrderedDict("z" => (AtmosCollected.zvals, Dict()))
+
+        # set up the variables we're going to be writing
+        vars = OrderedDict()
+        varnames = map(
+            s -> startswith(s, "moisture.") ? s[10:end] : s,
+            flattenednames(vars_atmos_les_default_simple(atmos, FT)),
+        )
+        ho_varnames = map(
+            s -> startswith(s, "moisture.") ? s[10:end] : s,
+            flattenednames(vars_atmos_les_default_ho(atmos, FT)),
+        )
+        append!(varnames, ho_varnames)
+        for varname in varnames
+            vars[varname] = (("z",), FT, Dict())
+        end
+        vars["cld_frac"] = (("z",), FT, Dict())
+        vars["cld_top"] = ((), FT, Dict())
+        vars["cld_base"] = ((), FT, Dict())
+        vars["cld_cover"] = ((), FT, Dict())
+
+        # create the output file
+        dprefix = @sprintf(
+            "%s_%s_%s",
+            dgngrp.out_prefix,
+            dgngrp.name,
+            Settings.starttime,
+        )
+        dfilename = joinpath(Settings.output_dir, dprefix)
+        init_data(dgngrp.writer, dfilename, dims, vars)
     end
-    vars["cld_frac"] = (("z",), FT, Dict())
-    vars["cld_top"] = ((), FT, Dict())
-    vars["cld_base"] = ((), FT, Dict())
-    vars["cld_cover"] = ((), FT, Dict())
-
-    # create the output file
-    dprefix = @sprintf(
-        "%s_%s_%s",
-        dgngrp.out_prefix,
-        dgngrp.name,
-        Settings.starttime,
-    )
-    dfilename = joinpath(Settings.output_dir, dprefix)
-    init_data(dgngrp.writer, dfilename, dims, vars)
 
     return nothing
 end
@@ -316,17 +309,17 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
 
     # get needed arrays onto the CPU
     if array_device(Q) isa CPU
-        host_state_conservative = Q.realdata
-        host_state_auxiliary = dg.state_auxiliary.realdata
-        host_vgeo = grid.vgeo
-        host_state_gradient_flux = dg.state_gradient_flux.realdata
+        state_data = Q.realdata
+        aux_data = dg.state_auxiliary.realdata
+        vgeo = grid.vgeo
+        gradflux_data = dg.state_gradient_flux.realdata
     else
-        host_state_conservative = Array(Q.realdata)
-        host_state_auxiliary = Array(dg.state_auxiliary.realdata)
-        host_vgeo = Array(grid.vgeo)
-        host_state_gradient_flux = Array(dg.state_gradient_flux.realdata)
+        state_data = Array(Q.realdata)
+        aux_data = Array(dg.state_auxiliary.realdata)
+        vgeo = Array(grid.vgeo)
+        gradflux_data = Array(dg.state_gradient_flux.realdata)
     end
-    FT = eltype(host_state_conservative)
+    FT = eltype(state_data)
 
     zvals = AtmosCollected.zvals
     repdvsr = AtmosCollected.repdvsr
@@ -350,23 +343,20 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     @visitQ nhorzelem nvertelem Nqk Nq begin
         evk = Nqk * (ev - 1) + k
 
-        state_conservative =
-            extract_state_conservative(dg, host_state_conservative, ijk, e)
-        state_gradient_flux =
-            extract_state_gradient_flux(dg, host_state_gradient_flux, ijk, e)
-        state_auxiliary =
-            extract_state_auxiliary(dg, host_state_auxiliary, ijk, e)
-        MH = host_vgeo[ijk, grid.MHid, e]
+        state = extract_state_conservative(dg, state_data, ijk, e)
+        gradflux = extract_state_gradient_flux(dg, gradflux_data, ijk, e)
+        aux = extract_state_auxiliary(dg, aux_data, ijk, e)
+        MH = vgeo[ijk, grid.MHid, e]
 
         thermo = thermo_vars(bl, thermo_array[ijk, e])
-        compute_thermo!(bl, state_conservative, state_auxiliary, thermo)
+        compute_thermo!(bl, state, aux, thermo)
 
         simple = atmos_les_default_simple_vars(bl, simple_sums[evk])
         atmos_les_default_simple_sums!(
             bl,
-            state_conservative,
-            state_gradient_flux,
-            state_auxiliary,
+            state,
+            gradflux,
+            aux,
             thermo,
             currtime,
             MH,
@@ -447,21 +437,13 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     @visitQ nhorzelem nvertelem Nqk Nq begin
         evk = Nqk * (ev - 1) + k
 
-        state_conservative =
-            extract_state_conservative(dg, host_state_conservative, ijk, e)
+        state = extract_state_conservative(dg, state_data, ijk, e)
         thermo = thermo_vars(bl, thermo_array[ijk, e])
-        MH = host_vgeo[ijk, grid.MHid, e]
+        MH = vgeo[ijk, grid.MHid, e]
 
         simple_ha = atmos_les_default_simple_vars(bl, simple_avgs[evk])
         ho = atmos_les_default_ho_vars(bl, ho_sums[evk])
-        atmos_les_default_ho_sums!(
-            bl,
-            state_conservative,
-            thermo,
-            MH,
-            simple_ha,
-            ho,
-        )
+        atmos_les_default_ho_sums!(bl, state, thermo, MH, simple_ha, ho)
     end
 
     # reduce across ranks and compute averages

--- a/src/Diagnostics/atmos_refstate_perturbations.jl
+++ b/src/Diagnostics/atmos_refstate_perturbations.jl
@@ -1,0 +1,268 @@
+# AtmosRefStatePerturbations
+#
+# Computes perturbations from the reference state and outputs them
+# on the specified interpolated grid.
+
+using ..Atmos
+using ..Mesh.Topologies
+using ..Mesh.Grids
+using ..Thermodynamics
+
+function vars_atmos_refstate_perturbations(m::AtmosModel, FT)
+    @vars begin
+        ref_state::vars_atmos_refstate_perturbations(m.ref_state, FT)
+    end
+end
+vars_atmos_refstate_perturbations(::ReferenceState, FT) = @vars()
+function vars_atmos_refstate_perturbations(rs::HydrostaticState, FT)
+    @vars begin
+        rho::FT
+        pres::FT
+        temp::FT
+        et::FT
+        qt::FT
+    end
+end
+num_atmos_refstate_perturbation_vars(m, FT) =
+    varsize(vars_atmos_refstate_perturbations(m, FT))
+atmos_refstate_perturbation_vars(m, array) =
+    Vars{vars_atmos_refstate_perturbations(m, eltype(array))}(array)
+
+function atmos_refstate_perturbations!(
+    atmos::AtmosModel,
+    state,
+    aux,
+    thermo,
+    vars,
+)
+    atmos_refstate_perturbations!(
+        atmos.ref_state,
+        atmos,
+        state,
+        aux,
+        thermo,
+        vars,
+    )
+    return nothing
+end
+function atmos_refstate_perturbations!(
+    ::ReferenceState,
+    ::AtmosModel,
+    state,
+    aux,
+    thermo,
+    vars,
+)
+    return nothing
+end
+function atmos_refstate_perturbations!(
+    rs::HydrostaticState,
+    atmos::AtmosModel,
+    state,
+    aux,
+    thermo,
+    vars,
+)
+    vars.ref_state.rho = state.ρ - aux.ref_state.ρ
+    vars.ref_state.pres = thermo.pres - aux.ref_state.p
+    vars.ref_state.temp = thermo.temp - aux.ref_state.T
+    vars.ref_state.et =
+        (state.ρe / state.ρ) - (aux.ref_state.ρe / aux.ref_state.ρ)
+    # FIXME properly
+    if atmos.moisture isa EquilMoist
+        vars.ref_state.qt =
+            (thermo.moisture.ρq_tot / state.ρ) -
+            (aux.ref_state.ρq_tot / aux.ref_state.ρ)
+    else
+        vars.ref_state.qt = NaN
+    end
+
+    return nothing
+end
+
+function atmos_refstate_perturbations_init(dgngrp::DiagnosticsGroup, currtime)
+    FT = eltype(Settings.Q)
+    atmos = Settings.dg.balance_law
+    mpicomm = Settings.mpicomm
+    mpirank = MPI.Comm_rank(mpicomm)
+
+    if mpirank == 0
+        # get dimensions for the interpolated grid
+        dims = dimensions(dgngrp.interpol)
+
+        # adjust the level dimension for `planet_radius` on 'CubedSphere's
+        if dgngrp.interpol isa InterpolationCubedSphere
+            level_val = dims["level"]
+            dims["level"] = (
+                level_val[1] .- FT(planet_radius(Settings.param_set)),
+                level_val[2],
+            )
+        end
+
+        # set up the variables we're going to be writing
+        vars = OrderedDict()
+        varnames = map(
+            s -> startswith(s, "ref_state.") ? s[11:end] : s,
+            flattenednames(vars_atmos_refstate_perturbations(atmos, FT)),
+        )
+        for varname in varnames
+            vars[varname] = (tuple(collect(keys(dims))...), FT, Dict())
+        end
+
+        # create the output file
+        dprefix = @sprintf(
+            "%s_%s_%s_rank%04d",
+            dgngrp.out_prefix,
+            dgngrp.name,
+            Settings.starttime,
+            mpirank,
+        )
+        dfilename = joinpath(Settings.output_dir, dprefix)
+        init_data(dgngrp.writer, dfilename, dims, vars)
+    end
+
+    return nothing
+end
+
+"""
+    atmos_refstate_perturbations_collect(dgngrp, currtime)
+
+Perform a global grid traversal to compute various diagnostics.
+"""
+function atmos_refstate_perturbations_collect(
+    dgngrp::DiagnosticsGroup,
+    currtime,
+)
+    dg = Settings.dg
+    atmos = dg.balance_law
+
+    # FIXME properly
+    if !isa(atmos.ref_state, HydrostaticState)
+        @warn """
+            Diagnostics $(dgngrp.name): has useful output only for `HydrostaticState`
+            """
+    end
+
+    Q = Settings.Q
+    mpicomm = Settings.mpicomm
+    mpirank = MPI.Comm_rank(mpicomm)
+    grid = dg.grid
+    topology = grid.topology
+    N = polynomialorder(grid)
+    Nq = N + 1
+    Nqk = dimensionality(grid) == 2 ? 1 : Nq
+    npoints = Nq * Nq * Nqk
+    nrealelem = length(topology.realelems)
+    nvertelem = topology.stacksize
+    nhorzelem = div(nrealelem, nvertelem)
+
+    # get needed arrays onto the CPU
+    if array_device(Q) isa CPU
+        ArrayType = Array
+        state_data = Q.realdata
+        aux_data = dg.state_auxiliary.realdata
+    else
+        ArrayType = CuArray
+        state_data = Array(Q.realdata)
+        aux_data = Array(dg.state_auxiliary.realdata)
+    end
+    FT = eltype(state_data)
+
+    # Compute thermo variables
+    thermo_array = Array{FT}(undef, npoints, num_thermo(atmos, FT), nrealelem)
+    @visitQ nhorzelem nvertelem Nqk Nq begin
+        state = extract_state_conservative(dg, state_data, ijk, e)
+        aux = extract_state_auxiliary(dg, aux_data, ijk, e)
+
+        thermo = thermo_vars(atmos, view(thermo_array, ijk, :, e))
+        compute_thermo!(atmos, state, aux, thermo)
+    end
+
+    # Interpolate the state and thermo variables.
+    interpol = dgngrp.interpol
+    istate =
+        ArrayType{FT}(undef, interpol.Npl, number_state_conservative(atmos, FT))
+    interpolate_local!(interpol, Q.realdata, istate)
+
+    if interpol isa InterpolationCubedSphere
+        # TODO: get indices here without hard-coding them
+        _ρu, _ρv, _ρw = 2, 3, 4
+        project_cubed_sphere!(interpol, istate, (_ρu, _ρv, _ρw))
+    end
+
+    iaux = ArrayType{FT}(undef, interpol.Npl, number_state_auxiliary(atmos, FT))
+    interpolate_local!(interpol, dg.state_auxiliary.realdata, iaux)
+
+    ithermo = ArrayType{FT}(undef, interpol.Npl, num_thermo(atmos, FT))
+    interpolate_local!(interpol, ArrayType(thermo_array), ithermo)
+
+    # FIXME: accumulating to rank 0 is not scalable
+    all_state_data = accumulate_interpolated_data(mpicomm, interpol, istate)
+    all_aux_data = accumulate_interpolated_data(mpicomm, interpol, iaux)
+    all_thermo_data = accumulate_interpolated_data(mpicomm, interpol, ithermo)
+
+    if mpirank == 0
+        # get dimensions for the interpolated grid
+        dims = dimensions(dgngrp.interpol)
+
+        # set up the array for the diagnostic variables based on the interpolated grid
+        nlong = length(dims["long"][1])
+        nlat = length(dims["lat"][1])
+        nlevel = length(dims["level"][1])
+
+        perturbations_array = Array{FT}(
+            undef,
+            nlong,
+            nlat,
+            nlevel,
+            num_atmos_refstate_perturbation_vars(atmos, FT),
+        )
+
+        @visitI nlong nlat nlevel begin
+            statei = Vars{vars_state_conservative(atmos, FT)}(view(
+                all_state_data,
+                lo,
+                la,
+                le,
+                :,
+            ))
+            auxi = Vars{vars_state_auxiliary(atmos, FT)}(view(
+                all_aux_data,
+                lo,
+                la,
+                le,
+                :,
+            ))
+            thermoi = thermo_vars(atmos, view(all_thermo_data, lo, la, le, :))
+
+            perturbations = atmos_refstate_perturbation_vars(
+                atmos,
+                view(perturbations_array, lo, la, le, :),
+            )
+            atmos_refstate_perturbations!(
+                atmos,
+                statei,
+                auxi,
+                thermoi,
+                perturbations,
+            )
+        end
+
+        varvals = OrderedDict()
+        varnames = map(
+            s -> startswith(s, "ref_state.") ? s[11:end] : s,
+            flattenednames(vars_atmos_refstate_perturbations(atmos, FT)),
+        )
+        for (vari, varname) in enumerate(varnames)
+            varvals[varname] = perturbations_array[:, :, :, vari]
+        end
+
+        # write output
+        append_data(dgngrp.writer, varvals, currtime)
+    end
+
+    MPI.Barrier(mpicomm)
+    return nothing
+end # function collect
+
+function atmos_refstate_perturbations_fini(dgngrp::DiagnosticsGroup, currtime) end

--- a/src/Diagnostics/dump_state.jl
+++ b/src/Diagnostics/dump_state.jl
@@ -1,25 +1,31 @@
 function dump_state_init(dgngrp, currtime)
-    bl = Settings.dg.balance_law
     FT = eltype(Settings.Q)
+    bl = Settings.dg.balance_law
+    mpicomm = Settings.mpicomm
+    mpirank = MPI.Comm_rank(mpicomm)
 
-    # get dimensions for the interpolated grid
-    dims = dimensions(dgngrp.interpol)
+    if mpirank == 0
+        # get dimensions for the interpolated grid
+        dims = dimensions(dgngrp.interpol)
 
-    # set up the variables we're going to be writing
-    vars = OrderedDict()
-    statenames = flattenednames(vars_state_conservative(bl, FT))
-    for varname in statenames
-        vars[varname] = (tuple(collect(keys(dims))...), FT, Dict())
+        # set up the variables we're going to be writing
+        vars = OrderedDict()
+        statenames = flattenednames(vars_state_conservative(bl, FT))
+        for varname in statenames
+            vars[varname] = (tuple(collect(keys(dims))...), FT, Dict())
+        end
+
+        dprefix = @sprintf(
+            "%s_%s-%s",
+            dgngrp.out_prefix,
+            dgngrp.name,
+            Settings.starttime,
+        )
+        dfilename = joinpath(Settings.output_dir, dprefix)
+        init_data(dgngrp.writer, dfilename, dims, vars)
     end
 
-    dprefix = @sprintf(
-        "%s_%s-%s",
-        dgngrp.out_prefix,
-        dgngrp.name,
-        Settings.starttime,
-    )
-    dfilename = joinpath(Settings.output_dir, dprefix)
-    init_data(dgngrp.writer, dfilename, dims, vars)
+    return nothing
 end
 
 function dump_state_collect(dgngrp, currtime)

--- a/src/Diagnostics/groups.jl
+++ b/src/Diagnostics/groups.jl
@@ -124,11 +124,11 @@ include("atmos_les_core.jl")
         interpol = nothing,
     )
 
-Create and return a `DiagnosticsGroup` containing the "AtmosLESCore" diagnostics
-for LES configurations. All the diagnostics in the group will run at the
-specified `interval`, be interpolated to the specified boundaries and
-resolution, and will be written to files prefixed by `out_prefix` using
-`writer`.
+Create and return a `DiagnosticsGroup` containing the "AtmosLESCore"
+diagnostics for LES configurations. All the diagnostics in the group
+will run at the specified `interval`, be interpolated to the specified
+boundaries and resolution, and will be written to files prefixed by
+`out_prefix` using `writer`.
 """
 function setup_atmos_core_diagnostics(
     ::AtmosLESConfigType,
@@ -145,6 +145,45 @@ function setup_atmos_core_diagnostics(
         Diagnostics.atmos_les_core_init,
         Diagnostics.atmos_les_core_fini,
         Diagnostics.atmos_les_core_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
+include("atmos_refstate_perturbations.jl")
+"""
+    setup_atmos_refstate_perturbations(
+        ::ClimateMachineConfigType,
+        interval::String,
+        out_prefix::String;
+        writer = NetCDFWriter(),
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing the
+"AtmosRefStatePerturbations" diagnostics for both LES and GCM
+configurations. All the diagnostics in the group will run at the
+specified `interval`, be interpolated to the specified boundaries
+and resolution, and written to files prefixed by `out_prefix`
+using `writer`.
+"""
+function setup_atmos_refstate_perturbations(
+    ::ClimateMachineConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    # TODO: remove this
+    @assert !isnothing(interpol)
+
+    return DiagnosticsGroup(
+        "AtmosRefStatePerturbations",
+        Diagnostics.atmos_refstate_perturbations_init,
+        Diagnostics.atmos_refstate_perturbations_fini,
+        Diagnostics.atmos_refstate_perturbations_collect,
         interval,
         out_prefix,
         writer,

--- a/src/Diagnostics/variables.jl
+++ b/src/Diagnostics/variables.jl
@@ -9,12 +9,30 @@ http://cfconventions.org/Data/cf-standard-names/71/build/cf-standard-name-table.
 TODO: will expand to include definition (code) as well.
 """
 struct DiagnosticVariable
-    short::String
-    units::String
-    long::String
-    standard::String
+    name::String
+    attrib::OrderedDict
+
+    DiagnosticVariable(name::String, attrib::OrderedDict = OrderedDict()) =
+        new(name, attrib)
 end
 const Variables = OrderedDict{String, DiagnosticVariable}()
+
+function var_attrib(
+    units::String,
+    long_name::String,
+    standard_name::String,
+    fill_value::Union{Nothing, Any} = nothing,
+)
+    attrib = OrderedDict(
+        "units" => units,
+        "long_name" => long_name,
+        "standard_name" => standard_name,
+    )
+    if !isnothing(fill_value)
+        attrib["_FillValue"] = fill_value
+    end
+    return attrib
+end
 
 """
     setup_variables()
@@ -23,62 +41,76 @@ Called at module initialization to define all currently defined diagnostic
 variables.
 """
 function setup_variables()
-    Variables["u"] =
-        DiagnosticVariable("u", "m s**-1", "zonal wind", "eastward_wind")
-    Variables["v"] =
-        DiagnosticVariable("v", "m s**-1", "meridional wind", "northward_wind")
+    Variables["u"] = DiagnosticVariable(
+        "u",
+        var_attrib("m s**-1", "zonal wind", "eastward_wind"),
+    )
+    Variables["v"] = DiagnosticVariable(
+        "v",
+        var_attrib("m s**-1", "meridional wind", "northward_wind"),
+    )
     Variables["w"] = DiagnosticVariable(
         "w",
-        "m s**-1",
-        "vertical wind",
-        "upward_air_velocity",
+        var_attrib("m s**-1", "vertical wind", "upward_air_velocity"),
     )
-    Variables["rho"] =
-        DiagnosticVariable("rho", "kg m**-3", "air density", "air_density")
-    Variables["temp"] =
-        DiagnosticVariable("temp", "K", "air temperature", "air_temperature")
-    Variables["pres"] =
-        DiagnosticVariable("pres", "Pa", "air pressure", "air_pressure")
+    Variables["rho"] = DiagnosticVariable(
+        "rho",
+        var_attrib("kg m**-3", "air density", "air_density"),
+    )
+    Variables["temp"] = DiagnosticVariable(
+        "temp",
+        var_attrib("K", "air temperature", "air_temperature"),
+    )
+    Variables["pres"] = DiagnosticVariable(
+        "pres",
+        var_attrib("Pa", "air pressure", "air_pressure"),
+    )
     Variables["thd"] = DiagnosticVariable(
         "thd",
-        "K",
-        "dry potential temperature",
-        "air_potential_temperature",
+        var_attrib(
+            "K",
+            "dry potential temperature",
+            "air_potential_temperature",
+        ),
     )
     Variables["thv"] = DiagnosticVariable(
         "thv",
-        "K",
-        "virtual potential temperature",
-        "virtual_potential_temperature",
+        var_attrib(
+            "K",
+            "virtual potential temperature",
+            "virtual_potential_temperature",
+        ),
     )
     Variables["et"] = DiagnosticVariable(
         "et",
-        "J kg**-1",
-        "total specific energy",
-        "specific_dry_energy_of_air",
+        var_attrib(
+            "J kg**-1",
+            "total specific energy",
+            "specific_dry_energy_of_air",
+        ),
     )
     Variables["ei"] = DiagnosticVariable(
         "ei",
-        "J kg**-1",
-        "internal specific energy",
-        "internal_energy",
+        var_attrib("J kg**-1", "internal specific energy", "internal_energy"),
     )
     Variables["ht"] = DiagnosticVariable(
         "ht",
-        "J kg**-1",
-        "specific enthalpy based on total energy",
-        "",
+        var_attrib("J kg**-1", "specific enthalpy based on total energy", ""),
     )
     Variables["hi"] = DiagnosticVariable(
         "hi",
-        "J kg**-1",
-        "specific enthalpy based on internal energy",
-        "atmosphere_enthalpy_content",
+        var_attrib(
+            "J kg**-1",
+            "specific enthalpy based on internal energy",
+            "atmosphere_enthalpy_content",
+        ),
     )
     Variables["vort"] = DiagnosticVariable(
         "vort",
-        "s**-1",
-        "vertical component of relative velocity",
-        "atmosphere_relative_velocity",
+        var_attrib(
+            "s**-1",
+            "vertical component of relative velocity",
+            "atmosphere_relative_velocity",
+        ),
     )
 end


### PR DESCRIPTION
# Description

Currently requires that an [`InterpolationConfiguration`](https://github.com/CliMA/ClimateMachine.jl/blob/master/src/Driver/diagnostics_configs.jl#L12-L16) be provided.

Add it to your experiment's diagnostics configuration the usual way (e.g. [BOMEX](https://github.com/CliMA/ClimateMachine.jl/blob/master/experiments/AtmosLES/bomex.jl#L464-L479), but with an `InterpolationConfiguration` specified, as in [Held Suarez](https://github.com/CliMA/ClimateMachine.jl/blob/master/experiments/AtmosGCM/heldsuarez.jl#L185-L201)).

Closes #1225.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
