### PR TITLE
Add doc build common error messages

### DIFF
--- a/.github/workflows/Documenter.yaml
+++ b/.github/workflows/Documenter.yaml
@@ -42,3 +42,7 @@ jobs:
           ClIMATEMACHINE_SETTINGS_DISABLE_GPU: "true"
           CLIMATEMACHINE_SETTINGS_DISABLE_CUSTOM_LOGGER: "true"
         run: xvfb-run -- julia --procs=auto docs/make.jl
+      - name: Help! Documenter Failed
+        run: |
+          cat .github/workflows/doc_build_common_error_messages.md
+        if: failure()

--- a/.github/workflows/doc_build_common_error_messages.md
+++ b/.github/workflows/doc_build_common_error_messages.md
@@ -1,0 +1,42 @@
+# Documenter common warning/error messages:
+
+## General notes
+ - Changing order of API/HowToGuides does not fix unresolved path issues
+
+## no doc found for reference
+```
+┌ Warning: no doc found for reference '[`BatchedGeneralizedMinimalResidual`](@ref)' in src/HowToGuides/Numerics/SystemSolvers/IterativeSolvers.md.
+└ @ Documenter.CrossReferences ~/.julia/packages/Documenter/PLD7m/src/CrossReferences.jl:160
+```
+ - Missing entry in ```@docs ``` in API
+
+
+## Reference could not be found
+```
+┌ Warning: reference for 'ClimateMachine.ODESolvers.solve!' could not be found in src\APIs\Driver\index.md.
+└ @ Documenter.CrossReferences C:\Users\kawcz\.julia\packages\Documenter\PLD7m\src\CrossReferences.jl:104
+```
+ - Missing doc string?
+
+## invalid local link: unresolved path
+```
+┌ Warning: invalid local link: unresolved path in APIs/Atmos/AtmosModel.md
+│   link.text =
+│    1-element Array{Any,1}:
+│     Markdown.Code("", "FlatOrientation")
+│   link.url = "@ref"
+```
+ - Missing entry in ```@docs ``` for FlatOrientation in API OR
+ - The "code" in the reference must be to actual code and not arbitrary text
+
+## unable to get the binding
+```
+┌ Warning: unable to get the binding for 'ClimateMachine.Atmos.AtmosModel.NoOrientation' in `@docs` block in src/APIs/Atmos/AtmosModel.md:9-14 from expression ':(ClimateMachine.Atmos.AtmosModel.NoOrientation)' in module ClimateMachine
+│ ```@docs
+│ ClimateMachine.Atmos.AtmosModel.NoOrientation
+...
+│ ```
+...
+```
+ - `ClimateMachine.Atmos.AtmosModel.NoOrientation` should be `ClimateMachine.Atmos.NoOrientation`
+


### PR DESCRIPTION
# Description

Adds a markdown file of common doc build error messages, and hints of what is wrong / how to fix it, to the `.github/workflows/` folder.

Disclaimer: this was my personal "cheat sheet" that I've been using while fixing docs. I don't know how accurate/precise it is, but perhaps we can update it as users come across mistakes.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
