### PR TITLE
Update atmos reference state

### DIFF
--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -8,7 +8,7 @@ using CLIMAParameters.Planet: R_d, MSLP, cp_d, grav, T_surf_ref, T_min_ref
 """
     ReferenceState
 
-Reference state, for example, used as initial
+Hydrostatic reference state, for example, used as initial
 condition or for linearization.
 """
 abstract type ReferenceState end
@@ -34,7 +34,11 @@ struct NoReferenceState <: ReferenceState end
 """
     HydrostaticState{P,T} <: ReferenceState
 
-A hydrostatic state specified by a virtual temperature profile and relative humidity.
+A hydrostatic state specified by a virtual
+temperature profile and relative humidity.
+
+By default, this is a dry hydrostatic reference
+state.
 """
 struct HydrostaticState{P, FT} <: ReferenceState
     virtual_temperature_profile::P
@@ -64,36 +68,30 @@ function atmos_init_aux!(
     FT = eltype(aux)
     _R_d::FT = R_d(atmos.param_set)
 
+    # Replace density by computation from pressure
+    # ρ = -1/g*dpdz
     ρ = p / (_R_d * T_virt)
     aux.ref_state.ρ = ρ
     aux.ref_state.p = p
-    # We evaluate the saturation vapor pressure, approximating
-    # temperature by virtual temperature
-    # ts = TemperatureSHumEquil(atmos.param_set, T_virt, ρ, FT(0))
-    ts = PhaseDry_given_ρT(atmos.param_set, ρ, T_virt)
-    q_vap_sat = q_vap_saturation(ts)
+    RH = m.relative_humidity
+    phase_type = PhaseEquil
+    (T, q_pt) = temperature_and_humidity_from_virtual_temperature(
+        atmos.param_set,
+        T_virt,
+        ρ,
+        RH,
+        phase_type,
+    )
 
-    ρq_tot = ρ * relative_humidity(m) * q_vap_sat
-    aux.ref_state.ρq_tot = ρq_tot
+    # Update temperature to be exactly consistent with
+    # p, ρ, and q_pt
+    T = air_temperature_from_ideal_gas_law(atmos.param_set, p, ρ, q_pt)
+    q_tot = q_pt.tot
+    ts = TemperatureSHumEquil(atmos.param_set, T, ρ, q_tot)
 
-    q_pt = PhasePartition(ρq_tot)
-    R_m = gas_constant_air(atmos.param_set, q_pt)
-    T = T_virt * R_m / _R_d
+    aux.ref_state.ρq_tot = ρ * q_tot
     aux.ref_state.T = T
-    aux.ref_state.ρe = ρ * internal_energy(atmos.param_set, T, q_pt)
-
     e_kin = F(0)
     e_pot = gravitational_potential(atmos.orientation, aux)
-    aux.ref_state.ρe = ρ * total_energy(atmos.param_set, e_kin, e_pot, T, q_pt)
+    aux.ref_state.ρe = ρ * total_energy(e_kin, e_pot, ts)
 end
-
-"""
-    relative_humidity(hs::HydrostaticState{P,FT})
-
-Here, we enforce that relative humidity is zero
-for a dry adiabatic profile.
-"""
-relative_humidity(hs::HydrostaticState{P, FT}) where {P, FT} =
-    hs.relative_humidity
-relative_humidity(hs::HydrostaticState{DryAdiabaticProfile, FT}) where {FT} =
-    FT(0)

--- a/test/Atmos/Model/ref_state.jl
+++ b/test/Atmos/Model/ref_state.jl
@@ -1,0 +1,82 @@
+using CLIMAParameters
+using CLIMAParameters.Planet: R_d, grav, MSLP
+using StaticArrays
+
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using ClimateMachine
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.Mesh.Geometry
+using ClimateMachine.Thermodynamics
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.Atmos: AtmosModel, DryModel, HydrostaticState
+using ClimateMachine.Atmos: atmos_init_aux!
+using ClimateMachine.Orientations: init_aux!
+using ClimateMachine.ConfigTypes
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods: vars_state_auxiliary, number_state_auxiliary
+using ClimateMachine.DGMethods: BalanceLaw, LocalGeometry
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.VariableTemplates
+
+using Test
+
+# We should provide an interface to call all physics
+# kernels in some way similar to this:
+function compute_ref_state(z::FT, atmos) where {FT}
+
+    vgeo = SArray{Tuple{3, 16, 3}, FT}(zeros(3, 16, 3)) # dummy, not used
+    local_geom = LocalGeometry(Val(5), vgeo, 1, 1) # dummy, not used
+    st = vars_state_auxiliary(atmos, FT)
+    nst = number_state_auxiliary(atmos, FT)
+    arr = MArray{Tuple{nst}, FT}(undef)
+    fill!(arr, 0)
+    aux = Vars{st}(arr)
+
+    # Hack: need coord in sync with incoming z, so that
+    # altitude returns correct value.
+    aux.coord = @SArray FT[0, 0, z]
+
+    # Need orientation defined, so that z
+    init_aux!(atmos.orientation, atmos.param_set, aux)
+    atmos_init_aux!(atmos.ref_state, atmos, aux, local_geom)
+    return aux
+end
+
+@testset "Hydrostatic reference states" begin
+
+    FT = Float64
+    RH = FT(0.5)
+    profile = DecayingTemperatureProfile{FT}(param_set)
+    m = AtmosModel{FT}(
+        AtmosLESConfigType,
+        param_set;
+        moisture = DryModel(),
+        ref_state = HydrostaticState(profile, RH),
+        init_state_conservative = x -> x,
+    )
+
+    z = collect(range(FT(0), stop = FT(25e3), length = 100))
+    phase_type = PhaseEquil
+
+    aux_arr = compute_ref_state.(z, Ref(m))
+    T = map(x -> x.ref_state.T, aux_arr)
+    p = map(x -> x.ref_state.p, aux_arr)
+    ρ = map(x -> x.ref_state.ρ, aux_arr)
+    q_tot = map(x -> x.ref_state.ρq_tot, aux_arr) ./ ρ
+    q_pt = PhasePartition.(q_tot)
+
+    # TODO: test that ρ and p are in discrete hydrostatic balance
+
+    # Test state for thermodynamic consistency (with ideal gas law)
+    @test all(
+        T .≈ air_temperature_from_ideal_gas_law.(Ref(param_set), p, ρ, q_pt),
+    )
+
+    # Test that relative humidity in reference state is approximately
+    # input relative humidity
+    RH_ref = relative_humidity.(Ref(param_set), T, p, Ref(phase_type), q_pt)
+    @test all(isapprox.(RH, RH_ref, atol = 0.05))
+
+end

--- a/test/Atmos/Model/runtests.jl
+++ b/test/Atmos/Model/runtests.jl
@@ -1,0 +1,5 @@
+using Test
+
+@testset "Atmos Model" begin
+    include("ref_state.jl")
+end

--- a/test/Atmos/runtests.jl
+++ b/test/Atmos/runtests.jl
@@ -2,7 +2,7 @@ using Test, Pkg
 
 @testset "Atmos" begin
     all_tests = isempty(ARGS) || "all" in ARGS ? true : false
-    for submodule in ["Parameterizations", "TemperatureProfiles"]
+    for submodule in ["Parameterizations", "TemperatureProfiles", "Model"]
         if all_tests ||
            "$submodule" in ARGS ||
            "Atmos/$submodule" in ARGS ||


### PR DESCRIPTION
# Description

This PR
 - Was split off from #1050
 - Updates the atmospheric reference state using newly added functions from #1050
 - Adds unit tests for the reference state
    - Tests state for thermodynamic consistency (with ideal gas law)
    - Tests that relative humidity in reference state is approximately equal to the input relative humidity

Closes #882

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
