### PR TITLE
Add `GenericCallbacks.fini!()`

### DIFF
--- a/docs/src/APIs/Numerics/ODESolvers/ODESolvers.md
+++ b/docs/src/APIs/Numerics/ODESolvers/ODESolvers.md
@@ -83,7 +83,8 @@ ODESolvers.updatedt!
 
 ```@docs
 GenericCallbacks
-GenericCallbacks.AtStart
+GenericCallbacks.AtInit
+GenericCallbacks.AtInitAndFini
 GenericCallbacks.EveryXWallTimeSeconds
 GenericCallbacks.EveryXSimulationTime
 GenericCallbacks.EveryXSimulationSteps

--- a/src/Diagnostics/groups.jl
+++ b/src/Diagnostics/groups.jl
@@ -28,18 +28,16 @@ mutable struct DiagnosticsGroup
     ) = new(name, init, fini, collect, interval, out_prefix, writer, interpol)
 end
 
-
-function GenericCallbacks.init!(dgngrp::DiagnosticsGroup, solver, Q, param, t0)
+function GenericCallbacks.init!(dgngrp::DiagnosticsGroup, solver, Q, param, t)
     @info @sprintf(
         """
     Diagnostics: %s
-        %s at %8.2f""",
+        initializing at %8.2f""",
         dgngrp.name,
-        "initializing",
-        t0,
+        t,
     )
-    dgngrp.init(dgngrp, t0)
-    dgngrp.collect(dgngrp, t0)
+    dgngrp.init(dgngrp, t)
+    dgngrp.collect(dgngrp, t)
     return nothing
 end
 function GenericCallbacks.call!(dgngrp::DiagnosticsGroup, solver, Q, param, t)
@@ -47,16 +45,26 @@ function GenericCallbacks.call!(dgngrp::DiagnosticsGroup, solver, Q, param, t)
     @info @sprintf(
         """
     Diagnostics: %s
-        %s at %8.2f""",
+        collecting at %8.2f""",
         dgngrp.name,
-        "collecting",
         t,
     )
     dgngrp.collect(dgngrp, t)
     @toc diagnostics
     return nothing
 end
-
+function GenericCallbacks.fini!(dgngrp::DiagnosticsGroup, solver, Q, param, t)
+    @info @sprintf(
+        """
+    Diagnostics: %s
+        finishing at %8.2f""",
+        dgngrp.name,
+        t,
+    )
+    dgngrp.collect(dgngrp, t)
+    dgngrp.fini(dgngrp, t)
+    return nothing
+end
 
 include("atmos_les_default.jl")
 """

--- a/src/Driver/Callbacks/Callbacks.jl
+++ b/src/Driver/Callbacks/Callbacks.jl
@@ -14,7 +14,7 @@ using CLIMAParameters.Planet: day
 using ..Courant
 using ..Checkpoint
 using ..DGMethods: courant
-using ..BalanceLaws: vars_state
+using ..BalanceLaws: vars_state, Prognostic, Auxiliary
 using ..Diagnostics
 using ..GenericCallbacks
 using ..MPIStateArrays
@@ -42,7 +42,7 @@ mutable struct SummaryLogCallback
     end
 end
 
-function GenericCallbacks.init!(cb::SummaryLogCallback, solver, Q, param, t0)
+function GenericCallbacks.init!(cb::SummaryLogCallback, solver, Q, param, t)
     cb.wtimestart = now()
     return nothing
 end
@@ -70,8 +70,9 @@ function GenericCallbacks.call!(cb::SummaryLogCallback, solver, Q, param, t)
     isnan(normQ) && error("norm(Q) is NaN")
     return nothing
 end
-
-
+function GenericCallbacks.fini!(cb::SummaryLogCallback, solver, Q, param, t)
+    return nothing
+end
 
 """
     show_updates(show_updates_opt, solver_config, user_info_callback)
@@ -86,15 +87,12 @@ function show_updates(show_updates_opt, solver_config, user_info_callback)
     if cb_constr !== nothing
         return cb_constr((
             SummaryLogCallback(solver_config.timeend),
-            GenericCallbacks.AtStart(user_info_callback),
+            GenericCallbacks.AtInit(user_info_callback),
         ))
     else
         return nothing
     end
 end
-
-
-
 
 """
     diagnostics(diagnostics_opt, solver_config, dgn_starttime, diagnostics_config)
@@ -131,70 +129,67 @@ file.
 """
 function vtk(vtk_opt, solver_config, output_dir, number_sample_points)
     cb_constr = CB_constructor(vtk_opt, solver_config)
-    if cb_constr !== nothing
-        vtknum = Ref(1)
+    cb_constr === nothing && return nothing
 
-        mpicomm = solver_config.mpicomm
-        dg = solver_config.dg
-        bl = dg.balance_law
-        Q = solver_config.Q
-        FT = eltype(Q)
+    vtknum = Ref(1)
 
-        cb_vtk = cb_constr() do
-            # TODO: make an object
-            @tic vtk
-            vprefix = @sprintf(
-                "%s_mpirank%04d_num%04d",
-                solver_config.name,
-                MPI.Comm_rank(mpicomm),
-                vtknum[],
-            )
-            outprefix = joinpath(output_dir, vprefix)
+    mpicomm = solver_config.mpicomm
+    dg = solver_config.dg
+    bl = dg.balance_law
+    Q = solver_config.Q
+    FT = eltype(Q)
 
-            statenames = flattenednames(vars_state(bl, Prognostic(), FT))
-            auxnames = flattenednames(vars_state(bl, Auxiliary(), FT))
+    cb_vtk = GenericCallbacks.AtInitAndFini() do
+        # TODO: make an object
+        vprefix = @sprintf(
+            "%s_mpirank%04d_num%04d",
+            solver_config.name,
+            MPI.Comm_rank(mpicomm),
+            vtknum[],
+        )
+        outprefix = joinpath(output_dir, vprefix)
 
-            writevtk(
-                outprefix,
-                Q,
-                dg,
-                statenames,
-                dg.state_auxiliary,
-                auxnames;
-                number_sample_points = number_sample_points,
-            )
+        statenames = flattenednames(vars_state(bl, Prognostic(), FT))
+        auxnames = flattenednames(vars_state(bl, Auxiliary(), FT))
 
-            # Generate the pvtu file for these vtk files
-            if MPI.Comm_rank(mpicomm) == 0
-                # name of the pvtu file
-                pprefix = @sprintf("%s_num%04d", solver_config.name, vtknum[])
-                pvtuprefix = joinpath(output_dir, pprefix)
+        writevtk(
+            outprefix,
+            Q,
+            dg,
+            statenames,
+            dg.state_auxiliary,
+            auxnames;
+            number_sample_points = number_sample_points,
+        )
 
-                # name of each of the ranks vtk files
-                prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
-                    @sprintf(
-                        "%s_mpirank%04d_num%04d",
-                        solver_config.name,
-                        i - 1,
-                        vtknum[],
-                    )
-                end
-                writepvtu(
-                    pvtuprefix,
-                    prefixes,
-                    (statenames..., auxnames...),
-                    eltype(Q),
+
+        # Generate the pvtu file for these vtk files
+        if MPI.Comm_rank(mpicomm) == 0
+            # name of the pvtu file
+            pprefix = @sprintf("%s_num%04d", solver_config.name, vtknum[])
+            pvtuprefix = joinpath(output_dir, pprefix)
+
+            # name of each of the ranks vtk files
+            prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+                @sprintf(
+                    "%s_mpirank%04d_num%04d",
+                    solver_config.name,
+                    i - 1,
+                    vtknum[],
                 )
             end
-
-            vtknum[] += 1
-            @toc vtk
-            nothing
+            writepvtu(
+                pvtuprefix,
+                prefixes,
+                (statenames..., auxnames...),
+                eltype(Q),
+            )
         end
-        return cb_vtk
-    else
-        return nothing
+
+        vtknum[] += 1
+        nothing
     end
+    return cb_constr(cb_vtk)
 end
 
 """
@@ -263,64 +258,62 @@ at `mcn_opt` intervals.
 """
 function monitor_courant_numbers(mcn_opt, solver_config)
     cb_constr = CB_constructor(mcn_opt, solver_config)
-    if cb_constr !== nothing
-        cb_cfl = cb_constr() do
-            Δt = solver_config.dt
-            c_v = courant(
-                nondiffusive_courant,
-                solver_config,
-                direction = VerticalDirection(),
-            )
-            c_h = courant(
-                nondiffusive_courant,
-                solver_config,
-                direction = HorizontalDirection(),
-            )
-            ca_v = courant(
-                advective_courant,
-                solver_config,
-                direction = VerticalDirection(),
-            )
-            ca_h = courant(
-                advective_courant,
-                solver_config,
-                direction = HorizontalDirection(),
-            )
-            cd_v = courant(
-                diffusive_courant,
-                solver_config,
-                direction = VerticalDirection(),
-            )
-            cd_h = courant(
-                diffusive_courant,
-                solver_config,
-                direction = HorizontalDirection(),
-            )
-            simtime = ODESolvers.gettime(solver_config.solver)
-            @info @sprintf(
-                """
+    cb_constr === nothing && return nothing
+
+    cb_cfl = cb_constr() do
+        Δt = solver_config.dt
+        c_v = courant(
+            nondiffusive_courant,
+            solver_config,
+            direction = VerticalDirection(),
+        )
+        c_h = courant(
+            nondiffusive_courant,
+            solver_config,
+            direction = HorizontalDirection(),
+        )
+        ca_v = courant(
+            advective_courant,
+            solver_config,
+            direction = VerticalDirection(),
+        )
+        ca_h = courant(
+            advective_courant,
+            solver_config,
+            direction = HorizontalDirection(),
+        )
+        cd_v = courant(
+            diffusive_courant,
+            solver_config,
+            direction = VerticalDirection(),
+        )
+        cd_h = courant(
+            diffusive_courant,
+            solver_config,
+            direction = HorizontalDirection(),
+        )
+        simtime = ODESolvers.gettime(solver_config.solver)
+        @info @sprintf(
+            """
 Courant numbers at simtime: %8.2f, Δt = %8.2f s
-    Acoustic (vertical) Courant number    = %.2g
-    Acoustic (horizontal) Courant number  = %.2g
-    Advection (vertical) Courant number   = %.2g
-    Advection (horizontal) Courant number = %.2g
-    Diffusion (vertical) Courant number   = %.2g
-    Diffusion (horizontal) Courant number = %.2g""",
-                simtime,
-                Δt,
-                c_v,
-                c_h,
-                ca_v,
-                ca_h,
-                cd_v,
-                cd_h,
-            )
-            nothing
-        end
-        return cb_cfl
-    else
-        return nothing
+Acoustic (vertical) Courant number    = %.2g
+Acoustic (horizontal) Courant number  = %.2g
+Advection (vertical) Courant number   = %.2g
+Advection (horizontal) Courant number = %.2g
+Diffusion (vertical) Courant number   = %.2g
+Diffusion (horizontal) Courant number = %.2g""",
+            simtime,
+            Δt,
+            c_v,
+            c_h,
+            ca_v,
+            ca_h,
+            cd_v,
+            cd_h,
+        )
+        nothing
     end
+    return cb_cfl
 end
 
 """
@@ -342,31 +335,29 @@ function checkpoint(
     checkpoint_dir,
 )
     cb_constr = CB_constructor(checkpoint_opt, solver_config)
-    if cb_constr !== nothing
-        cpnum = Ref(1)
-        cb_checkpoint = cb_constr() do
-            write_checkpoint(
-                solver_config,
+    cb_constr === nothing && return nothing
+
+    cpnum = Ref(1)
+    cb_checkpoint = cb_constr() do
+        write_checkpoint(
+            solver_config,
+            checkpoint_dir,
+            solver_config.name,
+            solver_config.mpicomm,
+            cpnum[],
+        )
+        if checkpoint_keep_one
+            rm_checkpoint(
                 checkpoint_dir,
                 solver_config.name,
                 solver_config.mpicomm,
-                cpnum[],
+                cpnum[] - 1,
             )
-            if checkpoint_keep_one
-                rm_checkpoint(
-                    checkpoint_dir,
-                    solver_config.name,
-                    solver_config.mpicomm,
-                    cpnum[] - 1,
-                )
-            end
-            cpnum[] += 1
-            nothing
         end
-        return cb_checkpoint
-    else
-        return nothing
+        cpnum[] += 1
+        nothing
     end
+    return cb_checkpoint
 end
 
 """

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -654,19 +654,6 @@ function invoke!(
         )
     end
 
-    # fini diagnostics groups
-    # TODO: come up with a better mechanism
-    if Settings.diagnostics != "never" && !isnothing(diagnostics_config)
-        currtime = ODESolvers.gettime(solver)
-        for dgngrp in diagnostics_config.groups
-            dgngrp.fini(dgngrp, currtime)
-        end
-    end
-
-    # fini VTK
-    !isnothing(cb_vtk) &&
-    GenericCallbacks.call!(cb_vtk, nothing, nothing, nothing, nothing)
-
     engf = norm(Q)
     @info @sprintf(
         """

--- a/src/Numerics/ODESolvers/ODESolvers.jl
+++ b/src/Numerics/ODESolvers/ODESolvers.jl
@@ -129,11 +129,15 @@ function solve!(
         end
 
         # Figure out if we should stop
-        if numberofsteps == step
-            return gettime(solver)
+        if step == numberofsteps
+            break
         end
     end
-    gettime(solver)
+
+    # Loop through to fini callbacks
+    GenericCallbacks.fini!(callbacks, solver, Q, param, time)
+
+    return gettime(solver)
 end
 # }}}
 


### PR DESCRIPTION
# Description

@akshaysridhar discovered that #1299 wasn't a sufficient fix (the final argument `t` is required and cannot be `nothing`). Then I saw that `call!`ing the VTK callback at finish checks if the requisite interval has expired first. So I added `fini!()` as a cleaner solution.

This should restore the original behavior for VTK and for diagnostics, i.e.:
1. Collect at `t0`.
2. Collect at specified intervals.
3. Collect at `timeend`.

If anyone prefers different behavior, please speak up!

This does not solve #1310 and #1085 will require further tweaks.

Closes #1376.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [X] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
