### PR TITLE
Create module TurbulenceClosures: move from `Atmos`->`Common`

### DIFF
--- a/docs/list_of_apis.jl
+++ b/docs/list_of_apis.jl
@@ -17,6 +17,7 @@ apis = [
         "Orientations" => "APIs/Common/Orientations.md",
         "Surface Fluxes" => "APIs/Common/SurfaceFluxes.md",
         "Thermodynamics" => "APIs/Common/Thermodynamics.md",
+        "TurbulenceClosures" => "APIs/Common/TurbulenceClosures.md",
     ],
     "Balance Laws" => "APIs/BalanceLaws/BalanceLaws.md",
     "Arrays" => "APIs/Arrays/Arrays.md",

--- a/docs/list_of_theory_docs.jl
+++ b/docs/list_of_theory_docs.jl
@@ -3,12 +3,14 @@
 ####
 
 theory_docs = Any[
-    "Common" => Any["SurfaceFluxes" => "Theory/Common/SurfaceFluxes.md",],
+    "Common" => Any[
+        "SurfaceFluxes" => "Theory/Common/SurfaceFluxes.md",
+        "Turbulence Closures" => "Theory/Common/Turbulence.md",
+    ],
     "Atmos" => Any[
         "AtmosModel" => "Theory/Atmos/AtmosModel.md",
         "Microphysics" => "Theory/Atmos/Microphysics.md",
         "EDMF equations" => "Theory/Atmos/EDMFEquations.md",
-        "Turbulence" => "Theory/Atmos/Model/turbulence.md",
         "Tracers" => "Theory/Atmos/Model/tracers.md",
     ],
 ]

--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -10,20 +10,6 @@ CurrentModule = ClimateMachine
 ClimateMachine.Atmos.AtmosModel
 ```
 
-## Turbulence / SGS
-
-```@docs
-ClimateMachine.Atmos.turbulence_tensors
-ClimateMachine.Atmos.principal_invariants
-ClimateMachine.Atmos.symmetrize
-ClimateMachine.Atmos.norm2
-ClimateMachine.Atmos.strain_rate_magnitude
-ClimateMachine.Atmos.ConstantViscosityWithDivergence
-ClimateMachine.Atmos.SmagorinskyLilly
-ClimateMachine.Atmos.Vreman
-ClimateMachine.Atmos.AnisoMinDiss
-```
-
 ## Moisture
 
 ```@docs

--- a/docs/src/APIs/Common/TurbulenceClosures.md
+++ b/docs/src/APIs/Common/TurbulenceClosures.md
@@ -1,0 +1,31 @@
+# TurbulenceClosures
+
+```@meta
+CurrentModule = ClimateMachine.TurbulenceClosures
+```
+
+```@docs
+TurbulenceClosures
+```
+
+## Turbulence Closure Model Constructors
+
+```@docs
+TurbulenceClosureModel
+ConstantViscosityWithDivergence
+SmagorinskyLilly
+Vreman
+AnisoMinDiss
+```
+
+## Supporting Methods
+
+```@docs
+turbulence_tensors
+init_aux_turbulence!
+turbulence_nodal_update_auxiliary_state!
+principal_invariants
+symmetrize
+norm2
+strain_rate_magnitude
+```

--- a/docs/src/Theory/Common/Turbulence.md
+++ b/docs/src/Theory/Common/Turbulence.md
@@ -1,7 +1,8 @@
 ## [Turbulence Closures](@id Turbulence-Closures-docs)
-In `turbulence.jl` we specify turbulence closures. Currently, pointwise
-models of the eddy viscosity/eddy diffusivity type are supported for
-turbulent shear and tracer diffusivity. Methods currently supported are:\
+Module `TurbulenceClosures.jl` currently supports 
+pointwise models of the eddy viscosity/eddy diffusivity type.
+
+Supported constructors include are:\
 [`ConstantViscosityWithDivergence`](@ref constant-viscosity)\
 [`SmagorinskyLilly`](@ref smagorinsky-lilly)\
 [`Vreman`](@ref vreman)\

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -26,6 +26,7 @@ using ClimateMachine.Mesh.Grids
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics:
     air_temperature, internal_energy, air_pressure
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 
 using Distributions: Uniform

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -62,6 +62,7 @@ using ClimateMachine.Mesh.Filters
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.ODESolvers
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 
 using Distributions

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -12,6 +12,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 
 using Distributions

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -11,6 +11,7 @@ using ClimateMachine.Diagnostics
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 
 using Distributions

--- a/experiments/AtmosLES/taylor-green.jl
+++ b/experiments/AtmosLES/taylor-green.jl
@@ -11,6 +11,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 
 using Distributions

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -22,6 +22,9 @@ import ..Orientations:
 using ..VariableTemplates
 using ..Thermodynamics
 using ..TemperatureProfiles
+
+using ..TurbulenceClosures
+
 import ..Thermodynamics: internal_energy
 using ..MPIStateArrays: MPIStateArray
 using ..Mesh.Grids:
