### PR TITLE
Add types and unify functions in BalanceLaws

### DIFF
--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -10,15 +10,23 @@ CurrentModule = ClimateMachine.BalanceLaws
 BalanceLaw
 ```
 
+## State variable types
+
+```@docs
+Prognostic
+Auxiliary
+Gradient
+GradientFlux
+GradientLaplacian
+Hyperdiffusive
+UpwardIntegrals
+DownwardIntegrals
+```
+
 ## Variable specification methods
 
 ```@docs
-vars_state_conservative
-vars_state_auxiliary
-vars_state_gradient
-vars_integrals
-vars_reverse_integrals
-vars_state_gradient_flux
+vars_state
 ```
 
 ## Initial condition methods

--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -32,7 +32,7 @@ vars_state
 ## Initial condition methods
 
 ```@docs
-init_state_conservative!
+init_state_prognostic!
 init_state_auxiliary!
 ```
 

--- a/docs/src/GettingStarted/Atmos.md
+++ b/docs/src/GettingStarted/Atmos.md
@@ -24,7 +24,7 @@ possible options for each subcomponent.
     source::S = (Gravity(), Coriolis(), GeostrophicForcing{FT}(7.62e-5, 0, 0)),
     tracers::TR = NoTracers(),
     boundarycondition::BC = AtmosBC(),
-    init_state_conservative::IS = nothing,
+    init_state_prognostic::IS = nothing,
     data_config::DC = nothing,
 ```
 
@@ -54,6 +54,6 @@ possible options for each subcomponent.
     source::S = (Gravity(), Coriolis()),
     tracers::TR = NoTracers(),
     boundarycondition::BC = AtmosBC(),
-    init_state_conservative::IS = nothing,
+    init_state_prognostic::IS = nothing,
     data_config::DC = nothing,
 ```

--- a/docs/src/HowToGuides/Numerics/DGMethods/how_to_make_a_balance_law.md
+++ b/docs/src/HowToGuides/Numerics/DGMethods/how_to_make_a_balance_law.md
@@ -71,7 +71,7 @@ the following methods, which are computed locally at each nodal point:
 ## Methods to set initial conditions
 | **Method** | Purpose |
 |:-----|:-----|
-| [`init_state_conservative!`](@ref) | provide initial values for the conservative state as a function of time and space. |
+| [`init_state_prognostic!`](@ref) | provide initial values for the conservative state as a function of time and space. |
 | [`init_state_auxiliary!`](@ref) | provide initial values for the auxiliary variables as a function of the geometry. |
 
 

--- a/docs/src/HowToGuides/Numerics/DGMethods/how_to_make_a_balance_law.md
+++ b/docs/src/HowToGuides/Numerics/DGMethods/how_to_make_a_balance_law.md
@@ -35,12 +35,12 @@ the following methods, which are computed locally at each nodal point:
 ## Variable name specification methods
 | **Method** | Necessary | Purpose |
 |:-----|:---|:----|
-| [`vars_state_conservative`](@ref)         | **YES** |  specify the names of the variables in the conservative state vector, typically mass, momentum, and various tracers. |
-| [`vars_state_auxiliary`](@ref)           | **YES** |  specify the names of any variables required for the balance law that aren't related to derivatives of the state variables (e.g. spatial coordinates or various integrals) or those needed to solve expensive auxiliary equations (e.g., temperature via a non-linear equation solve)     |
-| [`vars_state_gradient`](@ref)         | **YES** |  specify the names of the gradients of functions of the conservative state variables. used to represent values before **and** after differentiation |
-| [`vars_state_gradient_flux`](@ref)         | **YES** |  specify the names of the gradient fluxes necessary to impose Neumann boundary conditions. typically the product of a diffusivity tensor with a gradient state variable, potentially equivalent to the second-order flux for a conservative state variable |
-| [`vars_integrals`](@ref)         | **NO** |  specify the names of any one-dimensional vertical integrals from **bottom to top** of the domain required for the balance law. used to represent both the integrand **and** the resulting indefinite integral |
-| [`vars_reverse_integrals`](@ref)         | **NO** |  specify the names of any one-dimensional vertical integral from **top to bottom** of the domain required for the balance law. each variable here must also exist in `vars_integrals` since the reverse integral kernels use subtraction to reverse the integral instead of performing a new integral. use to represent the value before **and** after reversing direction |
+| [`vars_state`](@ref)         | **YES** |  specify the names of the variables in the conservative state vector, typically mass, momentum, and various tracers. |
+| [`vars_state`](@ref)           | **YES** |  specify the names of any variables required for the balance law that aren't related to derivatives of the state variables (e.g. spatial coordinates or various integrals) or those needed to solve expensive auxiliary equations (e.g., temperature via a non-linear equation solve)     |
+| [`vars_state`](@ref)         | **YES** |  specify the names of the gradients of functions of the conservative state variables. used to represent values before **and** after differentiation |
+| [`vars_state`](@ref)         | **YES** |  specify the names of the gradient fluxes necessary to impose Neumann boundary conditions. typically the product of a diffusivity tensor with a gradient state variable, potentially equivalent to the second-order flux for a conservative state variable |
+| [`vars_state`](@ref)         | **NO** |  specify the names of any one-dimensional vertical integrals from **bottom to top** of the domain required for the balance law. used to represent both the integrand **and** the resulting indefinite integral |
+| [`vars_state`](@ref)         | **NO** |  specify the names of any one-dimensional vertical integral from **top to bottom** of the domain required for the balance law. each variable here must also exist in `vars_state` since the reverse integral kernels use subtraction to reverse the integral instead of performing a new integral. use to represent the value before **and** after reversing direction |
 
 ## Methods to compute gradients and integrals
 | **Method** |  Purpose |
@@ -84,7 +84,7 @@ argument inside these methods behave as dictionaries, for example:
 ```julia
 struct MyModel <: BalanceLaw end
 
-function vars_state_conservative(m::MyModel, FT)
+function vars_state(m::MyModel, ::Prognostic, FT)
     @vars begin
         ρ::FT
         T::FT

--- a/docs/src/Theory/Atmos/Model/tracers.md
+++ b/docs/src/Theory/Atmos/Model/tracers.md
@@ -122,7 +122,7 @@ tracers required.  Note that tracer naming is not currently supported,
 i.e. the user must track each tracer variable based on its numerical
 index. Sources can be added to each tracer based on the corresponding
 numerical vector index. Initial profiles must be specified using the
-`init_state_conservative!` hook at the experiment level.
+`init_state_prognostic!` hook at the experiment level.
 
 ```@docs
 ClimateMachine.Atmos.NTracers{N,FT}

--- a/docs/src/Theory/Atmos/Model/tracers.md
+++ b/docs/src/Theory/Atmos/Model/tracers.md
@@ -45,10 +45,7 @@ Default stub functions for a generic tracer type are defined here.
 ```julia
 abstract type TracerModel <: BalanceLaw end
 
