### PR TITLE
Allow equispaced output in VTK

### DIFF
--- a/src/Driver/Callbacks/Callbacks.jl
+++ b/src/Driver/Callbacks/Callbacks.jl
@@ -179,7 +179,12 @@ function vtk(vtk_opt, solver_config, output_dir, number_sample_points)
                         vtknum[],
                     )
                 end
-                writepvtu(pvtuprefix, prefixes, (statenames..., auxnames...))
+                writepvtu(
+                    pvtuprefix,
+                    prefixes,
+                    (statenames..., auxnames...),
+                    eltype(Q),
+                )
             end
 
             vtknum[] += 1

--- a/src/Driver/Callbacks/Callbacks.jl
+++ b/src/Driver/Callbacks/Callbacks.jl
@@ -129,7 +129,7 @@ end
 Return a callback that saves state and auxiliary variables to a VTK
 file.
 """
-function vtk(vtk_opt, solver_config, output_dir)
+function vtk(vtk_opt, solver_config, output_dir, number_sample_points)
     cb_constr = CB_constructor(vtk_opt, solver_config)
     if cb_constr !== nothing
         vtknum = Ref(1)
@@ -154,7 +154,15 @@ function vtk(vtk_opt, solver_config, output_dir)
             statenames = flattenednames(vars_state_conservative(bl, FT))
             auxnames = flattenednames(vars_state_auxiliary(bl, FT))
 
-            writevtk(outprefix, Q, dg, statenames, dg.state_auxiliary, auxnames)
+            writevtk(
+                outprefix,
+                Q,
+                dg,
+                statenames,
+                dg.state_auxiliary,
+                auxnames;
+                number_sample_points = number_sample_points,
+            )
 
             # Generate the pvtu file for these vtk files
             if MPI.Comm_rank(mpicomm) == 0

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -58,6 +58,7 @@ Base.@kwdef mutable struct ClimateMachine_Settings
     show_updates::String = "60secs"
     diagnostics::String = "never"
     vtk::String = "never"
+    vtk_number_sample_points::Int = 0
     monitor_timestep_duration::String = "never"
     monitor_courant_numbers::String = "never"
     checkpoint::String = "never"
@@ -198,6 +199,12 @@ function parse_commandline(
         metavar = "<interval>"
         arg_type = String
         default = get_setting(:vtk, defaults, global_defaults)
+        "--vtk-number-sample-points"
+        help = "The number of sampling points in each element for VTK output"
+        metavar = "<number>"
+        arg_type = Int
+        default =
+            get_setting(:vtk_number_sample_points, defaults, global_defaults)
         "--monitor-timestep-duration"
         help = "interval in time-steps at which to output wall-clock time per time-step"
         metavar = "<interval>"
@@ -306,6 +313,8 @@ Recognized keyword arguments are:
         interval at which to collect diagnostics"
 - `vtk::String = "never"`:
         inteverval at which to write simulation vtk output
+- `vtk-number-sample-points::Int` = 0:
+        the number of sampling points in each element for VTK output
 - `monitor_timestep_duration::String = "never"`:
         interval in time-steps at which to output wall-clock time per time-step
 - `monitor_courant_numbers::String = "never"`:
@@ -561,7 +570,12 @@ function invoke!(
     end
 
     # vtk callback
-    cb_vtk = Callbacks.vtk(Settings.vtk, solver_config, Settings.output_dir)
+    cb_vtk = Callbacks.vtk(
+        Settings.vtk,
+        solver_config,
+        Settings.output_dir,
+        Settings.vtk_number_sample_points,
+    )
     if !isnothing(cb_vtk)
         callbacks = (callbacks..., cb_vtk)
     end

--- a/src/InputOutput/VTK/writepvtu.jl
+++ b/src/InputOutput/VTK/writepvtu.jl
@@ -1,12 +1,13 @@
 using ..TicToc
 
 """
-    writepvtu(pvtuprefix, vtkprefixes, fieldnames)
+    writepvtu(pvtuprefix, vtkprefixes, fieldnames, FT)
 
 Write a pvtu file with the prefix 'pvtuprefix' for the collection of vtk files
-given by 'vtkprefixes' using names  of fields 'fieldnames'
+given by 'vtkprefixes' using names  of fields 'fieldnames'. The data in the
+`vtu` files is of type `FT`.
 """
-function writepvtu(pvtuprefix, vtkprefixes, fieldnames)
+function writepvtu(pvtuprefix, vtkprefixes, fieldnames, FT)
     open(pvtuprefix * ".pvtu", "w") do pvtufile
         write(
             pvtufile,
@@ -15,7 +16,7 @@ function writepvtu(pvtuprefix, vtkprefixes, fieldnames)
             <VTKFile type="PUnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
               <PUnstructuredGrid GhostLevel="0">
                 <PPoints>
-                  <PDataArray type="Float64" Name="Position" NumberOfComponents="3" format="binary"/>
+                  <PDataArray type="$FT" Name="Position" NumberOfComponents="3" format="binary"/>
                 </PPoints>
                 <PPointData>
             """,
