### PR TITLE
Switch VTK to use VTK_LAGRANGE_XXX

### DIFF
--- a/src/InputOutput/VTK/writemesh.jl
+++ b/src/InputOutput/VTK/writemesh.jl
@@ -1,60 +1,110 @@
 using WriteVTK
 
-#=
-This is the 1D WriteMesh routine
-=#
-function writemesh(base_name, x1; fields = (), realelems = 1:size(x1)[end])
-    (Nqr, _) = size(x1)
-    Nsubcells = (Nqr - 1)
+function vtk_connectivity_map(Nqi, Nqj = 1, Nqk = 1)
+    connectivity = Array{Int, 1}(undef, Nqi * Nqj * Nqk)
+    L = LinearIndices((1:Nqi, 1:Nqj, 1:Nqk))
 
-    M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
-    cells = Array{M, 1}(undef, Nsubcells * length(realelems))
-    for e in realelems
-        offset = (e - 1) * Nqr
-        for i in 1:(Nqr - 1)
-            cells[i + (e - 1) * Nsubcells] =
-                MeshCell(VTKCellTypes.VTK_LINE, offset .+ [i, i + 1])
+    corners = (
+        (1, 1, 1),
+        (Nqi, 1, 1),
+        (Nqi, Nqj, 1),
+        (1, Nqj, 1),
+        (1, 1, Nqk),
+        (Nqi, 1, Nqk),
+        (Nqi, Nqj, Nqk),
+        (1, Nqj, Nqk),
+    )
+    edges = (
+        (2:(Nqi - 1), 1:1, 1:1),
+        (Nqi:Nqi, 2:(Nqj - 1), 1:1),
+        (2:(Nqi - 1), Nqj:Nqj, 1:1),
+        (1:1, 2:(Nqj - 1), 1:1, 1:1),
+        (2:(Nqi - 1), 1:1, Nqk:Nqk),
+        (Nqi:Nqi, 2:(Nqj - 1), Nqk:Nqk),
+        (2:(Nqi - 1), Nqj:Nqj, Nqk:Nqk),
+        (1:1, 2:(Nqj - 1), Nqk:Nqk),
+        (1:1, 1:1, 2:(Nqk - 1)),
+        (Nqi:Nqi, 1:1, 2:(Nqk - 1)),
+        (1:1, Nqj:Nqj, 2:(Nqk - 1)),
+        (Nqi:Nqi, Nqj:Nqj, 2:(Nqk - 1)),
+    )
+    faces = (
+        (1:1, 2:(Nqj - 1), 2:(Nqk - 1)),
+        (Nqi:Nqi, 2:(Nqj - 1), 2:(Nqk - 1)),
+        (2:(Nqi - 1), 1:1, 2:(Nqk - 1)),
+        (2:(Nqi - 1), Nqj:Nqj, 2:(Nqk - 1)),
+        (2:(Nqi - 1), 2:(Nqj - 1), 1:1),
+        (2:(Nqi - 1), 2:(Nqj - 1), Nqk:Nqk),
+    )
+    if Nqj == Nqk == 1
+        @assert Nqi > 1
+        corners = (corners[1:2]...,)
+        edges = (edges[1],)
+        faces = ()
+    elseif Nqk == 1
+        @assert Nqi > 1
+        @assert Nqj > 1
+        corners = (corners[1:4]...,)
+        edges = (edges[1:4]...,)
+        faces = (faces[5],)
+    end
+
+    # corners
+    iter = 1
+    for (i, j, k) in corners
+        connectivity[iter] = L[i, j, k]
+        iter += 1
+    end
+    # edges
+    for (is, js, ks) in edges
+        for k in ks, j in js, i in is
+            connectivity[iter] = L[i, j, k]
+            iter += 1
         end
     end
-
-    vtkfile = vtk_grid("$(base_name)", @view(x1[:]), cells; compress = false)
-    for (name, v) in fields
-        vtk_point_data(vtkfile, v, name)
+    # faces
+    for (is, js, ks) in faces
+        for k in ks, j in js, i in is
+            connectivity[iter] = L[i, j, k]
+            iter += 1
+        end
     end
-    outfiles = vtk_save(vtkfile)
+    # interior
+    for k in 2:(Nqk - 1), j in 2:(Nqj - 1), i in 2:(Nqi - 1)
+        connectivity[iter] = L[i, j, k]
+        iter += 1
+    end
+    return connectivity
 end
 
 #=