-vars_state_conservative(::TracerModel, FT) = @vars()
-vars_state_gradient(::TracerModel, FT) = @vars()
-vars_state_gradient_flux(::TracerModel, FT) = @vars()
-vars_state_auxiliary(::TracerModel, FT) = @vars()
+vars_state(::TracerModel, ::AbstractStateType, FT) = @vars()
 
 function atmos_init_aux!(
     ::TracerModel,

--- a/docs/src/Theory/Common/Turbulence.md
+++ b/docs/src/Theory/Common/Turbulence.md
@@ -34,9 +34,7 @@ be defined for a turbulence model.
 abstract type TurbulenceClosure end
 
 
-vars_state_gradient((::TurbulenceClosure, FT) = @vars()
-vars_state_gradient_flux(::TurbulenceClosure, FT) = @vars()
-vars_state_auxiliary(::TurbulenceClosure, FT) = @vars()
+vars_state(::TurbulenceClosure, ::AbstractStateType, FT) = @vars()
 
 function atmos_init_aux!(
     ::TurbulenceClosure,
@@ -67,7 +65,7 @@ additional state variables or auxiliary variable updates (e.g. TKE based
 models)
 
 ```julia
-vars_state_conservative(::TurbulenceClosure, FT) = @vars()
+vars_state(::TurbulenceClosure, ::Prognostic, FT) = @vars()
 function atmos_nodal_update_auxiliary_state!(
     ::TurbulenceClosure,
     ::AtmosModel,

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -100,7 +100,7 @@ function config_heldsuarez(FT, poly_order, resolution)
         hyperdiffusion = DryBiharmonic(τ_hyper),
         moisture = DryModel(),
         source = (Gravity(), Coriolis(), held_suarez_forcing!, sponge),
-        init_state_conservative = init_heldsuarez!,
+        init_state_prognostic = init_heldsuarez!,
         data_config = HeldSuarezDataConfig(T_ref),
         tracers = tracers,
     )

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -444,7 +444,7 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax)
             ),
             AtmosBC(),
         ),
-        init_state_conservative = ics,
+        init_state_prognostic = ics,
     )
 
     # Assemble configuration

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -77,7 +77,7 @@ using CLIMAParameters.Planet: e_int_v0, grav, day
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-import ClimateMachine.BalanceLaws: vars_state_conservative, vars_state_auxiliary
+import ClimateMachine.BalanceLaws: vars_state
 import ClimateMachine.Atmos: source!, atmos_source!, altitude
 import ClimateMachine.Atmos: flux_second_order!, thermo_state
 

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -14,6 +14,8 @@ using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
+using ClimateMachine.BalanceLaws:
+    AbstractStateType, Auxiliary, UpwardIntegrals, DownwardIntegrals
 
 using Distributions
 using Random
@@ -28,10 +30,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
 import ClimateMachine.BalanceLaws:
-    vars_state_conservative,
-    vars_state_auxiliary,
-    vars_integrals,
-    vars_reverse_integrals,
+    vars_state,
     indefinite_stack_integral!,
     reverse_indefinite_stack_integral!,
     integral_load_auxiliary_state!,
@@ -43,10 +42,7 @@ import ClimateMachine.BalanceLaws: boundary_state!
 import ClimateMachine.Atmos: flux_second_order!
 
 # -------------------- Radiation Model -------------------------- #
-vars_state_conservative(::RadiationModel, FT) = @vars()
-vars_state_auxiliary(::RadiationModel, FT) = @vars()
-vars_integrals(::RadiationModel, FT) = @vars()
-vars_reverse_integrals(::RadiationModel, FT) = @vars()
+vars_state(::RadiationModel, ::AbstractStateType, FT) = @vars()
 
 function atmos_nodal_update_auxiliary_state!(
     ::RadiationModel,
@@ -108,9 +104,10 @@ struct DYCOMSRadiation{FT} <: RadiationModel
     F_1::FT
 end
 
-vars_state_auxiliary(m::DYCOMSRadiation, FT) = @vars(Rad_flux::FT)
+vars_state(m::DYCOMSRadiation, ::Auxiliary, FT) = @vars(Rad_flux::FT)
 
-vars_integrals(m::DYCOMSRadiation, FT) = @vars(attenuation_coeff::FT)
+vars_state(m::DYCOMSRadiation, ::UpwardIntegrals, FT) =
+    @vars(attenuation_coeff::FT)
 function integral_load_auxiliary_state!(
     m::DYCOMSRadiation,
     integrand::Vars,
@@ -129,7 +126,8 @@ function integral_set_auxiliary_state!(
     aux.∫dz.radiation.attenuation_coeff = integral
 end
 
-vars_reverse_integrals(m::DYCOMSRadiation, FT) = @vars(attenuation_coeff::FT)
+vars_state(m::DYCOMSRadiation, ::DownwardIntegrals, FT) =
+    @vars(attenuation_coeff::FT)
 function reverse_integral_load_auxiliary_state!(
     m::DYCOMSRadiation,
     integrand::Vars,

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -320,7 +320,7 @@ function config_dycoms(FT, N, resolution, xmax, ymax, zmax)
             ),
             AtmosBC(),
         ),
-        init_state_conservative = ics,
+        init_state_prognostic = ics,
     )
 
     ode_solver = ClimateMachine.ExplicitSolverType(

--- a/experiments/AtmosLES/schar_scalar_advection.jl
+++ b/experiments/AtmosLES/schar_scalar_advection.jl
@@ -182,7 +182,7 @@ function config_schar(FT, N, resolution, xmax, ymax, zmax)
         moisture = DryModel(),
         source = source,
         tracers = NTracers{1, FT}(_δχ),
-        init_state_conservative = init_schar!,
+        init_state_prognostic = init_schar!,
         ref_state = ref_state,
     )
 

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -105,7 +105,7 @@ function config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
             AtmosBC(),
         ),
         moisture = EquilMoist{FT}(),
-        init_state_conservative = init_surfacebubble!,
+        init_state_prognostic = init_surfacebubble!,
     )
     config = ClimateMachine.AtmosLESConfiguration(
         "SurfaceDrivenBubble",

--- a/experiments/AtmosLES/taylor-green.jl
+++ b/experiments/AtmosLES/taylor-green.jl
@@ -26,10 +26,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
 import ClimateMachine.BalanceLaws:
-    vars_state_conservative,
-    vars_state_auxiliary,
-    vars_integrals,
-    vars_reverse_integrals,
+    vars_state,
     indefinite_stack_integral!,
     reverse_indefinite_stack_integral!,
     integral_load_auxiliary_state!,

--- a/experiments/AtmosLES/taylor-green.jl
+++ b/experiments/AtmosLES/taylor-green.jl
@@ -133,7 +133,7 @@ function config_greenvortex(
         turbulence = Vreman(_C_smag),       # Turbulence closure model
         moisture = DryModel(),
         source = (),
-        init_state_conservative = init_greenvortex!,             # Apply the initial condition
+        init_state_prognostic = init_greenvortex!,             # Apply the initial condition
     )
 
     # Finally,  we pass a `Problem Name` string, the mesh information, and the model type to  the [`AtmosLESConfiguration`] object.

--- a/experiments/OceanBoxGCM/homogeneous_box.jl
+++ b/experiments/OceanBoxGCM/homogeneous_box.jl
@@ -7,7 +7,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Mesh.Grids: polynomialorder
-using ClimateMachine.BalanceLaws: vars_state_conservative
+using ClimateMachine.BalanceLaws: vars_state, Prognostic
 using ClimateMachine.Ocean.HydrostaticBoussinesq
 
 using Test
@@ -91,11 +91,11 @@ function run_homogeneous_box(; imex::Bool = false, BC = nothing)
 
     result = ClimateMachine.invoke!(solver_config)
 
-    maxQ = Vars{vars_state_conservative(driver_config.bl, FT)}(maximum(
+    maxQ = Vars{vars_state(driver_config.bl, Prognostic(), FT)}(maximum(
         solver_config.Q,
         dims = (1, 3),
     ))
-    minQ = Vars{vars_state_conservative(driver_config.bl, FT)}(minimum(
+    minQ = Vars{vars_state(driver_config.bl, Prognostic(), FT)}(minimum(
         solver_config.Q,
         dims = (1, 3),
     ))

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -36,18 +36,10 @@ using ..Mesh.Grids:
     EveryDirection,
     Direction
 
-using ClimateMachine.BalanceLaws:
-    BalanceLaw, number_state_conservative, num_integrals
+using ClimateMachine.BalanceLaws
 
 import ClimateMachine.BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_gradient_laplacian,
-    vars_state_gradient_flux,
-    vars_hyperdiffusive,
-    vars_integrals,
-    vars_reverse_integrals,
+    vars_state,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -232,109 +224,109 @@ end
 
 
 """
-    vars_state_conservative(m::AtmosModel, FT)
+    vars_state(m::AtmosModel, ::Prognostic, FT)
 Conserved state variables (Prognostic Variables)
 """
-function vars_state_conservative(m::AtmosModel, FT)
+function vars_state(m::AtmosModel, st::Prognostic, FT)
     @vars begin
         ρ::FT
         ρu::SVector{3, FT}
         ρe::FT
-        turbulence::vars_state_conservative(m.turbulence, FT)
-        turbconv::vars_state_conservative(m.turbconv, FT)
-        hyperdiffusion::vars_state_conservative(m.hyperdiffusion, FT)
-        moisture::vars_state_conservative(m.moisture, FT)
-        radiation::vars_state_conservative(m.radiation, FT)
-        tracers::vars_state_conservative(m.tracers, FT)
+        turbulence::vars_state(m.turbulence, st, FT)
+        turbconv::vars_state(m.turbconv, st, FT)
+        hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
+        moisture::vars_state(m.moisture, st, FT)
+        radiation::vars_state(m.radiation, st, FT)
+        tracers::vars_state(m.tracers, st, FT)
     end
 end
 
 """
-    vars_state_gradient(m::AtmosModel, FT)
+    vars_state(m::AtmosModel, ::Gradient, FT)
 Pre-transform gradient variables
 """
-function vars_state_gradient(m::AtmosModel, FT)
+function vars_state(m::AtmosModel, st::Gradient, FT)
     @vars begin
         u::SVector{3, FT}
         h_tot::FT
-        turbulence::vars_state_gradient(m.turbulence, FT)
-        turbconv::vars_state_gradient(m.turbconv, FT)
-        hyperdiffusion::vars_state_gradient(m.hyperdiffusion, FT)
-        moisture::vars_state_gradient(m.moisture, FT)
-        tracers::vars_state_gradient(m.tracers, FT)
+        turbulence::vars_state(m.turbulence, st, FT)
+        turbconv::vars_state(m.turbconv, st, FT)
+        hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
+        moisture::vars_state(m.moisture, st, FT)
+        tracers::vars_state(m.tracers, st, FT)
     end
 end
 """
-    vars_state_gradient_flux(m::AtmosModel, FT)
+    vars_state(m::AtmosModel, ::GradientFlux, FT)
 Post-transform gradient variables
 """
-function vars_state_gradient_flux(m::AtmosModel, FT)
+function vars_state(m::AtmosModel, st::GradientFlux, FT)
     @vars begin
         ∇h_tot::SVector{3, FT}
-        turbulence::vars_state_gradient_flux(m.turbulence, FT)
-        turbconv::vars_state_gradient_flux(m.turbconv, FT)
-        hyperdiffusion::vars_state_gradient_flux(m.hyperdiffusion, FT)
-        moisture::vars_state_gradient_flux(m.moisture, FT)
-        tracers::vars_state_gradient_flux(m.tracers, FT)
+        turbulence::vars_state(m.turbulence, st, FT)
+        turbconv::vars_state(m.turbconv, st, FT)
+        hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
+        moisture::vars_state(m.moisture, st, FT)
+        tracers::vars_state(m.tracers, st, FT)
     end
 end
 
 """
-    vars_gradient_laplacian(m::AtmosModel, FT)
+    vars_state(m::AtmosModel, ::GradientLaplacian, FT)
 Pre-transform hyperdiffusive variables
 """
-function vars_gradient_laplacian(m::AtmosModel, FT)
+function vars_state(m::AtmosModel, st::GradientLaplacian, FT)
     @vars begin
-        hyperdiffusion::vars_gradient_laplacian(m.hyperdiffusion, FT)
+        hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
     end
 end
 
 """
-    vars_hyperdiffusive(m::AtmosModel, FT)
+    vars_state(m::AtmosModel, ::Hyperdiffusive, FT)
 Post-transform hyperdiffusive variables
 """
-function vars_hyperdiffusive(m::AtmosModel, FT)
+function vars_state(m::AtmosModel, st::Hyperdiffusive, FT)
     @vars begin
-        hyperdiffusion::vars_hyperdiffusive(m.hyperdiffusion, FT)
+        hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
     end
 end
 
 """
-    vars_state_auxiliary(m::AtmosModel, FT)
+    vars_state(m::AtmosModel, ::Auxiliary, FT)
 Auxiliary variables, such as vertical (stack)
 integrals, coordinates, orientation information,
 reference states, subcomponent auxiliary vars,
 debug variables
 """
-function vars_state_auxiliary(m::AtmosModel, FT)
+function vars_state(m::AtmosModel, st::Auxiliary, FT)
     @vars begin
-        ∫dz::vars_integrals(m, FT)
-        ∫dnz::vars_reverse_integrals(m, FT)
+        ∫dz::vars_state(m, UpwardIntegrals(), FT)
+        ∫dnz::vars_state(m, DownwardIntegrals(), FT)
         coord::SVector{3, FT}
-        orientation::vars_state_auxiliary(m.orientation, FT)
-        ref_state::vars_state_auxiliary(m.ref_state, FT)
-        turbulence::vars_state_auxiliary(m.turbulence, FT)
-        turbconv::vars_state_auxiliary(m.turbconv, FT)
-        hyperdiffusion::vars_state_auxiliary(m.hyperdiffusion, FT)
-        moisture::vars_state_auxiliary(m.moisture, FT)
-        tracers::vars_state_auxiliary(m.tracers, FT)
-        radiation::vars_state_auxiliary(m.radiation, FT)
+        orientation::vars_state(m.orientation, st, FT)
+        ref_state::vars_state(m.ref_state, st, FT)
+        turbulence::vars_state(m.turbulence, st, FT)
+        turbconv::vars_state(m.turbconv, st, FT)
+        hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
+        moisture::vars_state(m.moisture, st, FT)
+        tracers::vars_state(m.tracers, st, FT)
+        radiation::vars_state(m.radiation, st, FT)
     end
 end
 """
-    vars_integrals(m::AtmosModel, FT)
+    vars_state(m::AtmosModel, ::UpwardIntegrals, FT)
 """
-function vars_integrals(m::AtmosModel, FT)
+function vars_state(m::AtmosModel, st::UpwardIntegrals, FT)
     @vars begin
-        radiation::vars_integrals(m.radiation, FT)
+        radiation::vars_state(m.radiation, st, FT)
     end
 end
 """
-    vars_reverse_integrals(m::AtmosModel, FT)
+    vars_state(m::AtmosModel, ::DownwardIntegrals, FT)
 """
-function vars_reverse_integrals(m::AtmosModel, FT)
+function vars_state(m::AtmosModel, st::DownwardIntegrals, FT)
     @vars begin
-        radiation::vars_reverse_integrals(m.radiation, FT)
+        radiation::vars_state(m.radiation, st, FT)
     end
 end
 
@@ -558,8 +550,8 @@ end
     ss = soundspeed(m, m.moisture, state, aux)
 
     FT = typeof(state.ρ)
-    ws = fill(uN + ss, MVector{number_state_conservative(m, FT), FT})
-    vars_ws = Vars{vars_state_conservative(m, FT)}(ws)
+    ws = fill(uN + ss, MVector{number_states(m, Prognostic(), FT), FT})
+    vars_ws = Vars{vars_state(m, Prognostic(), FT)}(ws)
 
     wavespeed_tracers!(m.tracers, vars_ws, nM, state, aux, t)
 
@@ -577,7 +569,7 @@ function update_auxiliary_state!(
     FT = eltype(Q)
     state_auxiliary = dg.state_auxiliary
 
-    if num_integrals(m, FT) > 0
+    if number_states(m, UpwardIntegrals(), FT) > 0
         indefinite_stack_integral!(dg, m, Q, state_auxiliary, t, elems)
         reverse_indefinite_stack_integral!(dg, m, Q, state_auxiliary, t, elems)
     end

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -49,7 +49,7 @@ import ClimateMachine.BalanceLaws:
     compute_gradient_flux!,
     transform_post_gradient_laplacian!,
     init_state_auxiliary!,
-    init_state_conservative!,
+    init_state_prognostic!,
     update_auxiliary_state!,
     indefinite_stack_integral!,
     reverse_indefinite_stack_integral!,
@@ -95,7 +95,7 @@ Users may over-ride prescribed default values for each field.
         source,
         tracers,
         boundarycondition,
-        init_state_conservative
+        init_state_prognostic
     )
 
 # Fields
@@ -128,7 +128,7 @@ struct AtmosModel{FT, PS, O, RS, T, TC, HD, M, P, R, S, TR, BC, IS, DC} <:
     "Boundary condition specification"
     boundarycondition::BC
     "Initial Condition (Function to assign initial values of state variables)"
-    init_state_conservative::IS
+    init_state_prognostic::IS
     "Data Configuration (Helper field for experiment configuration)"
     data_config::DC
 end
@@ -158,11 +158,11 @@ function AtmosModel{FT}(
     ),
     tracers::TR = NoTracers(),
     boundarycondition::BC = AtmosBC(),
-    init_state_conservative::IS = nothing,
+    init_state_prognostic::IS = nothing,
     data_config::DC = nothing,
 ) where {FT <: AbstractFloat, O, RS, T, TC, HD, M, P, R, S, TR, BC, IS, DC}
     @assert param_set ≠ nothing
-    @assert init_state_conservative ≠ nothing
+    @assert init_state_prognostic ≠ nothing
 
     atmos = (
         param_set,
@@ -177,7 +177,7 @@ function AtmosModel{FT}(
         source,
         tracers,
         boundarycondition,
-        init_state_conservative,
+        init_state_prognostic,
         data_config,
     )
 
@@ -197,11 +197,11 @@ function AtmosModel{FT}(
     source::S = (Gravity(), Coriolis(), turbconv_sources(turbconv)...),
     tracers::TR = NoTracers(),
     boundarycondition::BC = AtmosBC(),
-    init_state_conservative::IS = nothing,
+    init_state_prognostic::IS = nothing,
     data_config::DC = nothing,
 ) where {FT <: AbstractFloat, O, RS, T, TC, HD, M, P, R, S, TR, BC, IS, DC}
     @assert param_set ≠ nothing
-    @assert init_state_conservative ≠ nothing
+    @assert init_state_prognostic ≠ nothing
     atmos = (
         param_set,
         orientation,
@@ -215,7 +215,7 @@ function AtmosModel{FT}(
         source,
         tracers,
         boundarycondition,
-        init_state_conservative,
+        init_state_prognostic,
         data_config,
     )
 
@@ -687,7 +687,7 @@ function source!(
 end
 
 @doc """
-    init_state_conservative!(
+    init_state_prognostic!(
         m::AtmosModel,
         state::Vars,
         aux::Vars,
@@ -697,8 +697,8 @@ end
 Initialise state variables.
 `args...` provides an option to include configuration data
 (current use cases include problem constants, spline-interpolants)
-""" init_state_conservative!
-function init_state_conservative!(
+""" init_state_prognostic!
+function init_state_prognostic!(
     m::AtmosModel,
     state::Vars,
     aux::Vars,
@@ -706,6 +706,6 @@ function init_state_conservative!(
     t,
     args...,
 )
-    m.init_state_conservative(m, state, aux, coords, t, args...)
+    m.init_state_prognostic(m, state, aux, coords, t, args...)
 end
 end # module

--- a/src/Atmos/Model/bc_initstate.jl
+++ b/src/Atmos/Model/bc_initstate.jl
@@ -1,7 +1,7 @@
 """
     InitStateBC
 
-Set the value at the boundary to match the `init_state_conservative!` function. This is
+Set the value at the boundary to match the `init_state_prognostic!` function. This is
 mainly useful for cases where the problem has an explicit solution.
 
 # TODO: This should be fixed later once BCs are figured out (likely want
@@ -21,7 +21,7 @@ function atmos_boundary_state!(
     t,
     _...,
 )
-    init_state_conservative!(m, state⁺, aux⁺, aux⁺.coord, t)
+    init_state_prognostic!(m, state⁺, aux⁺, aux⁺.coord, t)
 end
 
 function atmos_normal_boundary_flux_second_order!(
@@ -78,5 +78,5 @@ function boundary_state!(
     t,
     args...,
 )
-    init_state_conservative!(m, state⁺, aux⁺, aux⁺.coord, t)
+    init_state_prognostic!(m, state⁺, aux⁺, aux⁺.coord, t)
 end

--- a/src/Atmos/Model/filters.jl
+++ b/src/Atmos/Model/filters.jl
@@ -11,7 +11,7 @@ struct AtmosFilterPerturbations{M} <: AbstractFilterTarget
 end
 
 vars_state_filtered(target::AtmosFilterPerturbations, FT) =
-    vars_state_conservative(target.atmos, FT)
+    vars_state(target.atmos, Prognostic(), FT)
 
 function compute_filter_argument!(
     target::AtmosFilterPerturbations,

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -64,22 +64,19 @@ end
 
 abstract type AtmosLinearModel <: BalanceLaw end
 
-function vars_state_conservative(lm::AtmosLinearModel, FT)
+function vars_state(lm::AtmosLinearModel, st::Prognostic, FT)
     @vars begin
         ρ::FT
         ρu::SVector{3, FT}
         ρe::FT
-        turbulence::vars_state_conservative(lm.atmos.turbulence, FT)
-        hyperdiffusion::vars_state_conservative(lm.atmos.hyperdiffusion, FT)
-        moisture::vars_state_conservative(lm.atmos.moisture, FT)
+        turbulence::vars_state(lm.atmos.turbulence, st, FT)
+        hyperdiffusion::vars_state(lm.atmos.hyperdiffusion, st, FT)
+        moisture::vars_state(lm.atmos.moisture, st, FT)
     end
 end
-vars_state_gradient(lm::AtmosLinearModel, FT) = @vars()
-vars_state_gradient_flux(lm::AtmosLinearModel, FT) = @vars()
-vars_state_auxiliary(lm::AtmosLinearModel, FT) =
-    vars_state_auxiliary(lm.atmos, FT)
-vars_integrals(lm::AtmosLinearModel, FT) = @vars()
-vars_reverse_integrals(lm::AtmosLinearModel, FT) = @vars()
+vars_state(lm::AtmosLinearModel, ::AbstractStateType, FT) = @vars()
+vars_state(lm::AtmosLinearModel, st::Auxiliary, FT) =
+    vars_state(lm.atmos, st, FT)
 
 
 function update_auxiliary_state!(

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -154,7 +154,7 @@ function boundary_state!(
 end
 init_state_auxiliary!(lm::AtmosLinearModel, aux::Vars, geom::LocalGeometry) =
     nothing
-init_state_conservative!(
+init_state_prognostic!(
     lm::AtmosLinearModel,
     state::Vars,
     aux::Vars,

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -3,10 +3,7 @@ export DryModel, EquilMoist
 #### Moisture component in atmosphere model
 abstract type MoistureModel end
 
-vars_state_conservative(::MoistureModel, FT) = @vars()
-vars_state_gradient(::MoistureModel, FT) = @vars()
-vars_state_gradient_flux(::MoistureModel, FT) = @vars()
-vars_state_auxiliary(::MoistureModel, FT) = @vars()
+vars_state(::MoistureModel, ::AbstractStateType, FT) = @vars()
 
 function atmos_nodal_update_auxiliary_state!(
     ::MoistureModel,
@@ -93,7 +90,7 @@ Assumes the moisture components is in the dry limit.
 """
 struct DryModel <: MoistureModel end
 
-vars_state_auxiliary(::DryModel, FT) = @vars(θ_v::FT, air_T::FT)
+vars_state(::DryModel, ::Auxiliary, FT) = @vars(θ_v::FT, air_T::FT)
 @inline function atmos_nodal_update_auxiliary_state!(
     moist::DryModel,
     atmos::AtmosModel,
@@ -139,10 +136,10 @@ EquilMoist{FT}(;
 ) where {FT <: AbstractFloat, IT <: Int} = EquilMoist{FT}(maxiter, tolerance)
 
 
-vars_state_conservative(::EquilMoist, FT) = @vars(ρq_tot::FT)
-vars_state_gradient(::EquilMoist, FT) = @vars(q_tot::FT)
-vars_state_gradient_flux(::EquilMoist, FT) = @vars(∇q_tot::SVector{3, FT})
-vars_state_auxiliary(::EquilMoist, FT) =
+vars_state(::EquilMoist, ::Prognostic, FT) = @vars(ρq_tot::FT)
+vars_state(::EquilMoist, ::Gradient, FT) = @vars(q_tot::FT)
+vars_state(::EquilMoist, ::GradientFlux, FT) = @vars(∇q_tot::SVector{3, FT})
+vars_state(::EquilMoist, ::Auxiliary, FT) =
     @vars(temperature::FT, θ_v::FT, q_liq::FT)
 
 @inline function atmos_nodal_update_auxiliary_state!(

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -5,10 +5,7 @@ export NoPrecipitation, Rain
 
 using ..Microphysics
 
-vars_state_conservative(::PrecipitationModel, FT) = @vars()
-vars_state_gradient(::PrecipitationModel, FT) = @vars()
-vars_state_gradient_flux(::PrecipitationModel, FT) = @vars()
-vars_state_auxiliary(::PrecipitationModel, FT) = @vars()
+vars_state(::PrecipitationModel, ::AbstractStateType, FT) = @vars()
 
 function atmos_nodal_update_auxiliary_state!(
     ::PrecipitationModel,
@@ -66,10 +63,10 @@ Precipitation model with rain only.
 """
 struct Rain <: PrecipitationModel end
 
-vars_state_conservative(::Rain, FT) = @vars(ρq_rain::FT)
-vars_state_gradient(::Rain, FT) = @vars(q_rain::FT)
-vars_state_gradient_flux(::Rain, FT) = @vars(ρd_q_rain::SVector{3, FT})
-vars_state_auxiliary(::Rain, FT) =
+vars_state(::Rain, ::Prognostic, FT) = @vars(ρq_rain::FT)
+vars_state(::Rain, ::Gradient, FT) = @vars(q_rain::FT)
+vars_state(::Rain, ::GradientFlux, FT) = @vars(ρd_q_rain::SVector{3, FT})
+vars_state(::Rain, ::Auxiliary, FT) =
     @vars(terminal_velocity::FT, src_q_rai_tot::FT)
 
 function atmos_nodal_update_auxiliary_state!(

--- a/src/Atmos/Model/radiation.jl
+++ b/src/Atmos/Model/radiation.jl
@@ -2,10 +2,7 @@ export RadiationModel, NoRadiation
 
 abstract type RadiationModel end
 
-vars_state_conservative(::RadiationModel, FT) = @vars()
-vars_state_auxiliary(::RadiationModel, FT) = @vars()
-vars_integrals(::RadiationModel, FT) = @vars()
-vars_reverse_integrals(::RadiationModel, FT) = @vars()
+vars_state(::RadiationModel, ::AbstractStateType, FT) = @vars()
 
 function atmos_nodal_update_auxiliary_state!(
     ::RadiationModel,

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -13,10 +13,8 @@ condition or for linearization.
 """
 abstract type ReferenceState end
 
-vars_state_conservative(m::ReferenceState, FT) = @vars()
-vars_state_gradient(m::ReferenceState, FT) = @vars()
-vars_state_gradient_flux(m::ReferenceState, FT) = @vars()
-vars_state_auxiliary(m::ReferenceState, FT) = @vars()
+vars_state(m::ReferenceState, ::AbstractStateType, FT) = @vars()
+
 atmos_init_aux!(
     ::ReferenceState,
     ::AtmosModel,
@@ -53,7 +51,7 @@ function HydrostaticState(
     )
 end
 
-vars_state_auxiliary(m::HydrostaticState, FT) =
+vars_state(m::HydrostaticState, ::Auxiliary, FT) =
     @vars(ρ::FT, p::FT, T::FT, ρe::FT, ρq_tot::FT)
 
 

--- a/src/Atmos/Model/tracers.jl
+++ b/src/Atmos/Model/tracers.jl
@@ -37,10 +37,7 @@ abstract type TracerModel end
 
 export NoTracers, NTracers
 
-vars_state_conservative(::TracerModel, FT) = @vars()
-vars_state_gradient(::TracerModel, FT) = @vars()
-vars_state_gradient_flux(::TracerModel, FT) = @vars()
-vars_state_auxiliary(::TracerModel, FT) = @vars()
+vars_state(::TracerModel, ::AbstractStateType, FT) = @vars()
 
 function atmos_init_aux!(
     ::TracerModel,
@@ -148,11 +145,11 @@ struct NTracers{N, FT} <: TracerModel
     δ_χ::SVector{N, FT}
 end
 
-vars_state_conservative(tr::NTracers, FT) = @vars(ρχ::typeof(tr.δ_χ))
-vars_state_gradient(tr::NTracers, FT) = @vars(χ::typeof(tr.δ_χ))
-vars_state_gradient_flux(tr::NTracers, FT) =
+vars_state(tr::NTracers, ::Prognostic, FT) = @vars(ρχ::typeof(tr.δ_χ))
+vars_state(tr::NTracers, ::Gradient, FT) = @vars(χ::typeof(tr.δ_χ))
+vars_state(tr::NTracers, ::GradientFlux, FT) =
     @vars(∇χ::SMatrix{3, length(tr.δ_χ), FT, 3 * length(tr.δ_χ)})
-vars_state_auxiliary(tr::NTracers, FT) = @vars(δ_χ::typeof(tr.δ_χ))
+vars_state(tr::NTracers, ::Auxiliary, FT) = @vars(δ_χ::typeof(tr.δ_χ))
 
 function atmos_init_aux!(
     tr::NTracers,

--- a/src/Atmos/Model/tracers.jl
+++ b/src/Atmos/Model/tracers.jl
@@ -127,7 +127,7 @@ struct NoTracers <: TracerModel end
 # i.e. the user must track each tracer variable based on its
 # numerical index. Sources can be added to each tracer based on the
 # same numerical index. Initial profiles must be specified using the
-# `init_state_conservative!` hook at the experiment level.
+# `init_state_prognostic!` hook at the experiment level.
 
 """
     NTracers{N, FT} <: TracerModel

--- a/src/BalanceLaws/BalanceLaws.jl
+++ b/src/BalanceLaws/BalanceLaws.jl
@@ -12,10 +12,8 @@ using ..VariableTemplates
 using ..Courant
 
 export BalanceLaw,
-    vars_state_conservative,
-    vars_state_auxiliary,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
+    number_states,
     init_state_conservative!,
     init_state_auxiliary!,
     compute_gradient_flux!,
@@ -29,15 +27,14 @@ export BalanceLaw,
     update_auxiliary_state!,
     update_auxiliary_state_gradient!,
     nodal_update_auxiliary_state!,
-    vars_integrals,
     integral_load_auxiliary_state!,
     integral_set_auxiliary_state!,
     indefinite_stack_integral!,
-    vars_reverse_integrals,
     reverse_indefinite_stack_integral!,
     reverse_integral_load_auxiliary_state!,
     reverse_integral_set_auxiliary_state!
 
+include("state_types.jl")
 include("interface.jl")
 
 end

--- a/src/BalanceLaws/BalanceLaws.jl
+++ b/src/BalanceLaws/BalanceLaws.jl
@@ -14,7 +14,7 @@ using ..Courant
 export BalanceLaw,
     vars_state,
     number_states,
-    init_state_conservative!,
+    init_state_prognostic!,
     init_state_auxiliary!,
     compute_gradient_flux!,
     compute_gradient_argument!,

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -16,69 +16,15 @@ Subtypes `L` should define the methods below
 abstract type BalanceLaw end # PDE part
 
 """
-    vars_state_conservative(::L, FT)
+    vars_state(::L, ::AbstractStateType, FT)
 
 a tuple of symbols containing the state variables
 given a float type `FT`.
 """
-function vars_state_conservative end
+function vars_state end
 
-"""
-    vars_state_auxiliary(::L, FT)
-
-a tuple of symbols containing the auxiliary variables
-given a float type `FT`.
-"""
-function vars_state_auxiliary end
-
-"""
-    vars_state_gradient(::L, FT)
-
-a tuple of symbols containing the transformed variables
-of which gradients are computed given a float type `FT`.
-"""
-function vars_state_gradient end
-
-"""
-    vars_state_gradient_flux(::L, FT)
-
-a tuple of symbols containing the diffusive variables
-given a float type `FT`.
-"""
-function vars_state_gradient_flux end
-
-"""
-    vars_gradient_laplacian(::L, FT)
-
-a tuple of symbols containing the transformed variables
-of which gradients of laplacian are computed, they must
-be a subset of `vars_state_gradient`, given a float type `FT`.
-"""
-vars_gradient_laplacian(::BalanceLaw, FT) = @vars()
-
-"""
-    vars_hyperdiffusive(::L, FT)
-
-a tuple of symbols containing the hyperdiffusive variables
-given a float type `FT`.
-"""
-vars_hyperdiffusive(::BalanceLaw, FT) = @vars()
-
-"""
-    vars_integrals(::L, FT)
-
-a tuple of symbols containing variables to be integrated
-along a vertical stack, given a float type `FT`.
-"""
-vars_integrals(::BalanceLaw, FT) = @vars()
-
-"""
-    vars_reverse_integrals(::L, FT)
-
-a tuple of symbols containing variables to be integrated
-along a vertical stack, in reverse, given a float type `FT`.
-"""
-vars_reverse_integrals(::BalanceLaw, FT) = @vars()
+# Fallback: no variables
+vars_state(::BalanceLaw, ::AbstractStateType, FT) = @vars()
 
 """
     init_state_conservative!(
@@ -316,18 +262,8 @@ Compute reverse indefinite integral along stack.
 function reverse_indefinite_stack_integral! end
 
 # Internal methods
-number_state_conservative(m::BalanceLaw, FT) =
-    varsize(vars_state_conservative(m, FT))
-number_state_auxiliary(m::BalanceLaw, FT) = varsize(vars_state_auxiliary(m, FT))
-number_state_gradient(m::BalanceLaw, FT) = varsize(vars_state_gradient(m, FT))
-number_state_gradient_flux(m::BalanceLaw, FT) =
-    varsize(vars_state_gradient_flux(m, FT))
-num_gradient_laplacian(m::BalanceLaw, FT) =
-    varsize(vars_gradient_laplacian(m, FT))
-num_hyperdiffusive(m::BalanceLaw, FT) = varsize(vars_hyperdiffusive(m, FT))
-num_integrals(m::BalanceLaw, FT) = varsize(vars_integrals(m, FT))
-num_reverse_integrals(m::BalanceLaw, FT) =
-    varsize(vars_reverse_integrals(m, FT))
+number_states(m::BalanceLaw, st::AbstractStateType, FT = Int) =
+    varsize(vars_state(m, st, FT))
 
 ### split explicit functions
 function initialize_states! end

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -27,16 +27,16 @@ function vars_state end
 vars_state(::BalanceLaw, ::AbstractStateType, FT) = @vars()
 
 """
-    init_state_conservative!(
+    init_state_prognostic!(
       ::L,
-      state_conservative::Vars,
+      state_prognostic::Vars,
       state_auxiliary::Vars,
       coords,
       args...)
 
 Initialize the conservative state variables at ``t = 0``
 """
-function init_state_conservative! end
+function init_state_prognostic! end
 
 """
     init_state_auxiliary!(
@@ -53,7 +53,7 @@ function init_state_auxiliary! end
     flux_first_order!(
         ::L,
         flux::Grad,
-        state_conservative::Vars,
+        state_prognostic::Vars,
         state_auxiliary::Vars,
         t::Real,
         directions
@@ -67,7 +67,7 @@ function flux_first_order! end
     flux_second_order!(
         ::L,
         flux::Grad,
-        state_conservative::Vars,
+        state_prognostic::Vars,
         state_gradient_flux::Vars,
         hyperdiffusive::Vars,
         state_auxiliary::Vars,
@@ -82,7 +82,7 @@ function flux_second_order! end
     source!(
         ::L,
         source::Vars,
-        state_conservative::Vars,
+        state_prognostic::Vars,
         diffusive::Vars,
         state_auxiliary::Vars,
         t::Real
@@ -96,7 +96,7 @@ function source! end
     compute_gradient_argument!(
         ::L,
         transformstate::Vars,
-        state_conservative::Vars,
+        state_prognostic::Vars,
         state_auxiliary::Vars,
         t::Real
     )
@@ -135,7 +135,7 @@ function transform_post_gradient_laplacian! end
     wavespeed(
         ::L,
         n⁻,
-        state_conservative::Vars,
+        state_prognostic::Vars,
         state_auxiliary::Vars,
         t::Real,
         direction
@@ -149,10 +149,10 @@ function wavespeed end
     boundary_state!(
         ::NumericalFluxGradient,
         ::L,
-        state_conservative⁺::Vars,
+        state_prognostic⁺::Vars,
         state_auxiliary⁺::Vars,
         normal⁻,
-        state_conservative⁻::Vars,
+        state_prognostic⁻::Vars,
         state_auxiliary⁻::Vars,
         bctype,
         t
@@ -160,10 +160,10 @@ function wavespeed end
     boundary_state!(
         ::NumericalFluxFirstOrder,
         ::L,
-        state_conservative⁺::Vars,
+        state_prognostic⁺::Vars,
         state_auxiliary⁺::Vars,
         normal⁻,
-        state_conservative⁻::Vars,
+        state_prognostic⁻::Vars,
         state_auxiliary⁻::Vars,
         bctype,
         t
@@ -171,11 +171,11 @@ function wavespeed end
     boundary_state!(
         ::NumericalFluxSecondOrder,
         ::L,
-        state_conservative⁺::Vars,
+        state_prognostic⁺::Vars,
         state_gradient_flux⁺::Vars,
         state_auxiliary⁺:
         Vars, normal⁻,
-        state_conservative⁻::Vars,
+        state_prognostic⁻::Vars,
         state_gradient_flux⁻::Vars,
         state_auxiliary⁻::Vars,
         bctype,

--- a/src/BalanceLaws/state_types.jl
+++ b/src/BalanceLaws/state_types.jl
@@ -1,0 +1,76 @@
+#### State types
+
+export AbstractStateType,
+    Prognostic,
+    Auxiliary,
+    Gradient,
+    GradientFlux,
+    GradientLaplacian,
+    Hyperdiffusive,
+    UpwardIntegrals,
+    DownwardIntegrals
+
+abstract type AbstractStateType end
+
+"""
+    Prognostic <: AbstractStateType
+
+Prognostic variables in the PDE system,
+which are specified by the `BalanceLaw`, and
+solved for by the ODE solver.
+"""
+struct Prognostic <: AbstractStateType end
+
+"""
+    Auxiliary <: AbstractStateType
+
+Auxiliary variables help serve several purposes:
+
+ - Pre-compute and store "expensive" variables,
+   for example, quantities computed in vertical
+   integrals.
+ - Diagnostic exports
+"""
+struct Auxiliary <: AbstractStateType end
+
+"""
+    Gradient <: AbstractStateType
+
+Variables whose gradients must be computed.
+"""
+struct Gradient <: AbstractStateType end
+
+"""
+    GradientFlux <: AbstractStateType
+
+Flux variables, which are functions of gradients.
+"""
+struct GradientFlux <: AbstractStateType end
+
+"""
+    GradientLaplacian <: AbstractStateType
+
+Gradient-Laplacian variables.
+"""
+struct GradientLaplacian <: AbstractStateType end
+
+"""
+    Hyperdiffusive <: AbstractStateType
+
+Hyper-diffusive variables
+"""
+struct Hyperdiffusive <: AbstractStateType end
+
+"""
+    UpwardIntegrals <: AbstractStateType
+
+Variables computed in upward integrals
+"""
+struct UpwardIntegrals <: AbstractStateType end
+
+"""
+    DownwardIntegrals <: AbstractStateType
+
+Variables computed in downward integrals
+"""
+struct DownwardIntegrals <: AbstractStateType end

--- a/src/Common/Orientations/Orientations.jl
+++ b/src/Common/Orientations/Orientations.jl
@@ -26,7 +26,8 @@ using StaticArrays
 using LinearAlgebra
 
 using ..VariableTemplates
-import ..BalanceLaws: BalanceLaw, vars_state_auxiliary
+using ..BalanceLaws
+import ..BalanceLaws: vars_state
 
 export Orientation, NoOrientation, FlatOrientation, SphericalOrientation
 
@@ -47,7 +48,7 @@ abstract type Orientation <: BalanceLaw end
 ##### Fallbacks
 #####
 
-function vars_state_auxiliary(m::Orientation, FT)
+function vars_state(m::Orientation, ::Auxiliary, FT)
     @vars begin
         Φ::FT # gravitational potential
         ∇Φ::SVector{3, FT}
@@ -103,7 +104,8 @@ No gravitational force or potential.
 struct NoOrientation <: Orientation end
 
 init_aux!(::NoOrientation, param_set::APS, aux::Vars) = nothing
-vars_state_auxiliary(m::NoOrientation, FT) = @vars()
+
+vars_state(m::NoOrientation, ::Auxiliary, FT) = @vars()
 
 gravitational_potential(::NoOrientation, aux::Vars) = -zero(eltype(aux))
 ∇gravitational_potential(::NoOrientation, aux::Vars) =

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -54,7 +54,7 @@ import ClimateMachine.BalanceLaws:
     compute_gradient_argument!,
     compute_gradient_flux!,
     transform_post_gradient_laplacian!,
-    init_state_conservative!,
+    init_state_prognostic!,
     update_auxiliary_state!,
     nodal_update_auxiliary_state!,
     indefinite_stack_integral!,

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -47,12 +47,7 @@ using CLIMAParameters.Atmos.SubgridScale: inv_Pr_turb
 
 
 import ClimateMachine.BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_gradient_laplacian,
-    vars_state_gradient_flux,
-    vars_hyperdiffusive,
+    vars_state,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -62,10 +57,6 @@ import ClimateMachine.BalanceLaws:
     init_state_conservative!,
     update_auxiliary_state!,
     nodal_update_auxiliary_state!,
-    number_state_conservative,
-    num_integrals,
-    vars_integrals,
-    vars_reverse_integrals,
     indefinite_stack_integral!,
     reverse_indefinite_stack_integral!,
     integral_load_auxiliary_state!,
@@ -100,18 +91,12 @@ arbitrary turbulence closure models.
 """
 abstract type TurbulenceClosureModel end
 
+vars_state(::TurbulenceClosureModel, ::AbstractStateType, FT) = @vars()
+
 """
     Abstract type for Hyperdiffusion models
 """
 abstract type HyperDiffusion end
-
-vars_state_conservative(::TurbulenceClosureModel, FT) = @vars()
-vars_state_auxiliary(::TurbulenceClosureModel, FT) = @vars()
-vars_state_gradient(::TurbulenceClosureModel, FT) = @vars()
-vars_state_gradient_flux(::TurbulenceClosureModel, FT) = @vars()
-vars_gradient_laplacian(::TurbulenceClosureModel, FT) = @vars()
-vars_integrals(::TurbulenceClosureModel, FT) = @vars()
-vars_reverse_integrals(::TurbulenceClosureModel, FT) = @vars()
 
 """
     init_aux_turbulence!
@@ -163,17 +148,9 @@ function compute_gradient_flux!(
     t,
 ) end
 
-"""
-    HyperDiffusion fallback methods
-Fallback functions for hyperdiffusion model
-"""
+# Fallback functions for hyperdiffusion model
+vars_state(::HyperDiffusion, ::AbstractStateType, FT) = @vars()
 
-vars_state_conservative(::HyperDiffusion, FT) = @vars()
-vars_state_auxiliary(::HyperDiffusion, FT) = @vars()
-vars_state_gradient(::HyperDiffusion, FT) = @vars()
-vars_gradient_laplacian(::HyperDiffusion, FT) = @vars()
-vars_state_gradient_flux(::HyperDiffusion, FT) = @vars()
-vars_hyperdiffusive(::HyperDiffusion, FT) = @vars()
 function init_aux_hyperdiffusion!(
     ::HyperDiffusion,
     ::BalanceLaw,
@@ -243,8 +220,8 @@ for the returned quantities.
 
 - `::TurbulenceClosureModel` = Struct identifier for turbulence closure model
 - `orientation` = `BalanceLaw.orientation`
-- `param_set` = `BalanceLaw.param_set`
-- `state` = Array of prognostic (state) variables. See `vars_state_conservative` in `BalanceLaw`
+- `param_set` parameter set
+- `state` = Array of prognostic (state) variables. See `vars_state` in `BalanceLaw`
 - `diffusive` = Array of diffusive variables
 - `aux` = Array of auxiliary variables
 - `t` = time
@@ -366,8 +343,8 @@ struct ConstantViscosityWithDivergence{FT} <: TurbulenceClosureModel
     ρν::FT
 end
 
-vars_state_gradient(::ConstantViscosityWithDivergence, FT) = @vars()
-vars_state_gradient_flux(::ConstantViscosityWithDivergence, FT) =
+vars_state(::ConstantViscosityWithDivergence, ::Gradient, FT) = @vars()
+vars_state(::ConstantViscosityWithDivergence, ::GradientFlux, FT) =
     @vars(S::SHermitianCompact{3, FT, 6})
 
 function compute_gradient_flux!(
@@ -482,9 +459,9 @@ struct SmagorinskyLilly{FT} <: TurbulenceClosureModel
     C_smag::FT
 end
 
-vars_state_auxiliary(::SmagorinskyLilly, FT) = @vars(Δ::FT)
-vars_state_gradient(::SmagorinskyLilly, FT) = @vars(θ_v::FT)
-vars_state_gradient_flux(::SmagorinskyLilly, FT) =
+vars_state(::SmagorinskyLilly, ::Auxiliary, FT) = @vars(Δ::FT)
+vars_state(::SmagorinskyLilly, ::Gradient, FT) = @vars(θ_v::FT)
+vars_state(::SmagorinskyLilly, ::GradientFlux, FT) =
     @vars(S::SHermitianCompact{3, FT, 6}, N²::FT)
 
 
@@ -607,9 +584,10 @@ struct Vreman{FT} <: TurbulenceClosureModel
     "Smagorinsky Coefficient [dimensionless]"
     C_smag::FT
 end
-vars_state_auxiliary(::Vreman, FT) = @vars(Δ::FT)
-vars_state_gradient(::Vreman, FT) = @vars(θ_v::FT)
-vars_state_gradient_flux(::Vreman, FT) = @vars(∇u::SMatrix{3, 3, FT, 9}, N²::FT)
+vars_state(::Vreman, ::Auxiliary, FT) = @vars(Δ::FT)
+vars_state(::Vreman, ::Gradient, FT) = @vars(θ_v::FT)
+vars_state(::Vreman, ::GradientFlux, FT) =
+    @vars(∇u::SMatrix{3, 3, FT, 9}, N²::FT)
 
 function init_aux_turbulence!(
     ::Vreman,
@@ -713,9 +691,9 @@ $(DocStringExtensions.FIELDS)
 struct AnisoMinDiss{FT} <: TurbulenceClosureModel
     C_poincare::FT
 end
-vars_state_auxiliary(::AnisoMinDiss, FT) = @vars(Δ::FT)
-vars_state_gradient(::AnisoMinDiss, FT) = @vars(θ_v::FT)
-vars_state_gradient_flux(::AnisoMinDiss, FT) =
+vars_state(::AnisoMinDiss, ::Auxiliary, FT) = @vars(Δ::FT)
+vars_state(::AnisoMinDiss, ::Gradient, FT) = @vars(θ_v::FT)
+vars_state(::AnisoMinDiss, ::GradientFlux, FT) =
     @vars(∇u::SMatrix{3, 3, FT, 9}, N²::FT)
 function init_aux_turbulence!(
     ::AnisoMinDiss,
@@ -810,12 +788,12 @@ $(DocStringExtensions.FIELDS)
 struct EquilMoistBiharmonic{FT} <: HyperDiffusion
     τ_timescale::FT
 end
-vars_state_auxiliary(::EquilMoistBiharmonic, FT) = @vars(Δ::FT)
-vars_state_gradient(::EquilMoistBiharmonic, FT) =
+vars_state(::EquilMoistBiharmonic, ::Auxiliary, FT) = @vars(Δ::FT)
+vars_state(::EquilMoistBiharmonic, ::Gradient, FT) =
     @vars(u_h::SVector{3, FT}, h_tot::FT, q_tot::FT)
-vars_gradient_laplacian(::EquilMoistBiharmonic, FT) =
+vars_state(::EquilMoistBiharmonic, ::GradientLaplacian, FT) =
     @vars(u_h::SVector{3, FT}, h_tot::FT, q_tot::FT)
-vars_hyperdiffusive(::EquilMoistBiharmonic, FT) = @vars(
+vars_state(::EquilMoistBiharmonic, ::Hyperdiffusive, FT) = @vars(
     ν∇³u_h::SMatrix{3, 3, FT, 9},
     ν∇³h_tot::SVector{3, FT},
     ν∇³q_tot::SVector{3, FT}
@@ -898,11 +876,12 @@ $(DocStringExtensions.FIELDS)
 struct DryBiharmonic{FT} <: HyperDiffusion
     τ_timescale::FT
 end
-vars_state_auxiliary(::DryBiharmonic, FT) = @vars(Δ::FT)
-vars_state_gradient(::DryBiharmonic, FT) = @vars(u_h::SVector{3, FT}, h_tot::FT)
-vars_gradient_laplacian(::DryBiharmonic, FT) =
+vars_state(::DryBiharmonic, ::Auxiliary, FT) = @vars(Δ::FT)
+vars_state(::DryBiharmonic, ::Gradient, FT) =
     @vars(u_h::SVector{3, FT}, h_tot::FT)
-vars_hyperdiffusive(::DryBiharmonic, FT) =
+vars_state(::DryBiharmonic, ::GradientLaplacian, FT) =
+    @vars(u_h::SVector{3, FT}, h_tot::FT)
+vars_state(::DryBiharmonic, ::Hyperdiffusive, FT) =
     @vars(ν∇³u_h::SMatrix{3, 3, FT, 9}, ν∇³h_tot::SVector{3, FT})
 
 function init_aux_hyperdiffusion!(

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -6,7 +6,7 @@ the Eddy-Diffusivity Mass-Flux model
 """
 module TurbulenceConvection
 
-using ..BalanceLaws: BalanceLaw
+using ..BalanceLaws: BalanceLaw, AbstractStateType
 using ..VariableTemplates: @vars, Vars, Grad
 
 export TurbulenceConvectionModel, NoTurbConv
@@ -14,10 +14,7 @@ export TurbulenceConvectionModel, NoTurbConv
 export init_aux_turbconv!, turbconv_nodal_update_auxiliary_state!
 
 import ..BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     init_state_auxiliary!,
     update_auxiliary_state!,
     flux_first_order!,
@@ -40,10 +37,7 @@ pass through and do nothing.
 """
 struct NoTurbConv <: TurbulenceConvectionModel end
 
-vars_state_conservative(m::TurbulenceConvectionModel, FT) = @vars()
-vars_state_auxiliary(m::TurbulenceConvectionModel, FT) = @vars()
-vars_state_gradient(m::TurbulenceConvectionModel, FT) = @vars()
-vars_state_gradient_flux(m::TurbulenceConvectionModel, FT) = @vars()
+vars_state(m::TurbulenceConvectionModel, ::AbstractStateType, FT) = @vars()
 
 function init_aux_turbconv!(
     m::TurbulenceConvectionModel,

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -26,13 +26,7 @@ import KernelAbstractions: CPU
 
 using ..ConfigTypes
 using ..DGMethods
-using ..BalanceLaws:
-    number_state_conservative,
-    vars_state_conservative,
-    number_state_auxiliary,
-    vars_state_auxiliary,
-    vars_state_gradient_flux,
-    number_state_gradient_flux
+using ..BalanceLaws
 using ..Mesh.Interpolation
 using ..MPIStateArrays
 using ..VariableTemplates

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -235,8 +235,8 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
     # Compute thermo variables
     thermo_array = Array{FT}(undef, npoints, num_thermo(atmos, FT), nrealelem)
     @visitQ nhorzelem nvertelem Nqk Nq begin
-        state = extract_state_conservative(dg, state_data, ijk, e)
-        aux = extract_state_auxiliary(dg, aux_data, ijk, e)
+        state = extract_state(dg, state_data, ijk, e, Prognostic())
+        aux = extract_state(dg, aux_data, ijk, e, Auxiliary())
 
         thermo = thermo_vars(atmos, view(thermo_array, ijk, :, e))
         compute_thermo!(atmos, state, aux, thermo)
@@ -244,8 +244,11 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
 
     # Interpolate the state, thermo and dyn vars to sphere (u and vorticity
     # need projection to zonal, merid). All this may happen on the GPU.
-    istate =
-        ArrayType{FT}(undef, interpol.Npl, number_state_conservative(atmos, FT))
+    istate = ArrayType{FT}(
+        undef,
+        interpol.Npl,
+        number_states(atmos, Prognostic(), FT),
+    )
     interpolate_local!(interpol, Q.realdata, istate)
 
     ithermo = ArrayType{FT}(undef, interpol.Npl, num_thermo(atmos, FT))
@@ -283,7 +286,7 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
         )
 
         @visitI nlong nlat nlevel begin
-            statei = Vars{vars_state_conservative(atmos, FT)}(view(
+            statei = Vars{vars_state(atmos, Prognostic(), FT)}(view(
                 all_state_data,
                 lo,
                 la,

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -66,19 +66,19 @@ atmos_gcm_default_simple_3d_vars(m, array) =
 
 function atmos_gcm_default_simple_3d_vars!(
     atmos::AtmosModel,
-    state_conservative,
+    state_prognostic,
     thermo,
     dyni,
     vars,
 )
-    vars.u = state_conservative.ρu[1] / state_conservative.ρ
-    vars.v = state_conservative.ρu[2] / state_conservative.ρ
-    vars.w = state_conservative.ρu[3] / state_conservative.ρ
-    vars.rho = state_conservative.ρ
+    vars.u = state_prognostic.ρu[1] / state_prognostic.ρ
+    vars.v = state_prognostic.ρu[2] / state_prognostic.ρ
+    vars.w = state_prognostic.ρu[3] / state_prognostic.ρ
+    vars.rho = state_prognostic.ρ
     vars.temp = thermo.temp
     vars.pres = thermo.pres
     vars.thd = thermo.θ_dry
-    vars.et = state_conservative.ρe / state_conservative.ρ
+    vars.et = state_prognostic.ρe / state_prognostic.ρ
     vars.ei = thermo.e_int
     vars.ht = thermo.h_tot
     vars.hi = thermo.h_int
@@ -87,7 +87,7 @@ function atmos_gcm_default_simple_3d_vars!(
 
     atmos_gcm_default_simple_3d_vars!(
         atmos.moisture,
-        state_conservative,
+        state_prognostic,
         thermo,
         vars,
     )
@@ -96,7 +96,7 @@ function atmos_gcm_default_simple_3d_vars!(
 end
 function atmos_gcm_default_simple_3d_vars!(
     ::MoistureModel,
-    state_conservative,
+    state_prognostic,
     thermo,
     vars,
 )
@@ -104,11 +104,11 @@ function atmos_gcm_default_simple_3d_vars!(
 end
 function atmos_gcm_default_simple_3d_vars!(
     moist::EquilMoist,
-    state_conservative,
+    state_prognostic,
     thermo,
     vars,
 )
-    vars.moisture.qt = state_conservative.moisture.ρq_tot / state_conservative.ρ
+    vars.moisture.qt = state_prognostic.moisture.ρq_tot / state_prognostic.ρ
     vars.moisture.ql = thermo.moisture.q_liq
     vars.moisture.qv = thermo.moisture.q_vap
     vars.moisture.qi = thermo.moisture.q_ice

--- a/src/Diagnostics/atmos_les_core.jl
+++ b/src/Diagnostics/atmos_les_core.jl
@@ -210,8 +210,8 @@ function atmos_les_core_collect(dgngrp::DiagnosticsGroup, currtime)
     @visitQ nhorzelem nvertelem Nqk Nq begin
         evk = Nqk * (ev - 1) + k
 
-        state = extract_state_conservative(dg, state_data, ijk, e)
-        aux = extract_state_auxiliary(dg, aux_data, ijk, e)
+        state = extract_state(dg, state_data, ijk, e, Prognostic())
+        aux = extract_state(dg, aux_data, ijk, e, Auxiliary())
         MH = vgeo[ijk, grid.MHid, e]
 
         thermo = thermo_vars(bl, thermo_array[ijk, e])
@@ -266,7 +266,7 @@ function atmos_les_core_collect(dgngrp::DiagnosticsGroup, currtime)
     @visitQ nhorzelem nvertelem Nqk Nq begin
         evk = Nqk * (ev - 1) + k
 
-        state = extract_state_conservative(dg, state_data, ijk, e)
+        state = extract_state(dg, state_data, ijk, e, Prognostic())
         thermo = thermo_vars(bl, thermo_array[ijk, e])
         MH = vgeo[ijk, grid.MHid, e]
 

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -344,9 +344,9 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     @visitQ nhorzelem nvertelem Nqk Nq begin
         evk = Nqk * (ev - 1) + k
 
-        state = extract_state_conservative(dg, state_data, ijk, e)
-        gradflux = extract_state_gradient_flux(dg, gradflux_data, ijk, e)
-        aux = extract_state_auxiliary(dg, aux_data, ijk, e)
+        state = extract_state(dg, state_data, ijk, e, Prognostic())
+        gradflux = extract_state(dg, gradflux_data, ijk, e, GradientFlux())
+        aux = extract_state(dg, aux_data, ijk, e, Auxiliary())
         MH = vgeo[ijk, grid.MHid, e]
 
         thermo = thermo_vars(bl, thermo_array[ijk, e])
@@ -438,7 +438,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     @visitQ nhorzelem nvertelem Nqk Nq begin
         evk = Nqk * (ev - 1) + k
 
-        state = extract_state_conservative(dg, state_data, ijk, e)
+        state = extract_state(dg, state_data, ijk, e, Prognostic())
         thermo = thermo_vars(bl, thermo_array[ijk, e])
         MH = vgeo[ijk, grid.MHid, e]
 

--- a/src/Diagnostics/atmos_les_default_perturbations.jl
+++ b/src/Diagnostics/atmos_les_default_perturbations.jl
@@ -247,7 +247,7 @@ function atmos_les_default_perturbations_collect(
     # Compute thermo variables
     thermo_array = Array{FT}(undef, npoints, num_thermo(atmos, FT), nrealelem)
     @visitQ nhorzelem nvertelem Nqk Nq begin
-        state = extract_state_conservative(dg, state_data, ijk, e)
+        state = extract_state_prognostic(dg, state_data, ijk, e)
         aux = extract_state_auxiliary(dg, aux_data, ijk, e)
 
         thermo = thermo_vars(atmos, view(thermo_array, ijk, :, e))
@@ -257,7 +257,7 @@ function atmos_les_default_perturbations_collect(
     # Interpolate the state and thermo variables.
     interpol = dgngrp.interpol
     istate =
-        ArrayType{FT}(undef, interpol.Npl, number_state_conservative(atmos, FT))
+        ArrayType{FT}(undef, interpol.Npl, number_state_prognostic(atmos, FT))
     interpolate_local!(interpol, Q.realdata, istate)
 
     ithermo = ArrayType{FT}(undef, interpol.Npl, num_thermo(atmos, FT))

--- a/src/Diagnostics/atmos_les_default_perturbations.jl
+++ b/src/Diagnostics/atmos_les_default_perturbations.jl
@@ -281,7 +281,7 @@ function atmos_les_default_perturbations_collect(
             for _ in 1:nz
         ]
         @visitI nx ny nz begin
-            statei = Vars{vars_state_conservative(atmos, FT)}(view(
+            statei = Vars{vars_state(atmos, Prognostic(), FT)}(view(
                 all_state_data,
                 lo,
                 la,
@@ -331,7 +331,7 @@ function atmos_les_default_perturbations_collect(
             num_atmos_les_default_perturbation_vars(atmos, FT),
         )
         @visitI nx ny nz begin
-            statei = Vars{vars_state_conservative(atmos, FT)}(view(
+            statei = Vars{vars_state(atmos, Prognostic(), FT)}(view(
                 all_state_data,
                 lo,
                 la,

--- a/src/Diagnostics/diagnostic_fields.jl
+++ b/src/Diagnostics/diagnostic_fields.jl
@@ -101,8 +101,8 @@ function VectorGradients(dg::DGModel, Q::MPIStateArray)
     data = similar(Q.realdata, npoints, 9, nrealelem)
 
     ind = [
-        varsindex(vars_state_conservative(bl, FT), :ρ)
-        varsindex(vars_state_conservative(bl, FT), :ρu)
+        varsindex(vars_state(bl, Prognostic(), FT), :ρ)
+        varsindex(vars_state(bl, Prognostic(), FT), :ρu)
     ]
     _ρ, _ρu, _ρv, _ρw = ind[1], ind[2], ind[3], ind[4]
 

--- a/src/Diagnostics/dump_aux.jl
+++ b/src/Diagnostics/dump_aux.jl
@@ -1,32 +1,4 @@
-function dump_aux_init(dgngrp, currtime)
-    FT = eltype(Settings.Q)
-    bl = Settings.dg.balance_law
-    mpicomm = Settings.mpicomm
-    mpirank = MPI.Comm_rank(mpicomm)
-
-    if mpirank == 0
-        # get dimensions for the interpolated grid
-        dims = dimensions(dgngrp.interpol)
-
-        # set up the variables we're going to be writing
-        vars = OrderedDict()
-        auxnames = flattenednames(vars_state_auxiliary(bl, FT))
-        for varname in auxnames
-            vars[varname] = (tuple(collect(keys(dims))...), FT, Dict())
-        end
-
-        dprefix = @sprintf(
-            "%s_%s-%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
-        dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
-    end
-
-    return nothing
-end
+dump_aux_init(dgngrp, currtime) = dump_init(dgngrp, currtime, Auxiliary())
 
 function dump_aux_collect(dgngrp, currtime)
     interpol = dgngrp.interpol
@@ -40,14 +12,17 @@ function dump_aux_collect(dgngrp, currtime)
     iaux = similar(
         dg.state_auxiliary.data,
         interpol.Npl,
-        number_state_auxiliary(bl, FT),
+        number_states(bl, Auxiliary(), FT),
     )
+
+
     interpolate_local!(interpol, dg.state_auxiliary.data, iaux)
+
 
     all_aux_data = accumulate_interpolated_data(mpicomm, interpol, iaux)
 
     if mpirank == 0
-        auxnames = flattenednames(vars_state_auxiliary(bl, FT))
+        auxnames = flattenednames(vars_state(bl, Auxiliary(), FT))
         varvals = OrderedDict()
         for (vari, varname) in enumerate(auxnames)
             varvals[varname] = all_aux_data[:, :, :, vari]

--- a/src/Diagnostics/dump_init.jl
+++ b/src/Diagnostics/dump_init.jl
@@ -1,0 +1,29 @@
+function dump_init(dgngrp, currtime, st::AbstractStateType)
+    FT = eltype(Settings.Q)
+    bl = Settings.dg.balance_law
+    mpicomm = Settings.mpicomm
+    mpirank = MPI.Comm_rank(mpicomm)
+
+    if mpirank == 0
+        # get dimensions for the interpolated grid
+        dims = dimensions(dgngrp.interpol)
+
+        # set up the variables we're going to be writing
+        vars = OrderedDict()
+        statenames = flattenednames(vars_state(bl, st, FT))
+        for varname in statenames
+            vars[varname] = (tuple(collect(keys(dims))...), FT, Dict())
+        end
+
+        dprefix = @sprintf(
+            "%s_%s-%s",
+            dgngrp.out_prefix,
+            dgngrp.name,
+            Settings.starttime,
+        )
+        dfilename = joinpath(Settings.output_dir, dprefix)
+        init_data(dgngrp.writer, dfilename, dims, vars)
+    end
+
+    return nothing
+end

--- a/src/Diagnostics/dump_state.jl
+++ b/src/Diagnostics/dump_state.jl
@@ -1,32 +1,4 @@
-function dump_state_init(dgngrp, currtime)
-    FT = eltype(Settings.Q)
-    bl = Settings.dg.balance_law
-    mpicomm = Settings.mpicomm
-    mpirank = MPI.Comm_rank(mpicomm)
-
-    if mpirank == 0
-        # get dimensions for the interpolated grid
-        dims = dimensions(dgngrp.interpol)
-
-        # set up the variables we're going to be writing
-        vars = OrderedDict()
-        statenames = flattenednames(vars_state_conservative(bl, FT))
-        for varname in statenames
-            vars[varname] = (tuple(collect(keys(dims))...), FT, Dict())
-        end
-
-        dprefix = @sprintf(
-            "%s_%s-%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
-        dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
-    end
-
-    return nothing
-end
+dump_state_init(dgngrp, currtime) = dump_init(dgngrp, currtime, Prognostic())
 
 function dump_state_collect(dgngrp, currtime)
     interpol = dgngrp.interpol
@@ -37,7 +9,7 @@ function dump_state_collect(dgngrp, currtime)
     bl = dg.balance_law
     mpirank = MPI.Comm_rank(mpicomm)
 
-    istate = similar(Q.data, interpol.Npl, number_state_conservative(bl, FT))
+    istate = similar(Q.data, interpol.Npl, number_states(bl, Prognostic(), FT))
     interpolate_local!(interpol, Q.data, istate)
 
     if interpol isa InterpolationCubedSphere
@@ -49,7 +21,7 @@ function dump_state_collect(dgngrp, currtime)
     all_state_data = accumulate_interpolated_data(mpicomm, interpol, istate)
 
     if mpirank == 0
-        statenames = flattenednames(vars_state_conservative(bl, FT))
+        statenames = flattenednames(vars_state(bl, Prognostic(), FT))
         varvals = OrderedDict()
         for (vari, varname) in enumerate(statenames)
             varvals[varname] = all_state_data[:, :, :, vari]

--- a/src/Diagnostics/groups.jl
+++ b/src/Diagnostics/groups.jl
@@ -248,6 +248,7 @@ function setup_atmos_refstate_perturbations(
     )
 end
 
+include("dump_init.jl")
 include("dump_state.jl")
 """
     setup_dump_state_diagnostics(

--- a/src/Diagnostics/helpers.jl
+++ b/src/Diagnostics/helpers.jl
@@ -38,34 +38,13 @@ macro visitI(nlong, nlat, nlevel, expr)
 end
 
 # Helpers to extract data from the various state arrays
-function extract_state_conservative(dg, state_conservative, ijk, e)
+function extract_state(dg, state, ijk, e, st::AbstractStateType)
     bl = dg.balance_law
-    FT = eltype(state_conservative)
-    num_state_conservative = number_state_conservative(bl, FT)
-    local_state_conservative = MArray{Tuple{num_state_conservative}, FT}(undef)
-    for s in 1:num_state_conservative
-        local_state_conservative[s] = state_conservative[ijk, s, e]
+    FT = eltype(state)
+    num_state = number_states(bl, st, FT)
+    local_state = MArray{Tuple{num_state}, FT}(undef)
+    for s in 1:num_state
+        local_state[s] = state[ijk, s, e]
     end
-    return Vars{vars_state_conservative(bl, FT)}(local_state_conservative)
-end
-function extract_state_auxiliary(dg, state_auxiliary, ijk, e)
-    bl = dg.balance_law
-    FT = eltype(state_auxiliary)
-    num_state_auxiliary = number_state_auxiliary(bl, FT)
-    local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
-    for s in 1:num_state_auxiliary
-        local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
-    end
-    return Vars{vars_state_auxiliary(bl, FT)}(local_state_auxiliary)
-end
-function extract_state_gradient_flux(dg, state_gradient_flux, ijk, e)
-    bl = dg.balance_law
-    FT = eltype(state_gradient_flux)
-    num_state_gradient_flux = number_state_gradient_flux(bl, FT)
-    local_state_gradient_flux =
-        MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-    for s in 1:num_state_gradient_flux
-        local_state_gradient_flux[s] = state_gradient_flux[ijk, s, e]
-    end
-    return Vars{vars_state_gradient_flux(bl, FT)}(local_state_gradient_flux)
+    return Vars{vars_state(bl, st, FT)}(local_state)
 end

--- a/src/Driver/Callbacks/Callbacks.jl
+++ b/src/Driver/Callbacks/Callbacks.jl
@@ -14,7 +14,7 @@ using CLIMAParameters.Planet: day
 using ..Courant
 using ..Checkpoint
 using ..DGMethods: courant
-using ..BalanceLaws: vars_state_conservative, vars_state_auxiliary
+using ..BalanceLaws: vars_state
 using ..Diagnostics
 using ..GenericCallbacks
 using ..MPIStateArrays
@@ -151,8 +151,8 @@ function vtk(vtk_opt, solver_config, output_dir, number_sample_points)
             )
             outprefix = joinpath(output_dir, vprefix)
 
-            statenames = flattenednames(vars_state_conservative(bl, FT))
-            auxnames = flattenednames(vars_state_auxiliary(bl, FT))
+            statenames = flattenednames(vars_state(bl, Prognostic(), FT))
+            auxnames = flattenednames(vars_state(bl, Auxiliary(), FT))
 
             writevtk(
                 outprefix,

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -17,11 +17,7 @@ using ..SystemSolvers
 using ..ConfigTypes
 using ..Diagnostics
 using ..DGMethods
-using ..BalanceLaws:
-    BalanceLaw,
-    vars_state_conservative,
-    vars_state_auxiliary,
-    update_auxiliary_state!
+using ..BalanceLaws: BalanceLaw, vars_state, update_auxiliary_state!
 using ..DGMethods: remainder_DGModel
 using ..DGMethods.NumericalFluxes
 using ..Ocean.HydrostaticBoussinesq

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -122,7 +122,7 @@ function AtmosLESConfiguration(
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         param_set;
-        init_state_conservative = init_LES!,
+        init_state_prognostic = init_LES!,
     ),
     mpicomm = MPI.COMM_WORLD,
     boundary = ((0, 0), (0, 0), (1, 2)),
@@ -209,7 +209,7 @@ function AtmosGCMConfiguration(
     model = AtmosModel{FT}(
         AtmosGCMConfigType,
         param_set;
-        init_state_conservative = init_GCM!,
+        init_state_prognostic = init_GCM!,
     ),
     mpicomm = MPI.COMM_WORLD,
     meshwarp::Function = cubedshellwarp,

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -63,8 +63,8 @@ the ODE solver, and return a `SolverConfiguration` to be used with
 # - `t0::FT`: simulation start time.
 # - `timeend::FT`: simulation end time.
 # - `driver_config::DriverConfiguration`: from `AtmosLESConfiguration()`, etc.
-# - `init_args...`: passed through to `init_state_conservative!()`.
-# - `init_on_cpu=false`: run `init_state_conservative!()` on CPU?
+# - `init_args...`: passed through to `init_state_prognostic!()`.
+# - `init_on_cpu=false`: run `init_state_prognostic!()` on CPU?
 # - `ode_solver_type=driver_config.solver_type`: override solver choice.
 # - `ode_dt=nothing`: override timestep computation.
 # - `modeldata=nothing`: passed through to `DGModel`.

--- a/src/Land/Model/LandModel.jl
+++ b/src/Land/Model/LandModel.jl
@@ -6,12 +6,10 @@ using LinearAlgebra, StaticArrays
 using ..VariableTemplates
 using ..MPIStateArrays
 
-import ClimateMachine.DGMethods:
+using ..BalanceLaws
+import ..BalanceLaws:
     BalanceLaw,
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -21,10 +19,9 @@ import ClimateMachine.DGMethods:
     init_state_auxiliary!,
     init_state_conservative!,
     update_auxiliary_state!,
-    LocalGeometry,
-    DGModel,
     nodal_update_auxiliary_state!
 
+using ..DGMethods: LocalGeometry, DGModel
 
 export LandModel
 
@@ -51,53 +48,53 @@ struct LandModel{PS, S, SRC} <: BalanceLaw
 end
 
 """
-    vars_state_conservative(land::LandModel, FT)
+    vars_state(land::LandModel, ::Prognostic, FT)
 
 Conserved state variables (Prognostic Variables)
 """
-function vars_state_conservative(land::LandModel, FT)
+function vars_state(land::LandModel, st::Prognostic, FT)
     @vars begin
-        soil::vars_state_conservative(land.soil, FT)
+        soil::vars_state(land.soil, st, FT)
     end
 end
 
 """
-    vars_state_auxiliary(land::LandModel, FT)
+    vars_state(land::LandModel, st::Auxiliary, FT)
 
-Names of variables required for the balance law that aren't related to 
-derivatives of the state variables (e.g. spatial coordinates or various 
-integrals) or those needed to solve expensive auxiliary equations 
+Names of variables required for the balance law that aren't related to
+derivatives of the state variables (e.g. spatial coordinates or various
+integrals) or those needed to solve expensive auxiliary equations
 (e.g., temperature via a non-linear equation solve)
 """
-function vars_state_auxiliary(land::LandModel, FT)
+function vars_state(land::LandModel, st::Auxiliary, FT)
     @vars begin
-        soil::vars_state_auxiliary(land.soil, FT)
+        soil::vars_state(land.soil, st, FT)
     end
 end
 
 """
-    vars_state_gradient(land::LandModel, FT)
+    vars_state(land::LandModel, st::Gradient, FT)
 
-Names of the gradients of functions of the conservative state 
+Names of the gradients of functions of the conservative state
 variables.
 
 Used to represent values before **and** after differentiation.
 """
-function vars_state_gradient(land::LandModel, FT)
+function vars_state(land::LandModel, st::Gradient, FT)
     @vars begin
-        soil::vars_state_gradient(land.soil, FT)
+        soil::vars_state(land.soil, st, FT)
     end
 end
 
 """
-    vars_state_gradient_flux(land::LandModel, FT)
+    vars_state(land::LandModel, st::GradientFlux, FT)
 
-Names of the gradient fluxes necessary to impose Neumann boundary 
+Names of the gradient fluxes necessary to impose Neumann boundary
 conditions.
 """
-function vars_state_gradient_flux(land::LandModel, FT)
+function vars_state(land::LandModel, st::GradientFlux, FT)
     @vars begin
-        soil::vars_state_gradient_flux(land.soil, FT)
+        soil::vars_state(land.soil, st, FT)
     end
 end
 
@@ -221,7 +218,7 @@ end
         elems::UnitRange,
     )
 
-Perform any updates to the auxiliary variables needed at the 
+Perform any updates to the auxiliary variables needed at the
 beginning of each time-step.
 """
 function update_auxiliary_state!(

--- a/src/Land/Model/LandModel.jl
+++ b/src/Land/Model/LandModel.jl
@@ -17,7 +17,7 @@ import ..BalanceLaws:
     compute_gradient_argument!,
     compute_gradient_flux!,
     init_state_auxiliary!,
-    init_state_conservative!,
+    init_state_prognostic!,
     update_auxiliary_state!,
     nodal_update_auxiliary_state!
 

--- a/src/Land/Model/soil_heat.jl
+++ b/src/Land/Model/soil_heat.jl
@@ -12,10 +12,10 @@ The balance law for internal energy in soil.
 struct SoilHeatModel <: AbstractHeatModel end
 
 """
-    vars_state_conservative(soil::AbstractHeatModel, FT)
+    vars_state(soil::AbstractHeatModel, ::Prognostic, FT)
 
 """
-function vars_state_conservative(soil::AbstractHeatModel, FT)
+function vars_state(soil::AbstractHeatModel, ::Prognostic, FT)
     @vars()
 end
 

--- a/src/Land/Model/soil_model.jl
+++ b/src/Land/Model/soil_model.jl
@@ -23,54 +23,54 @@ struct SoilModel{W, H} <: BalanceLaw
 end
 
 """
-    vars_state_conservative(soil::SoilModel, FT)
+    vars_state(soil::SoilModel, st::Prognostic, FT)
 
 Conserved state variables (Prognostic Variables)
 """
-function vars_state_conservative(soil::SoilModel, FT)
+function vars_state(soil::SoilModel, st::Prognostic, FT)
     @vars begin
-        water::vars_state_conservative(soil.water, FT)
-        heat::vars_state_conservative(soil.heat, FT)
+        water::vars_state(soil.water, st, FT)
+        heat::vars_state(soil.heat, st, FT)
     end
 end
 
 """
-    vars_state_auxiliary(soil::SoilModel, FT)
+    vars_state(soil::SoilModel, st::Auxiliary, FT)
 
-Names of variables required for the balance law that aren't related to 
-derivatives of the state variables (e.g. spatial coordinates or various 
-integrals) or those needed to solve expensive auxiliary equations 
+Names of variables required for the balance law that aren't related to
+derivatives of the state variables (e.g. spatial coordinates or various
+integrals) or those needed to solve expensive auxiliary equations
 (e.g., temperature via a non-linear equation solve)
 """
-function vars_state_auxiliary(soil::SoilModel, FT)
+function vars_state(soil::SoilModel, st::Auxiliary, FT)
     @vars begin
-        water::vars_state_auxiliary(soil.water, FT)
-        heat::vars_state_auxiliary(soil.heat, FT)
+        water::vars_state(soil.water, st, FT)
+        heat::vars_state(soil.heat, st, FT)
     end
 end
 
 """
-    vars_state_gradient(soil::SoilModel, FT)
+    vars_state(soil::SoilModel, st::Gradient, FT)
 
-Names of the gradients of functions of the conservative state variables. 
+Names of the gradients of functions of the conservative state variables.
 Used to represent values before **and** after differentiation
 """
-function vars_state_gradient(soil::SoilModel, FT)
+function vars_state(soil::SoilModel, st::Gradient, FT)
     @vars begin
-        water::vars_state_gradient(soil.water, FT)
-        heat::vars_state_gradient(soil.heat, FT)
+        water::vars_state(soil.water, st, FT)
+        heat::vars_state(soil.heat, st, FT)
     end
 end
 
 """
-    vars_state_gradient_flux(soil::SoilModel, FT)
+    vars_state(soil::SoilModel, st::GradientFlux, FT)
 
 Names of the gradient fluxes necessary to impose Neumann boundary conditions
 """
-function vars_state_gradient_flux(soil::SoilModel, FT)
+function vars_state(soil::SoilModel, st::GradientFlux, FT)
     @vars begin
-        water::vars_state_gradient_flux(soil.water, FT)
-        heat::vars_state_gradient_flux(soil.heat, FT)
+        water::vars_state(soil.water, st, FT)
+        heat::vars_state(soil.heat, st, FT)
     end
 end
 

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -26,7 +26,7 @@ using ..BalanceLaws:
 
 import ..BalanceLaws:
     BalanceLaw,
-    init_state_conservative!,
+    init_state_prognostic!,
     init_state_auxiliary!,
     flux_first_order!,
     flux_second_order!,

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -12,23 +12,17 @@ using ..VariableTemplates
 using ..Courant
 using ..BalanceLaws:
     BalanceLaw,
-    vars_state_conservative,
-    vars_state_auxiliary,
-    vars_state_gradient,
-    vars_state_gradient_flux,
-    vars_gradient_laplacian,
-    vars_hyperdiffusive,
-    vars_integrals,
-    vars_reverse_integrals,
-    number_state_conservative,
-    number_state_gradient_flux,
-    number_state_conservative,
-    number_state_auxiliary,
-    number_state_gradient,
-    num_gradient_laplacian,
-    num_hyperdiffusive,
-    num_integrals,
-    num_reverse_integrals
+    AbstractStateType,
+    Prognostic,
+    Auxiliary,
+    Gradient,
+    GradientFlux,
+    GradientLaplacian,
+    Hyperdiffusive,
+    UpwardIntegrals,
+    DownwardIntegrals,
+    vars_state,
+    number_states
 
 import ..BalanceLaws:
     BalanceLaw,

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -82,33 +82,27 @@ function basic_grid_info(dg::DGModel)
 end
 
 """
-    (dg::DGModel)(tendency, state_conservative, nothing, t, α, β)
+    (dg::DGModel)(tendency, state_prognostic, nothing, t, α, β)
 
 Computes the tendency terms compatible with `IncrementODEProblem`
 
-    tendency .= α .* dQdt(state_conservative, p, t) .+ β .* tendency
+    tendency .= α .* dQdt(state_prognostic, p, t) .+ β .* tendency
 
 The 4-argument form will just compute
 
-    tendency .= dQdt(state_conservative, p, t)
+    tendency .= dQdt(state_prognostic, p, t)
 
 """
-function (dg::DGModel)(
-    tendency,
-    state_conservative,
-    param,
-    t;
-    increment = false,
-)
+function (dg::DGModel)(tendency, state_prognostic, param, t; increment = false)
     # TODO deprecate increment argument
-    dg(tendency, state_conservative, param, t, true, increment)
+    dg(tendency, state_prognostic, param, t, true, increment)
 end
 
-function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
+function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
 
 
     balance_law = dg.balance_law
-    device = array_device(state_conservative)
+    device = array_device(state_prognostic)
 
     grid = dg.grid
     topology = grid.topology
@@ -124,13 +118,13 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
     Qhypervisc_grad, Qhypervisc_div = dg.states_higher_order
     state_auxiliary = dg.state_auxiliary
 
-    FT = eltype(state_conservative)
-    num_state_conservative = number_states(balance_law, Prognostic(), FT)
+    FT = eltype(state_prognostic)
+    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
     num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
     nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
     num_state_tendency = size(tendency, 2)
 
-    @assert num_state_conservative ≤ num_state_tendency
+    @assert num_state_prognostic ≤ num_state_tendency
 
     Np = dofs_per_element(grid)
 
@@ -140,7 +134,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
     ndrange_interior_surface = Nfp * length(grid.interiorelems)
     ndrange_exterior_surface = Nfp * length(grid.exteriorelems)
 
-    if num_state_conservative < num_state_tendency && β != 1
+    if num_state_prognostic < num_state_tendency && β != 1
         # if we don't operate on the full state, then we need to scale here instead of volume_tendency!
         tendency .*= β
         β = β != 0 # if β==0 then we can avoid the memory load in volume_tendency!
@@ -152,7 +146,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
     update_auxiliary_state!(
         dg,
         balance_law,
-        state_conservative,
+        state_prognostic,
         t,
         dg.grid.topology.realelems,
     )
@@ -166,7 +160,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
         hypervisc_indexmap = nothing
     end
 
-    exchange_state_conservative = NoneEvent()
+    exchange_state_prognostic = NoneEvent()
     exchange_state_gradient_flux = NoneEvent()
     exchange_Qhypervisc_grad = NoneEvent()
     exchange_Qhypervisc_div = NoneEvent()
@@ -177,8 +171,8 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
     # Gradient Computation #
     ########################
     if communicate
-        exchange_state_conservative = MPIStateArrays.begin_ghost_exchange!(
-            state_conservative;
+        exchange_state_prognostic = MPIStateArrays.begin_ghost_exchange!(
+            state_prognostic;
             dependencies = comp_stream,
         )
     end
@@ -190,7 +184,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
             Val(dim),
             Val(N),
             dg.diffusion_direction,
-            state_conservative.data,
+            state_prognostic.data,
             state_gradient_flux.data,
             Qhypervisc_grad.data,
             state_auxiliary.data,
@@ -209,7 +203,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
             Val(N),
             dg.diffusion_direction,
             dg.numerical_flux_gradient,
-            state_conservative.data,
+            state_prognostic.data,
             state_gradient_flux.data,
             Qhypervisc_grad.data,
             state_auxiliary.data,
@@ -226,22 +220,22 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
         )
 
         if communicate
-            exchange_state_conservative = MPIStateArrays.end_ghost_exchange!(
-                state_conservative;
-                dependencies = exchange_state_conservative,
+            exchange_state_prognostic = MPIStateArrays.end_ghost_exchange!(
+                state_prognostic;
+                dependencies = exchange_state_prognostic,
             )
 
             # update_aux may start asynchronous work on the compute device and
             # we synchronize those here through a device event.
-            wait(device, exchange_state_conservative)
+            wait(device, exchange_state_prognostic)
             update_auxiliary_state!(
                 dg,
                 balance_law,
-                state_conservative,
+                state_prognostic,
                 t,
                 dg.grid.topology.ghostelems,
             )
-            exchange_state_conservative = Event(device)
+            exchange_state_prognostic = Event(device)
         end
 
         comp_stream = interface_gradients!(device, workgroups_surface)(
@@ -250,7 +244,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
             Val(N),
             dg.diffusion_direction,
             dg.numerical_flux_gradient,
-            state_conservative.data,
+            state_prognostic.data,
             state_gradient_flux.data,
             Qhypervisc_grad.data,
             state_auxiliary.data,
@@ -263,7 +257,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
             Val(hypervisc_indexmap),
             grid.exteriorelems;
             ndrange = ndrange_exterior_surface,
-            dependencies = (comp_stream, exchange_state_conservative),
+            dependencies = (comp_stream, exchange_state_prognostic),
         )
 
         if communicate
@@ -289,7 +283,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
             update_auxiliary_state_gradient!(
                 dg,
                 balance_law,
-                state_conservative,
+                state_prognostic,
                 t,
                 dg.grid.topology.realelems,
             )
@@ -381,7 +375,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
                 dg.diffusion_direction,
                 Qhypervisc_grad.data,
                 Qhypervisc_div.data,
-                state_conservative.data,
+                state_prognostic.data,
                 state_auxiliary.data,
                 grid.vgeo,
                 grid.ω,
@@ -401,7 +395,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
                 CentralNumericalFluxHigherOrder(),
                 Qhypervisc_grad.data,
                 Qhypervisc_div.data,
-                state_conservative.data,
+                state_prognostic.data,
                 state_auxiliary.data,
                 grid.vgeo,
                 grid.sgeo,
@@ -430,7 +424,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
                 CentralNumericalFluxHigherOrder(),
                 Qhypervisc_grad.data,
                 Qhypervisc_div.data,
-                state_conservative.data,
+                state_prognostic.data,
                 state_auxiliary.data,
                 grid.vgeo,
                 grid.sgeo,
@@ -461,7 +455,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
         Val(N),
         dg.direction,
         tendency.data,
-        state_conservative.data,
+        state_prognostic.data,
         state_gradient_flux.data,
         Qhypervisc_grad.data,
         state_auxiliary.data,
@@ -484,7 +478,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
         dg.numerical_flux_first_order,
         dg.numerical_flux_second_order,
         tendency.data,
-        state_conservative.data,
+        state_prognostic.data,
         state_gradient_flux.data,
         Qhypervisc_grad.data,
         state_auxiliary.data,
@@ -516,7 +510,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
                 update_auxiliary_state_gradient!(
                     dg,
                     balance_law,
-                    state_conservative,
+                    state_prognostic,
                     t,
                     dg.grid.topology.ghostelems,
                 )
@@ -529,22 +523,22 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
                 )
             end
         else
-            exchange_state_conservative = MPIStateArrays.end_ghost_exchange!(
-                state_conservative;
-                dependencies = exchange_state_conservative,
+            exchange_state_prognostic = MPIStateArrays.end_ghost_exchange!(
+                state_prognostic;
+                dependencies = exchange_state_prognostic,
             )
 
             # update_aux may start asynchronous work on the compute device and
             # we synchronize those here through a device event.
-            wait(device, exchange_state_conservative)
+            wait(device, exchange_state_prognostic)
             update_auxiliary_state!(
                 dg,
                 balance_law,
-                state_conservative,
+                state_prognostic,
                 t,
                 dg.grid.topology.ghostelems,
             )
-            exchange_state_conservative = Event(device)
+            exchange_state_prognostic = Event(device)
         end
     end
 
@@ -556,7 +550,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
         dg.numerical_flux_first_order,
         dg.numerical_flux_second_order,
         tendency.data,
-        state_conservative.data,
+        state_prognostic.data,
         state_gradient_flux.data,
         Qhypervisc_grad.data,
         state_auxiliary.data,
@@ -571,7 +565,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
         ndrange = ndrange_exterior_surface,
         dependencies = (
             comp_stream,
-            exchange_state_conservative,
+            exchange_state_prognostic,
             exchange_state_gradient_flux,
             exchange_Qhypervisc_grad,
         ),
@@ -589,7 +583,7 @@ function init_ode_state(dg::DGModel, args...; init_on_cpu = false)
     balance_law = dg.balance_law
     grid = dg.grid
 
-    state_conservative = create_state(balance_law, grid, Prognostic())
+    state_prognostic = create_state(balance_law, grid, Prognostic())
 
     topology = grid.topology
     Np = dofs_per_element(grid)
@@ -601,11 +595,11 @@ function init_ode_state(dg::DGModel, args...; init_on_cpu = false)
 
     if !init_on_cpu
         event = Event(device)
-        event = kernel_init_state_conservative!(device, min(Np, 1024))(
+        event = kernel_init_state_prognostic!(device, min(Np, 1024))(
             balance_law,
             Val(dim),
             Val(N),
-            state_conservative.data,
+            state_prognostic.data,
             state_auxiliary.data,
             grid.vgeo,
             topology.realelems,
@@ -615,14 +609,14 @@ function init_ode_state(dg::DGModel, args...; init_on_cpu = false)
         )
         wait(device, event)
     else
-        h_state_conservative = similar(state_conservative, Array)
+        h_state_prognostic = similar(state_prognostic, Array)
         h_state_auxiliary = similar(state_auxiliary, Array)
         h_state_auxiliary .= state_auxiliary
-        event = kernel_init_state_conservative!(CPU(), Np)(
+        event = kernel_init_state_prognostic!(CPU(), Np)(
             balance_law,
             Val(dim),
             Val(N),
-            h_state_conservative.data,
+            h_state_prognostic.data,
             h_state_auxiliary.data,
             Array(grid.vgeo),
             topology.realelems,
@@ -630,21 +624,21 @@ function init_ode_state(dg::DGModel, args...; init_on_cpu = false)
             ndrange = Np * nrealelem,
         )
         wait(event) # XXX: This could be `wait(device, event)` once KA supports that.
-        state_conservative .= h_state_conservative
+        state_prognostic .= h_state_prognostic
     end
 
     event = Event(device)
     event = MPIStateArrays.begin_ghost_exchange!(
-        state_conservative;
+        state_prognostic;
         dependencies = event,
     )
     event = MPIStateArrays.end_ghost_exchange!(
-        state_conservative;
+        state_prognostic;
         dependencies = event,
     )
     wait(device, event)
 
-    return state_conservative
+    return state_prognostic
 end
 
 function restart_ode_state(dg::DGModel, state_data; init_on_cpu = false)
@@ -671,14 +665,14 @@ function restart_auxiliary_state(bl, grid, aux_data)
 end
 
 # fallback
-function update_auxiliary_state!(dg, balance_law, state_conservative, t, elems)
+function update_auxiliary_state!(dg, balance_law, state_prognostic, t, elems)
     return false
 end
 
 function update_auxiliary_state_gradient!(
     dg::DGModel,
     balance_law,
-    state_conservative,
+    state_prognostic,
     t,
     elems,
 )
@@ -688,13 +682,13 @@ end
 function indefinite_stack_integral!(
     dg::DGModel,
     m::BalanceLaw,
-    state_conservative::MPIStateArray,
+    state_prognostic::MPIStateArray,
     state_auxiliary::MPIStateArray,
     t::Real,
     elems::UnitRange = dg.grid.topology.elems,
 )
 
-    device = array_device(state_conservative)
+    device = array_device(state_prognostic)
 
     grid = dg.grid
     topology = grid.topology
@@ -704,7 +698,7 @@ function indefinite_stack_integral!(
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
 
-    FT = eltype(state_conservative)
+    FT = eltype(state_prognostic)
 
     # do integrals
     nelem = length(elems)
@@ -717,7 +711,7 @@ function indefinite_stack_integral!(
         Val(dim),
         Val(N),
         Val(nvertelem),
-        state_conservative.data,
+        state_prognostic.data,
         state_auxiliary.data,
         grid.vgeo,
         grid.Imat,
@@ -731,7 +725,7 @@ end
 function reverse_indefinite_stack_integral!(
     dg::DGModel,
     m::BalanceLaw,
-    state_conservative::MPIStateArray,
+    state_prognostic::MPIStateArray,
     state_auxiliary::MPIStateArray,
     t::Real,
     elems::UnitRange = dg.grid.topology.elems,
@@ -760,7 +754,7 @@ function reverse_indefinite_stack_integral!(
         Val(dim),
         Val(N),
         Val(nvertelem),
-        state_conservative.data,
+        state_prognostic.data,
         state_auxiliary.data,
         horzelems;
         ndrange = (length(horzelems) * Nq, Nqk),
@@ -774,12 +768,12 @@ function nodal_update_auxiliary_state!(
     f!,
     dg::DGModel,
     m::BalanceLaw,
-    state_conservative::MPIStateArray,
+    state_prognostic::MPIStateArray,
     t::Real,
     elems::UnitRange = dg.grid.topology.realelems;
     diffusive = false,
 )
-    device = array_device(state_conservative)
+    device = array_device(state_prognostic)
 
     grid = dg.grid
     topology = grid.topology
@@ -801,7 +795,7 @@ function nodal_update_auxiliary_state!(
             Val(dim),
             Val(N),
             f!,
-            state_conservative.data,
+            state_prognostic.data,
             dg.state_auxiliary.data,
             dg.state_gradient_flux.data,
             t,
@@ -816,7 +810,7 @@ function nodal_update_auxiliary_state!(
             Val(dim),
             Val(N),
             f!,
-            state_conservative.data,
+            state_prognostic.data,
             dg.state_auxiliary.data,
             t,
             elems,
@@ -830,14 +824,14 @@ end
 
 """
     courant(local_courant::Function, dg::DGModel, m::BalanceLaw,
-            state_conservative::MPIStateArray, direction=EveryDirection())
+            state_prognostic::MPIStateArray, direction=EveryDirection())
 Returns the maximum of the evaluation of the function `local_courant`
 pointwise throughout the domain.  The function `local_courant` is given an
 approximation of the local node distance `Δx`.  The `direction` controls which
 reference directions are considered when computing the minimum node distance
 `Δx`.
 An example `local_courant` function is
-    function local_courant(m::AtmosModel, state_conservative::Vars, state_auxiliary::Vars,
+    function local_courant(m::AtmosModel, state_prognostic::Vars, state_auxiliary::Vars,
                            diffusive::Vars, Δx)
       return Δt * cmax / Δx
     end
@@ -848,7 +842,7 @@ function courant(
     local_courant::Function,
     dg::DGModel,
     m::BalanceLaw,
-    state_conservative::MPIStateArray,
+    state_prognostic::MPIStateArray,
     Δt,
     simtime,
     direction = EveryDirection(),
@@ -884,7 +878,7 @@ function courant(
             Val(N),
             pointwise_courant,
             local_courant,
-            state_conservative.data,
+            state_prognostic.data,
             dg.state_auxiliary.data,
             dg.state_gradient_flux.data,
             topology.realelems,
@@ -897,7 +891,7 @@ function courant(
         wait(device, event)
         rank_courant_max = maximum(pointwise_courant)
     else
-        rank_courant_max = typemin(eltype(state_conservative))
+        rank_courant_max = typemin(eltype(state_prognostic))
     end
 
     MPI.Allreduce(rank_courant_max, max, topology.mpicomm)
@@ -907,7 +901,7 @@ function MPIStateArrays.MPIStateArray(dg::DGModel)
     balance_law = dg.balance_law
     grid = dg.grid
 
-    state_conservative = create_state(balance_law, grid, Prognostic())
+    state_prognostic = create_state(balance_law, grid, Prognostic())
 
-    return state_conservative
+    return state_prognostic
 end

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -21,13 +21,18 @@ function DGModel(
     numerical_flux_first_order,
     numerical_flux_second_order,
     numerical_flux_gradient;
-    state_auxiliary = create_auxiliary_state(balance_law, grid),
-    state_gradient_flux = create_gradient_state(balance_law, grid),
-    states_higher_order = create_higher_order_states(balance_law, grid),
+    state_auxiliary = create_state(balance_law, grid, Auxiliary()),
+    state_gradient_flux = create_state(balance_law, grid, GradientFlux()),
+    states_higher_order = (
+        create_state(balance_law, grid, GradientLaplacian()),
+        create_state(balance_law, grid, Hyperdiffusive()),
+    ),
     direction = EveryDirection(),
     diffusion_direction = direction,
     modeldata = nothing,
 )
+    state_auxiliary =
+        init_state(state_auxiliary, balance_law, grid, Auxiliary())
     DGModel(
         balance_law,
         grid,
@@ -120,9 +125,9 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
     state_auxiliary = dg.state_auxiliary
 
     FT = eltype(state_conservative)
-    num_state_conservative = number_state_conservative(balance_law, FT)
-    num_state_gradient_flux = number_state_gradient_flux(balance_law, FT)
-    nhyperviscstate = num_hyperdiffusive(balance_law, FT)
+    num_state_conservative = number_states(balance_law, Prognostic(), FT)
+    num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
+    nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
     num_state_tendency = size(tendency, 2)
 
     @assert num_state_conservative ≤ num_state_tendency
@@ -154,8 +159,8 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
 
     if nhyperviscstate > 0
         hypervisc_indexmap = varsindices(
-            vars_state_gradient(balance_law, FT),
-            fieldnames(vars_gradient_laplacian(balance_law, FT)),
+            vars_state(balance_law, Gradient(), FT),
+            fieldnames(vars_state(balance_law, GradientLaplacian(), FT)),
         )
     else
         hypervisc_indexmap = nothing
@@ -584,7 +589,7 @@ function init_ode_state(dg::DGModel, args...; init_on_cpu = false)
     balance_law = dg.balance_law
     grid = dg.grid
 
-    state_conservative = create_conservative_state(balance_law, grid)
+    state_conservative = create_state(balance_law, grid, Prognostic())
 
     topology = grid.topology
     Np = dofs_per_element(grid)
@@ -646,7 +651,7 @@ function restart_ode_state(dg::DGModel, state_data; init_on_cpu = false)
     bl = dg.balance_law
     grid = dg.grid
 
-    state = create_conservative_state(bl, grid)
+    state = create_state(bl, grid, Prognostic())
     state .= state_data
 
     device = arraytype(dg.grid) <: Array ? CPU() : CUDADevice()
@@ -659,7 +664,8 @@ function restart_ode_state(dg::DGModel, state_data; init_on_cpu = false)
 end
 
 function restart_auxiliary_state(bl, grid, aux_data)
-    state_auxiliary = create_auxiliary_state(bl, grid)
+    state_auxiliary = create_state(bl, grid, Auxiliary())
+    state_auxiliary = init_state(state_auxiliary, bl, grid, Auxiliary())
     state_auxiliary .= aux_data
     return state_auxiliary
 end
@@ -901,7 +907,7 @@ function MPIStateArrays.MPIStateArray(dg::DGModel)
     balance_law = dg.balance_law
     grid = dg.grid
 
-    state_conservative = create_conservative_state(balance_law, grid)
+    state_conservative = create_state(balance_law, grid, Prognostic())
 
     return state_conservative
 end

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -53,12 +53,12 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
     @uniform begin
         N = polyorder
         FT = eltype(state_conservative)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        num_state_gradient_flux = number_state_gradient_flux(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
 
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
-        nhyperviscstate = num_hyperdiffusive(balance_law, FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
 
         Nq = N + 1
 
@@ -132,11 +132,11 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
             fill!(local_flux, -zero(eltype(local_flux)))
             flux_first_order!(
                 balance_law,
-                Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary,
                 ),
                 t,
@@ -152,17 +152,17 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
             fill!(local_flux, -zero(eltype(local_flux)))
             flux_second_order!(
                 balance_law,
-                Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative,
                 ),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(
                     local_state_gradient_flux,
                 ),
-                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
                     local_state_hyperdiffusion,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary,
                 ),
                 t,
@@ -198,13 +198,13 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
                     fill!(local_flux, -zero(eltype(local_flux)))
                     flux_first_order!(
                         balance_law,
-                        Grad{vars_state_conservative(balance_law, FT)}(
+                        Grad{vars_state(balance_law, Prognostic(), FT)}(
                             local_flux,
                         ),
-                        Vars{vars_state_conservative(balance_law, FT)}(
+                        Vars{vars_state(balance_law, Prognostic(), FT)}(
                             local_state_conservative,
                         ),
-                        Vars{vars_state_auxiliary(balance_law, FT)}(
+                        Vars{vars_state(balance_law, Auxiliary(), FT)}(
                             local_state_auxiliary,
                         ),
                         t,
@@ -225,13 +225,13 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
                     fill!(local_flux, -zero(eltype(local_flux)))
                     flux_first_order!(
                         balance_law,
-                        Grad{vars_state_conservative(balance_law, FT)}(
+                        Grad{vars_state(balance_law, Prognostic(), FT)}(
                             local_flux,
                         ),
-                        Vars{vars_state_conservative(balance_law, FT)}(
+                        Vars{vars_state(balance_law, Prognostic(), FT)}(
                             local_state_conservative,
                         ),
-                        Vars{vars_state_auxiliary(balance_law, FT)}(
+                        Vars{vars_state(balance_law, Auxiliary(), FT)}(
                             local_state_auxiliary,
                         ),
                         t,
@@ -263,14 +263,14 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
             fill!(local_source, -zero(eltype(local_source)))
             source!(
                 balance_law,
-                Vars{vars_state_conservative(balance_law, FT)}(local_source),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_source),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative,
                 ),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(
                     local_state_gradient_flux,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary,
                 ),
                 t,
@@ -334,12 +334,12 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(state_conservative)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        num_state_gradient_flux = number_state_gradient_flux(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
 
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
-        nhyperviscstate = num_hyperdiffusive(balance_law, FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
 
         Nq = N + 1
 
@@ -413,11 +413,11 @@ end
             fill!(local_flux, -zero(eltype(local_flux)))
             flux_first_order!(
                 balance_law,
-                Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary,
                 ),
                 t,
@@ -433,17 +433,17 @@ end
             fill!(local_flux, -zero(eltype(local_flux)))
             flux_second_order!(
                 balance_law,
-                Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative,
                 ),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(
                     local_state_gradient_flux,
                 ),
-                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
                     local_state_hyperdiffusion,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary,
                 ),
                 t,
@@ -481,14 +481,14 @@ end
             fill!(local_source, -zero(eltype(local_source)))
             source!(
                 balance_law,
-                Vars{vars_state_conservative(balance_law, FT)}(local_source),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_source),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative,
                 ),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(
                     local_state_gradient_flux,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary,
                 ),
                 t,
@@ -560,11 +560,11 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
     @uniform begin
         N = polyorder
         FT = eltype(state_conservative)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        num_state_gradient_flux = number_state_gradient_flux(balance_law, FT)
-        nhyperviscstate = num_hyperdiffusive(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
 
         if dim == 1
             Np = (N + 1)
@@ -692,18 +692,18 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
             numerical_flux_first_order!(
                 numerical_flux_first_order,
                 balance_law,
-                Vars{vars_state_conservative(balance_law, FT)}(local_flux),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
                 SVector(normal_vector),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁻,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁻,
                 ),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁺nondiff,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁺nondiff,
                 ),
                 t,
@@ -712,30 +712,30 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
             numerical_flux_second_order!(
                 numerical_flux_second_order,
                 balance_law,
-                Vars{vars_state_conservative(balance_law, FT)}(local_flux),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
                 normal_vector,
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁻,
                 ),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(
                     local_state_gradient_flux⁻,
                 ),
-                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
                     local_state_hyperdiffusion⁻,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁻,
                 ),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁺diff,
                 ),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(
                     local_state_gradient_flux⁺,
                 ),
-                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
                     local_state_hyperdiffusion⁺,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁺diff,
                 ),
                 t,
@@ -759,68 +759,68 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
             numerical_boundary_flux_first_order!(
                 numerical_flux_first_order,
                 balance_law,
-                Vars{vars_state_conservative(balance_law, FT)}(local_flux),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
                 SVector(normal_vector),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁻,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁻,
                 ),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁺nondiff,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁺nondiff,
                 ),
                 bctype,
                 t,
                 face_direction,
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative_bottom1,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary_bottom1,
                 ),
             )
             numerical_boundary_flux_second_order!(
                 numerical_flux_second_order,
                 balance_law,
-                Vars{vars_state_conservative(balance_law, FT)}(local_flux),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
                 normal_vector,
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁻,
                 ),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(
                     local_state_gradient_flux⁻,
                 ),
-                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
                     local_state_hyperdiffusion⁻,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁻,
                 ),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁺diff,
                 ),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(
                     local_state_gradient_flux⁺,
                 ),
-                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
                     local_state_hyperdiffusion⁺,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁺diff,
                 ),
                 bctype,
                 t,
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative_bottom1,
                 ),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(
                     local_state_gradient_flux_bottom1,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary_bottom1,
                 ),
             )
@@ -855,11 +855,11 @@ end
         N = polyorder
 
         FT = eltype(state_conservative)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        ngradstate = number_state_gradient(balance_law, FT)
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
-        num_state_gradient_flux = number_state_gradient_flux(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        ngradstate = number_states(balance_law, Gradient(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
 
         Nq = N + 1
 
@@ -906,12 +906,12 @@ end
             fill!(local_transform, -zero(eltype(local_transform)))
             compute_gradient_argument!(
                 balance_law,
-                Vars{vars_state_gradient(balance_law, FT)}(local_transform),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[
+                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_conservative[
                     :,
                     k,
                 ]),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[
                     :,
                     k,
                 ]),
@@ -986,19 +986,19 @@ end
                 )
                 compute_gradient_flux!(
                     balance_law,
-                    Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
                         local_state_gradient_flux,
                     ),
-                    Grad{vars_state_gradient(balance_law, FT)}(local_transform_gradient[
+                    Grad{vars_state(balance_law, Gradient(), FT)}(local_transform_gradient[
                         :,
                         :,
                         k,
                     ]),
-                    Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_conservative[
                         :,
                         k,
                     ]),
-                    Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[
                         :,
                         k,
                     ]),
@@ -1033,11 +1033,11 @@ end
         N = polyorder
 
         FT = eltype(state_conservative)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        ngradstate = number_state_gradient(balance_law, FT)
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
-        num_state_gradient_flux = number_state_gradient_flux(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        ngradstate = number_states(balance_law, Gradient(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
 
         Nq = N + 1
 
@@ -1098,12 +1098,12 @@ end
             fill!(local_transform, -zero(eltype(local_transform)))
             compute_gradient_argument!(
                 balance_law,
-                Vars{vars_state_gradient(balance_law, FT)}(local_transform),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[
+                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_conservative[
                     :,
                     k,
                 ]),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[
                     :,
                     k,
                 ]),
@@ -1163,19 +1163,19 @@ end
                 )
                 compute_gradient_flux!(
                     balance_law,
-                    Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
                         local_state_gradient_flux,
                     ),
-                    Grad{vars_state_gradient(balance_law, FT)}(local_transform_gradient[
+                    Grad{vars_state(balance_law, Gradient(), FT)}(local_transform_gradient[
                         :,
                         :,
                         k,
                     ]),
-                    Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_conservative[
                         :,
                         k,
                     ]),
-                    Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[
                         :,
                         k,
                     ]),
@@ -1213,11 +1213,11 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(state_conservative)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        ngradstate = number_state_gradient(balance_law, FT)
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
-        num_state_gradient_flux = number_state_gradient_flux(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        ngradstate = number_states(balance_law, Gradient(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
 
         if dim == 1
             Np = (N + 1)
@@ -1299,11 +1299,13 @@ end
         fill!(local_transform⁻, -zero(eltype(local_transform⁻)))
         compute_gradient_argument!(
             balance_law,
-            Vars{vars_state_gradient(balance_law, FT)}(local_transform⁻),
-            Vars{vars_state_conservative(balance_law, FT)}(
+            Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁻),
+            Vars{vars_state(balance_law, Prognostic(), FT)}(
                 local_state_conservative⁻,
             ),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
+            Vars{vars_state(balance_law, Auxiliary(), FT)}(
+                local_state_auxiliary⁻,
+            ),
             t,
         )
 
@@ -1319,11 +1321,13 @@ end
         fill!(local_transform⁺, -zero(eltype(local_transform⁺)))
         compute_gradient_argument!(
             balance_law,
-            Vars{vars_state_gradient(balance_law, FT)}(local_transform⁺),
-            Vars{vars_state_conservative(balance_law, FT)}(
+            Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁺),
+            Vars{vars_state(balance_law, Prognostic(), FT)}(
                 local_state_conservative⁺,
             ),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁺),
+            Vars{vars_state(balance_law, Auxiliary(), FT)}(
+                local_state_auxiliary⁺,
+            ),
             t,
         )
 
@@ -1338,18 +1342,18 @@ end
                 balance_law,
                 local_transform_gradient,
                 SVector(normal_vector),
-                Vars{vars_state_gradient(balance_law, FT)}(local_transform⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁻),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁻,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁻,
                 ),
-                Vars{vars_state_gradient(balance_law, FT)}(local_transform⁺),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁺),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁺,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁺,
                 ),
                 t,
@@ -1357,16 +1361,16 @@ end
             if num_state_gradient_flux > 0
                 compute_gradient_flux!(
                     balance_law,
-                    Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
                         local_state_gradient_flux,
                     ),
-                    Grad{vars_state_gradient(balance_law, FT)}(
+                    Grad{vars_state(balance_law, Gradient(), FT)}(
                         local_transform_gradient,
                     ),
-                    Vars{vars_state_conservative(balance_law, FT)}(
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(
                         local_state_conservative⁻,
                     ),
-                    Vars{vars_state_auxiliary(balance_law, FT)}(
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
                         local_state_auxiliary⁻,
                     ),
                     t,
@@ -1389,42 +1393,42 @@ end
                 balance_law,
                 local_transform_gradient,
                 SVector(normal_vector),
-                Vars{vars_state_gradient(balance_law, FT)}(local_transform⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁻),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁻,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁻,
                 ),
-                Vars{vars_state_gradient(balance_law, FT)}(local_transform⁺),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁺),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁺,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁺,
                 ),
                 bctype,
                 t,
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative_bottom1,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary_bottom1,
                 ),
             )
             if num_state_gradient_flux > 0
                 compute_gradient_flux!(
                     balance_law,
-                    Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
                         local_state_gradient_flux,
                     ),
-                    Grad{vars_state_gradient(balance_law, FT)}(
+                    Grad{vars_state(balance_law, Gradient(), FT)}(
                         local_transform_gradient,
                     ),
-                    Vars{vars_state_conservative(balance_law, FT)}(
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(
                         local_state_conservative⁻,
                     ),
-                    Vars{vars_state_auxiliary(balance_law, FT)}(
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
                         local_state_auxiliary⁻,
                     ),
                     t,
@@ -1450,14 +1454,16 @@ end
 
         compute_gradient_flux!(
             balance_law,
-            Vars{vars_state_gradient_flux(balance_law, FT)}(
+            Vars{vars_state(balance_law, GradientFlux(), FT)}(
                 local_state_conservative⁻visc,
             ),
-            Grad{vars_state_gradient(balance_law, FT)}(l_nG⁻),
-            Vars{vars_state_conservative(balance_law, FT)}(
+            Grad{vars_state(balance_law, Gradient(), FT)}(l_nG⁻),
+            Vars{vars_state(balance_law, Prognostic(), FT)}(
                 local_state_conservative⁻,
             ),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
+            Vars{vars_state(balance_law, Auxiliary(), FT)}(
+                local_state_auxiliary⁻,
+            ),
             t,
         )
 
@@ -1488,8 +1494,8 @@ end
 ) where {dim, polyorder}
     N = polyorder
     FT = eltype(state_auxiliary)
-    num_state_auxiliary = number_state_auxiliary(balance_law, FT)
-    num_state_conservative = number_state_conservative(balance_law, FT)
+    num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+    num_state_conservative = number_states(balance_law, Prognostic(), FT)
 
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
@@ -1512,8 +1518,10 @@ end
         end
         init_state_conservative!(
             balance_law,
-            Vars{vars_state_conservative(balance_law, FT)}(l_state),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
+            Vars{vars_state(balance_law, Prognostic(), FT)}(l_state),
+            Vars{vars_state(balance_law, Auxiliary(), FT)}(
+                local_state_auxiliary,
+            ),
             coords,
             args...,
         )
@@ -1541,7 +1549,7 @@ See [`BalanceLaw`](@ref) for usage.
 ) where {dim, polyorder}
     N = polyorder
     FT = eltype(state_auxiliary)
-    num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+    num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
 
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
@@ -1560,7 +1568,9 @@ See [`BalanceLaw`](@ref) for usage.
 
         init_state_auxiliary!(
             balance_law,
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
+            Vars{vars_state(balance_law, Auxiliary(), FT)}(
+                local_state_auxiliary,
+            ),
             LocalGeometry(Val(polyorder), vgeo, n, e),
         )
 
@@ -1588,8 +1598,8 @@ Update the auxiliary state array
     activedofs,
 ) where {dim, N}
     FT = eltype(state_conservative)
-    num_state_conservative = number_state_conservative(balance_law, FT)
-    num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+    num_state_conservative = number_states(balance_law, Prognostic(), FT)
+    num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
 
     Nq = N + 1
 
@@ -1620,10 +1630,10 @@ Update the auxiliary state array
 
             f!(
                 balance_law,
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary,
                 ),
                 t,
@@ -1649,9 +1659,9 @@ end
     activedofs,
 ) where {dim, N}
     FT = eltype(state_conservative)
-    num_state_conservative = number_state_conservative(balance_law, FT)
-    num_state_gradient_flux = number_state_gradient_flux(balance_law, FT)
-    num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+    num_state_conservative = number_states(balance_law, Prognostic(), FT)
+    num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
+    num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
 
     Nq = N + 1
 
@@ -1688,13 +1698,13 @@ end
 
             f!(
                 balance_law,
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary,
                 ),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(
                     local_state_gradient_flux,
                 ),
                 t,
@@ -1727,9 +1737,9 @@ See [`BalanceLaw`](@ref) for usage.
 ) where {dim, N, nvertelem}
     @uniform begin
         FT = eltype(state_conservative)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
-        nout = num_integrals(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        nout = number_states(balance_law, UpwardIntegrals(), FT)
 
         Nq = N + 1
         Nqj = dim == 2 ? 1 : Nq
@@ -1780,15 +1790,15 @@ See [`BalanceLaw`](@ref) for usage.
 
                 integral_load_auxiliary_state!(
                     balance_law,
-                    Vars{vars_integrals(balance_law, FT)}(view(
+                    Vars{vars_state(balance_law, UpwardIntegrals(), FT)}(view(
                         local_kernel,
                         :,
                         k,
                     )),
-                    Vars{vars_state_conservative(balance_law, FT)}(
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(
                         local_state_conservative,
                     ),
-                    Vars{vars_state_auxiliary(balance_law, FT)}(
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
                         local_state_auxiliary,
                     ),
                 )
@@ -1816,13 +1826,13 @@ See [`BalanceLaw`](@ref) for usage.
                 ijk = i + Nq * ((j - 1) + Nqj * (k - 1))
                 integral_set_auxiliary_state!(
                     balance_law,
-                    Vars{vars_state_auxiliary(balance_law, FT)}(view(
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(view(
                         state_auxiliary,
                         ijk,
                         :,
                         e,
                     )),
-                    Vars{vars_integrals(balance_law, FT)}(view(
+                    Vars{vars_state(balance_law, UpwardIntegrals(), FT)}(view(
                         local_kernel,
                         :,
                         k,
@@ -1850,7 +1860,7 @@ end
 
         Nq = N + 1
         Nqj = dim == 2 ? 1 : Nq
-        nout = num_reverse_integrals(balance_law, FT)
+        nout = number_states(balance_law, DownwardIntegrals(), FT)
 
         # note that k is the second not 4th index (since this is scratch memory and k
         # needs to be persistent across threads)
@@ -1869,14 +1879,14 @@ end
         et = nvertelem + (eh - 1) * nvertelem
         reverse_integral_load_auxiliary_state!(
             balance_law,
-            Vars{vars_reverse_integrals(balance_law, FT)}(l_T),
-            Vars{vars_state_conservative(balance_law, FT)}(view(
+            Vars{vars_state(balance_law, DownwardIntegrals(), FT)}(l_T),
+            Vars{vars_state(balance_law, Prognostic(), FT)}(view(
                 state,
                 ijk,
                 :,
                 et,
             )),
-            Vars{vars_state_auxiliary(balance_law, FT)}(view(
+            Vars{vars_state(balance_law, Auxiliary(), FT)}(view(
                 state_auxiliary,
                 ijk,
                 :,
@@ -1891,14 +1901,14 @@ end
                 ijk = i + Nq * ((j - 1) + Nqj * (k - 1))
                 reverse_integral_load_auxiliary_state!(
                     balance_law,
-                    Vars{vars_reverse_integrals(balance_law, FT)}(l_V),
-                    Vars{vars_state_conservative(balance_law, FT)}(view(
+                    Vars{vars_state(balance_law, DownwardIntegrals(), FT)}(l_V),
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(view(
                         state,
                         ijk,
                         :,
                         e,
                     )),
-                    Vars{vars_state_auxiliary(balance_law, FT)}(view(
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(view(
                         state_auxiliary,
                         ijk,
                         :,
@@ -1908,13 +1918,13 @@ end
                 l_V .= l_T .- l_V
                 reverse_integral_set_auxiliary_state!(
                     balance_law,
-                    Vars{vars_state_auxiliary(balance_law, FT)}(view(
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(view(
                         state_auxiliary,
                         ijk,
                         :,
                         e,
                     )),
-                    Vars{vars_reverse_integrals(balance_law, FT)}(l_V),
+                    Vars{vars_state(balance_law, DownwardIntegrals(), FT)}(l_V),
                 )
             end
         end
@@ -1935,7 +1945,7 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
 
         Nq = N + 1
 
@@ -2026,7 +2036,7 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
 
         Nq = N + 1
 
@@ -2107,7 +2117,7 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
 
         if dim == 1
             Np = (N + 1)
@@ -2175,19 +2185,19 @@ end
             numerical_flux_divergence!(
                 divgradnumpenalty,
                 balance_law,
-                Vars{vars_gradient_laplacian(balance_law, FT)}(l_div),
+                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_div),
                 normal_vector,
-                Grad{vars_gradient_laplacian(balance_law, FT)}(l_grad⁻),
-                Grad{vars_gradient_laplacian(balance_law, FT)}(l_grad⁺),
+                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad⁻),
+                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad⁺),
             )
         else
             numerical_boundary_flux_divergence!(
                 divgradnumpenalty,
                 balance_law,
-                Vars{vars_gradient_laplacian(balance_law, FT)}(l_div),
+                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_div),
                 normal_vector,
-                Grad{vars_gradient_laplacian(balance_law, FT)}(l_grad⁻),
-                Grad{vars_gradient_laplacian(balance_law, FT)}(l_grad⁺),
+                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad⁻),
+                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad⁺),
                 bctype,
             )
         end
@@ -2219,10 +2229,10 @@ end
         N = polyorder
 
         FT = eltype(Qhypervisc_grad)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
-        nhyperviscstate = num_hyperdiffusive(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
         ngradtransformstate = num_state_conservative
 
         Nq = N + 1
@@ -2313,12 +2323,12 @@ end
         )
         transform_post_gradient_laplacian!(
             balance_law,
-            Vars{vars_hyperdiffusive(balance_law, FT)}(
+            Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
                 local_state_hyperdiffusion,
             ),
-            Grad{vars_gradient_laplacian(balance_law, FT)}(l_grad_lap),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[:]),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[:]),
+            Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad_lap),
+            Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_conservative[:]),
+            Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:]),
             t,
         )
         @unroll for s in 1:nhyperviscstate
@@ -2347,10 +2357,10 @@ end
         N = polyorder
 
         FT = eltype(Qhypervisc_grad)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
-        nhyperviscstate = num_hyperdiffusive(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
         ngradtransformstate = num_state_conservative
 
         Nq = N + 1
@@ -2421,12 +2431,12 @@ end
         )
         transform_post_gradient_laplacian!(
             balance_law,
-            Vars{vars_hyperdiffusive(balance_law, FT)}(
+            Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
                 local_state_hyperdiffusion,
             ),
-            Grad{vars_gradient_laplacian(balance_law, FT)}(l_grad_lap),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[:]),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[:]),
+            Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad_lap),
+            Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_conservative[:]),
+            Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:]),
             t,
         )
         @unroll for s in 1:nhyperviscstate
@@ -2457,10 +2467,10 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        ngradlapstate = num_gradient_laplacian(balance_law, FT)
-        nhyperviscstate = num_hyperdiffusive(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
         ngradtransformstate = num_state_conservative
 
         if dim == 1
@@ -2549,22 +2559,22 @@ end
             numerical_flux_higher_order!(
                 hyperviscnumflux,
                 balance_law,
-                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
                     local_state_hyperdiffusion,
                 ),
                 normal_vector,
-                Vars{vars_gradient_laplacian(balance_law, FT)}(l_lap⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_lap⁻),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁻,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁻,
                 ),
-                Vars{vars_gradient_laplacian(balance_law, FT)}(l_lap⁺),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_lap⁺),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁺,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁺,
                 ),
                 t,
@@ -2573,22 +2583,22 @@ end
             numerical_boundary_flux_higher_order!(
                 hyperviscnumflux,
                 balance_law,
-                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
                     local_state_hyperdiffusion,
                 ),
                 normal_vector,
-                Vars{vars_gradient_laplacian(balance_law, FT)}(l_lap⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_lap⁻),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁻,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁻,
                 ),
-                Vars{vars_gradient_laplacian(balance_law, FT)}(l_lap⁺),
-                Vars{vars_state_conservative(balance_law, FT)}(
+                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_lap⁺),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(
                     local_state_conservative⁺,
                 ),
-                Vars{vars_state_auxiliary(balance_law, FT)}(
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(
                     local_state_auxiliary⁺,
                 ),
                 bctype,
@@ -2621,9 +2631,9 @@ end
 ) where {dim, N}
     @uniform begin
         FT = eltype(state_conservative)
-        num_state_conservative = number_state_conservative(balance_law, FT)
-        num_state_gradient_flux = number_state_gradient_flux(balance_law, FT)
-        num_state_auxiliary = number_state_auxiliary(balance_law, FT)
+        num_state_conservative = number_states(balance_law, Prognostic(), FT)
+        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
+        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
 
         Nq = N + 1
 
@@ -2658,11 +2668,13 @@ end
         Δx = pointwise_courant[n, e]
         c = local_courant(
             balance_law,
-            Vars{vars_state_conservative(balance_law, FT)}(
+            Vars{vars_state(balance_law, Prognostic(), FT)}(
                 local_state_conservative,
             ),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
-            Vars{vars_state_gradient_flux(balance_law, FT)}(
+            Vars{vars_state(balance_law, Auxiliary(), FT)}(
+                local_state_auxiliary,
+            ),
+            Vars{vars_state(balance_law, GradientFlux(), FT)}(
                 local_state_gradient_flux,
             ),
             Δx,

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -32,8 +32,8 @@ Any `P <: NumericalFluxGradient` should define methods for:
 
    numerical_flux_gradient!(gnf::P, balance_law::BalanceLaw, diffF, n⁻, Q⁻, Qstate_gradient_flux⁻, Qaux⁻, Q⁺,
                             Qstate_gradient_flux⁺, Qaux⁺, t)
-   numerical_boundary_flux_gradient!(gnf::P, balance_law::BalanceLaw, local_state_gradient_flux, n⁻, local_transform⁻, local_state_conservative⁻,
-                                     local_state_auxiliary⁻, local_transform⁺, local_state_conservative⁺, local_state_auxiliary⁺, bctype, t)
+   numerical_boundary_flux_gradient!(gnf::P, balance_law::BalanceLaw, local_state_gradient_flux, n⁻, local_transform⁻, local_state_prognostic⁻,
+                                     local_state_auxiliary⁻, local_transform⁺, local_state_prognostic⁺, local_state_auxiliary⁺, bctype, t)
 
 """
 abstract type NumericalFluxGradient end
@@ -50,10 +50,10 @@ function numerical_flux_gradient!(
     transform_gradient::MMatrix,
     normal_vector::SVector,
     state_gradient⁻::Vars{T},
-    state_conservative⁻::Vars{S},
+    state_prognostic⁻::Vars{S},
     state_auxiliary⁻::Vars{A},
     state_gradient⁺::Vars{T},
-    state_conservative⁺::Vars{S},
+    state_prognostic⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
     t,
 ) where {T, S, A}
@@ -69,10 +69,10 @@ function numerical_boundary_flux_gradient!(
     transform_gradient::MMatrix,
     normal_vector::SVector,
     state_gradient⁻::Vars{T},
-    state_conservative⁻::Vars{S},
+    state_prognostic⁻::Vars{S},
     state_auxiliary⁻::Vars{A},
     state_gradient⁺::Vars{T},
-    state_conservative⁺::Vars{S},
+    state_prognostic⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
     bctype,
     t,
@@ -82,10 +82,10 @@ function numerical_boundary_flux_gradient!(
     boundary_state!(
         numerical_flux,
         balance_law,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         normal_vector,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
         bctype,
         t,
@@ -96,7 +96,7 @@ function numerical_boundary_flux_gradient!(
     compute_gradient_argument!(
         balance_law,
         state_gradient⁺,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         t,
     )
@@ -132,9 +132,9 @@ function numerical_boundary_flux_first_order!(
     balance_law::BalanceLaw,
     fluxᵀn::Vars{S},
     normal_vector::SVector,
-    state_conservative⁻::Vars{S},
+    state_prognostic⁻::Vars{S},
     state_auxiliary⁻::Vars{A},
-    state_conservative⁺::Vars{S},
+    state_prognostic⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
     bctype,
     t,
@@ -146,10 +146,10 @@ function numerical_boundary_flux_first_order!(
     boundary_state!(
         numerical_flux,
         balance_law,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         normal_vector,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
         bctype,
         t,
@@ -162,9 +162,9 @@ function numerical_boundary_flux_first_order!(
         balance_law,
         fluxᵀn,
         normal_vector,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         t,
         direction,
@@ -192,9 +192,9 @@ function numerical_flux_first_order!(
     balance_law::BalanceLaw,
     fluxᵀn::Vars{S},
     normal_vector::SVector,
-    state_conservative⁻::Vars{S},
+    state_prognostic⁻::Vars{S},
     state_auxiliary⁻::Vars{A},
-    state_conservative⁺::Vars{S},
+    state_prognostic⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
     t,
     direction,
@@ -205,9 +205,9 @@ function numerical_flux_first_order!(
         balance_law,
         fluxᵀn,
         normal_vector,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         t,
         direction,
@@ -217,7 +217,7 @@ function numerical_flux_first_order!(
     wavespeed⁻ = wavespeed(
         balance_law,
         normal_vector,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
         t,
         direction,
@@ -225,15 +225,14 @@ function numerical_flux_first_order!(
     wavespeed⁺ = wavespeed(
         balance_law,
         normal_vector,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         t,
         direction,
     )
     max_wavespeed = max.(wavespeed⁻, wavespeed⁺)
     penalty =
-        max_wavespeed .*
-        (parent(state_conservative⁻) - parent(state_conservative⁺))
+        max_wavespeed .* (parent(state_prognostic⁻) - parent(state_prognostic⁺))
 
     # TODO: should this operate on ΔQ or penalty?
     update_penalty!(
@@ -242,9 +241,9 @@ function numerical_flux_first_order!(
         normal_vector,
         max_wavespeed,
         Vars{S}(penalty),
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         t,
     )
@@ -270,35 +269,35 @@ function numerical_flux_first_order!(
     balance_law::BalanceLaw,
     fluxᵀn::Vars{S},
     normal_vector::SVector,
-    state_conservative⁻::Vars{S},
+    state_prognostic⁻::Vars{S},
     state_auxiliary⁻::Vars{A},
-    state_conservative⁺::Vars{S},
+    state_prognostic⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
     t,
     direction,
 ) where {S, A}
 
     FT = eltype(fluxᵀn)
-    num_state_conservative = number_states(balance_law, Prognostic(), FT)
+    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
     fluxᵀn = parent(fluxᵀn)
 
-    flux⁻ = similar(fluxᵀn, Size(3, num_state_conservative))
+    flux⁻ = similar(fluxᵀn, Size(3, num_state_prognostic))
     fill!(flux⁻, -zero(FT))
     flux_first_order!(
         balance_law,
         Grad{S}(flux⁻),
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
         t,
         direction,
     )
 
-    flux⁺ = similar(fluxᵀn, Size(3, num_state_conservative))
+    flux⁺ = similar(fluxᵀn, Size(3, num_state_prognostic))
     fill!(flux⁺, -zero(FT))
     flux_first_order!(
         balance_law,
         Grad{S}(flux⁺),
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         t,
         direction,
@@ -353,11 +352,11 @@ function numerical_flux_second_order!(
     balance_law::BalanceLaw,
     fluxᵀn::Vars{S},
     normal_vector⁻::SVector,
-    state_conservative⁻::Vars{S},
+    state_prognostic⁻::Vars{S},
     state_gradient_flux⁻::Vars{D},
     state_hyperdiffusive⁻::Vars{HD},
     state_auxiliary⁻::Vars{A},
-    state_conservative⁺::Vars{S},
+    state_prognostic⁺::Vars{S},
     state_gradient_flux⁺::Vars{D},
     state_hyperdiffusive⁺::Vars{HD},
     state_auxiliary⁺::Vars{A},
@@ -365,27 +364,27 @@ function numerical_flux_second_order!(
 ) where {S, D, HD, A}
 
     FT = eltype(fluxᵀn)
-    num_state_conservative = number_states(balance_law, Prognostic(), FT)
+    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
     fluxᵀn = parent(fluxᵀn)
 
-    flux⁻ = similar(fluxᵀn, Size(3, num_state_conservative))
+    flux⁻ = similar(fluxᵀn, Size(3, num_state_prognostic))
     fill!(flux⁻, -zero(FT))
     flux_second_order!(
         balance_law,
         Grad{S}(flux⁻),
-        state_conservative⁻,
+        state_prognostic⁻,
         state_gradient_flux⁻,
         state_hyperdiffusive⁻,
         state_auxiliary⁻,
         t,
     )
 
-    flux⁺ = similar(fluxᵀn, Size(3, num_state_conservative))
+    flux⁺ = similar(fluxᵀn, Size(3, num_state_prognostic))
     fill!(flux⁺, -zero(FT))
     flux_second_order!(
         balance_law,
         Grad{S}(flux⁺),
-        state_conservative⁺,
+        state_prognostic⁺,
         state_gradient_flux⁺,
         state_hyperdiffusive⁺,
         state_auxiliary⁺,
@@ -446,10 +445,10 @@ function numerical_flux_higher_order!(
     hyperdiff::Vars{HD},
     normal_vector::SVector,
     lap⁻::Vars{GL},
-    state_conservative⁻::Vars{S},
+    state_prognostic⁻::Vars{S},
     state_auxiliary⁻::Vars{A},
     lap⁺::Vars{GL},
-    state_conservative⁺::Vars{S},
+    state_prognostic⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
     t,
 ) where {HD, GL, S, A}
@@ -458,7 +457,7 @@ function numerical_flux_higher_order!(
         balance_law,
         hyperdiff,
         Grad{GL}(G),
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
         t,
     )
@@ -470,10 +469,10 @@ function numerical_boundary_flux_higher_order!(
     hyperdiff::Vars{HD},
     normal_vector::SVector,
     lap⁻::Vars{GL},
-    state_conservative⁻::Vars{S},
+    state_prognostic⁻::Vars{S},
     state_auxiliary⁻::Vars{A},
     lap⁺::Vars{GL},
-    state_conservative⁺::Vars{S},
+    state_prognostic⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
     bctype,
     t,
@@ -481,11 +480,11 @@ function numerical_boundary_flux_higher_order!(
     boundary_state!(
         numerical_flux,
         balance_law,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         lap⁺,
         normal_vector,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
         lap⁻,
         bctype,
@@ -497,10 +496,10 @@ function numerical_boundary_flux_higher_order!(
         hyperdiff,
         normal_vector,
         lap⁻,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
         lap⁺,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         t,
     )
@@ -511,11 +510,11 @@ numerical_boundary_flux_second_order!(
     balance_law::BalanceLaw,
     fluxᵀn::Vars{S},
     normal_vector::SVector,
-    state_conservative⁻::Vars{S},
+    state_prognostic⁻::Vars{S},
     state_gradient_flux⁻::Vars{D},
     state_hyperdiffusive⁻::Vars{HD},
     state_auxiliary⁻::Vars{A},
-    state_conservative⁺::Vars{S},
+    state_prognostic⁺::Vars{S},
     state_gradient_flux⁺::Vars{D},
     state_hyperdiffusive⁺::Vars{HD},
     state_auxiliary⁺::Vars{A},
@@ -529,11 +528,11 @@ numerical_boundary_flux_second_order!(
     balance_law,
     fluxᵀn,
     normal_vector,
-    state_conservative⁻,
+    state_prognostic⁻,
     state_gradient_flux⁻,
     state_hyperdiffusive⁻,
     state_auxiliary⁻,
-    state_conservative⁺,
+    state_prognostic⁺,
     state_gradient_flux⁺,
     state_hyperdiffusive⁺,
     state_auxiliary⁺,
@@ -549,11 +548,11 @@ function normal_boundary_flux_second_order!(
     balance_law::BalanceLaw,
     fluxᵀn::Vars{S},
     normal_vector,
-    state_conservative⁻,
+    state_prognostic⁻,
     state_gradient_flux⁻,
     state_hyperdiffusive⁻,
     state_auxiliary⁻,
-    state_conservative⁺,
+    state_prognostic⁺,
     state_gradient_flux⁺,
     state_hyperdiffusive⁺,
     state_auxiliary⁺,
@@ -564,21 +563,21 @@ function normal_boundary_flux_second_order!(
     aux1⁻,
 ) where {S}
     FT = eltype(fluxᵀn)
-    num_state_conservative = number_states(balance_law, Prognostic(), FT)
+    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
     fluxᵀn = parent(fluxᵀn)
 
-    flux = similar(fluxᵀn, Size(3, num_state_conservative))
+    flux = similar(fluxᵀn, Size(3, num_state_prognostic))
     fill!(flux, -zero(FT))
     boundary_flux_second_order!(
         numerical_flux,
         balance_law,
         Grad{S}(flux),
-        state_conservative⁺,
+        state_prognostic⁺,
         state_gradient_flux⁺,
         state_hyperdiffusive⁺,
         state_auxiliary⁺,
         normal_vector,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_gradient_flux⁻,
         state_hyperdiffusive⁻,
         state_auxiliary⁻,
@@ -597,12 +596,12 @@ function boundary_flux_second_order!(
     numerical_flux::NumericalFluxSecondOrder,
     balance_law,
     flux,
-    state_conservative⁺,
+    state_prognostic⁺,
     state_gradient_flux⁺,
     state_hyperdiffusive⁺,
     state_auxiliary⁺,
     normal_vector,
-    state_conservative⁻,
+    state_prognostic⁻,
     state_gradient_flux⁻,
     state_hyperdiffusive⁻,
     state_auxiliary⁻,
@@ -615,11 +614,11 @@ function boundary_flux_second_order!(
     boundary_state!(
         numerical_flux,
         balance_law,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_gradient_flux⁺,
         state_auxiliary⁺,
         normal_vector,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_gradient_flux⁻,
         state_auxiliary⁻,
         bctype,
@@ -631,7 +630,7 @@ function boundary_flux_second_order!(
     flux_second_order!(
         balance_law,
         flux,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_gradient_flux⁺,
         state_hyperdiffusive⁺,
         state_auxiliary⁺,

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -14,23 +14,15 @@ export NumericalFluxGradient,
 using StaticArrays, LinearAlgebra
 using ClimateMachine.VariableTemplates
 using KernelAbstractions.Extras: @unroll
+using ...BalanceLaws
 import ...BalanceLaws:
-    BalanceLaw,
-    vars_state_conservative,
-    vars_state_gradient_flux,
-    vars_state_auxiliary,
-    vars_state_gradient,
+    vars_state,
     boundary_state!,
     wavespeed,
     flux_first_order!,
     flux_second_order!,
     compute_gradient_flux!,
-    number_state_conservative,
-    number_state_gradient,
     compute_gradient_argument!,
-    num_gradient_laplacian,
-    vars_gradient_laplacian,
-    vars_hyperdiffusive,
     transform_post_gradient_laplacian!
 
 """
@@ -287,7 +279,7 @@ function numerical_flux_first_order!(
 ) where {S, A}
 
     FT = eltype(fluxᵀn)
-    num_state_conservative = number_state_conservative(balance_law, FT)
+    num_state_conservative = number_states(balance_law, Prognostic(), FT)
     fluxᵀn = parent(fluxᵀn)
 
     flux⁻ = similar(fluxᵀn, Size(3, num_state_conservative))
@@ -373,7 +365,7 @@ function numerical_flux_second_order!(
 ) where {S, D, HD, A}
 
     FT = eltype(fluxᵀn)
-    num_state_conservative = number_state_conservative(balance_law, FT)
+    num_state_conservative = number_states(balance_law, Prognostic(), FT)
     fluxᵀn = parent(fluxᵀn)
 
     flux⁻ = similar(fluxᵀn, Size(3, num_state_conservative))
@@ -572,7 +564,7 @@ function normal_boundary_flux_second_order!(
     aux1⁻,
 ) where {S}
     FT = eltype(fluxᵀn)
-    num_state_conservative = number_state_conservative(balance_law, FT)
+    num_state_conservative = number_states(balance_law, Prognostic(), FT)
     fluxᵀn = parent(fluxᵀn)
 
     flux = similar(fluxᵀn, Size(3, num_state_conservative))

--- a/src/Numerics/DGMethods/create_states.jl
+++ b/src/Numerics/DGMethods/create_states.jl
@@ -1,22 +1,25 @@
 #### Create states
 
-function create_conservative_state(balance_law::BalanceLaw, grid)
+function create_state(balance_law, grid, st::AbstractStateType)
     topology = grid.topology
-    # FIXME: Remove after updating CUDA
+    Np = dofs_per_element(grid)
+
     h_vgeo = Array(grid.vgeo)
     FT = eltype(h_vgeo)
-    Np = dofs_per_element(grid)
     DA = arraytype(grid)
 
     weights = view(h_vgeo, :, grid.Mid, :)
     weights = reshape(weights, size(weights, 1), 1, size(weights, 2))
 
-    V = vars_state_conservative(balance_law, FT)
-    state_conservative = MPIStateArray{FT, V}(
+    # TODO: Clean up this MPIStateArray interface...
+    ns = number_states(balance_law, st, FT)
+    st isa GradientLaplacian && (ns = 3ns)
+    V = vars_state(balance_law, st, FT)
+    state = MPIStateArray{FT, V}(
         topology.mpicomm,
         DA,
         Np,
-        number_state_conservative(balance_law, FT),
+        ns,
         length(topology.elems),
         realelems = topology.realelems,
         ghostelems = topology.ghostelems,
@@ -27,142 +30,30 @@ function create_conservative_state(balance_law::BalanceLaw, grid)
         nabrtovmapsend = grid.nabrtovmapsend,
         weights = weights,
     )
-    return state_conservative
+    return state
 end
 
-function create_auxiliary_state(balance_law, grid)
+function init_state(state, balance_law, grid, ::Auxiliary)
     topology = grid.topology
     Np = dofs_per_element(grid)
-
-    h_vgeo = Array(grid.vgeo)
-    FT = eltype(h_vgeo)
-    DA = arraytype(grid)
-
-    weights = view(h_vgeo, :, grid.Mid, :)
-    weights = reshape(weights, size(weights, 1), 1, size(weights, 2))
-
-    V = vars_state_auxiliary(balance_law, FT)
-    state_auxiliary = MPIStateArray{FT, V}(
-        topology.mpicomm,
-        DA,
-        Np,
-        number_state_auxiliary(balance_law, FT),
-        length(topology.elems),
-        realelems = topology.realelems,
-        ghostelems = topology.ghostelems,
-        vmaprecv = grid.vmaprecv,
-        vmapsend = grid.vmapsend,
-        nabrtorank = topology.nabrtorank,
-        nabrtovmaprecv = grid.nabrtovmaprecv,
-        nabrtovmapsend = grid.nabrtovmapsend,
-        weights = weights,
-    )
-
     dim = dimensionality(grid)
     polyorder = polynomialorder(grid)
     vgeo = grid.vgeo
-    device = array_device(state_auxiliary)
+    device = array_device(state)
     nrealelem = length(topology.realelems)
     event = Event(device)
     event = kernel_init_state_auxiliary!(device, min(Np, 1024), Np * nrealelem)(
         balance_law,
         Val(dim),
         Val(polyorder),
-        state_auxiliary.data,
+        state.data,
         vgeo,
         topology.realelems,
         dependencies = (event,),
     )
-    event = MPIStateArrays.begin_ghost_exchange!(
-        state_auxiliary;
-        dependencies = event,
-    )
-    event = MPIStateArrays.end_ghost_exchange!(
-        state_auxiliary;
-        dependencies = event,
-    )
+    event = MPIStateArrays.begin_ghost_exchange!(state; dependencies = event)
+    event = MPIStateArrays.end_ghost_exchange!(state; dependencies = event)
     wait(device, event)
 
-    return state_auxiliary
-end
-
-function create_gradient_state(balance_law, grid)
-    topology = grid.topology
-    Np = dofs_per_element(grid)
-
-    h_vgeo = Array(grid.vgeo)
-    FT = eltype(h_vgeo)
-    DA = arraytype(grid)
-
-    weights = view(h_vgeo, :, grid.Mid, :)
-    weights = reshape(weights, size(weights, 1), 1, size(weights, 2))
-
-    # TODO: Clean up this MPIStateArray interface...
-    V = vars_state_gradient_flux(balance_law, FT)
-    state_gradient_flux = MPIStateArray{FT, V}(
-        topology.mpicomm,
-        DA,
-        Np,
-        number_state_gradient_flux(balance_law, FT),
-        length(topology.elems),
-        realelems = topology.realelems,
-        ghostelems = topology.ghostelems,
-        vmaprecv = grid.vmaprecv,
-        vmapsend = grid.vmapsend,
-        nabrtorank = topology.nabrtorank,
-        nabrtovmaprecv = grid.nabrtovmaprecv,
-        nabrtovmapsend = grid.nabrtovmapsend,
-        weights = weights,
-    )
-
-    return state_gradient_flux
-end
-
-function create_higher_order_states(balance_law, grid)
-    topology = grid.topology
-    Np = dofs_per_element(grid)
-
-    h_vgeo = Array(grid.vgeo)
-    FT = eltype(h_vgeo)
-    DA = arraytype(grid)
-
-    weights = view(h_vgeo, :, grid.Mid, :)
-    weights = reshape(weights, size(weights, 1), 1, size(weights, 2))
-
-    ngradlapstate = num_gradient_laplacian(balance_law, FT)
-    # TODO: Clean up this MPIStateArray interface...
-    V = vars_gradient_laplacian(balance_law, FT)
-    Qhypervisc_grad = MPIStateArray{FT, V}(
-        topology.mpicomm,
-        DA,
-        Np,
-        3ngradlapstate,
-        length(topology.elems),
-        realelems = topology.realelems,
-        ghostelems = topology.ghostelems,
-        vmaprecv = grid.vmaprecv,
-        vmapsend = grid.vmapsend,
-        nabrtorank = topology.nabrtorank,
-        nabrtovmaprecv = grid.nabrtovmaprecv,
-        nabrtovmapsend = grid.nabrtovmapsend,
-        weights = weights,
-    )
-
-    V = vars_hyperdiffusive(balance_law, FT)
-    Qhypervisc_div = MPIStateArray{FT, V}(
-        topology.mpicomm,
-        DA,
-        Np,
-        ngradlapstate,
-        length(topology.elems),
-        realelems = topology.realelems,
-        ghostelems = topology.ghostelems,
-        vmaprecv = grid.vmaprecv,
-        vmapsend = grid.vmapsend,
-        nabrtorank = topology.nabrtorank,
-        nabrtovmaprecv = grid.nabrtovmaprecv,
-        nabrtovmapsend = grid.nabrtovmapsend,
-        weights = weights,
-    )
-    return Qhypervisc_grad, Qhypervisc_div
+    return state
 end

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -2,14 +2,7 @@ using StaticNumbers
 export remainder_DGModel
 
 import ..BalanceLaws:
-    vars_state_conservative,
-    vars_state_auxiliary,
-    vars_state_gradient,
-    vars_state_gradient_flux,
-    vars_integrals,
-    vars_reverse_integrals,
-    vars_gradient_laplacian,
-    vars_hyperdiffusive,
+    vars_state,
     init_state_conservative!,
     init_state_auxiliary!,
     flux_first_order!,
@@ -113,25 +106,25 @@ function remainder_DGModel(
     # If any of these asserts fail, the remainder model will need to be extended
     # to allow for it; see `flux_first_order!` and `source!` below.
     for subdg in subsdg
-        @assert number_state_conservative(subdg.balance_law, FT) <=
-                number_state_conservative(maindg.balance_law, FT)
+        @assert number_states(subdg.balance_law, Prognostic(), FT) <=
+                number_states(maindg.balance_law, Prognostic(), FT)
 
-        @assert number_state_auxiliary(subdg.balance_law, FT) ==
-                number_state_auxiliary(maindg.balance_law, FT)
+        @assert number_states(subdg.balance_law, Auxiliary(), FT) ==
+                number_states(maindg.balance_law, Auxiliary(), FT)
 
-        @assert number_state_gradient(subdg.balance_law, FT) == 0
-        @assert number_state_gradient_flux(subdg.balance_law, FT) == 0
+        @assert number_states(subdg.balance_law, Gradient(), FT) == 0
+        @assert number_states(subdg.balance_law, GradientFlux(), FT) == 0
 
-        @assert num_gradient_laplacian(subdg.balance_law, FT) == 0
-        @assert num_hyperdiffusive(subdg.balance_law, FT) == 0
+        @assert number_states(subdg.balance_law, GradientLaplacian(), FT) == 0
+        @assert number_states(subdg.balance_law, Hyperdiffusive(), FT) == 0
 
         # Do not currenlty support nested remainder models
         # For this to work the way directions and numerical fluxes are handled
         # would need to be updated.
         @assert !(subdg.balance_law isa RemBL)
 
-        @assert num_integrals(subdg.balance_law, FT) == 0
-        @assert num_reverse_integrals(subdg.balance_law, FT) == 0
+        @assert number_states(subdg.balance_law, UpwardIntegrals(), FT) == 0
+        @assert number_states(subdg.balance_law, DownwardIntegrals(), FT) == 0
 
         # The remainder model requires that the subcomponent direction be
         # included in the main model directions
@@ -164,29 +157,8 @@ function remainder_DGModel(
 end
 
 # Inherit most of the functionality from the main model
-vars_state_conservative(rem_balance_law::RemBL, FT) =
-    vars_state_conservative(rem_balance_law.main, FT)
-
-vars_state_gradient(rem_balance_law::RemBL, FT) =
-    vars_state_gradient(rem_balance_law.main, FT)
-
-vars_state_gradient_flux(rem_balance_law::RemBL, FT) =
-    vars_state_gradient_flux(rem_balance_law.main, FT)
-
-vars_state_auxiliary(rem_balance_law::RemBL, FT) =
-    vars_state_auxiliary(rem_balance_law.main, FT)
-
-vars_integrals(rem_balance_law::RemBL, FT) =
-    vars_integrals(rem_balance_law.main, FT)
-
-vars_reverse_integrals(rem_balance_law::RemBL, FT) =
-    vars_integrals(rem_balance_law.main, FT)
-
-vars_gradient_laplacian(rem_balance_law::RemBL, FT) =
-    vars_gradient_laplacian(rem_balance_law.main, FT)
-
-vars_hyperdiffusive(rem_balance_law::RemBL, FT) =
-    vars_hyperdiffusive(rem_balance_law.main, FT)
+vars_state(rem_balance_law::RemBL, st::AbstractStateType, FT) =
+    vars_state(rem_balance_law.main, st, FT)
 
 update_auxiliary_state!(dg::DGModel, rem_balance_law::RemBL, args...) =
     update_auxiliary_state!(dg, rem_balance_law.main, args...)
@@ -381,11 +353,11 @@ function wavespeed(
 
     ws = fill(
         -zero(FT),
-        MVector{number_state_conservative(rem_balance_law.main, FT), FT},
+        MVector{number_states(rem_balance_law.main, Prognostic(), FT), FT},
     )
     rs = fill(
         -zero(FT),
-        MVector{number_state_conservative(rem_balance_law.main, FT), FT},
+        MVector{number_states(rem_balance_law.main, Prognostic(), FT), FT},
     )
 
     # Compute the main components wavespeed
@@ -403,7 +375,7 @@ function wavespeed(
     # Compute the sub components wavespeed
     for (sub, subdir) in zip(rem_balance_law.subs, rem_balance_law.subsdir)
         @inbounds if subdir isa Union{Dirs.types...}
-            num_state = static(number_state_conservative(sub, Float32))
+            num_state = static(number_states(sub, Prognostic(), Float32))
             rs[static(1):num_state] .+=
                 wavespeed(sub, nM, state, aux, t, (subdir,))
         end
@@ -488,7 +460,7 @@ function numerical_flux_first_order!(
             nf = numerical_fluxes[2][k]
 
             FT = eltype(a_fluxᵀn)
-            num_state_conservative = number_state_conservative(sub, FT)
+            num_state_conservative = number_states(sub, Prognostic(), FT)
 
             a_sub_fluxᵀn = MVector{num_state_conservative, FT}(undef)
             a_sub_state_conservative⁻ =
@@ -496,7 +468,7 @@ function numerical_flux_first_order!(
             a_sub_state_conservative⁺ =
                 MVector{num_state_conservative, FT}(undef)
 
-            state_rng = static(1):static(number_state_conservative(sub, FT))
+            state_rng = static(1):static(number_states(sub, Prognostic(), FT))
             a_sub_fluxᵀn .= a_fluxᵀn[state_rng]
             a_sub_state_conservative⁻ .= parent(state_conservative⁻)[state_rng]
             a_sub_state_conservative⁺ .= parent(state_conservative⁺)[state_rng]
@@ -506,13 +478,13 @@ function numerical_flux_first_order!(
             numerical_flux_first_order!(
                 nf,
                 sub,
-                Vars{vars_state_conservative(sub, FT)}(a_sub_fluxᵀn),
+                Vars{vars_state(sub, Prognostic(), FT)}(a_sub_fluxᵀn),
                 normal_vector,
-                Vars{vars_state_conservative(sub, FT)}(
+                Vars{vars_state(sub, Prognostic(), FT)}(
                     a_sub_state_conservative⁻,
                 ),
                 state_auxiliary⁻,
-                Vars{vars_state_conservative(sub, FT)}(
+                Vars{vars_state(sub, Prognostic(), FT)}(
                     a_sub_state_conservative⁺,
                 ),
                 state_auxiliary⁺,
@@ -614,7 +586,7 @@ function numerical_boundary_flux_first_order!(
             a_state_auxiliary⁺ .= a_back_state_auxiliary⁺
 
             FT = eltype(a_fluxᵀn)
-            num_state_conservative = number_state_conservative(sub, FT)
+            num_state_conservative = number_states(sub, Prognostic(), FT)
 
             a_sub_fluxᵀn = MVector{num_state_conservative, FT}(undef)
             a_sub_state_conservative⁻ =
@@ -624,7 +596,7 @@ function numerical_boundary_flux_first_order!(
             a_sub_state_conservative1⁻ =
                 MVector{num_state_conservative, FT}(undef)
 
-            state_rng = static(1):static(number_state_conservative(sub, FT))
+            state_rng = static(1):static(number_states(sub, Prognostic(), FT))
             a_sub_fluxᵀn .= a_fluxᵀn[state_rng]
             a_sub_state_conservative⁻ .= parent(state_conservative⁻)[state_rng]
             a_sub_state_conservative⁺ .= parent(state_conservative⁺)[state_rng]
@@ -637,20 +609,20 @@ function numerical_boundary_flux_first_order!(
             numerical_boundary_flux_first_order!(
                 nf,
                 sub,
-                Vars{vars_state_conservative(sub, FT)}(a_sub_fluxᵀn),
+                Vars{vars_state(sub, Prognostic(), FT)}(a_sub_fluxᵀn),
                 normal_vector,
-                Vars{vars_state_conservative(sub, FT)}(
+                Vars{vars_state(sub, Prognostic(), FT)}(
                     a_sub_state_conservative⁻,
                 ),
                 state_auxiliary⁻,
-                Vars{vars_state_conservative(sub, FT)}(
+                Vars{vars_state(sub, Prognostic(), FT)}(
                     a_sub_state_conservative⁺,
                 ),
                 state_auxiliary⁺,
                 bctype,
                 t,
                 (rem_balance_law.subsdir[k],),
-                Vars{vars_state_conservative(sub, FT)}(
+                Vars{vars_state(sub, Prognostic(), FT)}(
                     a_sub_state_conservative1⁻,
                 ),
                 state_auxiliary1⁻,

--- a/src/Numerics/SystemSolvers/SystemSolvers.jl
+++ b/src/Numerics/SystemSolvers/SystemSolvers.jl
@@ -8,8 +8,7 @@ import ..Mesh.Grids: polynomialorder, dimensionality
 using ..Mesh.Topologies
 using ..DGMethods
 using ..DGMethods: DGModel
-using ..BalanceLaws:
-    BalanceLaw, number_state_conservative, number_state_gradient_flux
+using ..BalanceLaws
 
 using Adapt
 using LinearAlgebra

--- a/src/Numerics/SystemSolvers/columnwise_lu_solver.jl
+++ b/src/Numerics/SystemSolvers/columnwise_lu_solver.jl
@@ -269,13 +269,13 @@ function banded_matrix(
     FT = eltype(Q.data)
     device = array_device(Q)
 
-    nstate = number_state_conservative(bl, FT)
+    nstate = number_states(bl, Prognostic(), FT)
     N = polynomialorder(grid)
     Nq = N + 1
 
     # p is lower bandwidth
     # q is upper bandwidth
-    eband = number_state_gradient_flux(bl, FT) == 0 ? 1 : 2
+    eband = number_states(bl, GradientFlux(), FT) == 0 ? 1 : 2
     p = q = nstate * Nq * eband - 1
 
     nrealelem = length(topology.realelems)

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -13,15 +13,13 @@ using ...Mesh.Grids: VerticalDirection
 using ...Mesh.Geometry
 using ...DGMethods
 using ...DGMethods.NumericalFluxes
-using ...BalanceLaws
-using ...BalanceLaws: number_state_auxiliary
-
 import ...DGMethods.NumericalFluxes: update_penalty!
+using ...DGMethods.NumericalFluxes: RusanovNumericalFlux
+using ...BalanceLaws
+using ...BalanceLaws: number_states
+
 import ...BalanceLaws:
-    vars_state_conservative,
-    vars_state_auxiliary,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     init_state_conservative!,
     init_state_auxiliary!,
     compute_gradient_argument!,
@@ -33,11 +31,9 @@ import ...BalanceLaws:
     boundary_state!,
     update_auxiliary_state!,
     update_auxiliary_state_gradient!,
-    vars_integrals,
     integral_load_auxiliary_state!,
     integral_set_auxiliary_state!,
     indefinite_stack_integral!,
-    vars_reverse_integrals,
     reverse_indefinite_stack_integral!,
     reverse_integral_load_auxiliary_state!,
     reverse_integral_set_auxiliary_state!
@@ -120,7 +116,7 @@ end
 HBModel = HydrostaticBoussinesqModel
 
 """
-    vars_state_conservative(::HBModel)
+    vars_state(::HBModel, ::Prognostic)
 
 prognostic variables evolved forward in time
 
@@ -128,7 +124,7 @@ u = (u,v) = (zonal velocity, meridional velocity)
 η = sea surface height
 θ = temperature
 """
-function vars_state_conservative(m::HBModel, T)
+function vars_state(m::HBModel, ::Prognostic, T)
     @vars begin
         u::SVector{2, T}
         η::T # real a 2-D variable TODO: should be 2D
@@ -148,7 +144,7 @@ function init_state_conservative!(m::HBModel, Q::Vars, A::Vars, coords, t)
 end
 
 """
-    vars_state_auxiliary(::HBModel)
+    vars_state(::HBModel, ::Auxiliary)
 helper variables for computation
 
 second half is because there is no dedicated integral kernels
@@ -162,7 +158,7 @@ first half of these are fields that are used for computation
 y = north-south coordinate
 
 """
-function vars_state_auxiliary(m::HBModel, T)
+function vars_state(m::HBModel, ::Auxiliary, T)
     @vars begin
         y::T     # y-coordinate of the box
         w::T     # ∫(-∇⋅u)
@@ -183,12 +179,12 @@ function init_state_auxiliary!(m::HBModel, A::Vars, geom::LocalGeometry)
 end
 
 """
-    vars_state_gradient(::HBModel)
+    vars_state(::HBModel, ::Gradient)
 
 variables that you want to take a gradient of
 these are just copies in our model
 """
-function vars_state_gradient(m::HBModel, T)
+function vars_state(m::HBModel, ::Gradient, T)
     @vars begin
         ∇u::SVector{2, T}
         ∇θ::T
@@ -216,12 +212,12 @@ this computation is done pointwise at each nodal point
 end
 
 """
-    vars_state_gradient_flux(::HBModel)
+    vars_state(::HBModel, ::GradientFlux, FT)
 
 the output of the gradient computations
 multiplies ∇u by viscosity tensor and ∇θ by the diffusivity tensor
 """
-function vars_state_gradient_flux(m::HBModel, T)
+function vars_state(m::HBModel, ::GradientFlux, T)
     @vars begin
         ν∇u::SMatrix{3, 2, T, 6}
         κ∇θ::SVector{3, T}
@@ -291,7 +287,7 @@ end
 location to store integrands for bottom up integrals
 ∇hu = the horizontal divegence of u, e.g. dw/dz
 """
-function vars_integrals(m::HBModel, T)
+function vars_state(m::HBModel, ::UpwardIntegrals, T)
     @vars begin
         ∇ʰu::T
         αᵀθ::T
@@ -346,7 +342,7 @@ end
 location to store integrands for top down integrals
 αᵀθ = density perturbation
 """
-function vars_reverse_integrals(m::HBModel, T)
+function vars_state(m::HBModel, ::DownwardIntegrals, T)
     @vars begin
         αᵀθ::T
     end
@@ -635,9 +631,9 @@ function update_auxiliary_state_gradient!(
     # We are unable to use vars (ie A.w) for this because this operation will
     # return a SubArray, and adapt (used for broadcasting along reshaped arrays)
     # has a limited recursion depth for the types allowed.
-    number_auxiliary = number_state_auxiliary(m, FT)
-    index_w = varsindex(vars_state_auxiliary(m, FT), :w)
-    index_wz0 = varsindex(vars_state_auxiliary(m, FT), :wz0)
+    number_auxiliary = number_states(m, Auxiliary(), FT)
+    index_w = varsindex(vars_state(m, Auxiliary(), FT), :w)
+    index_wz0 = varsindex(vars_state(m, Auxiliary(), FT), :wz0)
     Nq, Nqk, _, _, nelemv, nelemh, nhorzrealelem, _ = basic_grid_info(dg)
 
     # project w(z=0) down the stack

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -20,7 +20,7 @@ using ...BalanceLaws: number_states
 
 import ...BalanceLaws:
     vars_state,
-    init_state_conservative!,
+    init_state_prognostic!,
     init_state_auxiliary!,
     compute_gradient_argument!,
     compute_gradient_flux!,
@@ -133,13 +133,13 @@ function vars_state(m::HBModel, ::Prognostic, T)
 end
 
 """
-    init_state_conservative!(::HBModel)
+    init_state_prognostic!(::HBModel)
 
 sets the initial value for state variables
 dispatches to ocean_init_state! which is defined in a problem file such as SimpleBoxProblem.jl
 """
 function ocean_init_state! end
-function init_state_conservative!(m::HBModel, Q::Vars, A::Vars, coords, t)
+function init_state_prognostic!(m::HBModel, Q::Vars, A::Vars, coords, t)
     return ocean_init_state!(m, m.problem, Q, A, coords, t)
 end
 

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -43,8 +43,7 @@ vars_state(lm::LinearHBModel, ::UpwardIntegrals, FT) = @vars()
     No need to init, initialize by full model
 """
 init_state_auxiliary!(lm::LinearHBModel, A::Vars, geom::LocalGeometry) = nothing
-init_state_conservative!(lm::LinearHBModel, Q::Vars, A::Vars, coords, t) =
-    nothing
+init_state_prognostic!(lm::LinearHBModel, Q::Vars, A::Vars, coords, t) = nothing
 
 """
     compute_gradient_argument!(::LinearHBModel)

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -24,13 +24,13 @@ end
 """
     Copy over state, aux, and diff variables from HBModel
 """
-vars_state_conservative(lm::LinearHBModel, FT) =
-    vars_state_conservative(lm.ocean, FT)
-vars_state_gradient(lm::LinearHBModel, FT) = vars_state_gradient(lm.ocean, FT)
-vars_state_gradient_flux(lm::LinearHBModel, FT) =
-    vars_state_gradient_flux(lm.ocean, FT)
-vars_state_auxiliary(lm::LinearHBModel, FT) = vars_state_auxiliary(lm.ocean, FT)
-vars_integrals(lm::LinearHBModel, FT) = @vars()
+vars_state(lm::LinearHBModel, ::Prognostic, FT) =
+    vars_state(lm.ocean, Prognostic(), FT)
+vars_state(lm::LinearHBModel, st::Gradient, FT) = vars_state(lm.ocean, st, FT)
+vars_state(lm::LinearHBModel, ::GradientFlux, FT) =
+    vars_state(lm.ocean, GradientFlux(), FT)
+vars_state(lm::LinearHBModel, st::Auxiliary, FT) = vars_state(lm.ocean, st, FT)
+vars_state(lm::LinearHBModel, ::UpwardIntegrals, FT) = @vars()
 
 """
     No integration, hyperbolic flux, or source terms

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -14,10 +14,7 @@ using ...BalanceLaws
 
 import ...DGMethods.NumericalFluxes: update_penalty!
 import ...BalanceLaws:
-    vars_state_conservative,
-    vars_state_auxiliary,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     init_state_conservative!,
     init_state_auxiliary!,
     compute_gradient_argument!,
@@ -55,27 +52,27 @@ end
 
 SWModel = ShallowWaterModel
 
-function vars_state_conservative(m::SWModel, T)
+function vars_state(m::SWModel, ::Prognostic, T)
     @vars begin
         η::T
         U::SVector{2, T}
     end
 end
 
-function vars_state_auxiliary(m::SWModel, T)
+function vars_state(m::SWModel, ::Auxiliary, T)
     @vars begin
         f::T
         τ::SVector{2, T}  # value includes τₒ, g, and ρ
     end
 end
 
-function vars_state_gradient(m::SWModel, T)
+function vars_state(m::SWModel, ::Gradient, T)
     @vars begin
         ∇U::SVector{2, T}
     end
 end
 
-function vars_state_gradient_flux(m::SWModel, T)
+function vars_state(m::SWModel, ::GradientFlux, T)
     @vars begin
         ν∇U::SMatrix{3, 2, T, 6}
     end

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -15,7 +15,7 @@ using ...BalanceLaws
 import ...DGMethods.NumericalFluxes: update_penalty!
 import ...BalanceLaws:
     vars_state,
-    init_state_conservative!,
+    init_state_prognostic!,
     init_state_auxiliary!,
     compute_gradient_argument!,
     compute_gradient_flux!,
@@ -241,7 +241,7 @@ function init_state_auxiliary!(m::SWModel, aux::Vars, geom::LocalGeometry)
 end
 
 function shallow_init_state! end
-function init_state_conservative!(m::SWModel, state::Vars, aux::Vars, coords, t)
+function init_state_prognostic!(m::SWModel, state::Vars, aux::Vars, coords, t)
     shallow_init_state!(m, m.problem, state, aux, coords, t)
 end
 

--- a/src/Ocean/SplitExplicit/VerticalIntegralModel.jl
+++ b/src/Ocean/SplitExplicit/VerticalIntegralModel.jl
@@ -1,6 +1,6 @@
 import ...BalanceLaws:
     vars_state,
-    init_state_conservative!,
+    init_state_prognostic!,
     init_state_auxiliary!,
     update_auxiliary_state!,
     integral_load_auxiliary_state!,

--- a/src/Ocean/SplitExplicit/VerticalIntegralModel.jl
+++ b/src/Ocean/SplitExplicit/VerticalIntegralModel.jl
@@ -1,12 +1,8 @@
 import ...BalanceLaws:
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
-    vars_state_auxiliary,
+    vars_state,
     init_state_conservative!,
     init_state_auxiliary!,
     update_auxiliary_state!,
-    vars_integrals,
     integral_load_auxiliary_state!,
     integral_set_auxiliary_state!
 
@@ -17,13 +13,10 @@ struct VerticalIntegralModel{M} <: BalanceLaw
     end
 end
 
-vars_state_gradient(tm::VerticalIntegralModel, FT) = @vars()
-vars_state_gradient_flux(tm::VerticalIntegralModel, FT) = @vars()
+vars_state(tm::VerticalIntegralModel, st::Prognostic, FT) =
+    vars_state(tm.ocean, st, FT)
 
-vars_state_conservative(tm::VerticalIntegralModel, FT) =
-    vars_state_conservative(tm.ocean, FT)
-
-function vars_state_auxiliary(m::VerticalIntegralModel, T)
+function vars_state(m::VerticalIntegralModel, ::Auxiliary, T)
     @vars begin
         ∫x::SVector{2, T}
     end
@@ -32,7 +25,7 @@ end
 init_state_auxiliary!(tm::VerticalIntegralModel, A::Vars, geom::LocalGeometry) =
     nothing
 
-function vars_integrals(m::VerticalIntegralModel, T)
+function vars_state(m::VerticalIntegralModel, ::UpwardIntegrals, T)
     @vars begin
         ∫x::SVector{2, T}
     end

--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -29,7 +29,7 @@ using ..VariableTemplates
     ) where {T, dim, N}
 
 Return a dictionary whose keys are the `flattenednames()` of the variables
-specified in `vars` (as returned by e.g. `vars_state_conservative()`), and
+specified in `vars` (as returned by e.g. `vars_state`), and
 whose values are arrays of the values for that variable along the vertical
 dimension in `Q`. Only a single element is expected in the horizontal as
 this is intended for the single stack configuration and `i` and `j` identify
@@ -123,7 +123,7 @@ end
     ) where {T, dim, N}
 
 Return a dictionary whose keys are the `flattenednames()` of the variables
-specified in `vars` (as returned by e.g. `vars_state_conservative()`), and
+specified in `vars` (as returned by e.g. `vars_state`), and
 whose values are arrays of the horizontal averages for that variable along
 the vertical dimension in `Q`. Only a single element is expected in the
 horizontal as this is intended for the single stack configuration.
@@ -168,7 +168,7 @@ end
     ) where {T, dim, N}
 
 Return a dictionary whose keys are the `flattenednames()` of the variables
-specified in `vars` (as returned by e.g. `vars_state_conservative()`), and
+specified in `vars` (as returned by e.g. `vars_state`), and
 whose values are arrays of the horizontal variance for that variable along
 the vertical dimension in `Q`. Only a single element is expected in the
 horizontal as this is intended for the single stack configuration.

--- a/test/Atmos/Model/ref_state.jl
+++ b/test/Atmos/Model/ref_state.jl
@@ -15,36 +15,37 @@ using ClimateMachine.Atmos: atmos_init_aux!
 using ClimateMachine.Orientations: init_aux!
 using ClimateMachine.ConfigTypes
 using ClimateMachine.DGMethods
-using ClimateMachine.DGMethods: vars_state_auxiliary, number_state_auxiliary
-using ClimateMachine.DGMethods: BalanceLaw, LocalGeometry
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, vars_state, number_states, Auxiliary
+using ClimateMachine.DGMethods: LocalGeometry
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.VariableTemplates
 
 using Test
 
-# We should provide an interface to call all physics
-# kernels in some way similar to this:
-function compute_ref_state(z::FT, atmos) where {FT}
-
-    vgeo = SArray{Tuple{3, 16, 3}, FT}(zeros(3, 16, 3)) # dummy, not used
-    local_geom = LocalGeometry(Val(5), vgeo, 1, 1) # dummy, not used
-    st = vars_state_auxiliary(atmos, FT)
-    nst = number_state_auxiliary(atmos, FT)
-    arr = MArray{Tuple{nst}, FT}(undef)
-    fill!(arr, 0)
-    aux = Vars{st}(arr)
-
-    # Hack: need coord in sync with incoming z, so that
-    # altitude returns correct value.
-    aux.coord = @SArray FT[0, 0, z]
-
-    # Need orientation defined, so that z
-    init_aux!(atmos.orientation, atmos.param_set, aux)
-    atmos_init_aux!(atmos.ref_state, atmos, aux, local_geom)
-    return aux
-end
 
 @testset "Hydrostatic reference states" begin
+    # We should provide an interface to call all physics
+    # kernels in some way similar to this:
+    function compute_ref_state(z::FT, atmos) where {FT}
+
+        vgeo = SArray{Tuple{3, 16, 3}, FT}(zeros(3, 16, 3)) # dummy, not used
+        local_geom = LocalGeometry(Val(5), vgeo, 1, 1) # dummy, not used
+        st = vars_state(atmos, Auxiliary(), FT)
+        nst = number_states(atmos, Auxiliary(), FT)
+        arr = MArray{Tuple{nst}, FT}(undef)
+        fill!(arr, 0)
+        aux = Vars{st}(arr)
+
+        # Hack: need coord in sync with incoming z, so that
+        # altitude returns correct value.
+        aux.coord = @SArray FT[0, 0, z]
+
+        # Need orientation defined, so that z
+        init_aux!(atmos.orientation, atmos.param_set, aux)
+        atmos_init_aux!(atmos.ref_state, atmos, aux, local_geom)
+        return aux
+    end
 
     FT = Float64
     RH = FT(0.5)

--- a/test/Atmos/Model/ref_state.jl
+++ b/test/Atmos/Model/ref_state.jl
@@ -55,7 +55,7 @@ using Test
         param_set;
         moisture = DryModel(),
         ref_state = HydrostaticState(profile, RH),
-        init_state_conservative = x -> x,
+        init_state_prognostic = x -> x,
     )
 
     z = collect(range(FT(0), stop = FT(25e3), length = 100))

--- a/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
@@ -2,7 +2,7 @@ using Dierckx
 
 include("KinematicModel.jl")
 
-function vars_state_conservative(m::KinematicModel, FT)
+function vars_state(m::KinematicModel, ::Prognostic, FT)
     @vars begin
         ρ::FT
         ρu::SVector{3, FT}
@@ -15,7 +15,7 @@ function vars_state_conservative(m::KinematicModel, FT)
     end
 end
 
-function vars_state_auxiliary(m::KinematicModel, FT)
+function vars_state(m::KinematicModel, ::Auxiliary, FT)
     @vars begin
         # defined in init_state_auxiliary
         p::FT
@@ -876,20 +876,20 @@ function main()
     mpicomm = MPI.COMM_WORLD
 
     # get state variables indices for filtering
-    ρq_liq_ind = varsindex(vars_state_conservative(model, FT), :ρq_liq)
-    ρq_ice_ind = varsindex(vars_state_conservative(model, FT), :ρq_ice)
-    ρq_rai_ind = varsindex(vars_state_conservative(model, FT), :ρq_rai)
-    ρq_sno_ind = varsindex(vars_state_conservative(model, FT), :ρq_sno)
+    ρq_liq_ind = varsindex(vars_state(model, Prognostic(), FT), :ρq_liq)
+    ρq_ice_ind = varsindex(vars_state(model, Prognostic(), FT), :ρq_ice)
+    ρq_rai_ind = varsindex(vars_state(model, Prognostic(), FT), :ρq_rai)
+    ρq_sno_ind = varsindex(vars_state(model, Prognostic(), FT), :ρq_sno)
     # get aux variables indices for testing
-    q_tot_ind = varsindex(vars_state_auxiliary(model, FT), :q_tot)
-    q_vap_ind = varsindex(vars_state_auxiliary(model, FT), :q_vap)
-    q_liq_ind = varsindex(vars_state_auxiliary(model, FT), :q_liq)
-    q_ice_ind = varsindex(vars_state_auxiliary(model, FT), :q_ice)
-    q_rai_ind = varsindex(vars_state_auxiliary(model, FT), :q_rai)
-    q_sno_ind = varsindex(vars_state_auxiliary(model, FT), :q_sno)
-    S_ind = varsindex(vars_state_auxiliary(model, FT), :S)
-    rain_w_ind = varsindex(vars_state_auxiliary(model, FT), :rain_w)
-    snow_w_ind = varsindex(vars_state_auxiliary(model, FT), :snow_w)
+    q_tot_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_tot)
+    q_vap_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_vap)
+    q_liq_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_liq)
+    q_ice_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_ice)
+    q_rai_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_rai)
+    q_sno_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_sno)
+    S_ind = varsindex(vars_state(model, Auxiliary(), FT), :S)
+    rain_w_ind = varsindex(vars_state(model, Auxiliary(), FT), :rain_w)
+    snow_w_ind = varsindex(vars_state(model, Auxiliary(), FT), :snow_w)
 
     # filter out negative values
     cb_tmar_filter =
@@ -926,9 +926,9 @@ function main()
                 out_path_prefix,
                 solver_config.Q,
                 solver_config.dg,
-                flattenednames(vars_state_conservative(model, FT)),
+                flattenednames(vars_state(model, Prognostic(), FT)),
                 solver_config.dg.state_auxiliary,
-                flattenednames(vars_state_auxiliary(model, FT)),
+                flattenednames(vars_state(model, Auxiliary(), FT)),
             )
             step[1] += 1
             nothing

--- a/test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl
@@ -1,6 +1,6 @@
 include("KinematicModel.jl")
 
-function vars_state_conservative(m::KinematicModel, FT)
+function vars_state(m::KinematicModel, ::Prognostic, FT)
     @vars begin
         ρ::FT
         ρu::SVector{3, FT}
@@ -9,7 +9,7 @@ function vars_state_conservative(m::KinematicModel, FT)
     end
 end
 
-function vars_state_auxiliary(m::KinematicModel, FT)
+function vars_state(m::KinematicModel, ::Auxiliary, FT)
     @vars begin
         # defined in init_state_auxiliary
         p::FT
@@ -253,20 +253,20 @@ function main()
             out_path_prefix,
             solver_config.Q,
             solver_config.dg,
-            flattenednames(vars_state_conservative(model, FT)),
+            flattenednames(vars_state(model, Prognostic(), FT)),
             solver_config.dg.state_auxiliary,
-            flattenednames(vars_state_auxiliary(model, FT)),
+            flattenednames(vars_state(model, Auxiliary(), FT)),
         )
         step[1] += 1
         nothing
     end
 
     # get aux variables indices for testing
-    q_tot_ind = varsindex(vars_state_auxiliary(model, FT), :q_tot)
-    q_vap_ind = varsindex(vars_state_auxiliary(model, FT), :q_vap)
-    q_liq_ind = varsindex(vars_state_auxiliary(model, FT), :q_liq)
-    q_ice_ind = varsindex(vars_state_auxiliary(model, FT), :q_ice)
-    S_ind = varsindex(vars_state_auxiliary(model, FT), :S)
+    q_tot_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_tot)
+    q_vap_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_vap)
+    q_liq_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_liq)
+    q_ice_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_ice)
+    S_ind = varsindex(vars_state(model, Auxiliary(), FT), :S)
 
     # call solve! function for time-integrator
     result = ClimateMachine.invoke!(

--- a/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
@@ -1,6 +1,6 @@
 include("KinematicModel.jl")
 
-function vars_state_conservative(m::KinematicModel, FT)
+function vars_state(m::KinematicModel, ::Prognostic, FT)
     @vars begin
         ρ::FT
         ρu::SVector{3, FT}
@@ -12,7 +12,7 @@ function vars_state_conservative(m::KinematicModel, FT)
     end
 end
 
-function vars_state_auxiliary(m::KinematicModel, FT)
+function vars_state(m::KinematicModel, ::Auxiliary, FT)
     @vars begin
         # defined in init_state_auxiliary
         p::FT
@@ -399,17 +399,17 @@ function main()
     mpicomm = MPI.COMM_WORLD
 
     # get state variables indices for filtering
-    ρq_liq_ind = varsindex(vars_state_conservative(model, FT), :ρq_liq)
-    ρq_ice_ind = varsindex(vars_state_conservative(model, FT), :ρq_ice)
-    ρq_rai_ind = varsindex(vars_state_conservative(model, FT), :ρq_rai)
+    ρq_liq_ind = varsindex(vars_state(model, Prognostic(), FT), :ρq_liq)
+    ρq_ice_ind = varsindex(vars_state(model, Prognostic(), FT), :ρq_ice)
+    ρq_rai_ind = varsindex(vars_state(model, Prognostic(), FT), :ρq_rai)
     # get aux variables indices for testing
-    q_tot_ind = varsindex(vars_state_auxiliary(model, FT), :q_tot)
-    q_vap_ind = varsindex(vars_state_auxiliary(model, FT), :q_vap)
-    q_liq_ind = varsindex(vars_state_auxiliary(model, FT), :q_liq)
-    q_ice_ind = varsindex(vars_state_auxiliary(model, FT), :q_ice)
-    q_rai_ind = varsindex(vars_state_auxiliary(model, FT), :q_rai)
-    S_ind = varsindex(vars_state_auxiliary(model, FT), :S)
-    rain_w_ind = varsindex(vars_state_auxiliary(model, FT), :rain_w)
+    q_tot_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_tot)
+    q_vap_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_vap)
+    q_liq_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_liq)
+    q_ice_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_ice)
+    q_rai_ind = varsindex(vars_state(model, Auxiliary(), FT), :q_rai)
+    S_ind = varsindex(vars_state(model, Auxiliary(), FT), :S)
+    rain_w_ind = varsindex(vars_state(model, Auxiliary(), FT), :rain_w)
 
     # filter out negative values
     cb_tmar_filter =
@@ -446,9 +446,9 @@ function main()
                 out_path_prefix,
                 solver_config.Q,
                 solver_config.dg,
-                flattenednames(vars_state_conservative(model, FT)),
+                flattenednames(vars_state(model, Prognostic(), FT)),
                 solver_config.dg.state_auxiliary,
-                flattenednames(vars_state_auxiliary(model, FT)),
+                flattenednames(vars_state(model, Auxiliary(), FT)),
             )
             step[1] += 1
             nothing

--- a/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
@@ -91,7 +91,7 @@ using ClimateMachine.BalanceLaws:
 
 import ClimateMachine.BalanceLaws:
     vars_state,
-    init_state_conservative!,
+    init_state_prognostic!,
     init_state_auxiliary!,
     update_auxiliary_state!,
     nodal_update_auxiliary_state!,
@@ -132,7 +132,7 @@ struct KinematicModel{FT, PS, O, M, P, S, BC, IS, DC} <: BalanceLaw
     precipitation::P
     source::S
     boundarycondition::BC
-    init_state_conservative::IS
+    init_state_prognostic::IS
     data_config::DC
 end
 
@@ -144,12 +144,12 @@ function KinematicModel{FT}(
     precipitation::P = nothing,
     source::S = nothing,
     boundarycondition::BC = nothing,
-    init_state_conservative::IS = nothing,
+    init_state_prognostic::IS = nothing,
     data_config::DC = nothing,
 ) where {FT <: AbstractFloat, O, M, P, S, BC, IS, DC}
 
     @assert param_set ≠ nothing
-    @assert init_state_conservative ≠ nothing
+    @assert init_state_prognostic ≠ nothing
 
     atmos = (
         param_set,
@@ -158,7 +158,7 @@ function KinematicModel{FT}(
         precipitation,
         source,
         boundarycondition,
-        init_state_conservative,
+        init_state_prognostic,
         data_config,
     )
 
@@ -202,7 +202,7 @@ function init_state_auxiliary!(
     end
 end
 
-function init_state_conservative!(
+function init_state_prognostic!(
     m::KinematicModel,
     state::Vars,
     aux::Vars,
@@ -210,7 +210,7 @@ function init_state_conservative!(
     t,
     args...,
 )
-    m.init_state_conservative(m, state, aux, coords, t, args...)
+    m.init_state_prognostic(m, state, aux, coords, t, args...)
 end
 
 function update_auxiliary_state!(
@@ -315,7 +315,7 @@ function config_kinematic_eddy(
     model = KinematicModel{FT}(
         AtmosLESConfigType,
         param_set;
-        init_state_conservative = init_kinematic_eddy!,
+        init_state_prognostic = init_kinematic_eddy!,
         data_config = kmc,
     )
 

--- a/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
@@ -86,13 +86,11 @@ const ice_param_set = param_set.microphys_param_set.ice
 const rain_param_set = param_set.microphys_param_set.rain
 const snow_param_set = param_set.microphys_param_set.snow
 
-using ClimateMachine.BalanceLaws: BalanceLaw
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, Hyperdiffusive
 
 import ClimateMachine.BalanceLaws:
-    vars_state_conservative,
-    vars_state_auxiliary,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     init_state_conservative!,
     init_state_auxiliary!,
     update_auxiliary_state!,
@@ -167,9 +165,9 @@ function KinematicModel{FT}(
     return KinematicModel{FT, typeof.(atmos)...}(atmos...)
 end
 
-vars_state_gradient(m::KinematicModel, FT) = @vars()
+vars_state(m::KinematicModel, ::Gradient, FT) = @vars()
 
-vars_state_gradient_flux(m::KinematicModel, FT) = @vars()
+vars_state(m::KinematicModel, ::GradientFlux, FT) = @vars()
 
 function init_state_auxiliary!(
     m::KinematicModel,

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -102,7 +102,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
         turbulence = SmagorinskyLilly{FT}(C_smag),
         source = (Gravity(),),
         ref_state = ref_state,
-        init_state_conservative = init_risingbubble!,
+        init_state_prognostic = init_risingbubble!,
     )
 
     # Problem configuration

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -9,6 +9,7 @@ using ClimateMachine.Atmos
 using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
+using ClimateMachine.BalanceLaws
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
@@ -23,7 +24,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
 import ClimateMachine.Mesh.Grids: _x1, _x2, _x3
-import ClimateMachine.BalanceLaws: vars_state_conservative
+import ClimateMachine.BalanceLaws: vars_state
 import ClimateMachine.VariableTemplates.varsindex
 
 # ------------------------ Description ------------------------- #
@@ -175,8 +176,8 @@ function run_brick_diagostics_fields_test()
         Npl = size(Q.realdata, 1)
 
         ind = [
-            varsindex(vars_state_conservative(model, FT), :ρ)
-            varsindex(vars_state_conservative(model, FT), :ρu)
+            varsindex(vars_state(model, Prognostic(), FT), :ρ)
+            varsindex(vars_state(model, Prognostic(), FT), :ρu)
         ]
         _ρ, _ρu, _ρv, _ρw = ind[1], ind[2], ind[3], ind[4]
 

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -89,7 +89,7 @@ function main()
         turbulence = turbulence,
         moisture = DryModel(),
         source = Gravity(),
-        init_state_conservative = setup,
+        init_state_prognostic = setup,
     )
 
     driver_config = ClimateMachine.AtmosGCMConfiguration(

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -80,7 +80,7 @@ function main()
         turbulence = turbulence,
         moisture = DryModel(),
         source = Gravity(),
-        init_state_conservative = setup,
+        init_state_prognostic = setup,
     )
 
     ode_solver = ClimateMachine.MultirateSolverType(

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -130,7 +130,7 @@ function main()
         moisture = MMSDryModel(),
         source = mms3_source!,
         boundarycondition = InitStateBC(),
-        init_state_conservative = mms3_init_state!,
+        init_state_prognostic = mms3_init_state!,
     )
 
     brickrange = (

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -126,7 +126,7 @@ function run(
         moisture = DryModel(),
         tracers = NTracers{length(δ_χ), FT}(δ_χ),
         source = Gravity(),
-        init_state_conservative = setup,
+        init_state_prognostic = setup,
     )
     linearmodel = AtmosAcousticGravityLinearModel(model)
 

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -28,8 +28,7 @@ using ClimateMachine.Atmos:
     NoPrecipitation,
     NoRadiation,
     NTracers,
-    vars_state_conservative,
-    vars_state_auxiliary,
+    vars_state,
     Gravity,
     HydrostaticState,
     AtmosAcousticGravityLinearModel
@@ -312,8 +311,8 @@ function do_output(
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
-    auxnames = flattenednames(vars_state_auxiliary(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+    auxnames = flattenednames(vars_state(model, Auxiliary(), eltype(Q)))
     writevtk(filename, Q, dg, statenames, dg.state_auxiliary, auxnames)
 
     ## Generate the pvtu file for these vtk files

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -33,8 +33,7 @@ using ClimateMachine.Atmos:
     NoRadiation,
     NTracers,
     ConstantViscosityWithDivergence,
-    vars_state_conservative,
-    vars_state_auxiliary,
+    vars_state,
     Gravity,
     HydrostaticState,
     AtmosAcousticGravityLinearModel,
@@ -353,8 +352,8 @@ function do_output(
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
-    auxnames = flattenednames(vars_state_auxiliary(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+    auxnames = flattenednames(vars_state(model, Auxiliary(), eltype(Q)))
     writevtk(filename, Q, dg, statenames, dg.state_auxiliary, auxnames)
 
     ## Generate the pvtu file for these vtk files

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -135,7 +135,7 @@ function run(
         moisture = DryModel(),
         tracers = NTracers{length(δ_χ), FT}(δ_χ),
         source = Gravity(),
-        init_state_conservative = setup,
+        init_state_prognostic = setup,
     )
     dg = DGModel(
         fullmodel,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -21,10 +21,11 @@ using ClimateMachine.Atmos:
     DryModel,
     NoPrecipitation,
     NoRadiation,
-    vars_state_conservative
+    vars_state
 using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: flattenednames
 using ClimateMachine.TurbulenceClosures
+using ClimateMachine.BalanceLaws: Prognostic
 
 using CLIMAParameters
 using CLIMAParameters.Planet: kappa_d
@@ -355,7 +356,7 @@ function do_output(
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -195,7 +195,7 @@ function run(
         moisture = DryModel(),
         source = nothing,
         boundarycondition = (),
-        init_state_conservative = isentropicvortex_initialcondition!,
+        init_state_prognostic = isentropicvortex_initialcondition!,
     )
 
     dg = DGModel(

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -24,11 +24,12 @@ using ClimateMachine.Atmos:
     DryModel,
     NoPrecipitation,
     NoRadiation,
-    vars_state_conservative
+    vars_state
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
-import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary
+using ClimateMachine.BalanceLaws: Prognostic, Auxiliary
+import ClimateMachine.Atmos: atmos_init_aux!, vars_state
 
 using CLIMAParameters
 using CLIMAParameters.Planet: kappa_d
@@ -291,7 +292,7 @@ end
 struct IsentropicVortexReferenceState{FT} <: ReferenceState
     setup::IsentropicVortexSetup{FT}
 end
-vars_state_auxiliary(::IsentropicVortexReferenceState, FT) =
+vars_state(::IsentropicVortexReferenceState, ::Auxiliary, FT) =
     @vars(ρ::FT, ρe::FT, p::FT, T::FT)
 function atmos_init_aux!(
     m::IsentropicVortexReferenceState,
@@ -368,7 +369,7 @@ function do_output(
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -161,7 +161,7 @@ function run(
         moisture = DryModel(),
         source = nothing,
         boundarycondition = (),
-        init_state_conservative = isentropicvortex_initialcondition!,
+        init_state_prognostic = isentropicvortex_initialcondition!,
     )
 
     linear_model = AtmosAcousticLinearModel(model)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -155,7 +155,7 @@ function run(
         moisture = DryModel(),
         source = nothing,
         boundarycondition = (),
-        init_state_conservative = isentropicvortex_initialcondition!,
+        init_state_prognostic = isentropicvortex_initialcondition!,
     )
     # The linear model has the fast time scales
     fast_model = AtmosAcousticLinearModel(model)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -24,11 +24,12 @@ using ClimateMachine.Atmos:
     DryModel,
     NoPrecipitation,
     NoRadiation,
-    vars_state_conservative
+    vars_state
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
-import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary
+using ClimateMachine.BalanceLaws: Prognostic, Auxiliary
+import ClimateMachine.Atmos: atmos_init_aux!, vars_state
 
 using CLIMAParameters
 using CLIMAParameters.Planet: kappa_d
@@ -276,7 +277,7 @@ end
 struct IsentropicVortexReferenceState{FT} <: ReferenceState
     setup::IsentropicVortexSetup{FT}
 end
-vars_state_auxiliary(::IsentropicVortexReferenceState, FT) =
+vars_state(::IsentropicVortexReferenceState, ::Auxiliary, FT) =
     @vars(ρ::FT, ρe::FT, p::FT, T::FT)
 function atmos_init_aux!(
     m::IsentropicVortexReferenceState,
@@ -353,7 +354,7 @@ function do_output(
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -156,7 +156,7 @@ function run(
         moisture = DryModel(),
         source = nothing,
         boundarycondition = (),
-        init_state_conservative = isentropicvortex_initialcondition!,
+        init_state_prognostic = isentropicvortex_initialcondition!,
     )
     # This is a bad idea; this test is just testing how
     # implicit GARK composes with explicit methods

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -24,11 +24,12 @@ using ClimateMachine.Atmos:
     DryModel,
     NoPrecipitation,
     NoRadiation,
-    vars_state_conservative
+    vars_state
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
-import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary
+using ClimateMachine.BalanceLaws: Prognostic, Auxiliary
+import ClimateMachine.Atmos: atmos_init_aux!, vars_state
 
 using CLIMAParameters
 using CLIMAParameters.Planet: kappa_d
@@ -286,7 +287,7 @@ end
 struct IsentropicVortexReferenceState{FT} <: ReferenceState
     setup::IsentropicVortexSetup{FT}
 end
-vars_state_auxiliary(::IsentropicVortexReferenceState, FT) =
+vars_state(::IsentropicVortexReferenceState, ::Auxiliary, FT) =
     @vars(ρ::FT, ρe::FT, p::FT, T::FT)
 function atmos_init_aux!(
     m::IsentropicVortexReferenceState,
@@ -363,7 +364,7 @@ function do_output(
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -159,7 +159,7 @@ function run(
         moisture = DryModel(),
         source = nothing,
         boundarycondition = (),
-        init_state_conservative = isentropicvortex_initialcondition!,
+        init_state_prognostic = isentropicvortex_initialcondition!,
     )
     # The linear model has the fast time scales
     fast_model = AtmosAcousticLinearModel(model)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -24,11 +24,12 @@ using ClimateMachine.Atmos:
     DryModel,
     NoPrecipitation,
     NoRadiation,
-    vars_state_conservative
+    vars_state
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations: NoOrientation
 using ClimateMachine.VariableTemplates: @vars, Vars, flattenednames
-import ClimateMachine.Atmos: atmos_init_aux!, vars_state_auxiliary
+using ClimateMachine.BalanceLaws: Prognostic, Auxiliary
+import ClimateMachine.Atmos: atmos_init_aux!, vars_state
 
 using CLIMAParameters
 using CLIMAParameters.Planet: kappa_d
@@ -299,7 +300,7 @@ end
 struct IsentropicVortexReferenceState{FT} <: ReferenceState
     setup::IsentropicVortexSetup{FT}
 end
-vars_state_auxiliary(::IsentropicVortexReferenceState, FT) =
+vars_state(::IsentropicVortexReferenceState, ::Auxiliary, FT) =
     @vars(ρ::FT, ρe::FT, p::FT, T::FT)
 function atmos_init_aux!(
     m::IsentropicVortexReferenceState,
@@ -375,7 +376,7 @@ function do_output(
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -14,7 +14,7 @@ import ClimateMachine.BalanceLaws:
     compute_gradient_flux!,
     init_state_auxiliary!,
     update_auxiliary_state!,
-    init_state_conservative!,
+    init_state_prognostic!,
     boundary_state!,
     wavespeed
 
@@ -245,7 +245,7 @@ function update_auxiliary_state!(
     return false
 end
 
-function init_state_conservative!(
+function init_state_prognostic!(
     m::AdvectionDiffusion,
     state::Vars,
     aux::Vars,

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -1,13 +1,12 @@
 using StaticArrays
 using ClimateMachine.VariableTemplates
 using ClimateMachine.DGMethods: nodal_update_auxiliary_state!
-using ClimateMachine.BalanceLaws: BalanceLaw
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux
 
 import ClimateMachine.BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
+    number_states,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -17,9 +16,7 @@ import ClimateMachine.BalanceLaws:
     update_auxiliary_state!,
     init_state_conservative!,
     boundary_state!,
-    wavespeed,
-    number_state_conservative,
-    number_state_gradient
+    wavespeed
 
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
@@ -55,10 +52,11 @@ end
 #   `coord` coordinate points (needed for BCs)
 #   `u` advection velocity
 #   `D` Diffusion tensor
-vars_state_auxiliary(::AdvectionDiffusion, FT) =
+vars_state(::AdvectionDiffusion, ::Auxiliary, FT) =
     @vars(coord::SVector{3, FT}, u::SVector{3, FT}, D::SMatrix{3, 3, FT, 9})
-function vars_state_auxiliary(
+function vars_state(
     ::AdvectionDiffusion{dim, P, fluxBC, true},
+    ::Auxiliary,
     FT,
 ) where {dim, P, fluxBC}
     @vars begin
@@ -68,19 +66,21 @@ function vars_state_auxiliary(
 end
 
 # Density is only state
-vars_state_conservative(::AdvectionDiffusion, FT) = @vars(ρ::FT)
+vars_state(::AdvectionDiffusion, ::Prognostic, FT) = @vars(ρ::FT)
 
 # Take the gradient of density
-vars_state_gradient(::AdvectionDiffusion, FT) = @vars(ρ::FT)
-vars_state_gradient(
+vars_state(::AdvectionDiffusion, ::Gradient, FT) = @vars(ρ::FT)
+vars_state(
     ::AdvectionDiffusion{dim, P, fluxBC, true},
+    ::Gradient,
     FT,
 ) where {dim, P, fluxBC} = @vars()
 
 # The DG auxiliary variable: D ∇ρ
-vars_state_gradient_flux(::AdvectionDiffusion, FT) = @vars(σ::SVector{3, FT})
-vars_state_gradient_flux(
+vars_state(::AdvectionDiffusion, ::GradientFlux, FT) = @vars(σ::SVector{3, FT})
+vars_state(
     ::AdvectionDiffusion{dim, P, fluxBC, true},
+    ::GradientFlux,
     FT,
 ) where {dim, P, fluxBC} = @vars()
 
@@ -299,8 +299,8 @@ function boundary_state!(
         diff⁺.σ = diff⁻.σ
     elseif bctype == 2 # Neumann with data
         FT = eltype(diff⁺)
-        ngrad = number_state_gradient(m, FT)
-        ∇state = Grad{vars_state_gradient(m, FT)}(similar(
+        ngrad = number_states(m, Gradient(), FT)
+        ∇state = Grad{vars_state(m, Gradient(), FT)}(similar(
             parent(diff⁺),
             Size(3, ngrad),
         ))
@@ -310,8 +310,8 @@ function boundary_state!(
         # compute the diffusive flux using the boundary state
     elseif bctype == 4 # zero Neumann
         FT = eltype(diff⁺)
-        ngrad = number_state_gradient(m, FT)
-        ∇state = Grad{vars_state_gradient(m, FT)}(similar(
+        ngrad = number_states(m, Gradient(), FT)
+        ∇state = Grad{vars_state(m, Gradient(), FT)}(similar(
             parent(diff⁺),
             Size(3, ngrad),
         ))
@@ -361,8 +361,8 @@ function boundary_flux_second_order!(
         flux_second_order!(m, F, state⁻, diff⁻, hyperdiff⁻, aux⁻, t)
     elseif bctype == 2 # Neumann data
         FT = eltype(diff⁺)
-        ngrad = number_state_gradient(m, FT)
-        ∇state = Grad{vars_state_gradient(m, FT)}(similar(
+        ngrad = number_states(m, Gradient(), FT)
+        ∇state = Grad{vars_state(m, Gradient(), FT)}(similar(
             parent(diff⁺),
             Size(3, ngrad),
         ))

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
@@ -82,7 +82,7 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
@@ -165,7 +165,7 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
@@ -16,7 +16,7 @@ import ClimateMachine.BalanceLaws:
     compute_gradient_argument!,
     compute_gradient_flux!,
     init_state_auxiliary!,
-    init_state_conservative!,
+    init_state_prognostic!,
     boundary_state!,
     wavespeed,
     transform_post_gradient_laplacian!
@@ -129,7 +129,7 @@ function init_state_auxiliary!(
     init_hyperdiffusion_tensor!(m.problem, aux, geom)
 end
 
-function init_state_conservative!(
+function init_state_prognostic!(
     m::HyperDiffusion,
     state::Vars,
     aux::Vars,

--- a/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
@@ -1,11 +1,15 @@
 using StaticArrays
 using ClimateMachine.VariableTemplates
-using ClimateMachine.BalanceLaws: BalanceLaw
+using ClimateMachine.BalanceLaws:
+    BalanceLaw,
+    Prognostic,
+    Auxiliary,
+    Gradient,
+    GradientFlux,
+    GradientLaplacian,
+    Hyperdiffusive
 import ClimateMachine.BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -15,8 +19,6 @@ import ClimateMachine.BalanceLaws:
     init_state_conservative!,
     boundary_state!,
     wavespeed,
-    vars_gradient_laplacian,
-    vars_hyperdiffusive,
     transform_post_gradient_laplacian!
 
 using ClimateMachine.Mesh.Geometry: LocalGeometry
@@ -33,19 +35,19 @@ struct HyperDiffusion{dim, P} <: BalanceLaw
     end
 end
 
-vars_state_auxiliary(::HyperDiffusion, FT) = @vars(D::SMatrix{3, 3, FT, 9})
+vars_state(::HyperDiffusion, ::Auxiliary, FT) = @vars(D::SMatrix{3, 3, FT, 9})
 #
 # Density is only state
-vars_state_conservative(::HyperDiffusion, FT) = @vars(ρ::FT)
+vars_state(::HyperDiffusion, ::Prognostic, FT) = @vars(ρ::FT)
 
 # Take the gradient of density
-vars_state_gradient(::HyperDiffusion, FT) = @vars(ρ::FT)
+vars_state(::HyperDiffusion, ::Gradient, FT) = @vars(ρ::FT)
 # Take the gradient of laplacian of density
-vars_gradient_laplacian(::HyperDiffusion, FT) = @vars(ρ::FT)
+vars_state(::HyperDiffusion, ::GradientLaplacian, FT) = @vars(ρ::FT)
 
-vars_state_gradient_flux(::HyperDiffusion, FT) = @vars()
+vars_state(::HyperDiffusion, ::GradientFlux, FT) = @vars()
 # The hyperdiffusion DG auxiliary variable: D ∇ Δρ
-vars_hyperdiffusive(::HyperDiffusion, FT) = @vars(σ::SVector{3, FT})
+vars_state(::HyperDiffusion, ::Hyperdiffusive, FT) = @vars(σ::SVector{3, FT})
 
 function flux_first_order!(m::HyperDiffusion, _...) end
 

--- a/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
@@ -71,7 +71,7 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
@@ -76,7 +76,7 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
@@ -82,7 +82,7 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
@@ -82,7 +82,7 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
     exactnames = statenames .* "_exact"
 
     writevtk(filename, Q, dg, statenames, Qe, exactnames)

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -22,7 +22,7 @@ using StaticArrays
 using Logging, Printf, Dates
 using ClimateMachine.VTK
 using Random
-using ClimateMachine.Atmos: vars_state_conservative, vars_state_auxiliary
+using ClimateMachine.Atmos: vars_state
 
 using CLIMAParameters
 using CLIMAParameters.Planet: R_d, cp_d, cv_d, grav, MSLP
@@ -194,9 +194,9 @@ function run(
             outprefix,
             Q,
             dg,
-            flattenednames(vars_state_conservative(model, FT)),
+            flattenednames(vars_state(model, Prognostic(), FT)),
             dg.state_auxiliary,
-            flattenednames(vars_state_auxiliary(model, FT)),
+            flattenednames(vars_state(model, Auxiliary(), FT)),
         )
         step[1] += 1
         nothing

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -137,7 +137,7 @@ function run(
         ref_state = HydrostaticState(T_profile),
         turbulence = AnisoMinDiss{FT}(1),
         source = source,
-        init_state_conservative = Initialise_Density_Current!,
+        init_state_prognostic = Initialise_Density_Current!,
     )
     # -------------- Define DGModel --------------------------- #
     dg = DGModel(

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -164,7 +164,7 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
             moisture = MMSDryModel(),
             source = mms2_source!,
             boundarycondition = InitStateBC(),
-            init_state_conservative = mms2_init_state!,
+            init_state_prognostic = mms2_init_state!,
         )
     else
         model = AtmosModel{FT}(
@@ -176,7 +176,7 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
             moisture = MMSDryModel(),
             source = mms3_source!,
             boundarycondition = InitStateBC(),
-            init_state_conservative = mms3_init_state!,
+            init_state_prognostic = mms3_init_state!,
         )
     end
 

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
@@ -1,12 +1,11 @@
 using ClimateMachine.VariableTemplates
 
-using ClimateMachine.BalanceLaws: BalanceLaw
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux
+
 
 import ClimateMachine.BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -23,10 +22,11 @@ using ClimateMachine.Mesh.Geometry: LocalGeometry
 
 struct MMSModel{dim} <: BalanceLaw end
 
-vars_state_auxiliary(::MMSModel, T) = @vars(x1::T, x2::T, x3::T)
-vars_state_conservative(::MMSModel, T) = @vars(ρ::T, ρu::T, ρv::T, ρw::T, ρe::T)
-vars_state_gradient(::MMSModel, T) = @vars(u::T, v::T, w::T)
-vars_state_gradient_flux(::MMSModel, T) =
+vars_state(::MMSModel, ::Auxiliary, T) = @vars(x1::T, x2::T, x3::T)
+vars_state(::MMSModel, ::Prognostic, T) =
+    @vars(ρ::T, ρu::T, ρv::T, ρw::T, ρe::T)
+vars_state(::MMSModel, ::Gradient, T) = @vars(u::T, v::T, w::T)
+vars_state(::MMSModel, ::GradientFlux, T) =
     @vars(τ11::T, τ22::T, τ33::T, τ12::T, τ13::T, τ23::T)
 
 function flux_first_order!(

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
@@ -14,7 +14,7 @@ import ClimateMachine.BalanceLaws:
     compute_gradient_argument!,
     compute_gradient_flux!,
     init_state_auxiliary!,
-    init_state_conservative!
+    init_state_prognostic!
 
 import ClimateMachine.DGMethods: init_ode_state
 using ClimateMachine.Mesh.Geometry: LocalGeometry
@@ -159,7 +159,7 @@ function boundary_state!(
     t,
     _...,
 )
-    init_state_conservative!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
+    init_state_prognostic!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
 end
 
 # FIXME: This is probably not right....
@@ -179,7 +179,7 @@ function boundary_state!(
     t,
     _...,
 )
-    init_state_conservative!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
+    init_state_prognostic!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
 end
 
 function init_state_auxiliary!(::MMSModel, aux::Vars, g::LocalGeometry)
@@ -189,7 +189,7 @@ function init_state_auxiliary!(::MMSModel, aux::Vars, g::LocalGeometry)
     aux.x3 = x3
 end
 
-function init_state_conservative!(
+function init_state_prognostic!(
     bl::MMSModel{dim},
     state::Vars,
     aux::Vars,

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/ref_state.jl
@@ -8,6 +8,7 @@ using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.ODESolvers
 using ClimateMachine.GenericCallbacks
+using ClimateMachine.BalanceLaws
 using ClimateMachine.Atmos
 using ClimateMachine.Orientations
 using ClimateMachine.VariableTemplates
@@ -36,7 +37,7 @@ import ClimateMachine.Atmos: MoistureModel, temperature, pressure, soundspeed
 init_state_conservative!(bl, state, aux, coords, t) = nothing
 
 # initial condition
-using ClimateMachine.Atmos: vars_state_auxiliary
+using ClimateMachine.Atmos: vars_state
 
 function run1(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
 
@@ -72,7 +73,7 @@ function run1(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
         outprefix,
         dg.state_auxiliary,
         dg,
-        flattenednames(vars_state_auxiliary(model, FT)),
+        flattenednames(vars_state(model, Auxiliary(), FT)),
     )
     return FT(0)
 end
@@ -110,7 +111,7 @@ function run2(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
         outprefix,
         dg.state_auxiliary,
         dg,
-        flattenednames(vars_state_auxiliary(model, FT)),
+        flattenednames(vars_state(model, Auxiliary(), FT)),
     )
     return FT(0)
 end

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/ref_state.jl
@@ -34,7 +34,7 @@ using ClimateMachine.Atmos
 using ClimateMachine.Atmos: internal_energy, thermo_state
 import ClimateMachine.Atmos: MoistureModel, temperature, pressure, soundspeed
 
-init_state_conservative!(bl, state, aux, coords, t) = nothing
+init_state_prognostic!(bl, state, aux, coords, t) = nothing
 
 # initial condition
 using ClimateMachine.Atmos: vars_state
@@ -54,7 +54,7 @@ function run1(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
         AtmosLESConfigType,
         param_set;
         ref_state = HydrostaticState(T_profile),
-        init_state_conservative = init_state_conservative!,
+        init_state_prognostic = init_state_prognostic!,
     )
 
     dg = DGModel(
@@ -92,7 +92,7 @@ function run2(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
         AtmosLESConfigType,
         param_set;
         ref_state = HydrostaticState(T_profile),
-        init_state_conservative = init_state_conservative!,
+        init_state_prognostic = init_state_prognostic!,
     )
 
     dg = DGModel(

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -37,7 +37,7 @@ import ClimateMachine.DGMethods:
     source!,
     boundary_state!,
     init_state_auxiliary!,
-    init_state_conservative!
+    init_state_prognostic!
 
 import ClimateMachine.DGMethods: init_ode_state
 using ClimateMachine.Mesh.Geometry: LocalGeometry
@@ -67,7 +67,7 @@ function init_state_auxiliary!(
     )
 end
 
-function init_state_conservative!(
+function init_state_prognostic!(
     ::ConservationTestModel,
     state::Vars,
     aux::Vars,

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -19,19 +19,19 @@ using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.ODESolvers
 using ClimateMachine.GenericCallbacks
+using ClimateMachine.BalanceLaws:
+    Prognostic, Auxiliary, AbstractStateType, BalanceLaw
+
 using LinearAlgebra
 using StaticArrays
 using Logging, Printf, Dates
 using Random
 
 using ClimateMachine.VariableTemplates
-using ClimateMachine.DGMethods: BalanceLaw
+
+import ClimateMachine.BalanceLaws: vars_state
 
 import ClimateMachine.DGMethods:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -48,11 +48,10 @@ import ClimateMachine.DGMethods.NumericalFluxes:
 
 struct ConservationTestModel <: BalanceLaw end
 
-vars_state_auxiliary(::ConservationTestModel, T) = @vars(vel::SVector{3, T})
-vars_state_conservative(::ConservationTestModel, T) = @vars(q::T, p::T)
+vars_state(::ConservationTestModel, ::Auxiliary, T) = @vars(vel::SVector{3, T})
+vars_state(::ConservationTestModel, ::Prognostic, T) = @vars(q::T, p::T)
 
-vars_state_gradient(::ConservationTestModel, T) = @vars()
-vars_state_gradient_flux(::ConservationTestModel, T) = @vars()
+vars_state(::ConservationTestModel, ::AbstractStateType, T) = @vars()
 
 function init_state_auxiliary!(
     ::ConservationTestModel,

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -124,7 +124,7 @@ let
                     moisture = DryModel(),
                     source = Gravity(),
                     boundarycondition = (),
-                    init_state_conservative = initialcondition!,
+                    init_state_prognostic = initialcondition!,
                 )
 
                 dg = DGModel(

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -26,7 +26,8 @@ using ClimateMachine.Atmos:
     NoPrecipitation,
     Gravity,
     HydrostaticState,
-    vars_state_conservative,
+    ConstantViscosityWithDivergence,
+    vars_state,
     soundspeed
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations

--- a/test/Numerics/DGMethods/integral_test.jl
+++ b/test/Numerics/DGMethods/integral_test.jl
@@ -11,13 +11,10 @@ using Printf
 using LinearAlgebra
 using Logging
 
-using ClimateMachine.BalanceLaws: BalanceLaw
+using ClimateMachine.BalanceLaws
 
 import ClimateMachine.BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -26,8 +23,6 @@ import ClimateMachine.BalanceLaws:
     init_state_auxiliary!,
     init_state_conservative!,
     update_auxiliary_state!,
-    vars_integrals,
-    vars_reverse_integrals,
     indefinite_stack_integral!,
     reverse_indefinite_stack_integral!,
     integral_load_auxiliary_state!,
@@ -41,11 +36,11 @@ using ClimateMachine.Mesh.Geometry: LocalGeometry
 
 struct IntegralTestModel{dim} <: BalanceLaw end
 
-vars_reverse_integrals(::IntegralTestModel, T) = @vars(a::T, b::T)
-vars_integrals(::IntegralTestModel, T) = @vars(a::T, b::T)
-vars_state_auxiliary(m::IntegralTestModel, T) = @vars(
-    int::vars_integrals(m, T),
-    rev_int::vars_reverse_integrals(m, T),
+vars_state(::IntegralTestModel, ::DownwardIntegrals, T) = @vars(a::T, b::T)
+vars_state(::IntegralTestModel, ::UpwardIntegrals, T) = @vars(a::T, b::T)
+vars_state(m::IntegralTestModel, ::Auxiliary, T) = @vars(
+    int::vars_state(m, UpwardIntegrals(), T),
+    rev_int::vars_state(m, DownwardIntegrals(), T),
     coord::SVector{3, T},
     a::T,
     b::T,
@@ -53,8 +48,7 @@ vars_state_auxiliary(m::IntegralTestModel, T) = @vars(
     rev_b::T
 )
 
-vars_state_conservative(::IntegralTestModel, T) = @vars()
-vars_state_gradient_flux(::IntegralTestModel, T) = @vars()
+vars_state(::IntegralTestModel, ::AbstractStateType, T) = @vars()
 
 flux_first_order!(::IntegralTestModel, _...) = nothing
 flux_second_order!(::IntegralTestModel, _...) = nothing

--- a/test/Numerics/DGMethods/integral_test.jl
+++ b/test/Numerics/DGMethods/integral_test.jl
@@ -21,7 +21,7 @@ import ClimateMachine.BalanceLaws:
     wavespeed,
     boundary_state!,
     init_state_auxiliary!,
-    init_state_conservative!,
+    init_state_prognostic!,
     update_auxiliary_state!,
     indefinite_stack_integral!,
     reverse_indefinite_stack_integral!,
@@ -54,7 +54,7 @@ flux_first_order!(::IntegralTestModel, _...) = nothing
 flux_second_order!(::IntegralTestModel, _...) = nothing
 source!(::IntegralTestModel, _...) = nothing
 boundary_state!(_, ::IntegralTestModel, _...) = nothing
-init_state_conservative!(::IntegralTestModel, _...) = nothing
+init_state_prognostic!(::IntegralTestModel, _...) = nothing
 wavespeed(::IntegralTestModel, _...) = 1
 
 function init_state_auxiliary!(

--- a/test/Numerics/DGMethods/integral_test_sphere.jl
+++ b/test/Numerics/DGMethods/integral_test_sphere.jl
@@ -11,13 +11,16 @@ using Printf
 using LinearAlgebra
 using Logging
 
-using ClimateMachine.BalanceLaws: BalanceLaw
+using ClimateMachine.BalanceLaws:
+    BalanceLaw,
+    Prognostic,
+    Auxiliary,
+    GradientFlux,
+    UpwardIntegrals,
+    DownwardIntegrals
+
 import ClimateMachine.BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
-    vars_integrals,
+    vars_state,
     integral_load_auxiliary_state!,
     flux_first_order!,
     flux_second_order!,
@@ -31,7 +34,6 @@ import ClimateMachine.BalanceLaws:
     init_state_auxiliary!,
     init_state_conservative!,
     integral_set_auxiliary_state!,
-    vars_reverse_integrals,
     reverse_integral_load_auxiliary_state!,
     reverse_integral_set_auxiliary_state!
 
@@ -56,13 +58,17 @@ function update_auxiliary_state!(
     return true
 end
 
-vars_integrals(::IntegralTestSphereModel, T) = @vars(v::T)
-vars_reverse_integrals(::IntegralTestSphereModel, T) = @vars(v::T)
-vars_state_auxiliary(m::IntegralTestSphereModel, T) =
-    @vars(int::vars_integrals(m, T), rev_int::vars_integrals(m, T), r::T, a::T)
+vars_state(::IntegralTestSphereModel, ::UpwardIntegrals, T) = @vars(v::T)
+vars_state(::IntegralTestSphereModel, ::DownwardIntegrals, T) = @vars(v::T)
+vars_state(m::IntegralTestSphereModel, ::Auxiliary, T) = @vars(
+    int::vars_state(m, UpwardIntegrals(), T),
+    rev_int::vars_state(m, UpwardIntegrals(), T),
+    r::T,
+    a::T
+)
 
-vars_state_conservative(::IntegralTestSphereModel, T) = @vars()
-vars_state_gradient_flux(::IntegralTestSphereModel, T) = @vars()
+vars_state(::IntegralTestSphereModel, ::Prognostic, T) = @vars()
+vars_state(::IntegralTestSphereModel, ::GradientFlux, T) = @vars()
 
 flux_first_order!(::IntegralTestSphereModel, _...) = nothing
 flux_second_order!(::IntegralTestSphereModel, _...) = nothing

--- a/test/Numerics/DGMethods/integral_test_sphere.jl
+++ b/test/Numerics/DGMethods/integral_test_sphere.jl
@@ -32,7 +32,7 @@ import ClimateMachine.BalanceLaws:
     boundary_state!,
     compute_gradient_argument!,
     init_state_auxiliary!,
-    init_state_conservative!,
+    init_state_prognostic!,
     integral_set_auxiliary_state!,
     reverse_integral_load_auxiliary_state!,
     reverse_integral_set_auxiliary_state!
@@ -74,7 +74,7 @@ flux_first_order!(::IntegralTestSphereModel, _...) = nothing
 flux_second_order!(::IntegralTestSphereModel, _...) = nothing
 source!(::IntegralTestSphereModel, _...) = nothing
 boundary_state!(_, ::IntegralTestSphereModel, _...) = nothing
-init_state_conservative!(::IntegralTestSphereModel, _...) = nothing
+init_state_prognostic!(::IntegralTestSphereModel, _...) = nothing
 wavespeed(::IntegralTestSphereModel, _...) = 1
 
 function init_state_auxiliary!(

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -111,7 +111,7 @@ function run(
         turbulence = Vreman(FT(0.23)),
         moisture = DryModel(),
         source = Gravity(),
-        init_state_conservative = setup,
+        init_state_prognostic = setup,
     )
     dg = DGModel(
         fullmodel,
@@ -156,11 +156,10 @@ function run(
     # Create some random data to check the wavespeed function with
     nM = rand(3)
     nM /= norm(nM)
-    state_conservative =
-        Vars{vars_state(dg.balance_law, Prognostic(), FT)}(rand(
-            FT,
-            number_states(dg.balance_law, Prognostic(), FT),
-        ))
+    state_prognostic = Vars{vars_state(dg.balance_law, Prognostic(), FT)}(rand(
+        FT,
+        number_states(dg.balance_law, Prognostic(), FT),
+    ))
     state_auxiliary = Vars{vars_state(dg.balance_law, Auxiliary(), FT)}(rand(
         FT,
         number_states(dg.balance_law, Auxiliary(), FT),
@@ -168,7 +167,7 @@ function run(
     full_wavespeed = wavespeed(
         dg.balance_law,
         nM,
-        state_conservative,
+        state_prognostic,
         state_auxiliary,
         FT(0),
         (EveryDirection(),),
@@ -176,7 +175,7 @@ function run(
     acoustic_wavespeed = wavespeed(
         acoustic_dg.balance_law,
         nM,
-        state_conservative,
+        state_prognostic,
         state_auxiliary,
         FT(0),
         (EveryDirection(),),
@@ -219,7 +218,7 @@ function run(
             every_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(),),
@@ -229,7 +228,7 @@ function run(
             horz_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (HorizontalDirection(),),
@@ -239,7 +238,7 @@ function run(
             vert_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (VerticalDirection(),),
@@ -249,7 +248,7 @@ function run(
             every_wavespeed .+ horz_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(), HorizontalDirection()),
@@ -259,7 +258,7 @@ function run(
             every_wavespeed .+ vert_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(), VerticalDirection()),
@@ -301,7 +300,7 @@ function run(
             every_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(),),
@@ -311,7 +310,7 @@ function run(
             horz_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (HorizontalDirection(),),
@@ -321,7 +320,7 @@ function run(
             vert_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (VerticalDirection(),),
@@ -331,7 +330,7 @@ function run(
             every_wavespeed .+ horz_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(), HorizontalDirection()),
@@ -341,7 +340,7 @@ function run(
             every_wavespeed .+ vert_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(), VerticalDirection()),
@@ -379,7 +378,7 @@ function run(
             every_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(),),
@@ -389,7 +388,7 @@ function run(
             horz_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (HorizontalDirection(),),
@@ -399,7 +398,7 @@ function run(
             vert_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (VerticalDirection(),),
@@ -409,7 +408,7 @@ function run(
             every_wavespeed .+ horz_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(), HorizontalDirection()),
@@ -419,7 +418,7 @@ function run(
             every_wavespeed .+ vert_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(), VerticalDirection()),
@@ -457,7 +456,7 @@ function run(
             every_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(),),
@@ -467,7 +466,7 @@ function run(
             horz_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (HorizontalDirection(),),
@@ -477,7 +476,7 @@ function run(
             vert_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (VerticalDirection(),),
@@ -487,7 +486,7 @@ function run(
             every_wavespeed .+ horz_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(), HorizontalDirection()),
@@ -497,7 +496,7 @@ function run(
             every_wavespeed .+ vert_wavespeed .≈ wavespeed(
                 rem_dg.balance_law,
                 nM,
-                state_conservative,
+                state_prognostic,
                 state_auxiliary,
                 FT(0),
                 (EveryDirection(), VerticalDirection()),

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -12,10 +12,9 @@ using ClimateMachine.DGMethods:
     init_ode_state,
     remainder_DGModel,
     wavespeed,
-    number_state_conservative,
-    number_state_auxiliary,
-    vars_state_conservative,
-    vars_state_auxiliary
+    number_states,
+    vars_state
+using ClimateMachine.BalanceLaws: Prognostic, Auxiliary
 using ClimateMachine.VariableTemplates: Vars
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -157,13 +156,14 @@ function run(
     # Create some random data to check the wavespeed function with
     nM = rand(3)
     nM /= norm(nM)
-    state_conservative = Vars{vars_state_conservative(dg.balance_law, FT)}(rand(
+    state_conservative =
+        Vars{vars_state(dg.balance_law, Prognostic(), FT)}(rand(
+            FT,
+            number_states(dg.balance_law, Prognostic(), FT),
+        ))
+    state_auxiliary = Vars{vars_state(dg.balance_law, Auxiliary(), FT)}(rand(
         FT,
-        number_state_conservative(dg.balance_law, FT),
-    ))
-    state_auxiliary = Vars{vars_state_auxiliary(dg.balance_law, FT)}(rand(
-        FT,
-        number_state_auxiliary(dg.balance_law, FT),
+        number_states(dg.balance_law, Auxiliary(), FT),
     ))
     full_wavespeed = wavespeed(
         dg.balance_law,

--- a/test/Numerics/DGMethods/vars_test.jl
+++ b/test/Numerics/DGMethods/vars_test.jl
@@ -23,7 +23,7 @@ import ClimateMachine.BalanceLaws:
     update_auxiliary_state!,
     boundary_state!,
     init_state_auxiliary!,
-    init_state_conservative!
+    init_state_prognostic!
 
 import ClimateMachine.DGMethods: init_ode_state
 using ClimateMachine.Mesh.Geometry: LocalGeometry
@@ -42,7 +42,7 @@ source!(::VarsTestModel, _...) = nothing
 boundary_state!(_, ::VarsTestModel, _...) = nothing
 wavespeed(::VarsTestModel, _...) = 1
 
-function init_state_conservative!(
+function init_state_prognostic!(
     m::VarsTestModel,
     state::Vars,
     aux::Vars,

--- a/test/Numerics/DGMethods/vars_test.jl
+++ b/test/Numerics/DGMethods/vars_test.jl
@@ -11,14 +11,11 @@ using Printf
 using LinearAlgebra
 using Logging
 
-using ClimateMachine.BalanceLaws: BalanceLaw
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Prognostic, Auxiliary, GradientFlux
 
 import ClimateMachine.BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
-    vars_integrals,
+    vars_state,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -34,10 +31,10 @@ using ClimateMachine.Mesh.Geometry: LocalGeometry
 
 struct VarsTestModel{dim} <: BalanceLaw end
 
-vars_state_conservative(::VarsTestModel, T) = @vars(x::T, coord::SVector{3, T})
-vars_state_auxiliary(m::VarsTestModel, T) =
+vars_state(::VarsTestModel, ::Prognostic, T) = @vars(x::T, coord::SVector{3, T})
+vars_state(m::VarsTestModel, ::Auxiliary, T) =
     @vars(coord::SVector{3, T}, polynomial::T)
-vars_state_gradient_flux(m::VarsTestModel, T) = @vars()
+vars_state(m::VarsTestModel, ::GradientFlux, T) = @vars()
 
 flux_first_order!(::VarsTestModel, _...) = nothing
 flux_second_order!(::VarsTestModel, _...) = nothing

--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -125,7 +125,7 @@ filtered(::HorizontalDirection, dim, x, y, z) =
 
 ClimateMachine.BalanceLaws.vars_state(::FilterTestModel{4}, ::Prognostic, FT) =
     @vars(q1::FT, q2::FT, q3::FT, q4::FT)
-function ClimateMachine.BalanceLaws.init_state_conservative!(
+function ClimateMachine.BalanceLaws.init_state_prognostic!(
     ::FilterTestModel{4},
     state::Vars,
     aux::Vars,
@@ -216,7 +216,7 @@ ClimateMachine.BalanceLaws.vars_state(
     ::Prognostic,
     FT,
 ) where {N} = @vars(q::FT)
-function ClimateMachine.BalanceLaws.init_state_conservative!(
+function ClimateMachine.BalanceLaws.init_state_prognostic!(
     ::FilterTestModel{1},
     state::Vars,
     aux::Vars,

--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -4,6 +4,7 @@ using ClimateMachine.VariableTemplates: @vars, Vars
 using ClimateMachine.Mesh.Grids:
     EveryDirection, HorizontalDirection, VerticalDirection
 using ClimateMachine.MPIStateArrays: weightedsum
+using ClimateMachine.BalanceLaws
 
 import GaussQuadrature
 using MPI
@@ -101,7 +102,8 @@ ClimateMachine.init()
 end
 
 struct FilterTestModel{N} <: ClimateMachine.BalanceLaws.BalanceLaw end
-ClimateMachine.BalanceLaws.vars_state_auxiliary(::FilterTestModel, FT) = @vars()
+ClimateMachine.BalanceLaws.vars_state(::FilterTestModel, ::Auxiliary, FT) =
+    @vars()
 ClimateMachine.BalanceLaws.init_state_auxiliary!(::FilterTestModel, _...) =
     nothing
 
@@ -121,7 +123,7 @@ filtered(::VerticalDirection, dim, x, y, z) =
 filtered(::HorizontalDirection, dim, x, y, z) =
     (dim == 2) ? l2(x) * l3(y) + l3(x) : l2(x) * l3(y) + l3(x) + l2(y)
 
-ClimateMachine.BalanceLaws.vars_state_conservative(::FilterTestModel{4}, FT) =
+ClimateMachine.BalanceLaws.vars_state(::FilterTestModel{4}, ::Prognostic, FT) =
     @vars(q1::FT, q2::FT, q3::FT, q4::FT)
 function ClimateMachine.BalanceLaws.init_state_conservative!(
     ::FilterTestModel{4},
@@ -209,8 +211,9 @@ end
     end
 end
 
-ClimateMachine.BalanceLaws.vars_state_conservative(
+ClimateMachine.BalanceLaws.vars_state(
     ::FilterTestModel{1},
+    ::Prognostic,
     FT,
 ) where {N} = @vars(q::FT)
 function ClimateMachine.BalanceLaws.init_state_conservative!(

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -127,7 +127,7 @@ function run_brick_interpolation_test()
             ref_state = NoReferenceState(),
             turbulence = ConstantViscosityWithDivergence(FT(0)),
             source = (Gravity(),),
-            init_state_conservative = Initialize_Brick_Interpolation_Test!,
+            init_state_prognostic = Initialize_Brick_Interpolation_Test!,
         )
 
         dg = DGModel(
@@ -288,7 +288,7 @@ function run_cubed_sphere_interpolation_test()
             turbulence = ConstantViscosityWithDivergence(FT(0)),
             moisture = DryModel(),
             source = nothing,
-            init_state_conservative = setup,
+            init_state_prognostic = setup,
         )
 
         dg = DGModel(

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -14,7 +14,7 @@ using ClimateMachine
 ClimateMachine.init()
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Atmos
-using ClimateMachine.Atmos: vars_state_conservative, vars_state_auxiliary
+using ClimateMachine.Atmos: vars_state
 using ClimateMachine.Orientations
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes

--- a/test/Numerics/SystemSolvers/bandedsystem.jl
+++ b/test/Numerics/SystemSolvers/bandedsystem.jl
@@ -7,11 +7,9 @@ using Logging
 using LinearAlgebra
 using Random
 using StaticArrays
-using ClimateMachine.BalanceLaws: BalanceLaw
-import ClimateMachine.BalanceLaws:
-    vars_state_conservative, number_state_conservative
-using ClimateMachine.DGMethods:
-    DGModel, init_ode_state, create_conservative_state
+using ClimateMachine.BalanceLaws
+import ClimateMachine.BalanceLaws: vars_state, number_states
+using ClimateMachine.DGMethods: DGModel, init_ode_state, create_state
 using ClimateMachine.SystemSolvers: banded_matrix, banded_matrix_vector_product!
 using ClimateMachine.DGMethods.NumericalFluxes:
     RusanovNumericalFlux,
@@ -41,7 +39,7 @@ function init_velocity_diffusion!(
 end
 
 struct BigAdvectionDiffusion <: BalanceLaw end
-function vars_state_conservative(::BigAdvectionDiffusion, FT)
+function vars_state(::BigAdvectionDiffusion, ::Prognostic, FT)
     @vars begin
         ρ::FT
         X::SVector{3, FT}
@@ -168,10 +166,16 @@ let
                         atol = 100 * eps(FT),
                     ))
 
-                    big_Q =
-                        create_conservative_state(BigAdvectionDiffusion(), grid)
-                    big_dQ =
-                        create_conservative_state(BigAdvectionDiffusion(), grid)
+                    big_Q = create_state(
+                        BigAdvectionDiffusion(),
+                        grid,
+                        Prognostic(),
+                    )
+                    big_dQ = create_state(
+                        BigAdvectionDiffusion(),
+                        grid,
+                        Prognostic(),
+                    )
 
                     big_Q .= NaN
                     big_dQ .= NaN

--- a/test/Numerics/SystemSolvers/poisson.jl
+++ b/test/Numerics/SystemSolvers/poisson.jl
@@ -11,12 +11,11 @@ using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.VariableTemplates
 using ClimateMachine.DGMethods
-using ClimateMachine.BalanceLaws: BalanceLaw
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux
+
 import ClimateMachine.DGMethods:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -41,10 +40,10 @@ end
 
 struct PoissonModel{dim} <: BalanceLaw end
 
-vars_state_auxiliary(::PoissonModel, T) = @vars(rhs_ϕ::T)
-vars_state_conservative(::PoissonModel, T) = @vars(ϕ::T)
-vars_state_gradient(::PoissonModel, T) = @vars(ϕ::T)
-vars_state_gradient_flux(::PoissonModel, T) = @vars(∇ϕ::SVector{3, T})
+vars_state(::PoissonModel, ::Auxiliary, T) = @vars(rhs_ϕ::T)
+vars_state(::PoissonModel, ::Prognostic, T) = @vars(ϕ::T)
+vars_state(::PoissonModel, ::Gradient, T) = @vars(ϕ::T)
+vars_state(::PoissonModel, ::GradientFlux, T) = @vars(∇ϕ::SVector{3, T})
 
 boundary_state!(nf, bl::PoissonModel, _...) = nothing
 

--- a/test/Numerics/SystemSolvers/poisson.jl
+++ b/test/Numerics/SystemSolvers/poisson.jl
@@ -23,7 +23,7 @@ import ClimateMachine.DGMethods:
     compute_gradient_argument!,
     compute_gradient_flux!,
     init_state_auxiliary!,
-    init_state_conservative!
+    init_state_prognostic!
 
 import ClimateMachine.DGMethods: numerical_boundary_flux_second_order!
 using ClimateMachine.Mesh.Geometry: LocalGeometry
@@ -148,7 +148,7 @@ function init_state_auxiliary!(
     end
 end
 
-function init_state_conservative!(
+function init_state_prognostic!(
     ::PoissonModel{dim},
     state::Vars,
     aux::Vars,

--- a/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
@@ -6,7 +6,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Mesh.Grids: polynomialorder
-using ClimateMachine.BalanceLaws: vars_state_conservative
+using ClimateMachine.BalanceLaws: vars_state, Prognostic
 using ClimateMachine.Ocean.HydrostaticBoussinesq
 
 using CLIMAParameters
@@ -89,11 +89,11 @@ function test_divergence_free(; imex::Bool = false, BC = nothing)
 
     result = ClimateMachine.invoke!(solver_config)
 
-    maxQ = Vars{vars_state_conservative(driver_config.bl, FT)}(maximum(
+    maxQ = Vars{vars_state(driver_config.bl, Prognostic(), FT)}(maximum(
         solver_config.Q,
         dims = (1, 3),
     ))
-    minQ = Vars{vars_state_conservative(driver_config.bl, FT)}(minimum(
+    minQ = Vars{vars_state(driver_config.bl, Prognostic(), FT)}(minimum(
         solver_config.Q,
         dims = (1, 3),
     ))

--- a/test/Ocean/ShallowWater/2D_hydrostatic_spindown.jl
+++ b/test/Ocean/ShallowWater/2D_hydrostatic_spindown.jl
@@ -12,7 +12,7 @@ using ClimateMachine.Ocean.ShallowWater
 using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.DGMethods
-using ClimateMachine.BalanceLaws: vars_state_conservative, vars_state_auxiliary
+using ClimateMachine.BalanceLaws: vars_state, Prognostic, Auxiliary
 using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.VTK
@@ -185,8 +185,8 @@ function make_callbacks(
             step
         )
         @info "doing VTK output" outprefix
-        statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
-        auxnames = flattenednames(vars_state_auxiliary(model, eltype(Q)))
+        statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+        auxnames = flattenednames(vars_state(model, Auxiliary(), eltype(Q)))
         writevtk(outprefix, Q, dg, statenames, dg.state_auxiliary, auxnames)
     end
 

--- a/test/Ocean/ShallowWater/GyreDriver.jl
+++ b/test/Ocean/ShallowWater/GyreDriver.jl
@@ -119,13 +119,13 @@ function run(mpicomm, topl, ArrayType, N, dt, FT, model, test)
 
     if test > 2
         outprefix = @sprintf("ic_mpirank%04d_ic", MPI.Comm_rank(mpicomm))
-        statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
-        auxnames = flattenednames(vars_state_auxiliary(model, eltype(Q)))
+        statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+        auxnames = flattenednames(vars_state(model, Auxiliary(), eltype(Q)))
         writevtk(outprefix, Q, dg, statenames, dg.state_auxiliary, auxnames)
 
         outprefix = @sprintf("exact_mpirank%04d", MPI.Comm_rank(mpicomm))
-        statenames = flattenednames(vars_state_conservative(model, eltype(Qe)))
-        auxnames = flattenednames(vars_state_auxiliary(model, eltype(Qe)))
+        statenames = flattenednames(vars_state(model, Prognostic(), eltype(Qe)))
+        auxnames = flattenednames(vars_state(model, Auxiliary(), eltype(Qe)))
         writevtk(outprefix, Qe, dg, statenames, dg.state_auxiliary, auxnames)
 
         step = [0]
@@ -140,9 +140,9 @@ function run(mpicomm, topl, ArrayType, N, dt, FT, model, test)
             )
             @debug "doing VTK output" outprefix
             statenames =
-                flattenednames(vars_state_conservative(model, eltype(Q)))
+                flattenednames(vars_state(model, Prognostic(), eltype(Q)))
             auxiliarynames =
-                flattenednames(vars_state_auxiliary(model, eltype(Q)))
+                flattenednames(vars_state(model, Auxiliary(), eltype(Q)))
             writevtk(
                 outprefix,
                 Q,

--- a/test/Ocean/ShallowWater/GyreInABox.jl
+++ b/test/Ocean/ShallowWater/GyreInABox.jl
@@ -16,8 +16,7 @@ using ClimateMachine.VTK
 import ClimateMachine.Ocean.ShallowWater:
     shallow_init_state!,
     shallow_init_aux!,
-    vars_state_conservative,
-    vars_state_auxiliary,
+    vars_state,
     shallow_boundary_state!,
     TurbulenceClosure,
     LinearDrag,

--- a/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
+++ b/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
@@ -13,7 +13,7 @@ using ClimateMachine.Ocean.SplitExplicit: VerticalIntegralModel
 
 using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
-using ClimateMachine.BalanceLaws: vars_state_conservative, vars_state_auxiliary
+using ClimateMachine.BalanceLaws: vars_state, Prognostic, Auxiliary
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.MPIStateArrays
@@ -262,8 +262,8 @@ function make_callbacks(
             step
         )
         @info "doing VTK output" outprefix
-        statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
-        auxnames = flattenednames(vars_state_auxiliary(model, eltype(Q)))
+        statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+        auxnames = flattenednames(vars_state(model, Auxiliary(), eltype(Q)))
         writevtk(outprefix, Q, dg, statenames, dg.state_auxiliary, auxnames)
     end
 

--- a/test/Utilities/SingleStackUtils/ssu_tests.jl
+++ b/test/Utilities/SingleStackUtils/ssu_tests.jl
@@ -17,7 +17,7 @@ using ClimateMachine.DGMethods: LocalGeometry
 using ClimateMachine.BalanceLaws:
     BalanceLaw, Auxiliary, Prognostic, Gradient, GradientFlux
 import ClimateMachine.BalanceLaws:
-    vars_state, init_state_auxiliary!, init_state_conservative!
+    vars_state, init_state_auxiliary!, init_state_prognostic!
 
 struct EmptyBalLaw{FT, PS} <: BalanceLaw
     "Parameters"
@@ -40,7 +40,7 @@ function init_state_auxiliary!(m::EmptyBalLaw, aux::Vars, geom::LocalGeometry)
     aux.z = geom.coord[3]
 end
 
-function init_state_conservative!(
+function init_state_prognostic!(
     m::EmptyBalLaw,
     state::Vars,
     aux::Vars,

--- a/test/Utilities/SingleStackUtils/ssu_tests.jl
+++ b/test/Utilities/SingleStackUtils/ssu_tests.jl
@@ -12,15 +12,12 @@ using ClimateMachine.DGMethods.Grids
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.VariableTemplates
 using ClimateMachine.SingleStackUtils
-using ClimateMachine.DGMethods: BalanceLaw, LocalGeometry
+using ClimateMachine.DGMethods: LocalGeometry
 
-import ClimateMachine.DGMethods:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
-    init_state_auxiliary!,
-    init_state_conservative!
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Auxiliary, Prognostic, Gradient, GradientFlux
+import ClimateMachine.BalanceLaws:
+    vars_state, init_state_auxiliary!, init_state_conservative!
 
 struct EmptyBalLaw{FT, PS} <: BalanceLaw
     "Parameters"
@@ -32,10 +29,10 @@ end
 EmptyBalLaw(param_set, zmax) =
     EmptyBalLaw{typeof(zmax), typeof(param_set)}(param_set, zmax)
 
-vars_state_auxiliary(::EmptyBalLaw, FT) = @vars(x::FT, y::FT, z::FT)
-vars_state_conservative(::EmptyBalLaw, FT) = @vars(ρ::FT)
-vars_state_gradient(::EmptyBalLaw, FT) = @vars()
-vars_state_gradient_flux(::EmptyBalLaw, FT) = @vars()
+vars_state(::EmptyBalLaw, ::Auxiliary, FT) = @vars(x::FT, y::FT, z::FT)
+vars_state(::EmptyBalLaw, ::Prognostic, FT) = @vars(ρ::FT)
+vars_state(::EmptyBalLaw, ::Gradient, FT) = @vars()
+vars_state(::EmptyBalLaw, ::GradientFlux, FT) = @vars()
 
 function init_state_auxiliary!(m::EmptyBalLaw, aux::Vars, geom::LocalGeometry)
     aux.x = geom.coord[1]
@@ -145,19 +142,19 @@ function main()
     test_hmean(
         driver_config.grid,
         solver_config.Q,
-        vars_state_conservative(m, FT),
+        vars_state(m, Prognostic(), FT),
     )
     test_hvar(
         driver_config.grid,
         solver_config.Q,
-        vars_state_conservative(m, FT),
+        vars_state(m, Prognostic(), FT),
     )
 
     r1, z1 = reduce_nodal_stack(
         max,
         solver_config.dg.grid,
         solver_config.Q,
-        vars_state_conservative(m, FT),
+        vars_state(m, Prognostic(), FT),
         "ρ",
         i = 6,
         j = 6,
@@ -167,7 +164,7 @@ function main()
         +,
         solver_config.dg.grid,
         solver_config.Q,
-        vars_state_conservative(m, FT),
+        vars_state(m, Prognostic(), FT),
         "ρ",
         i = 3,
         j = 3,
@@ -177,7 +174,7 @@ function main()
         +,
         solver_config.dg.grid,
         solver_config.Q,
-        vars_state_conservative(m, FT),
+        vars_state(m, Prognostic(), FT),
         "ρ",
     )
     (r3, z3) = let

--- a/test/Utilities/VariableTemplates/runtests.jl
+++ b/test/Utilities/VariableTemplates/runtests.jl
@@ -1,100 +1,102 @@
 using Test, StaticArrays
 using ClimateMachine.VariableTemplates
 
-struct TestModel{A, B, C}
-    a::A
-    b::B
-    c::C
-end
-
-struct SubModelA end
-struct SubModelB end
-struct SubModelC{N} end
-
-function state(m::TestModel, T)
-    @vars begin
-        ρ::T
-        ρu::SVector{3, T}
-        ρe::T
-        a::state(m.a, T)
-        b::state(m.b, T)
-        c::state(m.c, T)
-        S::SHermitianCompact{3, T, 6}
+@testset "VariableTemplates" begin
+    struct TestModel{A, B, C}
+        a::A
+        b::B
+        c::C
     end
+
+    struct SubModelA end
+    struct SubModelB end
+    struct SubModelC{N} end
+
+    function state(m::TestModel, T)
+        @vars begin
+            ρ::T
+            ρu::SVector{3, T}
+            ρe::T
+            a::state(m.a, T)
+            b::state(m.b, T)
+            c::state(m.c, T)
+            S::SHermitianCompact{3, T, 6}
+        end
+    end
+
+    state(m::SubModelA, T) = @vars()
+    state(m::SubModelB, T) = @vars(ρqt::T)
+    state(m::SubModelC{N}, T) where {N} = @vars(ρk::SVector{N, T})
+
+    model = TestModel(SubModelA(), SubModelB(), SubModelC{5}())
+
+    st = state(model, Float64)
+
+    @test varsize(st) == 17
+
+    v = Vars{st}(zeros(MVector{varsize(st), Float64}))
+    g = Grad{st}(zeros(MMatrix{3, varsize(st), Float64}))
+
+    @test v.ρ === 0.0
+    @test v.ρu === SVector(0.0, 0.0, 0.0)
+    v.ρu = SVector(1, 2, 3)
+    @test v.ρu === SVector(1.0, 2.0, 3.0)
+
+    @test v.b.ρqt === 0.0
+    v.b.ρqt = 12.0
+    @test v.b.ρqt === 12.0
+
+    @test v.S === zeros(SHermitianCompact{3, Float64, 6})
+    v.S = SHermitianCompact{3, Float64, 6}(1, 2, 3, 2, 3, 4, 3, 4, 5)
+    @test v.S[1, 1] === 1.0
+    @test v.S[1, 3] === 3.0
+    @test v.S[3, 1] === 3.0
+    @test v.S[3, 3] === 5.0
+
+    v.S = ones(SMatrix{3, 3, Int64})
+    @test v.S[1, 1] === 1.0
+    @test v.S[1, 3] === 1.0
+    @test v.S[3, 1] === 1.0
+    @test v.S[3, 3] === 1.0
+
+    @test propertynames(v.a) == ()
+    @test propertynames(g.a) == ()
+
+    @test g.ρu == zeros(SMatrix{3, 3, Float64})
+    g.ρu = SMatrix{3, 3}(1:9)
+    @test g.ρu == SMatrix{3, 3, Float64}(1:9)
+
+    @test size(v.c.ρk) == (5,)
+    @test size(g.c.ρk) == (3, 5)
+
+    sv = similar(v)
+    @test typeof(sv) == typeof(v)
+    @test size(parent(sv)) == size(parent(v))
+
+    sg = similar(g)
+    @test typeof(sg) == typeof(g)
+    @test size(parent(sg)) == size(parent(g))
+
+    @test flattenednames(st) == [
+        "ρ",
+        "ρu[1]",
+        "ρu[2]",
+        "ρu[3]",
+        "ρe",
+        "b.ρqt",
+        "c.ρk[1]",
+        "c.ρk[2]",
+        "c.ρk[3]",
+        "c.ρk[4]",
+        "c.ρk[5]",
+        "S[1,1]",
+        "S[2,1]",
+        "S[3,1]",
+        "S[2,2]",
+        "S[3,2]",
+        "S[3,3]",
+    ]
+
+    include("varsindex.jl")
+    include("ntuple_type.jl")
 end
-
-state(m::SubModelA, T) = @vars()
-state(m::SubModelB, T) = @vars(ρqt::T)
-state(m::SubModelC{N}, T) where {N} = @vars(ρk::SVector{N, T})
-
-model = TestModel(SubModelA(), SubModelB(), SubModelC{5}())
-
-st = state(model, Float64)
-
-@test varsize(st) == 17
-
-v = Vars{st}(zeros(MVector{varsize(st), Float64}))
-g = Grad{st}(zeros(MMatrix{3, varsize(st), Float64}))
-
-@test v.ρ === 0.0
-@test v.ρu === SVector(0.0, 0.0, 0.0)
-v.ρu = SVector(1, 2, 3)
-@test v.ρu === SVector(1.0, 2.0, 3.0)
-
-@test v.b.ρqt === 0.0
-v.b.ρqt = 12.0
-@test v.b.ρqt === 12.0
-
-@test v.S === zeros(SHermitianCompact{3, Float64, 6})
-v.S = SHermitianCompact{3, Float64, 6}(1, 2, 3, 2, 3, 4, 3, 4, 5)
-@test v.S[1, 1] === 1.0
-@test v.S[1, 3] === 3.0
-@test v.S[3, 1] === 3.0
-@test v.S[3, 3] === 5.0
-
-v.S = ones(SMatrix{3, 3, Int64})
-@test v.S[1, 1] === 1.0
-@test v.S[1, 3] === 1.0
-@test v.S[3, 1] === 1.0
-@test v.S[3, 3] === 1.0
-
-@test propertynames(v.a) == ()
-@test propertynames(g.a) == ()
-
-@test g.ρu == zeros(SMatrix{3, 3, Float64})
-g.ρu = SMatrix{3, 3}(1:9)
-@test g.ρu == SMatrix{3, 3, Float64}(1:9)
-
-@test size(v.c.ρk) == (5,)
-@test size(g.c.ρk) == (3, 5)
-
-sv = similar(v)
-@test typeof(sv) == typeof(v)
-@test size(parent(sv)) == size(parent(v))
-
-sg = similar(g)
-@test typeof(sg) == typeof(g)
-@test size(parent(sg)) == size(parent(g))
-
-@test flattenednames(st) == [
-    "ρ",
-    "ρu[1]",
-    "ρu[2]",
-    "ρu[3]",
-    "ρe",
-    "b.ρqt",
-    "c.ρk[1]",
-    "c.ρk[2]",
-    "c.ρk[3]",
-    "c.ρk[4]",
-    "c.ρk[5]",
-    "S[1,1]",
-    "S[2,1]",
-    "S[3,1]",
-    "S[2,2]",
-    "S[3,2]",
-    "S[3,3]",
-]
-
-include("varsindex.jl")
-include("ntuple_type.jl")

--- a/test/Utilities/VariableTemplates/varsindex.jl
+++ b/test/Utilities/VariableTemplates/varsindex.jl
@@ -2,28 +2,28 @@ using Test, StaticArrays
 using ClimateMachine.VariableTemplates: varsindex, @vars, varsindices
 using StaticArrays
 
-struct TestMoistureModel{FT} end
-struct TestAtmosModel{FT}
-    moisture::TestMoistureModel{FT}
-end
+@testset "varsindex" begin
+    struct TestMoistureModel{FT} end
+    struct TestAtmosModel{FT}
+        moisture::TestMoistureModel{FT}
+    end
 
-function vars_state(::TestMoistureModel, FT)
-    @vars begin
-        ρq_tot::FT
-        ρq_x::SVector{5, FT}
-        ρq_liq::FT
-        ρq_vap::FT
+    function vars_state(::TestMoistureModel, FT)
+        @vars begin
+            ρq_tot::FT
+            ρq_x::SVector{5, FT}
+            ρq_liq::FT
+            ρq_vap::FT
+        end
     end
-end
-function vars_state(m::TestAtmosModel, FT)
-    @vars begin
-        ρ::FT
-        ρu::SVector{3, FT}
-        ρe::FT
-        moisture::vars_state(m.moisture, FT)
+    function vars_state(m::TestAtmosModel, FT)
+        @vars begin
+            ρ::FT
+            ρu::SVector{3, FT}
+            ρe::FT
+            moisture::vars_state(m.moisture, FT)
+        end
     end
-end
-@testset "Varsindex" begin
     FT = Float64
     m = TestAtmosModel(TestMoistureModel{FT}())
 

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -231,7 +231,7 @@ function config_agnesi_hs_lin(FT, N, resolution, xmax, ymax, zmax)
         moisture = DryModel(),
         source = source,
         tracers = NoTracers(),
-        init_state_conservative = init_agnesi_hs_lin!,
+        init_state_prognostic = init_agnesi_hs_lin!,
         ref_state = ref_state,
     )
 

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -236,7 +236,7 @@ function config_agnesi_hs_lin(FT, N, resolution, xmax, ymax, zmax)
         moisture = DryModel(),
         source = source,
         tracers = NoTracers(),
-        init_state_conservative = init_agnesi_hs_lin!,
+        init_state_prognostic = init_agnesi_hs_lin!,
         ref_state = ref_state,
     )
 

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -69,7 +69,6 @@ using ClimateMachine.Mesh.Grids
 using ClimateMachine.Writers
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes
-using ClimateMachine.BalanceLaws: BalanceLaw
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.GenericCallbacks
@@ -79,12 +78,9 @@ using ClimateMachine.SingleStackUtils
 
 #  - import necessary ClimateMachine modules: (`import`ing enables us to
 #  provide implementations of these structs/methods)
-using ClimateMachine.BalanceLaws: BalanceLaw
+using ClimateMachine.BalanceLaws
 import ClimateMachine.BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     source!,
     flux_second_order!,
     flux_first_order!,
@@ -155,18 +151,19 @@ m = BurgersEquation{FT}();
 # by the solver.
 
 # Specify auxiliary variables for `BurgersEquation`
-vars_state_auxiliary(::BurgersEquation, FT) = @vars(z::FT, T::FT);
+vars_state(::BurgersEquation, ::Auxiliary, FT) = @vars(z::FT, T::FT);
 
 # Specify state variables, the variables solved for in the PDEs, for
 # `BurgersEquation`
-vars_state_conservative(::BurgersEquation, FT) =
+vars_state(::BurgersEquation, ::Prognostic, FT) =
     @vars(ρ::FT, ρu::SVector{3, FT}, ρcT::FT);
 
 # Specify state variables whose gradients are needed for `BurgersEquation`
-vars_state_gradient(::BurgersEquation, FT) = @vars(u::SVector{3, FT}, ρcT::FT);
+vars_state(::BurgersEquation, ::Gradient, FT) =
+    @vars(u::SVector{3, FT}, ρcT::FT);
 
 # Specify gradient variables for `BurgersEquation`
-vars_state_gradient_flux(::BurgersEquation, FT) =
+vars_state(::BurgersEquation, ::GradientFlux, FT) =
     @vars(μ∇u::SMatrix{3, 3, FT, 9}, α∇ρcT::SVector{3, FT});
 
 # ## Define the compute kernels
@@ -175,7 +172,7 @@ vars_state_gradient_flux(::BurgersEquation, FT) =
 # `init_state_conservative!`. Note that
 # - this method is only called at `t=0`
 # - `aux.z` and `aux.T` are available here because we've specified `z` and `T`
-# in `vars_state_auxiliary`
+# in `vars_state`
 function init_state_auxiliary!(
     m::BurgersEquation,
     aux::Vars,
@@ -188,7 +185,7 @@ end;
 # Specify the initial values in `state::Vars`. Note that
 # - this method is only called at `t=0`
 # - `state.ρ`, `state.ρu` and`state.ρcT` are available here because
-# we've specified `ρ`, `ρu` and `ρcT` in `vars_state_conservative`
+# we've specified `ρ`, `ρu` and `ρcT` in `vars_state`
 function init_state_conservative!(
     m::BurgersEquation,
     state::Vars,
@@ -227,7 +224,7 @@ end;
 
 # Compute/update all auxiliary variables at each node. Note that
 # - `aux.T` is available here because we've specified `T` in
-# `vars_state_auxiliary`
+# `vars_state`
 function heat_eq_nodal_update_aux!(
     m::BurgersEquation,
     state::Vars,
@@ -240,7 +237,7 @@ end;
 # Since we have second-order fluxes, we must tell `ClimateMachine` to compute
 # the gradient of `ρcT` and `u`. Here, we specify how `ρcT`, `u` are computed. Note that
 # `transform.ρcT` and `transform.u` are available here because we've specified `ρcT`
-# and `u`in `vars_state_gradient`
+# and `u`in `vars_state`
 function compute_gradient_argument!(
     m::BurgersEquation,
     transform::Vars,
@@ -255,9 +252,9 @@ end;
 # Specify where in `diffusive::Vars` to store the computed gradient from
 # `compute_gradient_argument!`. Note that:
 #  - `diffusive.μ∇u` is available here because we've specified `μ∇u` in
-#  `vars_state_gradient_flux`
+#  `vars_state`
 #  - `∇transform.u` is available here because we've specified `u` in
-#  `vars_state_gradient`
+#  `vars_state`
 #  - `diffusive.μ∇u` is built using an anisotropic diffusivity tensor
 function compute_gradient_flux!(
     m::BurgersEquation,
@@ -297,7 +294,7 @@ end;
 # Compute advective flux.
 # Note that:
 # - `state.ρu` is available here because we've specified `ρu` in
-# `vars_state_conservative`
+# `vars_state`
 function flux_first_order!(
     m::BurgersEquation,
     flux::Grad,
@@ -316,7 +313,7 @@ end;
 # Compute diffusive flux (e.g. ``F(μ, \mathbf{u}, t) = -μ∇\mathbf{u}`` in the original PDE).
 # Note that:
 # - `diffusive.μ∇u` is available here because we've specified `μ∇u` in
-# `vars_state_gradient_flux`
+# `vars_state`
 function flux_second_order!(
     m::BurgersEquation,
     flux::Grad,
@@ -450,14 +447,14 @@ z = get_z(driver_config.grid, z_scale)
 state_vars = get_vars_from_nodal_stack(
     driver_config.grid,
     solver_config.Q,
-    vars_state_conservative(m, FT),
+    vars_state(m, Prognostic(), FT),
     i = 1,
     j = 1,
 );
 aux_vars = get_vars_from_nodal_stack(
     driver_config.grid,
     solver_config.dg.state_auxiliary,
-    vars_state_auxiliary(m, FT),
+    vars_state(m, Auxiliary(), FT),
     i = 1,
     j = 1,
     exclude = [z_key],
@@ -493,13 +490,13 @@ export_plot_snapshot(
 state_vars_var = get_horizontal_variance(
     driver_config.grid,
     solver_config.Q,
-    vars_state_conservative(m, FT),
+    vars_state(m, Prognostic(), FT),
 );
 
 state_vars_avg = get_horizontal_mean(
     driver_config.grid,
     solver_config.Q,
-    vars_state_conservative(m, FT),
+    vars_state(m, Prognostic(), FT),
 );
 
 export_plot_snapshot(
@@ -545,12 +542,12 @@ callback = GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
     state_vars_var = get_horizontal_variance(
         driver_config.grid,
         solver_config.Q,
-        vars_state_conservative(m, FT),
+        vars_state(m, Prognostic(), FT),
     )
     state_vars_avg = get_horizontal_mean(
         driver_config.grid,
         solver_config.Q,
-        vars_state_conservative(m, FT),
+        vars_state(m, Prognostic(), FT),
     )
     step[1] += 1
     push!(data_var, state_vars_var)

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -89,7 +89,7 @@ import ClimateMachine.BalanceLaws:
     update_auxiliary_state!,
     nodal_update_auxiliary_state!,
     init_state_auxiliary!,
-    init_state_conservative!,
+    init_state_prognostic!,
     boundary_state!
 
 # ## Initialization
@@ -169,7 +169,7 @@ vars_state(::BurgersEquation, ::GradientFlux, FT) =
 # ## Define the compute kernels
 
 # Specify the initial values in `aux::Vars`, which are available in
-# `init_state_conservative!`. Note that
+# `init_state_prognostic!`. Note that
 # - this method is only called at `t=0`
 # - `aux.z` and `aux.T` are available here because we've specified `z` and `T`
 # in `vars_state`
@@ -186,7 +186,7 @@ end;
 # - this method is only called at `t=0`
 # - `state.ρ`, `state.ρu` and`state.ρcT` are available here because
 # we've specified `ρ`, `ρu` and `ρcT` in `vars_state`
-function init_state_conservative!(
+function init_state_prognostic!(
     m::BurgersEquation,
     state::Vars,
     aux::Vars,

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -213,7 +213,7 @@ function config_densitycurrent(FT, N, resolution, xmax, ymax, zmax)
         source = (Gravity(),),                          # Gravity is the only source term here
         tracers = NoTracers(),                          # Tracer model with diffusivity coefficients
         ref_state = ref_state,                          # Reference state
-        init_state_conservative = init_densitycurrent!, # Apply the initial condition
+        init_state_prognostic = init_densitycurrent!, # Apply the initial condition
     )
 
     ## Finally, we pass a `Problem Name` string, the mesh information, and the

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -151,7 +151,7 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
             ),
         ),
         tracers = NTracers{ntracers, FT}(δ_χ),
-        init_state_conservative = init_problem!,
+        init_state_prognostic = init_problem!,
         data_config = data_config,
     )
 

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -186,7 +186,7 @@ model = AtmosModel{FT}(
     hyperdiffusion = hyperdiffusion_model,
     moisture = DryModel(),
     source = (Gravity(), Coriolis(), held_suarez_forcing!, sponge),
-    init_state_conservative = init_heldsuarez!,
+    init_state_prognostic = init_heldsuarez!,
 );
 
 # This concludes the setup of the physical model!

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -235,7 +235,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
         source = (Gravity(),),                         # Gravity is the only source term here
         tracers = NTracers{ntracers, FT}(δ_χ),         # Tracer model with diffusivity coefficients
         ref_state = ref_state,                         # Reference state
-        init_state_conservative = init_risingbubble!,  # Apply the initial condition
+        init_state_prognostic = init_risingbubble!,  # Apply the initial condition
     )
 
     ## Finally, we pass a `Problem Name` string, the mesh information, and the

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -83,7 +83,7 @@ import ClimateMachine.BalanceLaws:
     update_auxiliary_state!,
     nodal_update_auxiliary_state!,
     init_state_auxiliary!,
-    init_state_conservative!,
+    init_state_prognostic!,
     boundary_state!
 
 # ## Initialization
@@ -150,7 +150,7 @@ vars_state(::HeatModel, ::GradientFlux, FT) = @vars(α∇ρcT::SVector{3, FT});
 # ## Define the compute kernels
 
 # Specify the initial values in `aux::Vars`, which are available in
-# `init_state_conservative!`. Note that
+# `init_state_prognostic!`. Note that
 # - this method is only called at `t=0`
 # - `aux.z` and `aux.T` are available here because we've specified `z` and `T`
 # in `vars_state`
@@ -163,7 +163,7 @@ end;
 # - this method is only called at `t=0`
 # - `state.ρcT` is available here because we've specified `ρcT` in
 # `vars_state`
-function init_state_conservative!(
+function init_state_prognostic!(
     m::HeatModel,
     state::Vars,
     aux::Vars,
@@ -385,7 +385,7 @@ export_plot_snapshot(
 );
 # ![](initial_condition.png)
 
-# It matches what we have in `init_state_conservative!(m::HeatModel, ...)`, so
+# It matches what we have in `init_state_prognostic!(m::HeatModel, ...)`, so
 # let's continue.
 
 # # Solver hooks / callbacks

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -61,7 +61,9 @@ using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes
-using ClimateMachine.BalanceLaws: BalanceLaw
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux
+
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.GenericCallbacks
@@ -72,10 +74,7 @@ using ClimateMachine.SingleStackUtils
 #  - import necessary ClimateMachine modules: (`import`ing enables us to
 #  provide implementations of these structs/methods)
 import ClimateMachine.BalanceLaws:
-    vars_state_auxiliary,
-    vars_state_conservative,
-    vars_state_gradient,
-    vars_state_gradient_flux,
+    vars_state,
     source!,
     flux_second_order!,
     flux_first_order!,
@@ -136,17 +135,17 @@ m = HeatModel{FT}();
 # the solver.
 
 # Specify auxiliary variables for `HeatModel`
-vars_state_auxiliary(::HeatModel, FT) = @vars(z::FT, T::FT);
+vars_state(::HeatModel, ::Auxiliary, FT) = @vars(z::FT, T::FT);
 
 # Specify state variables, the variables solved for in the PDEs, for
 # `HeatModel`
-vars_state_conservative(::HeatModel, FT) = @vars(ρcT::FT);
+vars_state(::HeatModel, ::Prognostic, FT) = @vars(ρcT::FT);
 
 # Specify state variables whose gradients are needed for `HeatModel`
-vars_state_gradient(::HeatModel, FT) = @vars(ρcT::FT);
+vars_state(::HeatModel, ::Gradient, FT) = @vars(ρcT::FT);
 
 # Specify gradient variables for `HeatModel`
-vars_state_gradient_flux(::HeatModel, FT) = @vars(α∇ρcT::SVector{3, FT});
+vars_state(::HeatModel, ::GradientFlux, FT) = @vars(α∇ρcT::SVector{3, FT});
 
 # ## Define the compute kernels
 
@@ -154,7 +153,7 @@ vars_state_gradient_flux(::HeatModel, FT) = @vars(α∇ρcT::SVector{3, FT});
 # `init_state_conservative!`. Note that
 # - this method is only called at `t=0`
 # - `aux.z` and `aux.T` are available here because we've specified `z` and `T`
-# in `vars_state_auxiliary`
+# in `vars_state`
 function init_state_auxiliary!(m::HeatModel, aux::Vars, geom::LocalGeometry)
     aux.z = geom.coord[3]
     aux.T = m.initialT
@@ -163,7 +162,7 @@ end;
 # Specify the initial values in `state::Vars`. Note that
 # - this method is only called at `t=0`
 # - `state.ρcT` is available here because we've specified `ρcT` in
-# `vars_state_conservative`
+# `vars_state`
 function init_state_conservative!(
     m::HeatModel,
     state::Vars,
@@ -193,7 +192,7 @@ end;
 
 # Compute/update all auxiliary variables at each node. Note that
 # - `aux.T` is available here because we've specified `T` in
-# `vars_state_auxiliary`
+# `vars_state`
 function heat_eq_nodal_update_aux!(
     m::HeatModel,
     state::Vars,
@@ -206,7 +205,7 @@ end;
 # Since we have second-order fluxes, we must tell `ClimateMachine` to compute
 # the gradient of `ρcT`. Here, we specify how `ρcT` is computed. Note that
 #  - `transform.ρcT` is available here because we've specified `ρcT` in
-#  `vars_state_gradient`
+#  `vars_state`
 function compute_gradient_argument!(
     m::HeatModel,
     transform::Vars,
@@ -220,9 +219,9 @@ end;
 # Specify where in `diffusive::Vars` to store the computed gradient from
 # `compute_gradient_argument!`. Note that:
 #  - `diffusive.α∇ρcT` is available here because we've specified `α∇ρcT` in
-#  `vars_state_gradient_flux`
+#  `vars_state`
 #  - `∇transform.ρcT` is available here because we've specified `ρcT`  in
-#  `vars_state_gradient`
+#  `vars_state`
 function compute_gradient_flux!(
     m::HeatModel,
     diffusive::Vars,
@@ -241,7 +240,7 @@ function flux_first_order!(m::HeatModel, _...) end;
 # Compute diffusive flux (``F(α, ρcT, t) = -α ∇ρcT`` in the original PDE).
 # Note that:
 # - `diffusive.α∇ρcT` is available here because we've specified `α∇ρcT` in
-# `vars_state_gradient_flux`
+# `vars_state`
 function flux_second_order!(
     m::HeatModel,
     flux::Grad,
@@ -369,12 +368,12 @@ z = get_z(grid, z_scale)
 state_vars = SingleStackUtils.get_vars_from_nodal_stack(
     grid,
     Q,
-    vars_state_conservative(m, FT),
+    vars_state(m, Prognostic(), FT),
 )
 aux_vars = SingleStackUtils.get_vars_from_nodal_stack(
     grid,
     aux,
-    vars_state_auxiliary(m, FT),
+    vars_state(m, Auxiliary(), FT),
 )
 all_vars = OrderedDict(state_vars..., aux_vars...);
 export_plot_snapshot(
@@ -410,12 +409,12 @@ callback = GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
     state_vars = SingleStackUtils.get_vars_from_nodal_stack(
         grid,
         Q,
-        vars_state_conservative(m, FT),
+        vars_state(m, Prognostic(), FT),
     )
     aux_vars = SingleStackUtils.get_vars_from_nodal_stack(
         grid,
         aux,
-        vars_state_auxiliary(m, FT);
+        vars_state(m, Auxiliary(), FT);
         exclude = [z_key],
     )
     all_vars = OrderedDict(state_vars..., aux_vars...)

--- a/tutorials/Numerics/DGMethods/nonnegative.jl
+++ b/tutorials/Numerics/DGMethods/nonnegative.jl
@@ -92,7 +92,7 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, model, testname)
         vtkstep
     )
 
-    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
 
     writevtk(filename, Q, dg, statenames)
 


### PR DESCRIPTION
# Description

 - Adds types to balance law (I have no strong opinions about the names here)

```julia
abstract type AbstractStateType end
struct Prognostic <: AbstractStateType end
struct Auxiliary <: AbstractStateType end
struct Gradient <: AbstractStateType end
struct GradientFlux <: AbstractStateType end
struct GradientLaplacian <: AbstractStateType end
struct Hyperdiffusive <: AbstractStateType end
struct UpwardIntegrals <: AbstractStateType end
struct DownwardIntegrals <: AbstractStateType end
```

 - Unifies `vars_state` (BalanceLaws) into a single function
 - Unifies `number_states` (BalanceLaws) into a single function
 - Unifies `create_state` (DGMethods) into a single function
 - Unifies `extract_state` (Diagnostics) into a single function

This PR also does a replace-all for `state_conservative` -> `state_prognostic`.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
