### PR TITLE
Disable `linkcheck` for `docs-build`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -53,7 +53,6 @@ makedocs(
     sitename = "ClimateMachine",
     doctest = false,
     strict = true,
-    linkcheck = true,
     format = format,
     checkdocs = :exports,
     clean = true,


### PR DESCRIPTION
# Description

Doing `makedocs(linkcheck = true, strict = true)` as we were previously doing will cause CI to fail if any of the linked sites is temporarily down or if any link breaks. While we do want to check the links periodically, we can't allow CI to depend on `n` external sites.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
