### PR TITLE
Add exceptions to thermo for failed convergence

### DIFF
--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -1105,9 +1105,25 @@ function saturation_adjustment(
             maxiter,
         )
         if !sol.converged
+            @print("-----------------------------------------\n")
             @print("maxiter reached in saturation_adjustment:\n")
+            @print(
+                "    e_int=",
+                e_int,
+                ", ρ=",
+                ρ,
+                ", q_tot=",
+                q_tot,
+                ", T = ",
+                sol.root,
+                ", maxiter=",
+                maxiter,
+                ", tol=",
+                tol.tol,
+                "\n"
+            )
             if error_on_non_convergence()
-                error("Exiting to avoid excessively large output logs")
+                error("Failed to converge with printed set of inputs.")
             end
         end
         return sol.root
@@ -1192,9 +1208,25 @@ function saturation_adjustment_SecantMethod(
             maxiter,
         )
         if !sol.converged
+            @print("-----------------------------------------\n")
             @print("maxiter reached in saturation_adjustment_SecantMethod:\n")
+            @print(
+                "    e_int=",
+                e_int,
+                ", ρ=",
+                ρ,
+                ", q_tot=",
+                q_tot,
+                ", T = ",
+                sol.root,
+                ", maxiter=",
+                maxiter,
+                ", tol=",
+                tol.tol,
+                "\n"
+            )
             if error_on_non_convergence()
-                error("Exiting to avoid excessively large output logs")
+                error("Failed to converge with printed set of inputs.")
             end
         end
         return sol.root
@@ -1263,9 +1295,25 @@ function saturation_adjustment_q_tot_θ_liq_ice(
             maxiter,
         )
         if !sol.converged
+            @print("-----------------------------------------\n")
             @print("maxiter reached in saturation_adjustment_q_tot_θ_liq_ice:\n")
+            @print(
+                "    θ_liq_ice=",
+                θ_liq_ice,
+                ", ρ=",
+                ρ,
+                ", q_tot=",
+                q_tot,
+                ", T = ",
+                sol.root,
+                ", maxiter=",
+                maxiter,
+                ", tol=",
+                tol.tol,
+                "\n"
+            )
             if error_on_non_convergence()
-                error("Exiting to avoid excessively large output logs")
+                error("Failed to converge with printed set of inputs.")
             end
         end
         return sol.root
@@ -1337,9 +1385,25 @@ function saturation_adjustment_q_tot_θ_liq_ice_given_pressure(
             maxiter,
         )
         if !sol.converged
+            @print("-----------------------------------------\n")
             @print("maxiter reached in saturation_adjustment_q_tot_θ_liq_ice_given_pressure:\n")
+            @print(
+                "    θ_liq_ice=",
+                θ_liq_ice,
+                ", p=",
+                p,
+                ", q_tot=",
+                q_tot,
+                ", T = ",
+                sol.root,
+                ", maxiter=",
+                maxiter,
+                ", tol=",
+                tol.tol,
+                "\n"
+            )
             if error_on_non_convergence()
-                error("Exiting to avoid excessively large output logs")
+                error("Failed to converge with printed set of inputs.")
             end
         end
         return sol.root
@@ -1493,8 +1557,8 @@ function temperature_and_humidity_from_virtual_temperature(
     ρ::FT,
     RH::FT,
     phase_type::Type{<:ThermodynamicState},
-    tol::AbstractTolerance = ResidualTolerance{FT}(sqrt(eps(FT))),
     maxiter::Int = 100,
+    tol::AbstractTolerance = ResidualTolerance{FT}(sqrt(eps(FT))),
 ) where {FT <: Real}
 
     _T_min::FT = T_min(param_set)
@@ -1513,9 +1577,25 @@ function temperature_and_humidity_from_virtual_temperature(
         maxiter,
     )
     if !sol.converged
+        @print("-----------------------------------------\n")
         @print("maxiter reached in temperature_and_humidity_from_virtual_temperature:\n")
+        @print(
+            "    T_virt=",
+            T_virt,
+            ", RH=",
+            RH,
+            ", ρ=",
+            ρ,
+            ", T = ",
+            sol.root,
+            ", maxiter=",
+            maxiter,
+            ", tol=",
+            tol.tol,
+            "\n"
+        )
         if error_on_non_convergence()
-            error("Exiting to avoid excessively large output logs")
+            error("Failed to converge with printed set of inputs.")
         end
     end
     T = sol.root
@@ -1598,9 +1678,29 @@ function air_temperature_from_liquid_ice_pottemp_non_linear(
         maxiter,
     )
     if !sol.converged
+        @print("-----------------------------------------\n")
         @print("maxiter reached in air_temperature_from_liquid_ice_pottemp_non_linear:\n")
+        @print(
+            "    θ_liq_ice=",
+            θ_liq_ice,
+            ", ρ=",
+            ρ,
+            ", q.tot=",
+            q.tot,
+            "q.liq = ",
+            q.liq,
+            "q.ice = ",
+            q.ice,
+            ", T = ",
+            sol.root,
+            ", maxiter=",
+            maxiter,
+            ", tol=",
+            tol.tol,
+            "\n"
+        )
         if error_on_non_convergence()
-            error("Exiting to avoid excessively large output logs")
+            error("Failed to converge with printed set of inputs.")
         end
     end
     return sol.root


### PR DESCRIPTION
# Description

 - Adds thrown exceptions to Thermodynamics when convergence fails.
 - Uses `@test_throws` to ensure that exceptions are thrown when expected (tested with low `maxiter` and small tolerance)

Should fix part 1 of #1274.

@vchuravy is this sufficient to ensure that errors are fatal in kernel calls?

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
