### PR TITLE
Prep thermodynamics for gpu unit tests

### DIFF
--- a/docs/src/HowToGuides/Common/Thermodynamics.md
+++ b/docs/src/HowToGuides/Common/Thermodynamics.md
@@ -153,9 +153,8 @@ using CLIMAParameters.Planet
 using Plots
 struct EarthParameterSet <: AbstractEarthParameterSet end;
 const param_set = EarthParameterSet();
-FT = Float64;
 include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "Thermodynamics", "profiles.jl"))
-profiles = PhaseDryProfiles(param_set, FT);
+profiles = PhaseDryProfiles(param_set, Array{Float32});
 @unpack_fields profiles T ρ z
 p1 = scatter(ρ, z./10^3, xlabel="Density [kg/m^3]", ylabel="z [km]", title="Density");
 p2 = scatter(T, z./10^3, xlabel="Temperature [K]", ylabel="z [km]", title="Temperature");
@@ -174,9 +173,8 @@ using CLIMAParameters.Planet
 using Plots
 struct EarthParameterSet <: AbstractEarthParameterSet end;
 const param_set = EarthParameterSet();
-FT = Float64;
 include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "Thermodynamics", "profiles.jl"))
-profiles = PhaseEquilProfiles(param_set, FT);
+profiles = PhaseEquilProfiles(param_set, Array{Float32});
 @unpack_fields profiles T ρ q_tot z
 p1 = scatter(ρ, z./10^3, xlabel="Density [kg/m^3]", ylabel="z [km]", title="Density");
 p2 = scatter(T, z./10^3, xlabel="Temperature [K]", ylabel="z [km]", title="Temperature");

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -22,13 +22,15 @@ rtol_density = rtol_temperature
 rtol_pressure = 1e-1
 rtol_energy = 1e-1
 
-float_types = [Float32, Float64]
+array_types = [Array{Float32}, Array{Float64}]
 
 include("profiles.jl")
 include("data_tests.jl")
 
 @testset "Thermodynamics - isentropic processes" begin
-    for FT in float_types
+    for ArrayType in array_types
+        FT = eltype(ArrayType)
+
         _R_d = FT(R_d(param_set))
         _molmass_ratio = FT(molmass_ratio(param_set))
         _cp_d = FT(cp_d(param_set))
@@ -54,8 +56,7 @@ include("data_tests.jl")
         _T_max = FT(T_max(param_set))
         _kappa_d = FT(kappa_d(param_set))
 
-        # for FT in float_types
-        profiles = PhaseEquilProfiles(param_set, FT)
+        profiles = PhaseEquilProfiles(param_set, ArrayType)
         @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
         # Test state for thermodynamic consistency (with ideal gas law)
@@ -395,8 +396,9 @@ end
     # Input arguments should be accurate within machine precision
     # Temperature is approximated via saturation adjustment, and should be within a physical tolerance
 
-    for FT in float_types
-        profiles = PhaseEquilProfiles(param_set, FT)
+    for ArrayType in array_types
+        FT = eltype(ArrayType)
+        profiles = PhaseEquilProfiles(param_set, ArrayType)
         @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
         # PhaseEquil
@@ -595,8 +597,9 @@ end
 
 @testset "Thermodynamics - exceptions on failed convergence" begin
 
-    FT = Float64
-    profiles = PhaseEquilProfiles(param_set, FT)
+    ArrayType = Array{Float64}
+    FT = eltype(ArrayType)
+    profiles = PhaseEquilProfiles(param_set, ArrayType)
     @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
     @test_throws ErrorException MT.saturation_adjustment.(
@@ -665,10 +668,11 @@ end
 
     # Make sure `ThermodynamicState` arguments are returned unchanged
 
-    for FT in float_types
+    for ArrayType in array_types
+        FT = eltype(ArrayType)
         _MSLP = FT(MSLP(param_set))
 
-        profiles = PhaseDryProfiles(param_set, FT)
+        profiles = PhaseDryProfiles(param_set, ArrayType)
         @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
         # PhaseDry
@@ -685,7 +689,7 @@ end
         @test all(air_density.(ts_p) .≈ air_density.(ts))
         @test all(internal_energy.(ts_p) .≈ internal_energy.(ts))
 
-        profiles = PhaseEquilProfiles(param_set, FT)
+        profiles = PhaseEquilProfiles(param_set, ArrayType)
         @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
         # PhaseEquil
@@ -864,7 +868,7 @@ end
         )
 
 
-        profiles = PhaseEquilProfiles(param_set, FT)
+        profiles = PhaseEquilProfiles(param_set, ArrayType)
         @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
         # Test that relative humidity is 1 for saturated conditions
@@ -952,8 +956,9 @@ end
 
     # NOTE: `Float32` saturation adjustment tends to have more difficulty
     # with converging to the same tolerances as `Float64`, so they're relaxed here.
-    FT = Float32
-    profiles = PhaseEquilProfiles(param_set, FT)
+    ArrayType = Array{Float32}
+    FT = eltype(ArrayType)
+    profiles = PhaseEquilProfiles(param_set, ArrayType)
     @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
     ρu = FT[1.0, 2.0, 3.0]
@@ -1060,8 +1065,9 @@ end
 
 @testset "Thermodynamics - dry limit" begin
 
-    FT = Float64
-    profiles = PhaseEquilProfiles(param_set, FT)
+    ArrayType = Array{Float64}
+    FT = eltype(ArrayType)
+    profiles = PhaseEquilProfiles(param_set, ArrayType)
     @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
     # PhasePartition test is noisy, so do this only once:


### PR DESCRIPTION
# Description

Thermodynamics currently has no GPU tests. It would be nice to ensure that all thermo constructors, and `fun(::ThermodynamicState)` methods, work on the GPU. This PR makes `profiles` use given `ArrayType`'s, which should have the flexibility to reside on the GPU.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
