### PR TITLE
Validate `ClimateMachine.init()` keyword arguments

### DIFF
--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -2,7 +2,6 @@ using StaticArrays
 using Test
 
 using ClimateMachine
-ClimateMachine.init()
 using ClimateMachine.Atmos
 using ClimateMachine.Orientations
 using ClimateMachine.Mesh.Grids
@@ -60,6 +59,9 @@ function init_test!(bl, state, aux, (x, y, z), t)
 end
 
 function main()
+    @test_throws ArgumentError ClimateMachine.init(dsisable_gpu = true)
+    ClimateMachine.init()
+
     FT = Float64
 
     # DG polynomial order


### PR DESCRIPTION
# Description

Closes #1333.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [X] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
