### PR TITLE
Fix turbulence_tensors call, add single stack to Atmos init

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -24,6 +24,7 @@ using ..Thermodynamics
 using ..TemperatureProfiles
 
 using ..TurbulenceClosures
+import ..TurbulenceClosures: turbulence_tensors
 
 import ..Thermodynamics: internal_energy
 using ..MPIStateArrays: MPIStateArray
@@ -144,7 +145,7 @@ Constructor for `AtmosModel` (where `AtmosModel <: BalanceLaw`)
 
 """
 function AtmosModel{FT}(
-    ::Type{AtmosLESConfigType},
+    ::Union{Type{AtmosLESConfigType}, Type{SingleStackConfigType}},
     param_set::AbstractParameterSet;
     orientation::O = FlatOrientation(),
     ref_state::RS = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),),
@@ -336,6 +337,10 @@ vertical_unit_vector(bl, aux) =
 gravitational_potential(bl, aux) = gravitational_potential(bl.orientation, aux)
 ∇gravitational_potential(bl, aux) =
     ∇gravitational_potential(bl.orientation, aux)
+
+turbulence_tensors(atmos::AtmosModel, args...) =
+    turbulence_tensors(atmos.turbulence, atmos, args...)
+
 
 include("ref_state.jl")
 include("hyperdiffusion.jl")

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -2,7 +2,7 @@
     TurbulenceClosures
 
 Functions for turbulence, sub-grid scale modelling. These include
-viscosity terms, diffusivity and stress tensors. 
+viscosity terms, diffusivity and stress tensors.
 
 - [`ConstantViscosityWithDivergence`](@ref)
 - [`SmagorinskyLilly`](@ref)
@@ -90,8 +90,8 @@ export TurbulenceClosureModel,
 
 
 """
-    Abstract type with default do-nothing behaviour for 
-arbitrary turbulence closure models. 
+    Abstract type with default do-nothing behaviour for
+arbitrary turbulence closure models.
 """
 abstract type TurbulenceClosureModel end
 
@@ -155,9 +155,6 @@ function compute_gradient_flux!(
 
 function turbulence_tensors end
 
-turbulence_tensors(atmos::BalanceLaw, args...) =
-    turbulence_tensors(atmos.turbulence, atmos, args...)
-
 """
     ν, D_t, τ = turbulence_tensors(
                     ::TurbulenceClosureModel,
@@ -182,8 +179,8 @@ for the returned quantities.
 - `aux` = Array of auxiliary variables
 - `t` = time
 """
-turbulence_tensors(m::TurbulenceClosureModel, atmos::BalanceLaw, args...) =
-    turbulence_tensors(m, atmos.orientation, atmos.param_set, args...)
+turbulence_tensors(m::TurbulenceClosureModel, bl::BalanceLaw, args...) =
+    turbulence_tensors(m, bl.orientation, bl.param_set, args...)
 
 # We also provide generic math functions for use within the turbulence closures,
 # commonly used quantities such as the [principal tensor invariants](@ref tensor-invariants), handling of


### PR DESCRIPTION
# Description

 - Moves `turbulence_tensors` wrapper to `AtmosModel`
 - Add `SingleStackConfigType` to `AtmosModel` initialization

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