@@ -100,7 +103,6 @@ Users may over-ride prescribed default values for each field.
         boundarycondition,
         init_state_conservative
     )
-
 
 # Fields
 $(DocStringExtensions.FIELDS)
@@ -336,7 +338,6 @@ gravitational_potential(bl, aux) = gravitational_potential(bl.orientation, aux)
     ∇gravitational_potential(bl.orientation, aux)
 
 include("ref_state.jl")
-include("turbulence.jl")
 include("hyperdiffusion.jl")
 include("moisture.jl")
 include("precipitation.jl")
@@ -561,8 +562,8 @@ function atmos_nodal_update_auxiliary_state!(
 )
     atmos_nodal_update_auxiliary_state!(m.moisture, m, state, aux, t)
     atmos_nodal_update_auxiliary_state!(m.radiation, m, state, aux, t)
-    atmos_nodal_update_auxiliary_state!(m.turbulence, m, state, aux, t)
     atmos_nodal_update_auxiliary_state!(m.tracers, m, state, aux, t)
+    turbulence_nodal_update_auxiliary_state!(m.turbulence, m, state, aux, t)
 end
 
 function integral_load_auxiliary_state!(
@@ -608,8 +609,8 @@ Store Cartesian coordinate information in `aux.coord`.
 function init_state_auxiliary!(m::AtmosModel, aux::Vars, geom::LocalGeometry)
     aux.coord = geom.coord
     init_aux!(m.orientation, m.param_set, aux)
+    init_aux_turbulence!(m.turbulence, m, aux, geom)
     atmos_init_aux!(m.ref_state, m, aux, geom)
-    atmos_init_aux!(m.turbulence, m, aux, geom)
     atmos_init_aux!(m.hyperdiffusion, m, aux, geom)
     atmos_init_aux!(m.tracers, m, aux, geom)
 end

--- a/src/Atmos/Model/bc_energy.jl
+++ b/src/Atmos/Model/bc_energy.jl
@@ -1,5 +1,7 @@
 abstract type EnergyBC end
 
+using ..TurbulenceClosures
+
 """
     Insulating() :: EnergyBC
 

--- a/src/Atmos/Model/courant.jl
+++ b/src/Atmos/Model/courant.jl
@@ -1,4 +1,5 @@
 using ..Mesh.Grids: Direction, HorizontalDirection, VerticalDirection
+using ..TurbulenceClosures
 
 advective_courant(m::AtmosLinearModel, a...) = advective_courant(m.atmos, a...)
 

--- a/src/ClimateMachine.jl
+++ b/src/ClimateMachine.jl
@@ -36,12 +36,14 @@ include(joinpath("Ocean", "SplitExplicit", "SplitExplicitModel.jl"))
 include(joinpath("Numerics", "SystemSolvers", "SystemSolvers.jl"))
 include(joinpath("Numerics", "ODESolvers", "GenericCallbacks.jl"))
 include(joinpath("Numerics", "ODESolvers", "ODESolvers.jl"))
-include(joinpath("Atmos", "Model", "AtmosModel.jl"))
 include(joinpath("InputOutput", "VTK", "VTK.jl"))
+include(joinpath("Common", "TurbulenceClosures", "TurbulenceClosures.jl"))
+include(joinpath("Atmos", "Model", "AtmosModel.jl"))
 include(joinpath("Diagnostics", "Diagnostics.jl"))
 include(joinpath("Diagnostics", "Debug", "StateCheck.jl"))
 include(joinpath("Utilities", "Checkpoint", "Checkpoint.jl"))
 include(joinpath("Utilities", "Callbacks", "Callbacks.jl"))
 include(joinpath("Driver", "Driver.jl"))
+
 
 end

--- a/src/Common/Orientations/Orientations.jl
+++ b/src/Common/Orientations/Orientations.jl
@@ -103,7 +103,6 @@ No gravitational force or potential.
 struct NoOrientation <: Orientation end
 
 init_aux!(::NoOrientation, param_set::APS, aux::Vars) = nothing
-
 vars_state_auxiliary(m::NoOrientation, FT) = @vars()
 
 gravitational_potential(::NoOrientation, aux::Vars) = -zero(eltype(aux))

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -23,7 +23,8 @@ using Printf
 using Statistics
 
 using ..Atmos
-using ..Atmos: thermo_state, turbulence_tensors
+using ..Atmos: thermo_state
+using ..TurbulenceClosures: turbulence_tensors
 
 include("diagnostic_fields.jl")
 

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -1,8 +1,9 @@
 using ..Atmos
-using ..Atmos: MoistureModel, thermo_state, turbulence_tensors
+using ..Atmos: MoistureModel, thermo_state
 using ..Mesh.Topologies
 using ..Mesh.Grids
 using ..Thermodynamics
+using ..TurbulenceClosures
 using LinearAlgebra
 
 # Simple horizontal averages

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -14,6 +14,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 
 using CLIMAParameters

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -12,6 +12,7 @@ using ClimateMachine.Checkpoint
 using ClimateMachine.ConfigTypes
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Grids
 using ClimateMachine.ODESolvers

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -4,6 +4,7 @@ using Test
 using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.Thermodynamics
 using ClimateMachine.VariableTemplates

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -9,6 +9,7 @@ using ClimateMachine.Checkpoint
 using ClimateMachine.ConfigTypes
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Grids
 using ClimateMachine.ODESolvers

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -8,6 +8,7 @@ using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.ODESolvers
 using ClimateMachine.VariableTemplates

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -28,12 +28,12 @@ using ClimateMachine.Atmos:
     NoPrecipitation,
     NoRadiation,
     NTracers,
-    ConstantViscosityWithDivergence,
     vars_state_conservative,
     vars_state_auxiliary,
     Gravity,
     HydrostaticState,
     AtmosAcousticGravityLinearModel
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations:
     SphericalOrientation, gravitational_potential, altitude, latitude, longitude
 using ClimateMachine.VariableTemplates: flattenednames

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -21,10 +21,10 @@ using ClimateMachine.Atmos:
     DryModel,
     NoPrecipitation,
     NoRadiation,
-    ConstantViscosityWithDivergence,
     vars_state_conservative
 using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: flattenednames
+using ClimateMachine.TurbulenceClosures
 
 using CLIMAParameters
 using CLIMAParameters.Planet: kappa_d

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -24,8 +24,8 @@ using ClimateMachine.Atmos:
     DryModel,
     NoPrecipitation,
     NoRadiation,
-    ConstantViscosityWithDivergence,
     vars_state_conservative
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
 import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -24,8 +24,8 @@ using ClimateMachine.Atmos:
     DryModel,
     NoPrecipitation,
     NoRadiation,
-    ConstantViscosityWithDivergence,
     vars_state_conservative
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
 import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -24,8 +24,8 @@ using ClimateMachine.Atmos:
     DryModel,
     NoPrecipitation,
     NoRadiation,
-    ConstantViscosityWithDivergence,
     vars_state_conservative
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
 import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -24,8 +24,8 @@ using ClimateMachine.Atmos:
     DryModel,
     NoPrecipitation,
     NoRadiation,
-    ConstantViscosityWithDivergence,
     vars_state_conservative
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
 import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -16,6 +16,7 @@ using ClimateMachine.Orientations
 using ClimateMachine.VariableTemplates
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using LinearAlgebra
 using StaticArrays
 using Logging, Printf, Dates

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -12,6 +12,7 @@ using ClimateMachine.Atmos
 using ClimateMachine.Orientations
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using LinearAlgebra
 using StaticArrays
 using Logging, Printf, Dates

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/ref_state.jl
@@ -9,6 +9,7 @@ using ClimateMachine.MPIStateArrays
 using ClimateMachine.ODESolvers
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.VariableTemplates
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -26,9 +26,10 @@ using ClimateMachine.Atmos:
     NoPrecipitation,
     Gravity,
     HydrostaticState,
-    ConstantViscosityWithDivergence,
     vars_state_conservative,
     soundspeed
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.Orientations
 using ClimateMachine.Atmos
 using ClimateMachine.ODESolvers
 

--- a/test/Numerics/DGMethods/horizontal_integral_test.jl
+++ b/test/Numerics/DGMethods/horizontal_integral_test.jl
@@ -15,6 +15,7 @@ using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.ODESolvers
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Thermodynamics
 

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -23,6 +23,7 @@ using ClimateMachine.Mesh.Grids
 using ClimateMachine.Mesh.Geometry
 using ClimateMachine.Mesh.Interpolation
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.ODESolvers
 using ClimateMachine.VariableTemplates

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -88,6 +88,7 @@ using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 using StaticArrays
 using Test

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -93,6 +93,7 @@ using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 using StaticArrays
 using Test

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -86,9 +86,10 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 # - Required so functions for computation of temperature profiles.
 using ClimateMachine.TemperatureProfiles
-# - Required so functions for computation of moist thermodynamic quantities is
-#   enabled.
+# - Required so functions for computation of moist thermodynamic quantities and turbulence closures 
+# are available.
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 # - Required so we may access our variable arrays by a sensible naming
 #   convention rather than by numerical array indices.
 using ClimateMachine.VariableTemplates

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -40,6 +40,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.Thermodynamics:
     TemperatureSHumEquil_given_pressure, internal_energy
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 
 using CLIMAParameters

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -29,6 +29,7 @@ using ClimateMachine.TemperatureProfiles
 using ClimateMachine.SystemSolvers
 using ClimateMachine.ODESolvers
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 
 # [ClimateMachine parameters](https://github.com/CliMA/CLIMAParameters.jl) are

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -76,6 +76,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 
 # In ClimateMachine we use `StaticArrays` for our variable arrays.


### PR DESCRIPTION
# Description

1) Move turbulence functions to `Common` level in module TurbulenceClosures. 
2) Update docs to reflect changes. 

Currently orientation is in `Atmos`: moving this out to `Common` addresses part of #1216. 

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
