### PR TITLE
sync cb_ctk with #1224

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -647,7 +647,8 @@ Starting %s
     end
 
     # fini VTK
-    !isnothing(cb_vtk) && cb_vtk()
+    !isnothing(cb_vtk) &&
+    GenericCallbacks.call!(cb_vtk, nothing, nothing, nothing, nothing)
 
     engf = norm(Q)
     @info @sprintf(


### PR DESCRIPTION
# Description

A one line change to src/Driver/Driver.jl that fixes call to cb_vtk. It looks like this fix was missed in #1224 

<!--- Please fill out the following section --->

I have

- [ x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