-This is the 2D WriteMesh routine
+This is the 1D WriteMesh routine
 =#
 function writemesh(
     base_name,
-    x1,
-    x2;
+    x1;
+    x2 = nothing,
     x3 = nothing,
     fields = (),
     realelems = 1:size(x1)[end],
 )
-    @assert size(x1) == size(x2)
-    (Nqr, Nqs, _) = size(x1)
-    Nsubcells = (Nqr - 1) * (Nqs - 1)
+    (Nqr, _) = size(x1)
+
+    con = vtk_connectivity_map(Nqr)
 
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
-    cells = Array{M, 1}(undef, Nsubcells * length(realelems))
-    ind = LinearIndices((1:Nqr, 1:Nqs))
-    for e in realelems
-        offset = (e - 1) * Nqr * Nqs
-        for j in 1:(Nqs - 1)
-            for i in 1:(Nqr - 1)
-                cells[i + (j - 1) * (Nqr - 1) + (e - 1) * Nsubcells] = MeshCell(
-                    VTKCellTypes.VTK_PIXEL,
-                    offset .+ ind[i:(i + 1), j:(j + 1)][:],
-                )
-            end
-        end
+    cells = Array{M, 1}(undef, length(realelems))
+
+    for (i, e) in enumerate(realelems)
+        offset = (e - 1) * Nqr
+        cells[i] = MeshCell(VTKCellTypes.VTK_LAGRANGE_CURVE, offset .+ con)
     end
 
