### PR TITLE
init with fix_rng_seed for all tests

### DIFF
--- a/test/Arrays/basics.jl
+++ b/test/Arrays/basics.jl
@@ -3,7 +3,7 @@ using Test, MPI
 using ClimateMachine
 using ClimateMachine.MPIStateArrays
 
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 const ArrayType = ClimateMachine.array_type()
 const mpicomm = MPI.COMM_WORLD
 

--- a/test/Arrays/broadcasting.jl
+++ b/test/Arrays/broadcasting.jl
@@ -3,7 +3,7 @@ using Test, MPI
 using ClimateMachine
 using ClimateMachine.MPIStateArrays
 
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 const ArrayType = ClimateMachine.array_type()
 const mpicomm = MPI.COMM_WORLD
 

--- a/test/Arrays/mpi_comm.jl
+++ b/test/Arrays/mpi_comm.jl
@@ -6,7 +6,7 @@ using ClimateMachine.Mesh.BrickMesh
 using Pkg
 using KernelAbstractions
 
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 const ArrayType = ClimateMachine.array_type()
 const comm = MPI.COMM_WORLD
 

--- a/test/Arrays/reductions.jl
+++ b/test/Arrays/reductions.jl
@@ -4,7 +4,7 @@ using LinearAlgebra
 using ClimateMachine
 using ClimateMachine.MPIStateArrays
 
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 const ArrayType = ClimateMachine.array_type()
 const mpicomm = MPI.COMM_WORLD
 