@@ -25,7 +26,7 @@ function writepvtu(pvtuprefix, vtkprefixes, fieldnames)
             write(
                 pvtufile,
                 """
-                      <PDataArray type="Float64" Name="$name" format="binary"/>
+                      <PDataArray type="$FT" Name="$name" format="binary"/>
                 """,
             )
         end

--- a/src/InputOutput/VTK/writevtk.jl
+++ b/src/InputOutput/VTK/writevtk.jl
@@ -1,12 +1,13 @@
 import KernelAbstractions: CPU
 
 using ..Mesh.Grids
+using ..Mesh.Elements: interpolationmatrix
 using ..MPIStateArrays
 using ..DGMethods
 using ..TicToc
 
 """
-    writevtk(prefix, Q::MPIStateArray, dg::DGModel [, fieldnames])
+    writevtk(prefix, Q::MPIStateArray, dg::DGModel [, fieldnames]; number_sample_points)
 
 Write a vtk file for all the fields in the state array `Q` using geometry and
 connectivity information from `dg.grid`. The filename will start with `prefix`
@@ -15,12 +16,27 @@ in the vtk file can be specified through the collection of strings `fieldnames`;
 if not specified the fields names will be `"Q1"` through `"Qk"` where `k` is the
 number of states in `Q`, i.e., `k = size(Q,2)`.
 
+If specified, fields are sampled on an equally spaced, tensor-product grid of
+points with 'number_sample_points' in each direction.
 """
-function writevtk(prefix, Q::MPIStateArray, dg::DGModel, fieldnames = nothing)
+function writevtk(
+    prefix,
+    Q::MPIStateArray,
+    dg::DGModel,
+    fieldnames = nothing;
+    number_sample_points = 0,
+)
     vgeo = dg.grid.vgeo
     device = array_device(Q)
     (h_vgeo, h_Q) = device isa CPU ? (vgeo, Q.data) : (Array(vgeo), Array(Q))
-    writevtk_helper(prefix, h_vgeo, h_Q, dg.grid, fieldnames)
+    writevtk_helper(
+        prefix,
+        h_vgeo,
+        h_Q,
+        dg.grid,
+        fieldnames;
+        number_sample_points = 0,
+    )
     return nothing
 end
 
@@ -41,6 +57,8 @@ If `auxfieldnames === nothing` then the fields names will be `"aux1"` through
 `"auxk"` where `k` is the number of states in `state_auxiliary`, i.e., `k =
 size(state_auxiliary,2)`.
 
+If specified, fields are sampled on an equally spaced, tensor-product grid of
+points with 'number_sample_points' in each direction.
 """
 function writevtk(
     prefix,
@@ -48,7 +66,8 @@ function writevtk(
     dg::DGModel,
     fieldnames,
     state_auxiliary,
-    auxfieldnames,
+    auxfieldnames;
+    number_sample_points = 0,
 )
     vgeo = dg.grid.vgeo
     device = array_device(Q)
@@ -62,11 +81,11 @@ function writevtk(
         dg.grid,
         fieldnames,
         h_aux,
-        auxfieldnames,
+        auxfieldnames;
+        number_sample_points = number_sample_points,
     )
     return nothing
 end
-
 
 """
     writevtk_helper(prefix, vgeo::Array, Q::Array, grid, fieldnames)
@@ -80,61 +99,65 @@ function writevtk_helper(
     grid,
     fieldnames,
     state_auxiliary = nothing,
-    auxfieldnames = nothing,
+    auxfieldnames = nothing;
+    number_sample_points,
 )
+    @assert number_sample_points >= 0
 
     dim = dimensionality(grid)
     N = polynomialorder(grid)
     Nq = N + 1
 
     nelem = size(Q)[end]
+
     Xid = (grid.x1id, grid.x2id, grid.x3id)
