### PR TITLE
Add ViscousSponge to TurbulenceClosures

### DIFF
--- a/docs/src/APIs/Common/TurbulenceClosures.md
+++ b/docs/src/APIs/Common/TurbulenceClosures.md
@@ -20,6 +20,9 @@ HyperDiffusion
 NoHyperDiffusion
 DryBiharmonic
 EquilMoistBiharmonic
+ViscousSponge
+NoViscousSponge
+UpperAtmosSponge
 ```
 
 ## Supporting Methods


### PR DESCRIPTION
# Description

Adds a viscous sponge layer to turbulence closures. This sponge later can be used (just like the Rayleigh sponge layer that we already have) to damp waves near the top of the domain. 

`turbconv` and `turbulence` models can be used simultaneously with viscous sponges in this configuration.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
