### PR TITLE
Revamp bc interface to remove `X_bottom1` from DG kernels

### DIFF
--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -84,8 +84,7 @@ function numerical_boundary_flux_gradient!(
     state_auxiliary⁺::Vars{A},
     bctype,
     t,
-    state1⁻::Vars{S},
-    aux1⁻::Vars{A},
+    bc_extra_data,
 ) where {D, T, S, A}
     boundary_state!(
         numerical_flux,
@@ -97,8 +96,7 @@ function numerical_boundary_flux_gradient!(
         state_auxiliary⁻,
         bctype,
         t,
-        state1⁻,
-        aux1⁻,
+        bc_extra_data,
     )
 
     compute_gradient_argument!(
@@ -147,8 +145,7 @@ function numerical_boundary_flux_first_order!(
     bctype,
     t,
     direction,
-    state1⁻::Vars{S},
-    aux1⁻::Vars{A},
+    bc_extra_data,
 ) where {S, A}
 
     boundary_state!(
@@ -161,8 +158,7 @@ function numerical_boundary_flux_first_order!(
         state_auxiliary⁻,
         bctype,
         t,
-        state1⁻,
-        aux1⁻,
+        bc_extra_data,
     )
 
     numerical_flux_first_order!(
@@ -529,9 +525,7 @@ numerical_boundary_flux_second_order!(
     state_auxiliary⁺::Vars{A},
     bctype,
     t,
-    state1⁻::Vars{S},
-    diff1⁻::Vars{D},
-    aux1⁻::Vars{A},
+    bc_extra_data,
 ) where {S, D, HD, A} = normal_boundary_flux_second_order!(
     numerical_flux,
     balance_law,
@@ -547,9 +541,7 @@ numerical_boundary_flux_second_order!(
     state_auxiliary⁺,
     bctype,
     t,
-    state1⁻,
-    diff1⁻,
-    aux1⁻,
+    bc_extra_data,
 )
 
 function normal_boundary_flux_second_order!(
@@ -567,9 +559,7 @@ function normal_boundary_flux_second_order!(
     state_auxiliary⁺,
     bctype,
     t,
-    state1⁻,
-    diff1⁻,
-    aux1⁻,
+    bc_extra_data,
 ) where {S}
     FT = eltype(fluxᵀn)
     num_state_conservative = number_state_conservative(balance_law, FT)
@@ -592,9 +582,7 @@ function normal_boundary_flux_second_order!(
         state_auxiliary⁻,
         bctype,
         t,
-        state1⁻,
-        diff1⁻,
-        aux1⁻,
+        bc_extra_data,
     )
 
     fluxᵀn .+= flux' * normal_vector
@@ -616,9 +604,7 @@ function boundary_flux_second_order!(
     state_auxiliary⁻,
     bctype,
     t,
-    state1⁻,
-    diff1⁻,
-    aux1⁻,
+    bc_extra_data,
 )
     boundary_state!(
         numerical_flux,
@@ -632,9 +618,7 @@ function boundary_flux_second_order!(
         state_auxiliary⁻,
         bctype,
         t,
-        state1⁻,
-        diff1⁻,
-        aux1⁻,
+        bc_extra_data,
     )
     flux_second_order!(
         balance_law,

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -568,8 +568,7 @@ function numerical_boundary_flux_first_order!(
     bctype,
     t,
     ::Dirs,
-    state_conservative1⁻::Vars{S},
-    state_auxiliary1⁻::Vars{A},
+    bc_extra_data,
 ) where {NumSubFluxes, S, A, Dirs <: NTuple{2, Direction}}
     # Since the fluxes are allowed to modified these we need backups so they can
     # be reset as we go
@@ -594,8 +593,7 @@ function numerical_boundary_flux_first_order!(
             bctype,
             t,
             (rem_balance_law.maindir,),
-            state_conservative1⁻,
-            state_auxiliary1⁻,
+            bc_extra_data,
         )
     end
 
@@ -621,16 +619,11 @@ function numerical_boundary_flux_first_order!(
                 MVector{num_state_conservative, FT}(undef)
             a_sub_state_conservative⁺ =
                 MVector{num_state_conservative, FT}(undef)
-            a_sub_state_conservative1⁻ =
-                MVector{num_state_conservative, FT}(undef)
 
             state_rng = static(1):static(number_state_conservative(sub, FT))
             a_sub_fluxᵀn .= a_fluxᵀn[state_rng]
             a_sub_state_conservative⁻ .= parent(state_conservative⁻)[state_rng]
             a_sub_state_conservative⁺ .= parent(state_conservative⁺)[state_rng]
-            a_sub_state_conservative1⁻ .=
-                parent(state_conservative1⁻)[state_rng]
-
 
             # compute this submodels flux
             fill!(a_sub_fluxᵀn, -zero(eltype(a_sub_fluxᵀn)))
@@ -650,10 +643,7 @@ function numerical_boundary_flux_first_order!(
                 bctype,
                 t,
                 (rem_balance_law.subsdir[k],),
-                Vars{vars_state_conservative(sub, FT)}(
-                    a_sub_state_conservative1⁻,
-                ),
-                state_auxiliary1⁻,
+                bc_extra_data,
             )
 
             # Subtract off this sub models flux

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -141,8 +141,7 @@ function numerical_boundary_flux_first_order!(
     bctype,
     t,
     direction,
-    state1⁻::Vars{S},
-    aux1⁻::Vars{A},
+    args...,
 ) where {S, A}
     un = dot(n, aux⁻.vel)
 

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -212,7 +212,7 @@ function run(
         ))
 
         # Test that wavespeeds are split by direction
-        every_wavespeed = full_wavespeed - acoustic_wavespeed
+        every_wavespeed = full_wavespeed .- acoustic_wavespeed
         horz_wavespeed = -zero(FT)
         vert_wavespeed = -zero(FT)
         @test all(


### PR DESCRIPTION
The bottom `X_bottom1` arrays in the `DGModel_kernels.jl` are atmos specific, this makes the interface a bit more general purpose for future extensions.