### PR TITLE
Add scaled-increment interface to main DG evaluation

### DIFF
--- a/docs/src/APIs/Numerics/DGMethods/DGMethods.md
+++ b/docs/src/APIs/Numerics/DGMethods/DGMethods.md
@@ -5,6 +5,7 @@ CurrentModule = ClimateMachine.DGMethods
 ```
 
 ```@docs
+DGModel
 remainder_DGModel
 ```
 


### PR DESCRIPTION
# Description

Adds a 6-argument form `f(du, u, param, t, α, β)` to the DG evaluation that computes

    du .= α .* f(u, param, t) .+ β .* du

which will be used by the new timestepping interface.

See https://github.com/SciML/DifferentialEquations.jl/issues/615

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)