### PR TITLE
Simpler calculation of hyperdiffusive variables indices

### DIFF
--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -192,7 +192,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
             grid.vgeo,
             t,
             grid.D,
-            hypervisc_indexmap,
+            Val(hypervisc_indexmap),
             topology.realelems,
             ndrange = (Nq * nrealelem, Nq),
             dependencies = (comp_stream,),
@@ -214,7 +214,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
             grid.vmap⁻,
             grid.vmap⁺,
             grid.elemtobndy,
-            hypervisc_indexmap,
+            Val(hypervisc_indexmap),
             grid.interiorelems;
             ndrange = ndrange_interior_surface,
             dependencies = (comp_stream,),
@@ -255,7 +255,7 @@ function (dg::DGModel)(tendency, state_conservative, _, t, α, β)
             grid.vmap⁻,
             grid.vmap⁺,
             grid.elemtobndy,
-            hypervisc_indexmap,
+            Val(hypervisc_indexmap),
             grid.exteriorelems;
             ndrange = ndrange_exterior_surface,
             dependencies = (comp_stream, exchange_state_conservative),

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -848,9 +848,9 @@ end
     vgeo,
     t,
     D,
-    hypervisc_indexmap,
+    ::Val{hypervisc_indexmap},
     elems,
-) where {dim, polyorder}
+) where {dim, polyorder, hypervisc_indexmap}
     @uniform begin
         N = polyorder
 
@@ -1026,9 +1026,9 @@ end
     vgeo,
     t,
     D,
-    hypervisc_indexmap,
+    ::Val{hypervisc_indexmap},
     elems,
-) where {dim, polyorder}
+) where {dim, polyorder, hypervisc_indexmap}
     @uniform begin
         N = polyorder
 
@@ -1207,9 +1207,9 @@ end
     vmap⁻,
     vmap⁺,
     elemtobndy,
-    hypervisc_indexmap,
+    ::Val{hypervisc_indexmap},
     elems,
-) where {dim, polyorder}
+) where {dim, polyorder, hypervisc_indexmap}
     @uniform begin
         N = polyorder
         FT = eltype(state_conservative)


### PR DESCRIPTION
# Description

This PR:
- Replaces `create_hypervisc_indexmap` with a simple application of `varsindices`
- Passes the resulting mapping as a compile time constant to get rid of local memory accesses on the GPU (resulting
from indirect addressing of the form `A[B[i]]`) which improves performance

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