--- a/test/Diagnostics/Debug/test_statecheck.jl
+++ b/test/Diagnostics/Debug/test_statecheck.jl
@@ -13,7 +13,7 @@ using ClimateMachine.StateCheck
 
 @testset "$(@__FILE__)" begin
 
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     FT = Float64
 
     # Define some dummy vector and tensor abstract variables with associated types

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -5,7 +5,7 @@ using Test
 import KernelAbstractions: CPU
 
 using ClimateMachine
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 using ClimateMachine.Atmos
 using ClimateMachine.Checkpoint
 using ClimateMachine.ConfigTypes

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -2,7 +2,7 @@ using StaticArrays
 using Test
 
 using ClimateMachine
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 using ClimateMachine.Atmos
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.Thermodynamics

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -2,7 +2,7 @@ using StaticArrays
 using Test
 
 using ClimateMachine
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 using ClimateMachine.Atmos
 using ClimateMachine.Checkpoint
 using ClimateMachine.ConfigTypes

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -1,5 +1,5 @@
 using ClimateMachine
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 using ClimateMachine.Atmos
 using ClimateMachine.ConfigTypes
 using ClimateMachine.DGMethods

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -53,7 +53,7 @@ const output_vtk = false
 const ntracers = 1
 
 function main()
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -43,7 +43,7 @@ end
 const output_vtk = false
 
 function main()
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -47,7 +47,7 @@ end
 const output_vtk = false
 
 function main()
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -47,7 +47,7 @@ end
 const output_vtk = false
 
 function main()
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -47,7 +47,7 @@ end
 const output_vtk = false
 
 function main()
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -47,7 +47,7 @@ end
 const output_vtk = false
 
 function main()
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
@@ -261,7 +261,7 @@ function run(
 end
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
@@ -318,7 +318,7 @@ end
 
 using Test
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
@@ -141,7 +141,7 @@ function run(
 end
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
     mpicomm = MPI.COMM_WORLD
     FT = Float64

--- a/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
@@ -205,7 +205,7 @@ end
 
 using Test
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
     mpicomm = MPI.COMM_WORLD
 

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
@@ -219,7 +219,7 @@ end
 
 using Test
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
@@ -254,7 +254,7 @@ function run(
 end
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
@@ -264,7 +264,7 @@ function run(
 end
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_heat_eqn.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_heat_eqn.jl
@@ -183,7 +183,7 @@ end
 
 using Test
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -219,7 +219,7 @@ end
 # --------------- Test block / Loggers ------------------ #
 using Test
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
     mpicomm = MPI.COMM_WORLD
 

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -239,7 +239,7 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
 end
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
@@ -95,7 +95,7 @@ end
 
 using Test
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/ref_state.jl
@@ -116,7 +116,7 @@ end
 
 using Test
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -204,7 +204,7 @@ end
 
 using Test
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
     mpicomm = MPI.COMM_WORLD
 

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -78,7 +78,7 @@ end
 
 let
     # boiler plate MPI stuff
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
     mpicomm = MPI.COMM_WORLD
 

--- a/test/Numerics/DGMethods/horizontal_integral_test.jl
+++ b/test/Numerics/DGMethods/horizontal_integral_test.jl
@@ -304,7 +304,7 @@ function run_test5(mpicomm, dim, Ne, N, FT, ArrayType)
 end
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/integral_test.jl
+++ b/test/Numerics/DGMethods/integral_test.jl
@@ -181,7 +181,7 @@ function run(mpicomm, dim, Ne, N, FT, ArrayType)
 end
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/integral_test_sphere.jl
+++ b/test/Numerics/DGMethods/integral_test_sphere.jl
@@ -154,7 +154,7 @@ function run(mpicomm, topl, ArrayType, N, FT, Rinner, Router)
 end
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/DGMethods/vars_test.jl
+++ b/test/Numerics/DGMethods/vars_test.jl
@@ -98,7 +98,7 @@ function run(mpicomm, dim, Ne, N, FT, ArrayType)
 end
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -9,7 +9,7 @@ import GaussQuadrature
 using MPI
 using LinearAlgebra
 
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 
 @testset "Exponential and Cutoff filter matrix" begin
     let

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -11,7 +11,7 @@ import GaussQuadrature
 using KernelAbstractions: CPU, CUDA
 
 using ClimateMachine
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Atmos
 using ClimateMachine.Atmos: vars_state_conservative, vars_state_auxiliary

--- a/test/Numerics/Mesh/min_node_distance.jl
+++ b/test/Numerics/Mesh/min_node_distance.jl
@@ -10,7 +10,7 @@ using LinearAlgebra
 
 let
     # boiler plate MPI stuff
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/ODESolvers/ode_tests_basic.jl
+++ b/test/Numerics/ODESolvers/ode_tests_basic.jl
@@ -4,7 +4,7 @@ using LinearAlgebra
 
 include("ode_tests_common.jl")
 
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 const ArrayType = ClimateMachine.array_type()
 
 a = 100

--- a/test/Numerics/ODESolvers/ode_tests_convergence.jl
+++ b/test/Numerics/ODESolvers/ode_tests_convergence.jl
@@ -7,7 +7,7 @@ using ClimateMachine.MPIStateArrays: array_device
 
 include("ode_tests_common.jl")
 
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 const ArrayType = ClimateMachine.array_type()
 
 @testset "ODE Solvers" begin

--- a/test/Numerics/SystemSolvers/bandedsystem.jl
+++ b/test/Numerics/SystemSolvers/bandedsystem.jl
@@ -65,7 +65,7 @@ end
 
 let
     # boiler plate MPI stuff
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Numerics/SystemSolvers/bgmres.jl
+++ b/test/Numerics/SystemSolvers/bgmres.jl
@@ -19,7 +19,7 @@ let
         arrays = [Array]
     end
     # Initialize
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     T = Float64
     mpicomm = MPI.COMM_WORLD
     # set the error threshold

--- a/test/Numerics/SystemSolvers/cg.jl
+++ b/test/Numerics/SystemSolvers/cg.jl
@@ -12,7 +12,7 @@ using Random
 Random.seed!(1235)
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     mpicomm = MPI.COMM_WORLD
     ArrayType = ClimateMachine.array_type()
     n = 100

--- a/test/Numerics/SystemSolvers/columnwiselu.jl
+++ b/test/Numerics/SystemSolvers/columnwiselu.jl
@@ -14,7 +14,7 @@ using ClimateMachine.SystemSolvers:
 
 import ClimateMachine.MPIStateArrays: array_device
 
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 const ArrayType = ClimateMachine.array_type()
 
 function band_to_full(B, p, q)

--- a/test/Numerics/SystemSolvers/poisson.jl
+++ b/test/Numerics/SystemSolvers/poisson.jl
@@ -213,7 +213,7 @@ function run(
 end
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD

--- a/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
@@ -1,6 +1,6 @@
 using Test
 using ClimateMachine
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters

--- a/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
@@ -1,6 +1,6 @@
 using Test
 using ClimateMachine
-ClimateMachine.init()
+ClimateMachine.init(fix_rng_seed=true)
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters

--- a/test/Ocean/ShallowWater/GyreDriver.jl
+++ b/test/Ocean/ShallowWater/GyreDriver.jl
@@ -168,7 +168,7 @@ end
 ################
 
 let
-    ClimateMachine.init()
+    ClimateMachine.init(fix_rng_seed=true)
     ArrayType = ClimateMachine.array_type()
     mpicomm = MPI.COMM_WORLD
 


### PR DESCRIPTION
# Description

For the tests, fixing the rng seed was done though a CLI argument, this forces the behavior for all test cases upon initialization.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
