### PR TITLE
Add input space plots to thermo constructors

### DIFF
--- a/docs/plothelpers.jl
+++ b/docs/plothelpers.jl
@@ -2,10 +2,6 @@
 export_plot(z, all_data, ϕ_all, filename, ylabel; xlabel) = nothing
 export_plot_snapshot(z, all_data, ϕ_all, filename, ylabel) = nothing
 
-# using Requires
-# @init @require Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80" begin
-#   using .Plots
-
 """
     plot_friendly_name(ϕ)
 
@@ -93,4 +89,38 @@ function export_plot_snapshot(z, all_data, ϕ_all, filename, ylabel)
     savefig(filename)
 end
 
-# end
+function save_binned_surface_plots(
+    x,
+    y,
+    z,
+    title,
+    filename,
+    n_plots = (3, 3),
+    z_label_prefix = "z",
+    n_digits = 5,
+)
+    n_z_partitions = prod(n_plots)
+    z_min_global = min(z...)
+    z_max_global = max(z...)
+    Δz = (z_max_global - z_min_global) / n_z_partitions
+    z_min = ntuple(i -> z_min_global + (i - 1) * Δz, n_z_partitions)
+    z_max = ntuple(i -> z_min_global + (i) * Δz, n_z_partitions)
+    p = []
+    for i in 1:n_z_partitions
+        mask = z_min[i] .<= z .<= z_max[i]
+        x_i = x[mask]
+        y_i = y[mask]
+        sz_min = string(z_min[i])[1:min(n_digits, length(string(z_min[i])))]
+        sz_max = string(z_max[i])[1:min(n_digits, length(string(z_max[i])))]
+        p_i = plot(
+            x_i,
+            y_i,
+            title = "$(title), in ($sz_min, $sz_max)",
+            seriestype = :scatter,
+            markersize = 5,
+        )
+        push!(p, p_i)
+    end
+    plot(p..., layout = n_plots, legend = false)
+    savefig(filename)
+end;

--- a/docs/src/HowToGuides/Common/Thermodynamics.md
+++ b/docs/src/HowToGuides/Common/Thermodynamics.md
@@ -184,3 +184,112 @@ savefig("tested_profiles_virt_temp.svg")
 ```
 ![](tested_profiles_virt_temp.svg)
 
+## Input space exploration
+
+In the previous section, we plotted the tested thermodynamic
+states. In this section, we explore the convergence of the
+input space beyond what is tested. In particular, rather than
+being interested in physically meaningful combinations of
+constructor inputs (e.g., `ρ, e_int, q_tot`), we are interested
+in all permutations of inputs within a given range of `ρ, e_int,
+q_tot`. Some of these permutations may not be physically meaningful,
+or likely to be observed in climate simulations, but showing
+the convergence space helps illustrate the buffer between our
+tested profiles and the nearest space where convergence fails.
+
+```@example
+using ClimateMachine.Thermodynamics
+using ClimateMachine.TemperatureProfiles
+using CLIMAParameters
+using CLIMAParameters.Planet
+using Plots
+import ClimateMachine.Thermodynamics
+Thermodynamics.print_warning() = false
+
+struct EarthParameterSet <: AbstractEarthParameterSet end;
+const param_set = EarthParameterSet();
+FT = Float64;
+clima_root = joinpath(@__DIR__, repeat([".."], 4)...);
+include(joinpath(clima_root, "test", "Common", "Thermodynamics", "profiles.jl"))
+include(joinpath(clima_root, "docs", "plothelpers.jl"));
+profiles = PhaseEquilProfiles(param_set, Array{FT});
+@unpack_fields profiles ρ e_int q_tot
+
+dims = (10, 10, 10);
+ρ = range(min(ρ...), stop=max(ρ...), length=dims[1]);
+e_int = range(min(e_int...), stop=max(e_int...), length=dims[2]);
+q_tot = range(min(q_tot...), stop=max(q_tot...), length=dims[3]);
+
+ρ_all = Array{FT}(undef, prod(dims));
+e_int_all = Array{FT}(undef, prod(dims));
+q_tot_all = Array{FT}(undef, prod(dims));
+
+linear_indices = LinearIndices((1:dims[1], 1:dims[2], 1:dims[3]));
+TS = Array{Union{ThermodynamicState, Nothing}}(undef, prod(dims));
+TS_no_err = Array{ThermodynamicState}(undef, prod(dims));
+
+@inbounds for i in linear_indices.indices[1]
+    @inbounds for j in linear_indices.indices[2]
+        @inbounds for k in linear_indices.indices[3]
+            p = linear_indices[i, j, k];
+            ρ_all[p] = ρ[i];
+            e_int_all[p] = e_int[j];
+            q_tot_all[p] = q_tot[k];
+
+            Thermodynamics.error_on_non_convergence() = false
+            TS_no_err[p] = PhaseEquil(param_set, e_int[j], ρ[i], q_tot[k]);
+            Thermodynamics.error_on_non_convergence() = true
+            # @show p/prod(linear_indices.indices)*100
+            try
+                TS[p] = PhaseEquil(param_set, e_int[j], ρ[i], q_tot[k]);
+            catch
+                TS[p] = nothing
+            end
+        end
+    end
+end
+
+# Full 3D scatter plot
+function save_masked_plot3D(TS_no_err, mask, title, filename)
+    ρ_mask = ρ_all[mask];
+    T_mask = air_temperature.(TS_no_err[mask]);
+    q_tot_mask = q_tot_all[mask];
+    pts = (ρ_mask, T_mask, q_tot_mask)
+    Plots.plot(pts..., seriestype=:scatter, markersize = 7)
+    plot!(xlabel="Density",
+          ylabel="Temperature",
+          zlabel="Total specific humidity",
+          title="$title")
+    savefig(filename)
+end;
+
+save_masked_plot3D(TS_no_err, TS .== nothing, "NC", "Scatter3DNonConverged.svg");
+save_masked_plot3D(TS_no_err, TS .!= nothing, "C", "Scatter3DConverged.svg");
+
+# 2D binned scatter plots
+function save_masked_plot2D_slices(TS_no_err, mask, title, filename)
+    ρ_mask = ρ_all[mask];
+    T_mask = air_temperature.(TS_no_err[mask]);
+    q_tot_mask = q_tot_all[mask];
+    save_binned_surface_plots(ρ_mask, T_mask, q_tot_mask, title, filename)
+end;
+
+save_masked_plot2D_slices(TS_no_err, TS .== nothing, "NC", "Slices2DNonConverged.svg");
+save_masked_plot2D_slices(TS_no_err, TS .!= nothing, "C", "Slices2DConverged.svg");
+
+@warn "Note that the temperature axis for the non-converged
+plot is not necessarily accurate, since the temperatures are
+the result of a non-converged saturation adjustment"
+```
+
+## Converged cases (3D view)
+![](Scatter3DConverged.svg)
+
+## Non-converged cases (3D view)
+![](Scatter3DNonConverged.svg)
+
+## Converged cases (2D view), binned by total specific humidity
+![](Slices2DConverged.svg)
+
+## Non-converged cases (2D view), binned by total specific humidity
+![](Slices2DNonConverged.svg)

--- a/src/Common/Thermodynamics/Thermodynamics.jl
+++ b/src/Common/Thermodynamics/Thermodynamics.jl
@@ -45,6 +45,9 @@ const APS = AbstractParameterSet
 # very large logs resulting in CI to seemingly hang.
 error_on_non_convergence() = true
 
+# Allow users to skip printing warnings on non-convergence
+print_warning() = true
+
 @inline q_pt_0(::Type{FT}) where {FT} = PhasePartition{FT}(FT(0), FT(0), FT(0))
 
 include("states.jl")

--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -1105,23 +1105,25 @@ function saturation_adjustment(
             maxiter,
         )
         if !sol.converged
-            @print("-----------------------------------------\n")
-            @print("maxiter reached in saturation_adjustment:\n")
-            @print(
-                "    e_int=",
-                e_int,
-                ", ρ=",
-                ρ,
-                ", q_tot=",
-                q_tot,
-                ", T = ",
-                sol.root,
-                ", maxiter=",
-                maxiter,
-                ", tol=",
-                tol.tol,
-                "\n"
-            )
+            if print_warning()
+                @print("-----------------------------------------\n")
+                @print("maxiter reached in saturation_adjustment:\n")
+                @print(
+                    "    e_int=",
+                    e_int,
+                    ", ρ=",
+                    ρ,
+                    ", q_tot=",
+                    q_tot,
+                    ", T = ",
+                    sol.root,
+                    ", maxiter=",
+                    maxiter,
+                    ", tol=",
+                    tol.tol,
+                    "\n"
+                )
+            end
             if error_on_non_convergence()
                 error("Failed to converge with printed set of inputs.")
             end
@@ -1208,23 +1210,25 @@ function saturation_adjustment_SecantMethod(
             maxiter,
         )
         if !sol.converged
-            @print("-----------------------------------------\n")
-            @print("maxiter reached in saturation_adjustment_SecantMethod:\n")
-            @print(
-                "    e_int=",
-                e_int,
-                ", ρ=",
-                ρ,
-                ", q_tot=",
-                q_tot,
-                ", T = ",
-                sol.root,
-                ", maxiter=",
-                maxiter,
-                ", tol=",
-                tol.tol,
-                "\n"
-            )
+            if print_warning()
+                @print("-----------------------------------------\n")
+                @print("maxiter reached in saturation_adjustment_SecantMethod:\n")
+                @print(
+                    "    e_int=",
+                    e_int,
+                    ", ρ=",
+                    ρ,
+                    ", q_tot=",
+                    q_tot,
+                    ", T = ",
+                    sol.root,
+                    ", maxiter=",
+                    maxiter,
+                    ", tol=",
+                    tol.tol,
+                    "\n"
+                )
+            end
             if error_on_non_convergence()
                 error("Failed to converge with printed set of inputs.")
             end
@@ -1295,23 +1299,25 @@ function saturation_adjustment_q_tot_θ_liq_ice(
             maxiter,
         )
         if !sol.converged
-            @print("-----------------------------------------\n")
-            @print("maxiter reached in saturation_adjustment_q_tot_θ_liq_ice:\n")
-            @print(
-                "    θ_liq_ice=",
-                θ_liq_ice,
-                ", ρ=",
-                ρ,
-                ", q_tot=",
-                q_tot,
-                ", T = ",
-                sol.root,
-                ", maxiter=",
-                maxiter,
-                ", tol=",
-                tol.tol,
-                "\n"
-            )
+            if print_warning()
+                @print("-----------------------------------------\n")
+                @print("maxiter reached in saturation_adjustment_q_tot_θ_liq_ice:\n")
+                @print(
+                    "    θ_liq_ice=",
+                    θ_liq_ice,
+                    ", ρ=",
+                    ρ,
+                    ", q_tot=",
+                    q_tot,
+                    ", T = ",
+                    sol.root,
+                    ", maxiter=",
+                    maxiter,
+                    ", tol=",
+                    tol.tol,
+                    "\n"
+                )
+            end
             if error_on_non_convergence()
                 error("Failed to converge with printed set of inputs.")
             end
@@ -1385,23 +1391,25 @@ function saturation_adjustment_q_tot_θ_liq_ice_given_pressure(
             maxiter,
         )
         if !sol.converged
-            @print("-----------------------------------------\n")
-            @print("maxiter reached in saturation_adjustment_q_tot_θ_liq_ice_given_pressure:\n")
-            @print(
-                "    θ_liq_ice=",
-                θ_liq_ice,
-                ", p=",
-                p,
-                ", q_tot=",
-                q_tot,
-                ", T = ",
-                sol.root,
-                ", maxiter=",
-                maxiter,
-                ", tol=",
-                tol.tol,
-                "\n"
-            )
+            if print_warning()
+                @print("-----------------------------------------\n")
+                @print("maxiter reached in saturation_adjustment_q_tot_θ_liq_ice_given_pressure:\n")
+                @print(
+                    "    θ_liq_ice=",
+                    θ_liq_ice,
+                    ", p=",
+                    p,
+                    ", q_tot=",
+                    q_tot,
+                    ", T = ",
+                    sol.root,
+                    ", maxiter=",
+                    maxiter,
+                    ", tol=",
+                    tol.tol,
+                    "\n"
+                )
+            end
             if error_on_non_convergence()
                 error("Failed to converge with printed set of inputs.")
             end
@@ -1583,23 +1591,25 @@ function temperature_and_humidity_from_virtual_temperature(
         maxiter,
     )
     if !sol.converged
-        @print("-----------------------------------------\n")
-        @print("maxiter reached in temperature_and_humidity_from_virtual_temperature:\n")
-        @print(
-            "    T_virt=",
-            T_virt,
-            ", RH=",
-            RH,
-            ", ρ=",
-            ρ,
-            ", T = ",
-            sol.root,
-            ", maxiter=",
-            maxiter,
-            ", tol=",
-            tol.tol,
-            "\n"
-        )
+        if print_warning()
+            @print("-----------------------------------------\n")
+            @print("maxiter reached in temperature_and_humidity_from_virtual_temperature:\n")
+            @print(
+                "    T_virt=",
+                T_virt,
+                ", RH=",
+                RH,
+                ", ρ=",
+                ρ,
+                ", T = ",
+                sol.root,
+                ", maxiter=",
+                maxiter,
+                ", tol=",
+                tol.tol,
+                "\n"
+            )
+        end
         if error_on_non_convergence()
             error("Failed to converge with printed set of inputs.")
         end
@@ -1684,27 +1694,29 @@ function air_temperature_from_liquid_ice_pottemp_non_linear(
         maxiter,
     )
     if !sol.converged
-        @print("-----------------------------------------\n")
-        @print("maxiter reached in air_temperature_from_liquid_ice_pottemp_non_linear:\n")
-        @print(
-            "    θ_liq_ice=",
-            θ_liq_ice,
-            ", ρ=",
-            ρ,
-            ", q.tot=",
-            q.tot,
-            "q.liq = ",
-            q.liq,
-            "q.ice = ",
-            q.ice,
-            ", T = ",
-            sol.root,
-            ", maxiter=",
-            maxiter,
-            ", tol=",
-            tol.tol,
-            "\n"
-        )
+        if print_warning()
+            @print("-----------------------------------------\n")
+            @print("maxiter reached in air_temperature_from_liquid_ice_pottemp_non_linear:\n")
+            @print(
+                "    θ_liq_ice=",
+                θ_liq_ice,
+                ", ρ=",
+                ρ,
+                ", q.tot=",
+                q.tot,
+                "q.liq = ",
+                q.liq,
+                "q.ice = ",
+                q.ice,
+                ", T = ",
+                sol.root,
+                ", maxiter=",
+                maxiter,
+                ", tol=",
+                tol.tol,
+                "\n"
+            )
+        end
         if error_on_non_convergence()
             error("Failed to converge with printed set of inputs.")
         end


### PR DESCRIPTION
# Description

For some strange reason, after rebasing and pushing #551, apparently, the delta (changes against master) was 0 and the PR was automatically closed. This PR re-applies what was in #551:

 - Adds plots showing space of converged & non-converged saturation adjustment for permutations of the inputs to thermodynamic constructors
 - Adds a plot-helper that bins the 3D plot into several 2D scatter plots.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