-    X = ntuple(
-        j -> reshape((@view vgeo[:, Xid[j], :]), ntuple(j -> Nq, dim)..., nelem),
-        dim,
+    X = ntuple(j -> (@view vgeo[:, Xid[j], :]), dim)
+    fields = ntuple(j -> (@view Q[:, j, :]), size(Q, 2))
+    auxfields = isnothing(state_auxiliary) ? () :
+        (
+        auxfields = ntuple(
+            j -> (@view state_auxiliary[:, j, :]),
+            size(state_auxiliary, 2),
+        )
     )
-    if fieldnames == nothing
-        fields = ntuple(
-            i -> ("Q$i", reshape((@view Q[:, i, :]), ntuple(j -> Nq, dim)..., nelem)),
-            size(Q, 2),
-        )
+
+    # Interpolate to an equally spaced grid if necessary
+    if number_sample_points > 0
+        FT = eltype(Q)
+        ξsrc = referencepoints(grid)
+        ξdst = range(FT(-1); length = number_sample_points, stop = 1)
+        I1d = interpolationmatrix(ξsrc, ξdst)
+        I = kron(ntuple(i -> I1d, dim)...)
+        fields = ntuple(i -> I * fields[i], length(fields))
+        auxfields = ntuple(i -> I * auxfields[i], length(auxfields))
+        X = ntuple(i -> I * X[i], length(X))
+        Nq = number_sample_points
+    end
+
+    X = ntuple(i -> reshape(X[i], ntuple(j -> Nq, dim)..., nelem), length(X))
+    fields = ntuple(
+        i -> reshape(fields[i], ntuple(j -> Nq, dim)..., nelem),
+        length(fields),
+    )
+    auxfields = ntuple(
+        i -> reshape(auxfields[i], ntuple(j -> Nq, dim)..., nelem),
+        length(auxfields),
+    )
+
+    if fieldnames === nothing
+        fields = ntuple(i -> ("Q$i", fields[i]), length(fields))
     else
-        fields = ntuple(
-            i -> (
-                fieldnames[i],
-                reshape((@view Q[:, i, :]), ntuple(j -> Nq, dim)..., nelem),
-            ),
-            size(Q, 2),
-        )
+        fields = ntuple(i -> (fieldnames[i], fields[i]), length(fields))
     end
-    if state_auxiliary !== nothing
-        if auxfieldnames === nothing
-            auxfields = ntuple(
-                i -> (
-                    "aux$i",
-                    reshape(
-                        (@view state_auxiliary[:, i, :]),
-                        ntuple(j -> Nq, dim)...,
-                        nelem,
-                    ),
-                ),
-                size(state_auxiliary, 2),
-            )
-        else
-            auxfields = ntuple(
-                i -> (
-                    auxfieldnames[i],
-                    reshape(
-                        (@view state_auxiliary[:, i, :]),
-                        ntuple(j -> Nq, dim)...,
-                        nelem,
-                    ),
-                ),
-                size(state_auxiliary, 2),
-            )
-        end
-        fields = (fields..., auxfields...)
+
+    if auxfieldnames === nothing
+        auxfields = ntuple(i -> ("aux$i", auxfields[i]), length(auxfields))
+    else
+        auxfields =
+            ntuple(i -> (auxfieldnames[i], auxfields[i]), length(auxfields))
     end
+
+    fields = (fields..., auxfields...)
     writemesh(
         prefix,
         X...;

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -326,7 +326,7 @@ function do_output(
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., auxnames...))
+        writepvtu(pvtuprefix, prefixes, (statenames..., auxnames...), eltype(Q))
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -367,7 +367,7 @@ function do_output(
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., auxnames...))
+        writepvtu(pvtuprefix, prefixes, (statenames..., auxnames...), eltype(Q))
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -370,7 +370,12 @@ function do_output(
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -383,7 +383,12 @@ function do_output(
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -368,7 +368,12 @@ function do_output(
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -378,7 +378,12 @@ function do_output(
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -390,7 +390,12 @@ function do_output(
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
@@ -97,7 +97,12 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
@@ -180,7 +180,12 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
@@ -86,7 +86,12 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
@@ -91,7 +91,12 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
@@ -97,7 +97,12 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
@@ -97,7 +97,12 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
 
         @info "Done writing VTK: $pvtuprefix"
     end

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_heat_eqn.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_heat_eqn.jl
@@ -12,7 +12,6 @@ using Printf
 using Dates
 using ClimateMachine.GenericCallbacks:
     EveryXWallTimeSeconds, EveryXSimulationSteps
-using ClimateMachine.VTK: writevtk, writepvtu
 import ClimateMachine.DGMethods.NumericalFluxes:
     normal_boundary_flux_second_order!
 

--- a/test/Numerics/Mesh/min_node_distance.jl
+++ b/test/Numerics/Mesh/min_node_distance.jl
@@ -67,7 +67,7 @@ let
                 # filename(rank) = @sprintf("%s_mpirank%04d", testname, rank)
                 # writevtk(filename(MPI.Comm_rank(mpicomm)), grid)
                 # if MPI.Comm_rank(mpicomm) == 0
-                #   writepvtu(testname, filename.(0:MPI.Comm_size(mpicomm)-1), ())
+                #   writepvtu(testname, filename.(0:MPI.Comm_size(mpicomm)-1), (), FT)
                 # end
 
                 ξ = referencepoints(grid)

--- a/tutorials/Numerics/DGMethods/nonnegative.jl
+++ b/tutorials/Numerics/DGMethods/nonnegative.jl
@@ -106,7 +106,7 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, model, testname)
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
 
-        writepvtu(pvtuprefix, prefixes, statenames)
+        writepvtu(pvtuprefix, prefixes, statenames, eltype(Q))
 
         @info "Done writing VTK: $pvtuprefix"
     end


### PR DESCRIPTION
Previously only VTK output at the LGL nodes was supported, this allows interpolation to an equidistant grid of points which allows for better visualization.

Co-authored-by:  Thomas Gibson <thomas.gibson@nps.edu>