-    if x3 == nothing
+    if x2 == nothing
+        @assert isnothing(x3)
+        vtkfile =
+            vtk_grid("$(base_name)", @view(x1[:]), cells; compress = false)
+    elseif x3 == nothing
         vtkfile = vtk_grid(
             "$(base_name)",
             @view(x1[:]),
@@ -79,6 +129,54 @@ function writemesh(
 end
 
 #=
+This is the 2D WriteMesh routine
+=#
+function writemesh(
+    base_name,
+    x1,
+    x2;
+    x3 = nothing,
+    fields = (),
+    realelems = 1:size(x1)[end],
+)
+    @assert size(x1) == size(x2)
+    (Nqr, Nqs, _) = size(x1)
+    @assert Nqr == Nqs
+    con = vtk_connectivity_map(Nqr, Nqs)
+
+    M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
+    cells = Array{M, 1}(undef, length(realelems))
+    for (i, e) in enumerate(realelems)
+        offset = (e - 1) * Nqr * Nqs
+        cells[i] =
+            MeshCell(VTKCellTypes.VTK_LAGRANGE_QUADRILATERAL, offset .+ con[:])
+    end
+
+    if x3 == nothing
+        vtkfile = vtk_grid(
+            "$(base_name)",
+            @view(x1[:]),
+            @view(x2[:]),
+            cells;
+            compress = false,
+        )
+    else
+        vtkfile = vtk_grid(
+            "$(base_name)",
+            @view(x1[:]),
+            @view(x2[:]),
+            @view(x3[:]),
+            cells;
+            compress = false,
+        )
+    end
+    for (name, v) in fields
+        vtk_cell_data(vtkfile, v, name)
+    end
+    outfiles = vtk_save(vtkfile)
+end
+
+#=
 This is the 3D WriteMesh routine
 =#
 function writemesh(
@@ -90,26 +188,13 @@ function writemesh(
     realelems = 1:size(x1)[end],
 )
     (Nqr, Nqs, Nqt, _) = size(x1)
-    (Nr, Ns, Nt) = (Nqr - 1, Nqs - 1, Nqt - 1)
-    Nsubcells = Nr * Ns * Nt
-
+    @assert Nqr == Nqs == Nqt
+    con = vtk_connectivity_map(Nqr, Nqs, Nqt)
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
-    cells = Array{M, 1}(undef, Nsubcells * length(realelems))
-    ind = LinearIndices((1:Nqr, 1:Nqs, 1:Nqt))
-    for e in realelems
+    cells = Array{M, 1}(undef, length(realelems))
+    for (i, e) in enumerate(realelems)
         offset = (e - 1) * Nqr * Nqs * Nqt
-        for k in 1:Nt
-            for j in 1:Ns
-                for i in 1:Nr
-                    cells[i + (j - 1) * Nr + (k - 1) * Nr * Ns + (e - 1) *
-                                                                 Nsubcells] =
-                        MeshCell(
-                            VTKCellTypes.VTK_VOXEL,
-                            offset .+ ind[i:(i + 1), j:(j + 1), k:(k + 1)][:],
-                        )
-                end
-            end
-        end
+        cells[i] = MeshCell(VTKCellTypes.VTK_LAGRANGE_HEXAHEDRON, offset .+ con)
     end
 
     vtkfile = vtk_grid(

--- a/test/InputOutput/VTK/runtests.jl
+++ b/test/InputOutput/VTK/runtests.jl
@@ -1,0 +1,82 @@
+using Test
+using GaussQuadrature
+using ClimateMachine.VTK: writemesh
+
+@testset "VTK" begin
+    for dim in 1:3
+        N = 5
+        nelem = 3
+        T = Float64
+
+        Nq = N + 1
+        (r, _) = GaussQuadrature.legendre(T, Nq, GaussQuadrature.both)
+        s = dim > 1 ? r : [0]
+        t = dim > 2 ? r : [0]
+        Nqi = length(r)
+        Nqj = length(s)
+        Nqk = length(t)
+        Np = Nqi * Nqj * Nqk
+
+        x1 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
+        x2 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
+        x3 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
+
+        for e in 1:nelem, k in 1:Nqk, j in 1:Nqj, i in 1:Nqi
+            xoffset = nelem + 1 - 2e
+            x1[i, j, k, e], x2[i, j, k, e], x3[i, j, k, e] =
+                r[i] - xoffset, s[j], t[k]
+        end
+
+        if dim == 1
+            x1 = x1 .^ 3
+        elseif dim == 2
+            x1, x2 = x1 + sin.(π * x2) / 5, x2 + exp.(-x1 .^ 2)
+        else
+            x1, x2, x3 = x1 + sin.(π * x2) / 5,
+            x2 + exp.(-hypot.(x1, x3) .^ 2),
+            x3 + sin.(π * x1) / 5
+        end
+        d = exp.(sin.(hypot.(x1, x2, x3)))
+        s = copy(d)
+
+        if dim == 1
+            @test "test$(dim)d.vtu" ==
+                  writemesh("test$(dim)d", x1; fields = (("d", d), ("s", s)))[1]
+            @test "test$(dim)d.vtu" == writemesh(
+                "test$(dim)d",
+                x1;
+                x2 = x2,
+                fields = (("d", d), ("s", s)),
+            )[1]
+            @test "test$(dim)d.vtu" == writemesh(
+                "test$(dim)d",
+                x1;
+                x2 = x2,
+                x3 = x3,
+                fields = (("d", d), ("s", s)),
+            )[1]
+        elseif dim == 2
+            @test "test$(dim)d.vtu" == writemesh(
+                "test$(dim)d",
+                x1,
+                x2;
+                fields = (("d", d), ("s", s)),
+            )[1]
+            @test "test$(dim)d.vtu" == writemesh(
+                "test$(dim)d",
+                x1,
+                x2;
+                x3 = x3,
+                fields = (("d", d), ("s", s)),
+            )[1]
+        elseif dim == 3
+            @test "test$(dim)d.vtu" == writemesh(
+                "test$(dim)d",
+                x1,
+                x2,
+                x3;
+                fields = (("d", d), ("s", s)),
+            )[1]
+        end
+    end
+end

--- a/test/InputOutput/runtests.jl
+++ b/test/InputOutput/runtests.jl
@@ -2,7 +2,7 @@ using Test, Pkg
 
 @testset "InputOutput" begin
     all_tests = isempty(ARGS) || "all" in ARGS ? true : false
-    for submodule in ["Writers"]
+    for submodule in ["VTK", "Writers"]
         if all_tests ||
            "$submodule" in ARGS ||
            "InputOutput/$submodule" in ARGS ||


### PR DESCRIPTION
By switching from `VTK_LINE`, `VTK_PIXEL`, and `VTK_VOXEL` to `VTK_LAGRANGE_CURVE`, `VTK_LAGRANGE_QUADRILATERAL`, and `VTK_LAGRANGE_HEXAHEDRON` the degree of freedom connecting lines are removed from the mesh.

Additionally, there is hope of eventually doing [high-order viz in paraview], but this requires an additional interpolation to an equally spaced mesh. Ideally we would want this done in paraview itself, since then the aliasing errors occur at the interpolation nodes (as in the code)

[high-order viz in paraview]: https://blog.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/