### PR TITLE
Use generic functions instead of MPI specific ones

### DIFF
--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -523,7 +523,7 @@ function LinearAlgebra.norm(
         locnorm = norm_impl(Q.realdata, Val(p), dims)
     end
 
-    mpiop = isfinite(p) ? MPI.SUM : MPI.MAX
+    mpiop = isfinite(p) ? (+) : max
     if locnorm isa AbstractArray
         locnorm = convert(Array, locnorm)
     end
@@ -550,7 +550,7 @@ function LinearAlgebra.dot(
     end
 
     @tic mpi_dot
-    r = MPI.Allreduce(locnorm, MPI.SUM, Q1.mpicomm)
+    r = MPI.Allreduce(locnorm, +, Q1.mpicomm)
     @toc mpi_dot
     return r
 end
@@ -568,7 +568,7 @@ function euclidean_distance(A::MPIStateArray, B::MPIStateArray)
 
     locnorm = mapreduce(identity, +, E, init = zero(eltype(A)))
     @tic mpi_euclidean_distance
-    r = sqrt(MPI.Allreduce(locnorm, MPI.SUM, A.mpicomm))
+    r = sqrt(MPI.Allreduce(locnorm, +, A.mpicomm))
     @toc mpi_euclidean_distance
     return r
 end

--- a/src/Diagnostics/Debug/StateCheck.jl
+++ b/src/Diagnostics/Debug/StateCheck.jl
@@ -270,14 +270,14 @@ function scstats(V, ivar, nprec)
 
     # Min
     phi_loc = minimum(getByField(V, ivar))
-    phi_min = MPI.Allreduce(phi_loc, MPI.MIN, Vmcomm)
+    phi_min = MPI.Allreduce(phi_loc, min, Vmcomm)
     phi = phi_min
     # minVstr=@sprintf("%23.15e",phi)
     min_v_str = sprintf1(fmt, phi)
 
     # Max
     phi_loc = maximum(getByField(V, ivar))
-    phi_max = MPI.Allreduce(phi_loc, MPI.MAX, Vmcomm)
+    phi_max = MPI.Allreduce(phi_loc, max, Vmcomm)
     phi = phi_max
     # maxVstr=@sprintf("%23.15e",phi)
     max_v_str = sprintf1(fmt, phi)

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -399,11 +399,11 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     end
     # FIXME properly
     if isa(bl.moisture, EquilMoist)
-        cld_top = MPI.Reduce(cld_top, MPI.MAX, 0, mpicomm)
+        cld_top = MPI.Reduce(cld_top, max, 0, mpicomm)
         if cld_top == FT(-100000)
             cld_top = NaN
         end
-        cld_base = MPI.Reduce(cld_base, MPI.MIN, 0, mpicomm)
+        cld_base = MPI.Reduce(cld_base, min, 0, mpicomm)
         if cld_base == FT(100000)
             cld_base = NaN
         end

--- a/src/Numerics/Mesh/BrickMesh.jl
+++ b/src/Numerics/Mesh/BrickMesh.jl
@@ -125,8 +125,8 @@ function centroidtocode(
     centroidmax =
         (nelem > 0) ? maximum(centroids, dims = 3) : fill(typemin(T), d)
 
-    centroidmin = MPI.Allreduce(centroidmin, MPI.MIN, comm)
-    centroidmax = MPI.Allreduce(centroidmax, MPI.MAX, comm)
+    centroidmin = MPI.Allreduce(centroidmin, min, comm)
+    centroidmax = MPI.Allreduce(centroidmax, max, comm)
     centroidsize = centroidmax - centroidmin
 
     # Fix centroidsize to be nonzero.  It can be zero for a couple of reasons.


### PR DESCRIPTION
This allows the use of non-MPI types in ClimateMachine (such as `DoubleFloat`)