### PR TITLE
Compute geopotential gradient numerically

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -71,7 +71,8 @@ import ClimateMachine.DGMethods:
     lengthscale,
     resolutionmetric,
     DGModel,
-    nodal_update_auxiliary_state!
+    nodal_update_auxiliary_state!,
+    nodal_init_state_auxiliary!
 import ..DGMethods.NumericalFluxes:
     boundary_state!,
     boundary_flux_second_order!,
@@ -645,17 +646,11 @@ function reverse_integral_set_auxiliary_state!(
     reverse_integral_set_auxiliary_state!(m.radiation, aux, integ)
 end
 
-
-@doc """
-    init_state_auxiliary!(
-        m::AtmosModel,
-        aux::Vars,
-        geom::LocalGeometry
-        )
-Initialise auxiliary variables for each AtmosModel subcomponent.
-Store Cartesian coordinate information in `aux.coord`.
-""" init_state_auxiliary!
-function init_state_auxiliary!(m::AtmosModel, aux::Vars, geom::LocalGeometry)
+function atmos_nodal_init_state_auxiliary!(
+    m::AtmosModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
     aux.coord = geom.coord
     init_aux!(m.orientation, m.param_set, aux)
     init_aux_turbulence!(m.turbulence, m, aux, geom)
@@ -663,6 +658,28 @@ function init_state_auxiliary!(m::AtmosModel, aux::Vars, geom::LocalGeometry)
     init_aux_hyperdiffusion!(m.hyperdiffusion, m, aux, geom)
     atmos_init_aux!(m.tracers, m, aux, geom)
     init_aux_turbconv!(m.turbconv, m, aux, geom)
+end
+
+@doc """
+    init_state_auxiliary!(
+        m::AtmosModel,
+        aux::MPIStateArray,
+        geom::grid,
+        )
+Initialise auxiliary variables for each AtmosModel subcomponent.
+Store Cartesian coordinate information in `aux.coord`.
+""" init_state_auxiliary!
+function init_state_auxiliary!(
+    m::AtmosModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        atmos_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 @doc """

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -652,7 +652,6 @@ function atmos_nodal_init_state_auxiliary!(
     geom::LocalGeometry,
 )
     aux.coord = geom.coord
-    init_aux!(m.orientation, m.param_set, aux)
     init_aux_turbulence!(m.turbulence, m, aux, geom)
     atmos_init_aux!(m.ref_state, m, aux, geom)
     init_aux_hyperdiffusion!(m.hyperdiffusion, m, aux, geom)
@@ -664,7 +663,7 @@ end
     init_state_auxiliary!(
         m::AtmosModel,
         aux::MPIStateArray,
-        geom::grid,
+        grid,
         )
 Initialise auxiliary variables for each AtmosModel subcomponent.
 Store Cartesian coordinate information in `aux.coord`.
@@ -674,6 +673,8 @@ function init_state_auxiliary!(
     state_auxiliary::MPIStateArray,
     grid,
 )
+    init_aux!(m, m.orientation, state_auxiliary, grid)
+
     nodal_init_state_auxiliary!(
         m,
         atmos_nodal_init_state_auxiliary!,

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -95,9 +95,8 @@ function init_state_conservative! end
 """
     init_state_auxiliary!(
       ::L,
-      state_auxiliary::Vars,
-      coords,
-      args...)
+      state_auxiliary::MPIStateArray,
+      grid)
 
 Initialize the auxiliary state, at ``t = 0``
 """

--- a/src/Common/Orientations/Orientations.jl
+++ b/src/Common/Orientations/Orientations.jl
@@ -26,7 +26,10 @@ using StaticArrays
 using LinearAlgebra
 
 using ..VariableTemplates
+using ..MPIStateArrays: MPIStateArray
 import ..BalanceLaws: BalanceLaw, vars_state_auxiliary
+using ..DGMethods:
+    nodal_init_state_auxiliary!, contiguous_field_gradient!, LocalGeometry
 
 export Orientation, NoOrientation, FlatOrientation, SphericalOrientation
 
@@ -91,6 +94,25 @@ function projection_tangential(
     return u⃗ .- projection_normal(orientation, param_set, aux, u⃗)
 end
 
+function init_aux!(m, ::Orientation, state_auxiliary::MPIStateArray, grid)
+    nodal_init_state_auxiliary!(
+        m,
+        (m, aux, geom) ->
+            orientation_nodal_init_aux!(m.orientation, m.param_set, aux, geom),
+        state_auxiliary,
+        grid,
+    )
+
+    contiguous_field_gradient!(
+        m,
+        state_auxiliary,
+        ("orientation.∇Φ",),
+        state_auxiliary,
+        ("orientation.Φ",),
+        grid,
+    )
+end
+
 #####
 ##### NoOrientation
 #####
@@ -102,7 +124,8 @@ No gravitational force or potential.
 """
 struct NoOrientation <: Orientation end
 
-init_aux!(::NoOrientation, param_set::APS, aux::Vars) = nothing
+init_aux!(m, ::NoOrientation, state_auxiliary::MPIStateArray, grid) = nothing
+
 vars_state_auxiliary(m::NoOrientation, FT) = @vars()
 
 gravitational_potential(::NoOrientation, aux::Vars) = -zero(eltype(aux))
@@ -123,14 +146,19 @@ to the surface of the planet.
 """
 struct SphericalOrientation <: Orientation end
 
-function init_aux!(::SphericalOrientation, param_set::APS, aux::Vars)
+function orientation_nodal_init_aux!(
+    ::SphericalOrientation,
+    param_set::APS,
+    aux::Vars,
+    geom::LocalGeometry,
+)
     FT = eltype(aux)
     _grav::FT = grav(param_set)
     _planet_radius::FT = planet_radius(param_set)
-    normcoord = norm(aux.coord)
+    normcoord = norm(geom.coord)
     aux.orientation.Φ = _grav * (normcoord - _planet_radius)
-    aux.orientation.∇Φ = _grav / normcoord .* aux.coord
 end
+
 
 # TODO: should we define these for non-spherical orientations?
 latitude(orientation::SphericalOrientation, aux::Vars) =
@@ -153,11 +181,15 @@ Gravity acts in the third coordinate, and the gravitational potential is relativ
 struct FlatOrientation <: Orientation
     # for Coriolis we could add latitude?
 end
-function init_aux!(::FlatOrientation, param_set::APS, aux::Vars)
+function orientation_nodal_init_aux!(
+    ::FlatOrientation,
+    param_set::APS,
+    aux::Vars,
+    geom::LocalGeometry,
+)
     FT = eltype(aux)
     _grav::FT = grav(param_set)
-    @inbounds aux.orientation.Φ = _grav * aux.coord[3]
-    aux.orientation.∇Φ = SVector{3, FT}(0, 0, _grav)
+    @inbounds aux.orientation.Φ = _grav * geom.coord[3]
 end
 
 end

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -53,8 +53,12 @@ import ..BalanceLaws:
     reverse_integral_set_auxiliary_state!
 
 export DGModel,
-    init_ode_state, restart_ode_state, restart_auxiliary_state, basic_grid_info,
-    nodal_init_state_auxiliary!
+    init_ode_state,
+    restart_ode_state,
+    restart_auxiliary_state,
+    basic_grid_info,
+    nodal_init_state_auxiliary!,
+    contiguous_field_gradient!
 
 include("NumericalFluxes.jl")
 include("DGModel.jl")

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -53,7 +53,8 @@ import ..BalanceLaws:
     reverse_integral_set_auxiliary_state!
 
 export DGModel,
-    init_ode_state, restart_ode_state, restart_auxiliary_state, basic_grid_info
+    init_ode_state, restart_ode_state, restart_auxiliary_state, basic_grid_info,
+    nodal_init_state_auxiliary!
 
 include("NumericalFluxes.jl")
 include("DGModel.jl")

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -664,6 +664,47 @@ function restart_auxiliary_state(bl, grid, aux_data)
     return state_auxiliary
 end
 
+function nodal_init_state_auxiliary!(
+    balance_law,
+    init_f!,
+    state_auxiliary,
+    grid,
+)
+    topology = grid.topology
+    dim = dimensionality(grid)
+    Np = dofs_per_element(grid)
+    polyorder = polynomialorder(grid)
+    vgeo = grid.vgeo
+    device = array_device(state_auxiliary)
+    nrealelem = length(topology.realelems)
+
+    event = Event(device)
+    event = kernel_nodal_init_state_auxiliary!(
+        device,
+        min(Np, 1024),
+        Np * nrealelem,
+    )(
+        balance_law,
+        Val(dim),
+        Val(polyorder),
+        init_f!,
+        state_auxiliary.data,
+        vgeo,
+        topology.realelems,
+        dependencies = (event,),
+    )
+
+    event = MPIStateArrays.begin_ghost_exchange!(
+        state_auxiliary;
+        dependencies = event,
+    )
+    event = MPIStateArrays.end_ghost_exchange!(
+        state_auxiliary;
+        dependencies = event,
+    )
+    wait(device, event)
+end
+
 # fallback
 function update_auxiliary_state!(dg, balance_law, state_conservative, t, elems)
     return false

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -2677,3 +2677,113 @@ end
         pointwise_courant[n, e] = c
     end
 end
+
+@kernel function kernel_contiguous_field_gradient!(
+    balance_law::BalanceLaw,
+    ::Val{dim},
+    ::Val{polyorder},
+    direction,
+    ∇state,
+    state,
+    vgeo,
+    D,
+    ω,
+    ::Val{I},
+    ::Val{O},
+) where {dim, polyorder, I, O}
+    @uniform begin
+        N = polyorder
+        FT = eltype(state)
+        ngradstate = length(I)
+        Nq = N + 1
+        Nqk = dim == 2 ? 1 : Nq
+    end
+
+    shared_transform = @localmem FT (Nq, Nq, ngradstate)
+    s_D = @localmem FT (Nq, Nq)
+
+    local_transform_gradient = @private FT (3, ngradstate, Nqk)
+    Gξ3 = @private FT (ngradstate, Nqk)
+
+    e = @index(Group, Linear)
+    i, j = @index(Local, NTuple)
+
+    @inbounds @views begin
+        s_D[i, j] = D[i, j]
+
+        @unroll for k in 1:Nqk
+            @unroll for s in 1:ngradstate
+                local_transform_gradient[1, s, k] = -zero(FT)
+                local_transform_gradient[2, s, k] = -zero(FT)
+                local_transform_gradient[3, s, k] = -zero(FT)
+                Gξ3[s, k] = -zero(FT)
+            end
+        end
+
+        @unroll for k in 1:Nqk
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+
+            @unroll for s in 1:ngradstate
+                shared_transform[i, j, s] = state[ijk, I[s], e]
+            end
+            @synchronize
+
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            ξ1x1, ξ1x2, ξ1x3 =
+                vgeo[ijk, _ξ1x1, e], vgeo[ijk, _ξ1x2, e], vgeo[ijk, _ξ1x3, e]
+
+            # Compute gradient of each state
+            @unroll for s in 1:ngradstate
+                Gξ1 = Gξ2 = zero(FT)
+
+                @unroll for n in 1:Nq
+                    Gξ1 += s_D[i, n] * shared_transform[n, j, s]
+                    if dim == 3 || (dim == 2 && direction isa EveryDirection)
+                        Gξ2 += s_D[j, n] * shared_transform[i, n, s]
+                    end
+                    if dim == 3 && direction isa EveryDirection
+                        Gξ3[s, n] += s_D[n, k] * shared_transform[i, j, s]
+                    end
+                end
+
+                local_transform_gradient[1, s, k] += ξ1x1 * Gξ1
+                local_transform_gradient[2, s, k] += ξ1x2 * Gξ1
+                local_transform_gradient[3, s, k] += ξ1x3 * Gξ1
+
+                if dim == 3 || (dim == 2 && direction isa EveryDirection)
+                    ξ2x1, ξ2x2, ξ2x3 = vgeo[ijk, _ξ2x1, e],
+                    vgeo[ijk, _ξ2x2, e],
+                    vgeo[ijk, _ξ2x3, e]
+                    local_transform_gradient[1, s, k] += ξ2x1 * Gξ2
+                    local_transform_gradient[2, s, k] += ξ2x2 * Gξ2
+                    local_transform_gradient[3, s, k] += ξ2x3 * Gξ2
+                end
+            end
+            @synchronize
+        end
+
+        @unroll for k in 1:Nqk
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+
+            if dim == 3 && direction isa EveryDirection
+                ξ3x1, ξ3x2, ξ3x3 = vgeo[ijk, _ξ3x1, e],
+                vgeo[ijk, _ξ3x2, e],
+                vgeo[ijk, _ξ3x3, e]
+                @unroll for s in 1:ngradstate
+                    local_transform_gradient[1, s, k] += ξ3x1 * Gξ3[s, k]
+                    local_transform_gradient[2, s, k] += ξ3x2 * Gξ3[s, k]
+                    local_transform_gradient[3, s, k] += ξ3x3 * Gξ3[s, k]
+                end
+            end
+
+            @unroll for s in 1:ngradstate
+                ∇state[ijk, O[3 * (s - 1) + 1], e] =
+                    local_transform_gradient[1, s, k]
+                ∇state[ijk, O[3 * (s - 1) + 2], e] =
+                    local_transform_gradient[2, s, k]
+                ∇state[ijk, O[3 * (s - 1) + 3], e] =
+                    local_transform_gradient[3, s, k]
+            end
+        end
+    end
+end

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -1525,16 +1525,19 @@ end
 
 
 @doc """
-    kernel_init_state_auxiliary!(balance_law::BalanceLaw, Val(polyorder), state_auxiliary, vgeo, elems)
+    kernel_nodal_init_state_auxiliary!(balance_law::BalanceLaw, Val(polyorder),
+                                       init_f!, state_auxiliary, state_init,
+                                       Val(vars_state_init), vgeo, elems)
 
 Computational kernel: Initialize the auxiliary state
 
 See [`BalanceLaw`](@ref) for usage.
-""" kernel_init_state_auxiliary!
-@kernel function kernel_init_state_auxiliary!(
+""" kernel_nodal_init_state_auxiliary!
+@kernel function kernel_nodal_init_state_auxiliary!(
     balance_law::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
+    init_f!,
     state_auxiliary,
     vgeo,
     elems,
@@ -1558,7 +1561,7 @@ See [`BalanceLaw`](@ref) for usage.
             local_state_auxiliary[s] = state_auxiliary[n, s, e]
         end
 
-        init_state_auxiliary!(
+        init_f!(
             balance_law,
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
             LocalGeometry(Val(polyorder), vgeo, n, e),

--- a/src/Numerics/DGMethods/create_states.jl
+++ b/src/Numerics/DGMethods/create_states.jl
@@ -58,30 +58,7 @@ function create_auxiliary_state(balance_law, grid)
         weights = weights,
     )
 
-    dim = dimensionality(grid)
-    polyorder = polynomialorder(grid)
-    vgeo = grid.vgeo
-    device = array_device(state_auxiliary)
-    nrealelem = length(topology.realelems)
-    event = Event(device)
-    event = kernel_init_state_auxiliary!(device, min(Np, 1024), Np * nrealelem)(
-        balance_law,
-        Val(dim),
-        Val(polyorder),
-        state_auxiliary.data,
-        vgeo,
-        topology.realelems,
-        dependencies = (event,),
-    )
-    event = MPIStateArrays.begin_ghost_exchange!(
-        state_auxiliary;
-        dependencies = event,
-    )
-    event = MPIStateArrays.end_ghost_exchange!(
-        state_auxiliary;
-        dependencies = event,
-    )
-    wait(device, event)
+    init_state_auxiliary!(balance_law, state_auxiliary, grid)
 
     return state_auxiliary
 end

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -178,8 +178,13 @@ sets the initial value for auxiliary variables (those that aren't related to ver
 dispatches to ocean_init_aux! which is defined in a problem file such as SimpleBoxProblem.jl
 """
 function ocean_init_aux! end
-function init_state_auxiliary!(m::HBModel, A::Vars, geom::LocalGeometry)
-    return ocean_init_aux!(m, m.problem, A, geom)
+function init_state_auxiliary!(m::HBModel, state_auxiliary::MPIStateArray, grid)
+    nodal_init_state_auxiliary!(
+        m,
+        (m, A, geom) -> ocean_init_aux!(m, m.problem, A, geom),
+        state_auxiliary,
+        grid,
+    )
 end
 
 """

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -42,7 +42,8 @@ vars_integrals(lm::LinearHBModel, FT) = @vars()
 """
     No need to init, initialize by full model
 """
-init_state_auxiliary!(lm::LinearHBModel, A::Vars, geom::LocalGeometry) = nothing
+init_state_auxiliary!(lm::LinearHBModel, state_auxiliary::MPIStateArray, grid) =
+    nothing
 init_state_conservative!(lm::LinearHBModel, Q::Vars, A::Vars, coords, t) =
     nothing
 

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -3,6 +3,8 @@ module ShallowWater
 export ShallowWaterModel, ShallowWaterProblem
 
 using StaticArrays
+using ..VariableTemplates
+using ..MPIStateArrays: MPIStateArray
 using LinearAlgebra: dot, Diagonal
 using CLIMAParameters.Planet: grav
 
@@ -26,7 +28,17 @@ import ...BalanceLaws:
     flux_second_order!,
     source!,
     wavespeed,
-    boundary_state!
+    boundary_state!,
+    compute_gradient_argument!,
+    init_state_auxiliary!,
+    init_state_conservative!,
+    compute_gradient_flux!
+
+import ...Mesh.Geometry: LocalGeometry
+
+using ..DGMethods.NumericalFluxes
+using ..DGMethods: nodal_init_state_auxiliary!
+>>>>>>> 048a84d87... Make auxiliary state initialization global
 
 ×(a::SVector, b::SVector) = StaticArrays.cross(a, b)
 ⋅(a::SVector, b::SVector) = StaticArrays.dot(a, b)
@@ -239,8 +251,13 @@ linear_drag!(::ConstantViscosity, _...) = nothing
 end
 
 function shallow_init_aux! end
-function init_state_auxiliary!(m::SWModel, aux::Vars, geom::LocalGeometry)
-    shallow_init_aux!(m.problem, aux, geom)
+function init_state_auxiliary!(m::SWModel, state_auxiliary::MPIStateArray, grid)
+    nodal_init_state_auxiliary!(
+        m,
+        (m, A, geom) -> shallow_init_aux!(m.problem, A, geom),
+        state_auxiliary,
+        grid,
+    )
 end
 
 function shallow_init_state! end

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -3,8 +3,7 @@ module ShallowWater
 export ShallowWaterModel, ShallowWaterProblem
 
 using StaticArrays
-using ..VariableTemplates
-using ..MPIStateArrays: MPIStateArray
+using ...MPIStateArrays: MPIStateArray
 using LinearAlgebra: dot, Diagonal
 using CLIMAParameters.Planet: grav
 
@@ -35,10 +34,7 @@ import ...BalanceLaws:
     compute_gradient_flux!
 
 import ...Mesh.Geometry: LocalGeometry
-
-using ..DGMethods.NumericalFluxes
-using ..DGMethods: nodal_init_state_auxiliary!
->>>>>>> 048a84d87... Make auxiliary state initialization global
+using ...DGMethods: nodal_init_state_auxiliary!
 
 ×(a::SVector, b::SVector) = StaticArrays.cross(a, b)
 ⋅(a::SVector, b::SVector) = StaticArrays.dot(a, b)

--- a/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
@@ -103,6 +103,7 @@ import ClimateMachine.BalanceLaws:
     boundary_state!,
     source!
 
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 import ClimateMachine.DGMethods: DGModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 
@@ -171,7 +172,7 @@ vars_state_gradient(m::KinematicModel, FT) = @vars()
 
 vars_state_gradient_flux(m::KinematicModel, FT) = @vars()
 
-function init_state_auxiliary!(
+function kinematic_nodal_init_state_auxiliary!(
     m::KinematicModel,
     aux::Vars,
     geom::LocalGeometry,
@@ -202,6 +203,19 @@ function init_state_auxiliary!(
         aux.x = x
         aux.z = z
     end
+end
+
+function init_state_auxiliary!(
+    m::KinematicModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        kinematic_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 function init_state_conservative!(

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -128,7 +128,7 @@ function main()
     ca_h = ugeo_abs * (Δt / Δh) + vgeo_abs * (Δt / Δh)
     # vertical velocity is 0
     caᵥ = FT(0.0)
-    @test isapprox(CFL_adv_v, caᵥ)
+    @test isapprox(CFL_adv_v, caᵥ, atol = 10 * eps(FT))
     @test isapprox(CFL_adv_h, ca_h, atol = 0.0005)
     @test isapprox(CFL_adv, ca_h, atol = 0.0005)
 

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -1,6 +1,7 @@
 using StaticArrays
 using ClimateMachine.VariableTemplates
-using ClimateMachine.DGMethods: nodal_update_auxiliary_state!
+using ClimateMachine.DGMethods:
+    nodal_update_auxiliary_state!, nodal_init_state_auxiliary!
 using ClimateMachine.BalanceLaws: BalanceLaw
 
 import ClimateMachine.BalanceLaws:
@@ -214,18 +215,31 @@ function wavespeed(
     abs(dot(nM, u))
 end
 
-"""
-    init_state_auxiliary!(m::AdvectionDiffusion, aux::Vars, geom::LocalGeometry)
-
-initialize the auxiliary state
-"""
-function init_state_auxiliary!(
+function advection_diffusion_nodal_init_state_auxiliary!(
     m::AdvectionDiffusion,
     aux::Vars,
     geom::LocalGeometry,
 )
     aux.coord = geom.coord
     init_velocity_diffusion!(m.problem, aux, geom)
+end
+
+"""
+    init_state_auxiliary!(m::AdvectionDiffusion, aux::MPIStateArray, grid)
+
+initialize the auxiliary state
+"""
+function init_state_auxiliary!(
+    m::AdvectionDiffusion,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        advection_diffusion_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 has_variable_coefficients(::AdvectionDiffusionProblem) = false

--- a/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
@@ -23,6 +23,8 @@ using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.DGMethods.NumericalFluxes:
     NumericalFluxFirstOrder, NumericalFluxSecondOrder
 
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
+
 abstract type HyperDiffusionProblem end
 struct HyperDiffusion{dim, P} <: BalanceLaw
     problem::P
@@ -115,16 +117,21 @@ There is no source in the hyperdiffusion model
 source!(m::HyperDiffusion, _...) = nothing
 
 """
-    init_state_auxiliary!(m::HyperDiffusion, aux::Vars, geom::LocalGeometry)
+    init_state_auxiliary!(m::HyperDiffusion, aux::MPIStateArray, grid)
 
 initialize the auxiliary state
 """
 function init_state_auxiliary!(
     m::HyperDiffusion,
-    aux::Vars,
-    geom::LocalGeometry,
+    state_auxiliary::MPIStateArray,
+    grid,
 )
-    init_hyperdiffusion_tensor!(m.problem, aux, geom)
+    nodal_init_state_auxiliary!(
+        m,
+        (m, aux, geom) -> init_hyperdiffusion_tensor!(m.problem, aux, geom),
+        state_auxiliary,
+        grid,
+    )
 end
 
 function init_state_conservative!(

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
@@ -18,6 +18,7 @@ import ClimateMachine.BalanceLaws:
     init_state_conservative!
 
 import ClimateMachine.DGMethods: init_ode_state
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 
 
@@ -182,11 +183,28 @@ function boundary_state!(
     init_state_conservative!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
 end
 
-function init_state_auxiliary!(::MMSModel, aux::Vars, g::LocalGeometry)
+function mms_nodal_init_state_auxiliary!(
+    ::MMSModel,
+    aux::Vars,
+    g::LocalGeometry,
+)
     x1, x2, x3 = g.coord
     aux.x1 = x1
     aux.x2 = x2
     aux.x3 = x3
+end
+
+function init_state_auxiliary!(
+    m::MMSModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        mms_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 function init_state_conservative!(

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -25,7 +25,7 @@ using Logging, Printf, Dates
 using Random
 
 using ClimateMachine.VariableTemplates
-using ClimateMachine.DGMethods: BalanceLaw
+using ClimateMachine.DGMethods: BalanceLaw, nodal_init_state_auxiliary!
 
 import ClimateMachine.DGMethods:
     vars_state_auxiliary,
@@ -54,7 +54,7 @@ vars_state_conservative(::ConservationTestModel, T) = @vars(q::T, p::T)
 vars_state_gradient(::ConservationTestModel, T) = @vars()
 vars_state_gradient_flux(::ConservationTestModel, T) = @vars()
 
-function init_state_auxiliary!(
+function conservation_nodal_init_state_auxiliary!(
     ::ConservationTestModel,
     aux::Vars,
     g::LocalGeometry,
@@ -65,6 +65,19 @@ function init_state_auxiliary!(
         cos(10 * π * x) * sin(10 * π * y) + cos(20 * π * z),
         exp(sin(π * r)),
         sin(π * (x + y + z)),
+    )
+end
+
+function init_state_auxiliary!(
+    m::ConservationTestModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        conservation_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
     )
 end
 

--- a/test/Numerics/DGMethods/grad_test.jl
+++ b/test/Numerics/DGMethods/grad_test.jl
@@ -1,0 +1,124 @@
+using MPI
+using StaticArrays
+using ClimateMachine
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.DGMethods
+
+using ClimateMachine.BalanceLaws: BalanceLaw
+
+import ClimateMachine.BalanceLaws:
+    vars_state_auxiliary, vars_state_conservative, init_state_auxiliary!
+
+using ClimateMachine.Mesh.Geometry: LocalGeometry
+
+struct GradTestModel{dim} <: BalanceLaw end
+
+vars_state_auxiliary(m::GradTestModel, T) = @vars begin
+    a::T
+    ∇a::SVector{3, T}
+    ∇a_exact::SVector{3, T}
+end
+vars_state_conservative(::GradTestModel, T) = @vars()
+
+function grad_nodal_init_state_auxiliary!(
+    ::GradTestModel{dim},
+    aux::Vars,
+    g::LocalGeometry,
+) where {dim}
+    x, y, z = g.coord
+    if dim == 2
+        aux.a = x^2 + y^3 - x * y
+        aux.∇a_exact = SVector(2 * x - y, 3 * y^2 - x, 0)
+    else
+        aux.a = x^2 + y^3 + z^2 * y^2 - x * y * z
+        aux.∇a_exact = SVector(
+            2 * x - y * z,
+            3 * y^2 + 2 * z^2 * y - x * z,
+            2 * z * y^2 - x * y,
+        )
+    end
+end
+
+function init_state_auxiliary!(
+    m::GradTestModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        grad_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
+end
+
+using Test
+function run(mpicomm, dim, Ne, N, FT, ArrayType)
+
+    brickrange = ntuple(j -> range(FT(0); length = Ne[j] + 1, stop = 3), dim)
+    topl = StackedBrickTopology(
+        mpicomm,
+        brickrange,
+        periodicity = ntuple(j -> true, dim),
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = N,
+    )
+
+    model = GradTestModel{dim}()
+    dg = DGModel(
+        model,
+        grid,
+        nothing,
+        nothing,
+        nothing;
+        state_gradient_flux = nothing,
+    )
+
+    contiguous_field_gradient!(
+        model,
+        dg.state_auxiliary,
+        (:∇a,),
+        dg.state_auxiliary,
+        (:a,),
+        grid,
+    )
+
+    # Wrapping in Array ensure both GPU and CPU code use same approx
+    @test Array(dg.state_auxiliary.∇a) ≈ Array(dg.state_auxiliary.∇a_exact)
+end
+
+let
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    numelem = (5, 5, 1)
+    lvls = 1
+    polynomialorder = 4
+
+    @testset for FT in (Float64, Float32)
+        @testset for dim in 2:3
+            for l in 1:lvls
+                run(
+                    mpicomm,
+                    dim,
+                    ntuple(j -> 2^(l - 1) * numelem[j], dim),
+                    polynomialorder,
+                    FT,
+                    ArrayType,
+                )
+            end
+        end
+    end
+end
+
+nothing

--- a/test/Numerics/DGMethods/grad_test_sphere.jl
+++ b/test/Numerics/DGMethods/grad_test_sphere.jl
@@ -1,0 +1,137 @@
+using MPI
+using StaticArrays
+using ClimateMachine
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.DGMethods
+using Printf
+
+using ClimateMachine.BalanceLaws: BalanceLaw
+
+import ClimateMachine.BalanceLaws:
+    vars_state_auxiliary, vars_state_conservative, init_state_auxiliary!
+
+using ClimateMachine.Mesh.Geometry: LocalGeometry
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+
+struct GradSphereTestModel <: BalanceLaw end
+
+vars_state_auxiliary(m::GradSphereTestModel, T) = @vars begin
+    a::T
+    ∇a::SVector{3, T}
+end
+vars_state_conservative(::GradSphereTestModel, T) = @vars()
+
+function grad_nodal_init_state_auxiliary!(
+    ::GradSphereTestModel,
+    aux::Vars,
+    g::LocalGeometry,
+)
+    x, y, z = g.coord
+    r = hypot(x, y, z)
+    aux.a = r
+    aux.∇a = g.coord / r
+end
+
+function init_state_auxiliary!(
+    m::GradSphereTestModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        grad_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
+end
+
+using Test
+function run(mpicomm, Ne_horz, Ne_vert, N, FT, ArrayType)
+
+    Rrange = range(FT(1 // 2); length = Ne_vert + 1, stop = FT(1))
+    topl = StackedCubedSphereTopology(mpicomm, Ne_horz, Rrange)
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = N,
+        meshwarp = Topologies.cubedshellwarp,
+    )
+
+    model = GradSphereTestModel()
+    dg = DGModel(
+        model,
+        grid,
+        nothing,
+        nothing,
+        nothing;
+        state_gradient_flux = nothing,
+    )
+
+    exact_aux = copy(dg.state_auxiliary)
+
+    contiguous_field_gradient!(
+        model,
+        dg.state_auxiliary,
+        (:∇a,),
+        dg.state_auxiliary,
+        (:a,),
+        grid,
+    )
+
+    err = euclidean_distance(exact_aux, dg.state_auxiliary)
+    return err
+end
+
+let
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 4
+    base_Nhorz = 4
+    base_Nvert = 2
+
+    expected_result = [
+        2.0924087890777517e-04
+        1.3897932154337201e-05
+        8.8256018429045312e-07
+        5.5381072850485303e-08
+    ]
+
+    lvls = integration_testing || ClimateMachine.Settings.integration_testing ?
+        length(expected_result) : 1
+
+    @testset for FT in (Float64,)
+        err = zeros(FT, lvls)
+        @testset for l in 1:lvls
+            Ne_horz = 2^(l - 1) * base_Nhorz
+            Ne_vert = 2^(l - 1) * base_Nvert
+
+            err[l] =
+                run(mpicomm, Ne_horz, Ne_vert, polynomialorder, FT, ArrayType)
+            @test err[l] ≈ expected_result[l]
+        end
+        @info begin
+            msg = ""
+            for l in 1:(lvls - 1)
+                rate = log2(err[l]) - log2(err[l + 1])
+                msg *= @sprintf("\n  rate for level %d = %e\n", l, rate)
+            end
+            msg
+        end
+    end
+end
+
+nothing

--- a/test/Numerics/DGMethods/integral_test.jl
+++ b/test/Numerics/DGMethods/integral_test.jl
@@ -6,6 +6,7 @@ using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 using ClimateMachine.DGMethods.NumericalFluxes
 using Printf
 using LinearAlgebra
@@ -63,7 +64,7 @@ boundary_state!(_, ::IntegralTestModel, _...) = nothing
 init_state_conservative!(::IntegralTestModel, _...) = nothing
 wavespeed(::IntegralTestModel, _...) = 1
 
-function init_state_auxiliary!(
+function integral_nodal_init_state_auxiliary!(
     ::IntegralTestModel{dim},
     aux::Vars,
     g::LocalGeometry,
@@ -88,6 +89,19 @@ function init_state_auxiliary!(
         aux.rev_a = a_top - aux.a
         aux.rev_b = b_top - aux.b
     end
+end
+
+function init_state_auxiliary!(
+    m::IntegralTestModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        integral_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 function update_auxiliary_state!(

--- a/test/Numerics/DGMethods/integral_test_sphere.jl
+++ b/test/Numerics/DGMethods/integral_test_sphere.jl
@@ -6,6 +6,7 @@ using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 using ClimateMachine.DGMethods.NumericalFluxes
 using Printf
 using LinearAlgebra
@@ -71,7 +72,7 @@ boundary_state!(_, ::IntegralTestSphereModel, _...) = nothing
 init_state_conservative!(::IntegralTestSphereModel, _...) = nothing
 wavespeed(::IntegralTestSphereModel, _...) = 1
 
-function init_state_auxiliary!(
+function integral_nodal_init_state_auxiliary!(
     m::IntegralTestSphereModel,
     aux::Vars,
     g::LocalGeometry,
@@ -85,6 +86,19 @@ function init_state_auxiliary!(
     aux.a = 1 + cos(ϕ)^2 * sin(θ)^2 + sin(ϕ)^2
     aux.int.v = exp(-aux.a * aux.r^2) - exp(-aux.a * m.Rinner^2)
     aux.rev_int.v = exp(-aux.a * m.Router^2) - exp(-aux.a * aux.r^2)
+end
+
+function init_state_auxiliary!(
+    m::IntegralTestSphereModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        integral_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 @inline function integral_load_auxiliary_state!(

--- a/test/Numerics/DGMethods/runtests.jl
+++ b/test/Numerics/DGMethods/runtests.jl
@@ -3,6 +3,8 @@ include(joinpath("..", "..", "testhelpers.jl"))
 
 @testset "DGMethods" begin
     runmpi(joinpath(@__DIR__, "courant.jl"), ntasks = 2)
+    runmpi(joinpath(@__DIR__, "grad_test.jl"))
+    runmpi(joinpath(@__DIR__, "grad_test_sphere.jl"))
     runmpi(joinpath(@__DIR__, "horizontal_integral_test.jl"))
     runmpi(joinpath(@__DIR__, "integral_test.jl"))
     runmpi(joinpath(@__DIR__, "integral_test_sphere.jl"))

--- a/test/Numerics/DGMethods/vars_test.jl
+++ b/test/Numerics/DGMethods/vars_test.jl
@@ -6,6 +6,7 @@ using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 using ClimateMachine.DGMethods.NumericalFluxes
 using Printf
 using LinearAlgebra
@@ -56,13 +57,26 @@ function init_state_conservative!(
     state.coord = coord
 end
 
-function init_state_auxiliary!(
+function vars_nodal_init_state_auxiliary!(
     ::VarsTestModel{dim},
     aux::Vars,
     g::LocalGeometry,
 ) where {dim}
     x, y, z = aux.coord = g.coord
     aux.polynomial = x * y + x * z + y * z
+end
+
+function init_state_auxiliary!(
+    m::VarsTestModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        vars_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 using Test

--- a/test/Numerics/SystemSolvers/poisson.jl
+++ b/test/Numerics/SystemSolvers/poisson.jl
@@ -26,7 +26,7 @@ import ClimateMachine.DGMethods:
     init_state_auxiliary!,
     init_state_conservative!
 
-using ClimateMachine.DGMethods: nodal_init_state_auxiliary
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 
 import ClimateMachine.DGMethods: numerical_boundary_flux_second_order!
 using ClimateMachine.Mesh.Geometry: LocalGeometry

--- a/test/Numerics/SystemSolvers/poisson.jl
+++ b/test/Numerics/SystemSolvers/poisson.jl
@@ -26,6 +26,8 @@ import ClimateMachine.DGMethods:
     init_state_auxiliary!,
     init_state_conservative!
 
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary
+
 import ClimateMachine.DGMethods: numerical_boundary_flux_second_order!
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 
@@ -134,7 +136,7 @@ sol1d(x) = sin(2pi * x)^4 - 3 / 8
 dxx_sol1d(x) =
     -16 * pi^2 * sin(2pi * x)^2 * (sin(2pi * x)^2 - 3 * cos(2pi * x)^2)
 
-function init_state_auxiliary!(
+function poisson_nodal_init_state_auxiliary!(
     ::PoissonModel{dim},
     aux::Vars,
     g::LocalGeometry,
@@ -147,6 +149,19 @@ function init_state_auxiliary!(
         x23 = SVector(x2, x3)
         aux.rhs_ϕ -= dxx_sol1d(x1) * prod(sol1d, view(x23, 1:(dim - 1)))
     end
+end
+
+function init_state_auxiliary!(
+    m::PoissonModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        poisson_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 function init_state_conservative!(

--- a/test/Utilities/SingleStackUtils/ssu_tests.jl
+++ b/test/Utilities/SingleStackUtils/ssu_tests.jl
@@ -37,10 +37,27 @@ vars_state_conservative(::EmptyBalLaw, FT) = @vars(ρ::FT)
 vars_state_gradient(::EmptyBalLaw, FT) = @vars()
 vars_state_gradient_flux(::EmptyBalLaw, FT) = @vars()
 
-function init_state_auxiliary!(m::EmptyBalLaw, aux::Vars, geom::LocalGeometry)
+function empty_nodal_init_state_auxiliary!(
+    m::EmptyBalLaw,
+    aux::Vars,
+    geom::LocalGeometry,
+)
     aux.x = geom.coord[1]
     aux.y = geom.coord[2]
     aux.z = geom.coord[3]
+end
+
+function init_state_auxiliary!(
+    m::EmptyBalLaw,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        empty_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 function init_state_conservative!(

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -176,7 +176,7 @@ vars_state_gradient_flux(::BurgersEquation, FT) =
 # - this method is only called at `t=0`
 # - `aux.z` and `aux.T` are available here because we've specified `z` and `T`
 # in `vars_state_auxiliary`
-function init_state_auxiliary!(
+function burgers_nodal_init_state_auxiliary!(
     m::BurgersEquation,
     aux::Vars,
     geom::LocalGeometry,
@@ -184,6 +184,19 @@ function init_state_auxiliary!(
     aux.z = geom.coord[3]
     aux.T = m.initialT
 end;
+
+function init_state_auxiliary!(
+    m::BurgersEquation,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        burgers_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
+end
 
 # Specify the initial values in `state::Vars`. Note that
 # - this method is only called at `t=0`

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -155,10 +155,27 @@ vars_state_gradient_flux(::HeatModel, FT) = @vars(α∇ρcT::SVector{3, FT});
 # - this method is only called at `t=0`
 # - `aux.z` and `aux.T` are available here because we've specified `z` and `T`
 # in `vars_state_auxiliary`
-function init_state_auxiliary!(m::HeatModel, aux::Vars, geom::LocalGeometry)
+function heat_eq_nodal_init_state_auxiliary!(
+    m::HeatModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
     aux.z = geom.coord[3]
     aux.T = m.initialT
 end;
+
+function init_state_auxiliary!(
+    m::HeatModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        heat_eq_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
+end
 
 # Specify the initial values in `state::Vars`. Note that
 # - this method is only called at `t=0`


### PR DESCRIPTION
# Description

This PR:
- makes auxiliary state initialization global
- adds a function for taking element gradient of a subset of fields
- changes computation of geopotential gradient to use discrete derivative instead of analytical which is needed for #1247. 

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
