### PR TITLE
add separate precompile step for unit build matrix

### DIFF
--- a/.github/workflows/Linux-UnitTests.yml
+++ b/.github/workflows/Linux-UnitTests.yml
@@ -33,7 +33,8 @@ jobs:
 
     - name: Install Project Packages
       run: |
-        julia --project=@. -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
+        julia --project=@. -e 'using Pkg; Pkg.instantiate()'
+        julia --project=@. -e 'using Pkg; Pkg.precompile()'
 
     - name: Run Unit Tests
       env:

--- a/.github/workflows/OS-UnitTests.yml
+++ b/.github/workflows/OS-UnitTests.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install Project Packages
       run: |
-        julia --project=@. -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
+        julia --project=@. -e 'using Pkg; Pkg.instantiate()'
 
     - name: Build System Image
       run: |


### PR DESCRIPTION
# Description

@kpamnany pointed out that there are some sporadic `EEXIST` errors in some `runmpi` tests when decomposed as part of the build matrix.  Add explicit `Pkg.precompile` step to build stage to see if this fixes the possible race issue.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
