### PR TITLE
generate tutorial output in parallel

### DIFF
--- a/.github/workflows/Documenter.yaml
+++ b/.github/workflows/Documenter.yaml
@@ -23,10 +23,17 @@ jobs:
         with:
           version: 1.4
       - name: Install dependencies
+        env:
+          JULIA_PROJECT: "docs/"
         run: |
-          sudo apt install libxt6 libxrender1 libxext6 libgl1-mesa-glx libqt5widgets5
+          sudo apt-get -qq install libxt6 libxrender1 libxext6 libgl1-mesa-glx libqt5widgets5
           julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
+          julia --project=docs/ -e 'using Pkg; Pkg.precompile()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia --project=docs/ docs/make.jl
+          JULIA_PROJECT: "docs/"
+          CLIMATEMACHINE_DOCS_GENERATE_TUTORIALS: "true"
+          ClIMATEMACHINE_SETTINGS_DISABLE_GPU: "true"
+          CLIMATEMACHINE_SETTINGS_DISABLE_CUSTOM_LOGGER: "true"
+        run: julia --procs=auto docs/make.jl

--- a/docs/clean_build_folder.jl
+++ b/docs/clean_build_folder.jl
@@ -1,11 +1,11 @@
 #####
-##### make sure there are no temporary files files (e.g., *.vtu) left around from the build in `generated_dir`
+##### make sure there are no temporary files files (e.g., *.vtu) left around from the build in `GENERATED_DIR`
 #####
 
 file_extensions_to_remove = [".vtu", ".pvtu", ".csv", ".vtk", ".dat", ".nc"]
 generated_files = [
     joinpath(root, f)
-    for (root, dirs, files) in Base.Filesystem.walkdir(generated_dir)
+    for (root, dirs, files) in Base.Filesystem.walkdir(GENERATED_DIR)
     for f in files
 ]
 println("Generated files: $(generated_files)")

--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -1,10 +1,12 @@
 ####
-#### Defines list of tutorials given `generated_dir`
+#### Defines list of tutorials given `GENERATED_DIR`
 ####
 
-generate_tutorials = true
+generate_tutorials =
+    parse(Bool, get(ENV, "CLIMATEMACHINE_DOCS_GENERATE_TUTORIALS", "true"))
 
 tutorials = []
+
 
 # Allow flag to skip generated
 # tutorials since this is by
@@ -13,11 +15,8 @@ tutorials = []
 if generate_tutorials
 
     # generate tutorials
-    import Literate
 
     include("pages_helper.jl")
-
-    tutorials_dir = joinpath(@__DIR__, "..", "tutorials")
 
     tutorials = [
         "Atmos" => [
@@ -45,18 +44,11 @@ if generate_tutorials
 
     # Prepend tutorials_dir
     tutorials_jl = flatten_to_array_of_strings(get_second(tutorials))
-    println("Building literate tutorials:")
-    for tutorial in tutorials_jl
-        println("    $(tutorial)")
-    end
-    transform(x) = joinpath(basename(generated_dir), replace(x, ".jl" => ".md"))
-    tutorials = transform_second(x -> transform(x), tutorials)
+    println("Building literate tutorials...")
 
-    tutorials_jl = map(x -> joinpath(tutorials_dir, x), tutorials_jl)
-
-    for tutorial in tutorials_jl
+    @everywhere function generate_tutorial(tutorials_dir, tutorial)
         gen_dir =
-            joinpath(generated_dir, relpath(dirname(tutorial), tutorials_dir))
+            joinpath(GENERATED_DIR, relpath(dirname(tutorial), tutorials_dir))
         input = abspath(tutorial)
         script = Literate.script(input, gen_dir)
         code = strip(read(script, String))
@@ -65,4 +57,11 @@ if generate_tutorials
         Literate.notebook(input, gen_dir, execute = true)
     end
 
+    tutorials_dir = joinpath(@__DIR__, "..", "tutorials")
+    tutorials_jl = map(x -> joinpath(tutorials_dir, x), tutorials_jl)
+    pmap(t -> generate_tutorial(tutorials_dir, t), tutorials_jl)
+
+    # update list of rendered markdown tutorial output for mkdocs
+    ext_jl2md(x) = joinpath(basename(GENERATED_DIR), replace(x, ".jl" => ".md"))
+    tutorials = transform_second(x -> ext_jl2md(x), tutorials)
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,18 +1,25 @@
 Base.HOME_PROJECT[] = abspath(Base.HOME_PROJECT[]) # JuliaLang/julia/pull/28625
 
-using ClimateMachine, Documenter, Literate
-
 # https://github.com/jheinen/GR.jl/issues/278#issuecomment-587090846
 ENV["GKSwstype"] = "100"
+# some of the tutorials cannot be run on the GPU
+ENV["CLIMATEMACHINE_SETTINGS_DISABLE_GPU"] = true
 # avoid problems with Documenter/Literate when using `global_logger()`
 ENV["CLIMATEMACHINE_SETTINGS_DISABLE_CUSTOM_LOGGER"] = true
 
-generated_dir = joinpath(@__DIR__, "src", "generated") # generated files directory
-rm(generated_dir, force = true, recursive = true)
-mkpath(generated_dir)
+using Distributed
+
+@everywhere using ClimateMachine
+@everywhere using Documenter, Literate
+
+@everywhere GENERATED_DIR = joinpath(@__DIR__, "src", "generated") # generated files directory
+rm(GENERATED_DIR, force = true, recursive = true)
+mkpath(GENERATED_DIR)
 
 include("list_of_getting_started_docs.jl")      # defines `getting_started_docs`
+
 include("list_of_tutorials.jl")                 # defines `tutorials`
+
 include("list_of_how_to_guides.jl")             # defines `how_to_guides`
 include("list_of_apis.jl")                      # defines `apis`
 include("list_of_theory_docs.jl")               # defines `theory_docs`


### PR DESCRIPTION
# Description

Generating the tutorial output when building the documentation can take a long time, so enable parallel generation of literate output.   This should not impact normal single core builds (ex. `julia --project=docs/ docs/make.jl`).

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
