### PR TITLE
Move orientations to Common/

### DIFF
--- a/docs/list_of_apis.jl
+++ b/docs/list_of_apis.jl
@@ -14,6 +14,7 @@ apis = [
         ["Hydrostatic Boussinesq" => "APIs/Ocean/HydrostaticBoussinesq.md"],
     "Land" => [],
     "Common" => [
+        "Orientations" => "APIs/Common/Orientations.md",
         "Surface Fluxes" => "APIs/Common/SurfaceFluxes.md",
         "Thermodynamics" => "APIs/Common/Thermodynamics.md",
     ],

--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -7,13 +7,11 @@ CurrentModule = ClimateMachine
 ## AtmosModel type
 
 ```@docs
-ClimateMachine.Atmos.NoOrientation
-ClimateMachine.Atmos.FlatOrientation
-ClimateMachine.Atmos.SphericalOrientation
 ClimateMachine.Atmos.AtmosModel
 ```
 
 ## Turbulence / SGS
+
 ```@docs
 ClimateMachine.Atmos.turbulence_tensors
 ClimateMachine.Atmos.principal_invariants
@@ -52,6 +50,7 @@ ClimateMachine.Atmos.StandardHyperDiffusion
 ```
 
 ## BCs
+
 ```@docs
 ClimateMachine.Atmos.AtmosBC
 ClimateMachine.Atmos.DragLaw

--- a/docs/src/APIs/Common/Orientations.md
+++ b/docs/src/APIs/Common/Orientations.md
@@ -1,0 +1,17 @@
+# Orientations
+
+```@meta
+CurrentModule = ClimateMachine.Orientations
+```
+
+```@docs
+Orientations
+```
+
+## Types
+
+```@docs
+NoOrientation
+FlatOrientation
+SphericalOrientation
+```

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -15,6 +15,7 @@ parsed_args = ClimateMachine.cli(custom_settings = s)
 const number_of_tracers = parsed_args["number-of-tracers"]
 
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -53,6 +53,7 @@ using ClimateMachine
 ClimateMachine.cli()
 
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.Diagnostics

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -3,6 +3,7 @@ using ClimateMachine
 ClimateMachine.cli()
 
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.DGMethods.NumericalFluxes

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -3,6 +3,7 @@ using ClimateMachine
 ClimateMachine.cli()
 
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.DGMethods.NumericalFluxes

--- a/experiments/AtmosLES/taylor-green.jl
+++ b/experiments/AtmosLES/taylor-green.jl
@@ -3,6 +3,7 @@ using ClimateMachine
 ClimateMachine.cli()
 
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.DGMethods.NumericalFluxes

--- a/src/ClimateMachine.jl
+++ b/src/ClimateMachine.jl
@@ -23,6 +23,7 @@ include(joinpath("Arrays", "MPIStateArrays.jl"))
 include(joinpath("Numerics", "Mesh", "Mesh.jl"))
 include(joinpath("Numerics", "DGMethods", "Courant.jl"))
 include(joinpath("Numerics", "DGMethods", "DGMethods.jl"))
+include(joinpath("Common", "Orientations", "Orientations.jl"))
 include(joinpath("Utilities", "SingleStackUtils", "SingleStackUtils.jl"))
 include(joinpath("Ocean", "ShallowWater", "ShallowWaterModel.jl"))
 include(joinpath(

--- a/src/Common/Orientations/Orientations.jl
+++ b/src/Common/Orientations/Orientations.jl
@@ -1,50 +1,80 @@
-# TODO: add Coriolis vectors
+"""
+    Orientations
+
+Orientation functions:
+
+ - `vertical_unit_vector`
+ - `altitude`
+ - `latitude`
+ - `longitude`
+ - `gravitational_potential`
+ - `projection_normal`
+ - `projection_tangential`
+
+for orientations:
+
+ - [`NoOrientation`](@ref)
+ - [`FlatOrientation`](@ref)
+ - [`SphericalOrientation`](@ref)
+"""
+module Orientations
+
+using CLIMAParameters: AbstractParameterSet
+const APS = AbstractParameterSet
 using CLIMAParameters.Planet: grav, planet_radius
+using StaticArrays
+using LinearAlgebra
+
+using ..VariableTemplates
+import ..DGMethods: BalanceLaw, vars_state_auxiliary
+
 export Orientation, NoOrientation, FlatOrientation, SphericalOrientation
-export vertical_unit_vector,
+
+export init_aux!,
+    vertical_unit_vector,
     altitude,
     latitude,
     longitude,
-    gravitational_potential,
     projection_normal,
+    gravitational_potential,
+    ∇gravitational_potential,
     projection_tangential
 
-abstract type Orientation end
 
+abstract type Orientation <: BalanceLaw end
 
-function vars_state_auxiliary(m::Orientation, T)
+#####
+##### Fallbacks
+#####
+
+function vars_state_auxiliary(m::Orientation, FT)
     @vars begin
-        Φ::T # gravitational potential
-        ∇Φ::SVector{3, T}
+        Φ::FT # gravitational potential
+        ∇Φ::SVector{3, FT}
     end
 end
 
-altitude(atmos::AtmosModel, aux::Vars) =
-    altitude(atmos.orientation, atmos.param_set, aux)
-latitude(atmos::AtmosModel, aux::Vars) = latitude(atmos.orientation, aux)
-longitude(atmos::AtmosModel, aux::Vars) = longitude(atmos.orientation, aux)
-vertical_unit_vector(atmos::AtmosModel, aux::Vars) =
-    vertical_unit_vector(atmos.orientation, atmos.param_set, aux)
-projection_normal(atmos::AtmosModel, aux::Vars, u⃗::AbstractVector) =
-    projection_normal(atmos.orientation, atmos.param_set, aux, u⃗)
-projection_tangential(atmos::AtmosModel, aux::Vars, u⃗::AbstractVector) =
-    projection_tangential(atmos.orientation, atmos.param_set, aux, u⃗)
-
-
 gravitational_potential(::Orientation, aux::Vars) = aux.orientation.Φ
+
 ∇gravitational_potential(::Orientation, aux::Vars) = aux.orientation.∇Φ
-function altitude(orientation::Orientation, param_set, aux::Vars)
+
+function altitude(orientation::Orientation, param_set::APS, aux::Vars)
     FT = eltype(aux)
     return gravitational_potential(orientation, aux) / FT(grav(param_set))
 end
-function vertical_unit_vector(orientation::Orientation, param_set, aux::Vars)
+
+function vertical_unit_vector(
+    orientation::Orientation,
+    param_set::APS,
+    aux::Vars,
+)
     FT = eltype(aux)
-    ∇gravitational_potential(orientation, aux) / FT(grav(param_set))
+    return ∇gravitational_potential(orientation, aux) / FT(grav(param_set))
 end
 
 function projection_normal(
     orientation::Orientation,
-    param_set,
+    param_set::APS,
     aux::Vars,
     u⃗::AbstractVector,
 )
@@ -54,29 +84,37 @@ end
 
 function projection_tangential(
     orientation::Orientation,
-    param_set,
+    param_set::APS,
     aux::Vars,
     u⃗::AbstractVector,
 )
     return u⃗ .- projection_normal(orientation, param_set, aux, u⃗)
 end
 
+#####
+##### NoOrientation
+#####
 
 """
     NoOrientation
 
-No gravitional force or potential.
+No gravitational force or potential.
 """
 struct NoOrientation <: Orientation end
-function vars_state_auxiliary(m::NoOrientation, T)
-    @vars()
-end
-atmos_init_aux!(::NoOrientation, ::AtmosModel, aux::Vars, geom::LocalGeometry) =
-    nothing
+
+init_aux!(::NoOrientation, param_set::APS, aux::Vars) = nothing
+
+vars_state_auxiliary(m::NoOrientation, FT) = @vars()
+
 gravitational_potential(::NoOrientation, aux::Vars) = -zero(eltype(aux))
 ∇gravitational_potential(::NoOrientation, aux::Vars) =
     SVector{3, eltype(aux)}(0, 0, 0)
-altitude(orientation::NoOrientation, param_set, aux::Vars) = -zero(eltype(aux))
+altitude(orientation::NoOrientation, param_set::APS, aux::Vars) =
+    -zero(eltype(aux))
+
+#####
+##### SphericalOrientation
+#####
 
 """
     SphericalOrientation <: Orientation
@@ -85,26 +123,27 @@ Gravity acts towards the origin `(0,0,0)`, and the gravitational potential is re
 to the surface of the planet.
 """
 struct SphericalOrientation <: Orientation end
-function atmos_init_aux!(
-    ::SphericalOrientation,
-    atmos::AtmosModel,
-    aux::Vars,
-    geom::LocalGeometry,
-)
+
+function init_aux!(::SphericalOrientation, param_set::APS, aux::Vars)
     FT = eltype(aux)
-    param_set = atmos.param_set
     _grav::FT = grav(param_set)
     _planet_radius::FT = planet_radius(param_set)
     normcoord = norm(aux.coord)
     aux.orientation.Φ = _grav * (normcoord - _planet_radius)
     aux.orientation.∇Φ = _grav / normcoord .* aux.coord
 end
+
 # TODO: should we define these for non-spherical orientations?
 latitude(orientation::SphericalOrientation, aux::Vars) =
     @inbounds asin(aux.coord[3] / norm(aux.coord, 2))
+
 longitude(orientation::SphericalOrientation, aux::Vars) =
     @inbounds atan(aux.coord[2], aux.coord[1])
 
+
+#####
+##### FlatOrientation
+#####
 
 """
     FlatOrientation <: Orientation
@@ -115,15 +154,11 @@ Gravity acts in the third coordinate, and the gravitational potential is relativ
 struct FlatOrientation <: Orientation
     # for Coriolis we could add latitude?
 end
-function atmos_init_aux!(
-    ::FlatOrientation,
-    atmos::AtmosModel,
-    aux::Vars,
-    geom::LocalGeometry,
-)
+function init_aux!(::FlatOrientation, param_set::APS, aux::Vars)
     FT = eltype(aux)
-    param_set = atmos.param_set
     _grav::FT = grav(param_set)
-    aux.orientation.Φ = _grav * aux.coord[3]
-    aux.orientation.∇Φ = SVector{3, eltype(aux)}(0, 0, _grav)
+    @inbounds aux.orientation.Φ = _grav * aux.coord[3]
+    aux.orientation.∇Φ = SVector{3, FT}(0, 0, _grav)
+end
+
 end

--- a/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
@@ -28,6 +28,7 @@ using Test
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.Grids

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -6,6 +6,7 @@ using Test
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -10,6 +10,7 @@ using Test
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -7,6 +7,7 @@ import KernelAbstractions: CPU
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.Checkpoint
 using ClimateMachine.ConfigTypes
 using ClimateMachine.TemperatureProfiles

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -4,6 +4,7 @@ using Test
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.Checkpoint
 using ClimateMachine.ConfigTypes
 using ClimateMachine.TemperatureProfiles

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -1,6 +1,7 @@
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.ConfigTypes
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -24,7 +24,6 @@ using ClimateMachine.Thermodynamics:
 using ClimateMachine.TemperatureProfiles: IsothermalProfile
 using ClimateMachine.Atmos:
     AtmosModel,
-    SphericalOrientation,
     DryModel,
     NoPrecipitation,
     NoRadiation,
@@ -34,11 +33,9 @@ using ClimateMachine.Atmos:
     vars_state_auxiliary,
     Gravity,
     HydrostaticState,
-    AtmosAcousticGravityLinearModel,
-    altitude,
-    latitude,
-    longitude,
-    gravitational_potential
+    AtmosAcousticGravityLinearModel
+using ClimateMachine.Orientations:
+    SphericalOrientation, gravitational_potential, altitude, latitude, longitude
 using ClimateMachine.VariableTemplates: flattenednames
 
 using CLIMAParameters

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -17,13 +17,13 @@ using ClimateMachine.Thermodynamics:
     air_density, total_energy, soundspeed_air, PhaseDry_given_pT
 using ClimateMachine.Atmos:
     AtmosModel,
-    NoOrientation,
     NoReferenceState,
     DryModel,
     NoPrecipitation,
     NoRadiation,
     ConstantViscosityWithDivergence,
     vars_state_conservative
+using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: flattenednames
 
 using CLIMAParameters

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -19,7 +19,6 @@ using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
     RemainderModel,
-    NoOrientation,
     NoReferenceState,
     ReferenceState,
     DryModel,
@@ -27,6 +26,7 @@ using ClimateMachine.Atmos:
     NoRadiation,
     ConstantViscosityWithDivergence,
     vars_state_conservative
+using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
 import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -19,7 +19,6 @@ using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
     RemainderModel,
-    NoOrientation,
     NoReferenceState,
     ReferenceState,
     DryModel,
@@ -27,6 +26,7 @@ using ClimateMachine.Atmos:
     NoRadiation,
     ConstantViscosityWithDivergence,
     vars_state_conservative
+using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
 import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -19,7 +19,6 @@ using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
     RemainderModel,
-    NoOrientation,
     NoReferenceState,
     ReferenceState,
     DryModel,
@@ -27,6 +26,7 @@ using ClimateMachine.Atmos:
     NoRadiation,
     ConstantViscosityWithDivergence,
     vars_state_conservative
+using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
 import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -19,7 +19,6 @@ using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
     RemainderModel,
-    NoOrientation,
     NoReferenceState,
     ReferenceState,
     DryModel,
@@ -27,6 +26,7 @@ using ClimateMachine.Atmos:
     NoRadiation,
     ConstantViscosityWithDivergence,
     vars_state_conservative
+using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
 import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary
 

--- a/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
@@ -9,6 +9,7 @@ using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.ODESolvers
 using ClimateMachine.Atmos: SphericalOrientation, latitude, longitude
+using ClimateMachine.Orientations
 using LinearAlgebra
 using Printf
 using Dates

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -12,6 +12,7 @@ using ClimateMachine.MPIStateArrays
 using ClimateMachine.ODESolvers
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.VariableTemplates
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics
@@ -99,7 +100,7 @@ function Initialise_Density_Current!(
     U, V, W = FT(0), FT(0), FT(0)  # momentum components
     # energy definitions
     e_kin = (U^2 + V^2 + W^2) / (2 * ρ) / ρ
-    e_pot = gravitational_potential(bl.orientation, aux)
+    e_pot = gravitational_potential(bl, aux)
     e_int = internal_energy(ts)
     E = ρ * (e_int + e_kin + e_pot)  #* total_energy(e_kin, e_pot, T, q_tot, q_liq, q_ice)
     state.ρ = ρ

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -9,6 +9,7 @@ using ClimateMachine.MPIStateArrays
 using ClimateMachine.ODESolvers
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Thermodynamics
 using LinearAlgebra

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -19,7 +19,6 @@ using ClimateMachine.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
     RemainderModel,
-    FlatOrientation,
     NoReferenceState,
     ReferenceState,
     DryModel,

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -15,6 +15,7 @@ ClimateMachine.init()
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Atmos
 using ClimateMachine.Atmos: vars_state_conservative, vars_state_auxiliary
+using ClimateMachine.Orientations
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.Mesh.Topologies

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -78,6 +78,7 @@ using ClimateMachine
 ClimateMachine.cli()
 
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -83,6 +83,7 @@ using ClimateMachine
 ClimateMachine.cli()
 
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -31,6 +31,7 @@ using Printf
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.Diagnostics

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -19,6 +19,7 @@ using StaticArrays
 # spectral filters, etc.).
 using ClimateMachine
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks
@@ -64,12 +65,7 @@ function held_suarez_forcing!(
     ρe = state.ρe
 
     coord = aux.coord
-    e_int = internal_energy(
-        balance_law.moisture,
-        balance_law.orientation,
-        state,
-        aux,
-    )
+    e_int = internal_energy(balance_law, state, aux)
     T = air_temperature(balance_law.param_set, e_int)
     _R_d = FT(R_d(balance_law.param_set))
     _day = FT(day(balance_law.param_set))
@@ -88,7 +84,7 @@ function held_suarez_forcing!(
     σ_b = FT(7 / 10)
 
     ## Held-Suarez forcing
-    φ = latitude(balance_law.orientation, aux)
+    φ = latitude(balance_law, aux)
     p = air_pressure(balance_law.param_set, T, ρ)
 
     ##TODO: replace _p0 with dynamic surface pressure in Δσ calculations to

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -69,6 +69,7 @@
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks
@@ -148,7 +149,7 @@ function init_risingbubble!(bl, state, aux, (x, y, z), t)
     ρu = SVector(FT(0), FT(0), FT(0))                   # momentum
     ## State (prognostic) variable assignment
     e_kin = FT(0)                                       # kinetic energy
-    e_pot = gravitational_potential(bl.orientation, aux)# potential energy
+    e_pot = gravitational_potential(bl, aux)            # potential energy
     ρe_tot = ρ * total_energy(e_kin, e_pot, ts)         # total energy
 
     ρχ = FT(0)                                          # tracer


### PR DESCRIPTION
# Description

Moves `orientations.jl` into its own module so that it can be shared by Land, Ocean and Atmosphere. A step towards #1216.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
