### PR TITLE
Enforce discrete hydrostatic balance

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -936,3 +936,21 @@ steps:
       slurm_ntasks: 3
       slurm_gres: "gpu:1"
 
+  - label: "cpu_discrete_hydrostatic_balance"
+    key: "cpu_discrete_hydrostatic_balance"
+    command:
+     - "mpiexec julia --color=yes --project test/Atmos/Model/discrete-hydrostatic-balance.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 3
+
+  - label: "gpu_discrete_hydrostatic_balance"
+    key: "gpu_discrete_hydrostatic_balance"
+    command:
+     - "mpiexec julia --color=yes --project test/Atmos/Model/discrete-hydrostatic-balance.jl"
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 3
+      slurm_gres: "gpu:1"

--- a/docs/src/APIs/Numerics/DGMethods/DGMethods.md
+++ b/docs/src/APIs/Numerics/DGMethods/DGMethods.md
@@ -7,6 +7,7 @@ CurrentModule = ClimateMachine.DGMethods
 ```@docs
 DGModel
 remainder_DGModel
+contiguous_field_gradient!
 ```
 
 ## Mathematical Formulation

--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -241,10 +241,11 @@ end
 
 # FIXME: should general cases be handled?
 function Base.similar(
-    Q::MPIStateArray{OLDFT, V},
+    Q::MPIStateArray,
     ::Type{A},
-    ::Type{FT},
-) where {A <: AbstractArray, FT <: Number, OLDFT, V}
+    ::Type{FT};
+    vars::Type{V} = vars(Q),
+) where {A <: AbstractArray, FT <: Number, V}
     MPIStateArray{FT, V}(
         Q.mpicomm,
         A,
@@ -261,15 +262,23 @@ function Base.similar(
 end
 function Base.similar(
     Q::MPIStateArray{FT},
-    ::Type{A},
-) where {A <: AbstractArray, FT <: Number}
-    similar(Q, A, FT)
+    ::Type{A};
+    vars::Type{V} = vars(Q),
+) where {A <: AbstractArray, FT <: Number, V}
+    similar(Q, A, FT; vars = V)
 end
-function Base.similar(Q::MPIStateArray, ::Type{FT}) where {FT <: Number}
-    similar(Q, typeof(Q.data), FT)
+function Base.similar(
+    Q::MPIStateArray,
+    ::Type{FT};
+    vars::Type{V} = vars(Q),
+) where {FT <: Number, V}
+    similar(Q, typeof(Q.data), FT; vars = V)
 end
-function Base.similar(Q::MPIStateArray{FT}) where {FT}
-    similar(Q, FT)
+function Base.similar(
+    Q::MPIStateArray{FT};
+    vars::Type{V} = vars(Q),
+) where {FT, V}
+    similar(Q, FT; vars = V)
 end
 
 Base.size(Q::MPIStateArray, x...; kw...) = size(Q.realdata, x...; kw...)

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -152,8 +152,7 @@ function boundary_state!(
 )
     nothing
 end
-init_state_auxiliary!(lm::AtmosLinearModel, aux::Vars, geom::LocalGeometry) =
-    nothing
+init_state_auxiliary!(lm::AtmosLinearModel, aux::MPIStateArray, grid) = nothing
 init_state_prognostic!(
     lm::AtmosLinearModel,
     state::Vars,

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -19,6 +19,7 @@ atmos_init_aux!(
     ::ReferenceState,
     ::AtmosModel,
     aux::Vars,
+    tmp::Vars,
     geom::LocalGeometry,
 ) = nothing
 
@@ -54,23 +55,35 @@ end
 vars_state(m::HydrostaticState, ::Auxiliary, FT) =
     @vars(ρ::FT, p::FT, T::FT, ρe::FT, ρq_tot::FT)
 
-
-function atmos_init_aux!(
+atmos_init_ref_state_pressure!(m, _...) = nothing
+function atmos_init_ref_state_pressure!(
     m::HydrostaticState{P, F},
     atmos::AtmosModel,
     aux::Vars,
     geom::LocalGeometry,
 ) where {P, F}
     z = altitude(atmos, aux)
+    _, p = m.virtual_temperature_profile(atmos.param_set, z)
+    aux.ref_state.p = p
+end
+
+function atmos_init_aux!(
+    m::HydrostaticState{P, F},
+    atmos::AtmosModel,
+    aux::Vars,
+    tmp::Vars,
+    geom::LocalGeometry,
+) where {P, F}
+    z = altitude(atmos, aux)
     T_virt, p = m.virtual_temperature_profile(atmos.param_set, z)
     FT = eltype(aux)
     _R_d::FT = R_d(atmos.param_set)
+    k = vertical_unit_vector(atmos, aux)
+    ∇Φ = ∇gravitational_potential(atmos, aux)
 
-    # Replace density by computation from pressure
-    # ρ = -1/g*dpdz
-    ρ = p / (_R_d * T_virt)
+    # density computation from pressure ρ = -1/g*dpdz
+    ρ = -k' * tmp.∇p / (k' * ∇Φ)
     aux.ref_state.ρ = ρ
-    aux.ref_state.p = p
     RH = m.relative_humidity
     phase_type = PhaseEquil
     (T, q_pt) = temperature_and_humidity_from_virtual_temperature(
@@ -92,4 +105,78 @@ function atmos_init_aux!(
     e_kin = F(0)
     e_pot = gravitational_potential(atmos.orientation, aux)
     aux.ref_state.ρe = ρ * total_energy(e_kin, e_pot, ts)
+end
+
+using ..MPIStateArrays: vars
+using ..DGMethods: init_ode_state
+using ..DGMethods.NumericalFluxes:
+    CentralNumericalFluxFirstOrder,
+    CentralNumericalFluxSecondOrder,
+    CentralNumericalFluxGradient
+
+
+"""
+    PressureGradientModel
+
+A mini balance law that is used to take the gradient of reference
+pressure. The gradient is computed as ∇ ⋅(pI) and the calculation
+uses the balance law interface to be numerically consistent with
+the way this gradient is computed in the dynamics.
+"""
+struct PressureGradientModel <: BalanceLaw end
+vars_state(::PressureGradientModel, ::Auxiliary, T) = @vars(p::T)
+vars_state(::PressureGradientModel, ::Prognostic, T) = @vars(∇p::SVector{3, T})
+vars_state(::PressureGradientModel, ::Gradient, T) = @vars()
+vars_state(::PressureGradientModel, ::GradientFlux, T) = @vars()
+function init_state_auxiliary!(
+    m::PressureGradientModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+) end
+function init_state_prognostic!(
+    ::PressureGradientModel,
+    state::Vars,
+    aux::Vars,
+    coord,
+    t,
+) end
+function flux_first_order!(
+    ::PressureGradientModel,
+    flux::Grad,
+    state::Vars,
+    auxstate::Vars,
+    t::Real,
+    direction,
+)
+    flux.∇p -= auxstate.p * I
+end
+flux_second_order!(::PressureGradientModel, _...) = nothing
+source!(::PressureGradientModel, _...) = nothing
+boundary_state!(nf, ::PressureGradientModel, _...) = nothing
+
+∇reference_pressure(::NoReferenceState, state_auxiliary, grid) = nothing
+function ∇reference_pressure(::ReferenceState, state_auxiliary, grid)
+    FT = eltype(state_auxiliary)
+    ∇p = similar(state_auxiliary; vars = @vars(∇p::SVector{3, FT}))
+
+    grad_model = PressureGradientModel()
+    # Note that the choice of numerical fluxes doesn't matter
+    # for taking the gradient of a continuous field
+    grad_dg = DGModel(
+        grad_model,
+        grid,
+        CentralNumericalFluxFirstOrder(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+
+    # initialize p
+    ix_p = varsindex(vars(state_auxiliary), :ref_state, :p)
+    grad_dg.state_auxiliary.data .= state_auxiliary.data[:, ix_p, :]
+
+    # FIXME: this isn't used but needs to be passed in
+    gradQ = init_ode_state(grad_dg, FT(0))
+
+    grad_dg(∇p, gradQ, nothing, FT(0))
+    return ∇p
 end

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -41,9 +41,8 @@ function init_state_prognostic! end
 """
     init_state_auxiliary!(
       ::L,
-      state_auxiliary::Vars,
-      coords,
-      args...)
+      state_auxiliary::MPIStateArray,
+      grid)
 
 Initialize the auxiliary state, at ``t = 0``
 """

--- a/src/Land/Model/LandModel.jl
+++ b/src/Land/Model/LandModel.jl
@@ -21,7 +21,7 @@ import ..BalanceLaws:
     update_auxiliary_state!,
     nodal_update_auxiliary_state!
 
-using ..DGMethods: LocalGeometry, DGModel
+using ..DGMethods: LocalGeometry, DGModel, nodal_init_state_auxiliary!
 
 export LandModel
 
@@ -102,12 +102,28 @@ function vars_state(land::LandModel, st::GradientFlux, FT)
     end
 end
 
+function init_state_auxiliary!(
+    m::LandModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
 
-function init_state_auxiliary!(land::LandModel, aux::Vars, geom::LocalGeometry)
+    nodal_init_state_auxiliary!(
+        m,
+        (m, aux, tmp, geom) -> land_nodal_init_state_auxiliary!(m, aux, geom),
+        state_auxiliary,
+        grid,
+    )
+end
+
+function land_nodal_init_state_auxiliary!(
+    land::LandModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
     aux.z = geom.coord[3]
     land_init_aux!(land, land.soil, aux, geom)
 end
-
 
 function flux_first_order!(
     land::LandModel,

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -47,7 +47,12 @@ import ..BalanceLaws:
     reverse_integral_set_auxiliary_state!
 
 export DGModel,
-    init_ode_state, restart_ode_state, restart_auxiliary_state, basic_grid_info
+    init_ode_state,
+    restart_ode_state,
+    restart_auxiliary_state,
+    basic_grid_info,
+    nodal_init_state_auxiliary!,
+    contiguous_field_gradient!
 
 include("NumericalFluxes.jl")
 include("DGModel.jl")

--- a/src/Numerics/DGMethods/create_states.jl
+++ b/src/Numerics/DGMethods/create_states.jl
@@ -40,26 +40,6 @@ function create_state(
 end
 
 function init_state(state, balance_law, grid, ::Auxiliary)
-    topology = grid.topology
-    Np = dofs_per_element(grid)
-    dim = dimensionality(grid)
-    polyorder = polynomialorder(grid)
-    vgeo = grid.vgeo
-    device = array_device(state)
-    nrealelem = length(topology.realelems)
-    event = Event(device)
-    event = kernel_init_state_auxiliary!(device, min(Np, 1024), Np * nrealelem)(
-        balance_law,
-        Val(dim),
-        Val(polyorder),
-        state.data,
-        vgeo,
-        topology.realelems,
-        dependencies = (event,),
-    )
-    event = MPIStateArrays.begin_ghost_exchange!(state; dependencies = event)
-    event = MPIStateArrays.end_ghost_exchange!(state; dependencies = event)
-    wait(device, event)
-
+    init_state_auxiliary!(balance_law, state, grid)
     return state
 end

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -13,6 +13,7 @@ using ...Mesh.Filters: apply!
 using ...Mesh.Grids: VerticalDirection
 using ...Mesh.Geometry
 using ...DGMethods
+using ...DGMethods: nodal_init_state_auxiliary!
 using ...DGMethods.NumericalFluxes
 using ...DGMethods.NumericalFluxes: RusanovNumericalFlux
 using ...BalanceLaws
@@ -171,14 +172,21 @@ function vars_state(m::HBModel, ::Auxiliary, T)
     end
 end
 
+function ocean_init_aux! end
+
 """
     init_state_auxiliary!(::HBModel)
 
 sets the initial value for auxiliary variables (those that aren't related to vertical integrals)
 dispatches to ocean_init_aux! which is defined in a problem file such as SimpleBoxProblem.jl
 """
-function init_state_auxiliary!(m::HBModel, A::Vars, geom::LocalGeometry)
-    return ocean_init_aux!(m, m.problem, A, geom)
+function init_state_auxiliary!(m::HBModel, state_auxiliary::MPIStateArray, grid)
+    nodal_init_state_auxiliary!(
+        m,
+        (m, A, tmp, geom) -> ocean_init_aux!(m, m.problem, A, geom),
+        state_auxiliary,
+        grid,
+    )
 end
 
 """

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -42,7 +42,8 @@ vars_state(lm::LinearHBModel, ::UpwardIntegrals, FT) = @vars()
 """
     No need to init, initialize by full model
 """
-init_state_auxiliary!(lm::LinearHBModel, A::Vars, geom::LocalGeometry) = nothing
+init_state_auxiliary!(lm::LinearHBModel, state_auxiliary::MPIStateArray, grid) =
+    nothing
 init_state_prognostic!(lm::LinearHBModel, Q::Vars, A::Vars, coords, t) = nothing
 
 """

--- a/src/Ocean/SplitExplicit/VerticalIntegralModel.jl
+++ b/src/Ocean/SplitExplicit/VerticalIntegralModel.jl
@@ -22,7 +22,7 @@ function vars_state(m::VerticalIntegralModel, ::Auxiliary, T)
     end
 end
 
-init_state_auxiliary!(tm::VerticalIntegralModel, A::Vars, geom::LocalGeometry) =
+init_state_auxiliary!(tm::VerticalIntegralModel, A::MPIStateArray, grid) =
     nothing
 
 function vars_state(m::VerticalIntegralModel, ::UpwardIntegrals, T)

--- a/test/Atmos/Model/discrete-hydrostatic-balance.jl
+++ b/test/Atmos/Model/discrete-hydrostatic-balance.jl
@@ -1,0 +1,159 @@
+using ClimateMachine
+ClimateMachine.init(parse_clargs = true)
+
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.Atmos
+using ClimateMachine.ConfigTypes
+using ClimateMachine.ODESolvers
+using ClimateMachine.SystemSolvers: ManyColumnLU
+using ClimateMachine.DGMethods.NumericalFluxes: CentralNumericalFluxFirstOrder
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.VariableTemplates
+
+using ClimateMachine.Mesh.Geometry: LocalGeometry
+using ClimateMachine.Atmos: ReferenceState
+using ClimateMachine.BalanceLaws: Auxiliary
+import ClimateMachine.BalanceLaws: vars_state
+import ClimateMachine.Atmos: atmos_init_ref_state_pressure!, atmos_init_aux!
+
+using LinearAlgebra
+using StaticArrays
+using Test
+
+using CLIMAParameters
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+# a simple wrapper around a hydrostatic state that
+# prevents factoring out of the state in the
+# momentum equation and lets us test the balance
+struct TestRefState{HS} <: ReferenceState
+    hydrostatic_state::HS
+end
+
+vars_state(m::TestRefState, ::Auxiliary, FT) =
+    vars_state(m.hydrostatic_state, Auxiliary(), FT)
+function atmos_init_ref_state_pressure!(
+    m::TestRefState,
+    atmos::AtmosModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    atmos_init_ref_state_pressure!(m.hydrostatic_state, atmos, aux, geom)
+end
+function atmos_init_aux!(
+    m::TestRefState,
+    atmos::AtmosModel,
+    aux::Vars,
+    tmp::Vars,
+    geom::LocalGeometry,
+)
+    atmos_init_aux!(m.hydrostatic_state, atmos, aux, tmp, geom)
+end
+
+function init_to_ref_state!(bl, state, aux, coords, t)
+    FT = eltype(state)
+    state.ρ = aux.ref_state.ρ
+    state.ρu = SVector{3, FT}(0, 0, 0)
+    state.ρe = aux.ref_state.ρe
+end
+
+function config_balanced(
+    FT,
+    poly_order,
+    temp_profile,
+    (config_type, config_fun, config_args),
+)
+    ref_state = HydrostaticState(temp_profile)
+
+    model = AtmosModel{FT}(
+        config_type,
+        param_set;
+        ref_state = TestRefState(ref_state),
+        turbulence = ConstantViscosityWithDivergence{FT}(0),
+        hyperdiffusion = NoHyperDiffusion(),
+        moisture = DryModel(),
+        source = Gravity(),
+        init_state_prognostic = init_to_ref_state!,
+    )
+
+    config = config_fun(
+        "balanced state",
+        poly_order,
+        config_args...,
+        param_set,
+        nothing;
+        model = model,
+        numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
+    )
+
+    return config
+end
+
+function main()
+    FT = Float64
+    poly_order = 4
+
+    timestart = FT(0)
+    timeend = FT(100)
+    domain_height = FT(50e3)
+
+    LES_params = let
+        LES_resolution = ntuple(_ -> domain_height / 3poly_order, 3)
+        LES_domain = ntuple(_ -> domain_height, 3)
+        (LES_resolution, LES_domain...)
+    end
+
+    GCM_params = let
+        GCM_resolution = (3, 3)
+        (GCM_resolution, domain_height)
+    end
+
+    GCM = (AtmosGCMConfigType, ClimateMachine.AtmosGCMConfiguration, GCM_params)
+    LES = (AtmosLESConfigType, ClimateMachine.AtmosLESConfiguration, LES_params)
+
+    imex_solver_type = ClimateMachine.IMEXSolverType(
+        splitting_type = HEVISplitting(),
+        implicit_model = AtmosAcousticGravityLinearModel,
+        implicit_solver = ManyColumnLU,
+        solver_method = ARK2GiraldoKellyConstantinescu,
+    )
+    explicit_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK54CarpenterKennedy,
+    )
+
+    @testset for config in (LES, GCM)
+        @testset for ode_solver_type in (explicit_solver_type, imex_solver_type)
+            @testset for temp_profile in (
+                IsothermalProfile(param_set, FT),
+                DecayingTemperatureProfile{FT}(param_set),
+            )
+                driver_config =
+                    config_balanced(FT, poly_order, temp_profile, config)
+
+                solver_config = ClimateMachine.SolverConfiguration(
+                    timestart,
+                    timeend,
+                    driver_config,
+                    Courant_number = FT(0.1),
+                    init_on_cpu = true,
+                    ode_solver_type = ode_solver_type,
+                    CFL_direction = EveryDirection(),
+                    diffdir = HorizontalDirection(),
+                )
+
+                Qinit = similar(solver_config.Q)
+                Qinit .= solver_config.Q
+
+                ClimateMachine.invoke!(solver_config)
+
+                error = euclidean_distance(solver_config.Q, Qinit) / norm(Qinit)
+                @test error <= 100 * eps(FT)
+            end
+        end
+    end
+end
+
+main()

--- a/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
@@ -101,6 +101,7 @@ import ClimateMachine.BalanceLaws:
     boundary_state!,
     source!
 
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 import ClimateMachine.DGMethods: DGModel
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 
@@ -169,9 +170,10 @@ vars_state(m::KinematicModel, ::Gradient, FT) = @vars()
 
 vars_state(m::KinematicModel, ::GradientFlux, FT) = @vars()
 
-function init_state_auxiliary!(
+function kinematic_nodal_init_state_auxiliary!(
     m::KinematicModel,
     aux::Vars,
+    tmp::Vars,
     geom::LocalGeometry,
 )
     FT = eltype(aux)
@@ -200,6 +202,19 @@ function init_state_auxiliary!(
         aux.x = x
         aux.z = z
     end
+end
+
+function init_state_auxiliary!(
+    m::KinematicModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        kinematic_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 function init_state_prognostic!(

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -128,7 +128,7 @@ function main()
     ca_h = ugeo_abs * (Δt / Δh) + vgeo_abs * (Δt / Δh)
     # vertical velocity is 0
     caᵥ = FT(0.0)
-    @test isapprox(CFL_adv_v, caᵥ)
+    @test isapprox(CFL_adv_v, caᵥ, atol = 10 * eps(FT))
     @test isapprox(CFL_adv_h, ca_h, atol = 0.0005)
     @test isapprox(CFL_adv, ca_h, atol = 0.0005)
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -298,6 +298,7 @@ function atmos_init_aux!(
     m::IsentropicVortexReferenceState,
     atmos::AtmosModel,
     aux::Vars,
+    tmp::Vars,
     geom::LocalGeometry,
 )
     setup = m.setup

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -283,6 +283,7 @@ function atmos_init_aux!(
     m::IsentropicVortexReferenceState,
     atmos::AtmosModel,
     aux::Vars,
+    tmp::Vars,
     geom::LocalGeometry,
 )
     setup = m.setup

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -293,6 +293,7 @@ function atmos_init_aux!(
     m::IsentropicVortexReferenceState,
     atmos::AtmosModel,
     aux::Vars,
+    tmp::Vars,
     geom::LocalGeometry,
 )
     setup = m.setup

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -306,6 +306,7 @@ function atmos_init_aux!(
     m::IsentropicVortexReferenceState,
     atmos::AtmosModel,
     aux::Vars,
+    tmp::Vars,
     geom::LocalGeometry,
 )
     setup = m.setup

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
@@ -17,6 +17,7 @@ import ClimateMachine.BalanceLaws:
     init_state_prognostic!
 
 import ClimateMachine.DGMethods: init_ode_state
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 
 
@@ -182,11 +183,29 @@ function boundary_state!(
     init_state_prognostic!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
 end
 
-function init_state_auxiliary!(::MMSModel, aux::Vars, g::LocalGeometry)
+function mms_nodal_init_state_auxiliary!(
+    ::MMSModel,
+    aux::Vars,
+    tmp::Vars,
+    g::LocalGeometry,
+)
     x1, x2, x3 = g.coord
     aux.x1 = x1
     aux.x2 = x2
     aux.x3 = x3
+end
+
+function init_state_auxiliary!(
+    m::MMSModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        mms_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 function init_state_prognostic!(

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -28,8 +28,8 @@ using Logging, Printf, Dates
 using Random
 
 using ClimateMachine.VariableTemplates
-
 import ClimateMachine.BalanceLaws: vars_state
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 
 import ClimateMachine.DGMethods:
     flux_first_order!,
@@ -53,9 +53,10 @@ vars_state(::ConservationTestModel, ::Prognostic, T) = @vars(q::T, p::T)
 
 vars_state(::ConservationTestModel, ::AbstractStateType, T) = @vars()
 
-function init_state_auxiliary!(
+function conservation_nodal_init_state_auxiliary!(
     ::ConservationTestModel,
     aux::Vars,
+    tmp::Vars,
     g::LocalGeometry,
 )
     x, y, z = g.coord
@@ -64,6 +65,19 @@ function init_state_auxiliary!(
         cos(10 * π * x) * sin(10 * π * y) + cos(20 * π * z),
         exp(sin(π * r)),
         sin(π * (x + y + z)),
+    )
+end
+
+function init_state_auxiliary!(
+    m::ConservationTestModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        conservation_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
     )
 end
 

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -159,6 +159,7 @@ let
                 simtime = FT(0)
 
                 # tests for non diffusive courant number
+                rtol = FT === Float64 ? 1e-4 : 1f-2
                 @test courant(
                     nondiffusive_courant,
                     dg,
@@ -167,7 +168,7 @@ let
                     Δt,
                     simtime,
                     HorizontalDirection(),
-                ) ≈ c_h rtol = 1e-4
+                ) ≈ c_h rtol = rtol
                 @test courant(
                     nondiffusive_courant,
                     dg,
@@ -176,7 +177,7 @@ let
                     Δt,
                     simtime,
                     VerticalDirection(),
-                ) ≈ c_v rtol = 1e-4
+                ) ≈ c_v rtol = rtol
 
                 # tests for diffusive courant number
                 @test courant(

--- a/test/Numerics/DGMethods/grad_test.jl
+++ b/test/Numerics/DGMethods/grad_test.jl
@@ -1,0 +1,124 @@
+using MPI
+using StaticArrays
+using ClimateMachine
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.DGMethods
+
+using ClimateMachine.BalanceLaws
+
+import ClimateMachine.BalanceLaws: vars_state, init_state_auxiliary!
+
+using ClimateMachine.Mesh.Geometry: LocalGeometry
+
+struct GradTestModel{dim} <: BalanceLaw end
+
+vars_state(m::GradTestModel, ::Auxiliary, T) = @vars begin
+    a::T
+    ∇a::SVector{3, T}
+    ∇a_exact::SVector{3, T}
+end
+vars_state(::GradTestModel, ::Prognostic, T) = @vars()
+
+function grad_nodal_init_state_auxiliary!(
+    ::GradTestModel{dim},
+    aux::Vars,
+    tmp::Vars,
+    g::LocalGeometry,
+) where {dim}
+    x, y, z = g.coord
+    if dim == 2
+        aux.a = x^2 + y^3 - x * y
+        aux.∇a_exact = SVector(2 * x - y, 3 * y^2 - x, 0)
+    else
+        aux.a = x^2 + y^3 + z^2 * y^2 - x * y * z
+        aux.∇a_exact = SVector(
+            2 * x - y * z,
+            3 * y^2 + 2 * z^2 * y - x * z,
+            2 * z * y^2 - x * y,
+        )
+    end
+end
+
+function init_state_auxiliary!(
+    m::GradTestModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        grad_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
+end
+
+using Test
+function run(mpicomm, dim, Ne, N, FT, ArrayType)
+
+    brickrange = ntuple(j -> range(FT(0); length = Ne[j] + 1, stop = 3), dim)
+    topl = StackedBrickTopology(
+        mpicomm,
+        brickrange,
+        periodicity = ntuple(j -> true, dim),
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = N,
+    )
+
+    model = GradTestModel{dim}()
+    dg = DGModel(
+        model,
+        grid,
+        nothing,
+        nothing,
+        nothing;
+        state_gradient_flux = nothing,
+    )
+
+    contiguous_field_gradient!(
+        model,
+        dg.state_auxiliary,
+        (:∇a,),
+        dg.state_auxiliary,
+        (:a,),
+        grid,
+    )
+
+    # Wrapping in Array ensure both GPU and CPU code use same approx
+    @test Array(dg.state_auxiliary.∇a) ≈ Array(dg.state_auxiliary.∇a_exact)
+end
+
+let
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    numelem = (5, 5, 1)
+    lvls = 1
+    polynomialorder = 4
+
+    @testset for FT in (Float64, Float32)
+        @testset for dim in 2:3
+            for l in 1:lvls
+                run(
+                    mpicomm,
+                    dim,
+                    ntuple(j -> 2^(l - 1) * numelem[j], dim),
+                    polynomialorder,
+                    FT,
+                    ArrayType,
+                )
+            end
+        end
+    end
+end
+
+nothing

--- a/test/Numerics/DGMethods/grad_test_sphere.jl
+++ b/test/Numerics/DGMethods/grad_test_sphere.jl
@@ -1,0 +1,137 @@
+using MPI
+using StaticArrays
+using ClimateMachine
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.DGMethods
+using Printf
+
+using ClimateMachine.BalanceLaws
+
+import ClimateMachine.BalanceLaws: vars_state, init_state_auxiliary!
+
+using ClimateMachine.Mesh.Geometry: LocalGeometry
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+
+struct GradSphereTestModel <: BalanceLaw end
+
+vars_state(m::GradSphereTestModel, ::Auxiliary, T) = @vars begin
+    a::T
+    ∇a::SVector{3, T}
+end
+vars_state(::GradSphereTestModel, ::Prognostic, T) = @vars()
+
+function grad_nodal_init_state_auxiliary!(
+    ::GradSphereTestModel,
+    aux::Vars,
+    tmp::Vars,
+    g::LocalGeometry,
+)
+    x, y, z = g.coord
+    r = hypot(x, y, z)
+    aux.a = r
+    aux.∇a = g.coord / r
+end
+
+function init_state_auxiliary!(
+    m::GradSphereTestModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        grad_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
+end
+
+using Test
+function run(mpicomm, Ne_horz, Ne_vert, N, FT, ArrayType)
+
+    Rrange = range(FT(1 // 2); length = Ne_vert + 1, stop = FT(1))
+    topl = StackedCubedSphereTopology(mpicomm, Ne_horz, Rrange)
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = N,
+        meshwarp = Topologies.cubedshellwarp,
+    )
+
+    model = GradSphereTestModel()
+    dg = DGModel(
+        model,
+        grid,
+        nothing,
+        nothing,
+        nothing;
+        state_gradient_flux = nothing,
+    )
+
+    exact_aux = copy(dg.state_auxiliary)
+
+    contiguous_field_gradient!(
+        model,
+        dg.state_auxiliary,
+        (:∇a,),
+        dg.state_auxiliary,
+        (:a,),
+        grid,
+    )
+
+    err = euclidean_distance(exact_aux, dg.state_auxiliary)
+    return err
+end
+
+let
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 4
+    base_Nhorz = 4
+    base_Nvert = 2
+
+    expected_result = [
+        2.0924087890777517e-04
+        1.3897932154337201e-05
+        8.8256018429045312e-07
+        5.5381072850485303e-08
+    ]
+
+    lvls = integration_testing || ClimateMachine.Settings.integration_testing ?
+        length(expected_result) : 1
+
+    @testset for FT in (Float64,)
+        err = zeros(FT, lvls)
+        @testset for l in 1:lvls
+            Ne_horz = 2^(l - 1) * base_Nhorz
+            Ne_vert = 2^(l - 1) * base_Nvert
+
+            err[l] =
+                run(mpicomm, Ne_horz, Ne_vert, polynomialorder, FT, ArrayType)
+            @test err[l] ≈ expected_result[l]
+        end
+        @info begin
+            msg = ""
+            for l in 1:(lvls - 1)
+                rate = log2(err[l]) - log2(err[l + 1])
+                msg *= @sprintf("\n  rate for level %d = %e\n", l, rate)
+            end
+            msg
+        end
+    end
+end
+
+nothing

--- a/test/Numerics/DGMethods/integral_test.jl
+++ b/test/Numerics/DGMethods/integral_test.jl
@@ -6,6 +6,7 @@ using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 using ClimateMachine.DGMethods.NumericalFluxes
 using Printf
 using LinearAlgebra
@@ -57,9 +58,10 @@ boundary_state!(_, ::IntegralTestModel, _...) = nothing
 init_state_prognostic!(::IntegralTestModel, _...) = nothing
 wavespeed(::IntegralTestModel, _...) = 1
 
-function init_state_auxiliary!(
+function integral_nodal_init_state_auxiliary!(
     ::IntegralTestModel{dim},
     aux::Vars,
+    tmp::Vars,
     g::LocalGeometry,
 ) where {dim}
     x, y, z = aux.coord = g.coord
@@ -82,6 +84,19 @@ function init_state_auxiliary!(
         aux.rev_a = a_top - aux.a
         aux.rev_b = b_top - aux.b
     end
+end
+
+function init_state_auxiliary!(
+    m::IntegralTestModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        integral_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 function update_auxiliary_state!(

--- a/test/Numerics/DGMethods/integral_test_sphere.jl
+++ b/test/Numerics/DGMethods/integral_test_sphere.jl
@@ -6,6 +6,7 @@ using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 using ClimateMachine.DGMethods.NumericalFluxes
 using Printf
 using LinearAlgebra
@@ -77,9 +78,10 @@ boundary_state!(_, ::IntegralTestSphereModel, _...) = nothing
 init_state_prognostic!(::IntegralTestSphereModel, _...) = nothing
 wavespeed(::IntegralTestSphereModel, _...) = 1
 
-function init_state_auxiliary!(
+function integral_nodal_init_state_auxiliary!(
     m::IntegralTestSphereModel,
     aux::Vars,
+    tmp::Vars,
     g::LocalGeometry,
 )
 
@@ -91,6 +93,19 @@ function init_state_auxiliary!(
     aux.a = 1 + cos(ϕ)^2 * sin(θ)^2 + sin(ϕ)^2
     aux.int.v = exp(-aux.a * aux.r^2) - exp(-aux.a * m.Rinner^2)
     aux.rev_int.v = exp(-aux.a * m.Router^2) - exp(-aux.a * aux.r^2)
+end
+
+function init_state_auxiliary!(
+    m::IntegralTestSphereModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        integral_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 @inline function integral_load_auxiliary_state!(

--- a/test/Numerics/DGMethods/runtests.jl
+++ b/test/Numerics/DGMethods/runtests.jl
@@ -3,6 +3,8 @@ include(joinpath("..", "..", "testhelpers.jl"))
 
 @testset "DGMethods" begin
     runmpi(joinpath(@__DIR__, "courant.jl"), ntasks = 2)
+    runmpi(joinpath(@__DIR__, "grad_test.jl"))
+    runmpi(joinpath(@__DIR__, "grad_test_sphere.jl"))
     runmpi(joinpath(@__DIR__, "horizontal_integral_test.jl"))
     runmpi(joinpath(@__DIR__, "integral_test.jl"))
     runmpi(joinpath(@__DIR__, "integral_test_sphere.jl"))

--- a/test/Numerics/DGMethods/vars_test.jl
+++ b/test/Numerics/DGMethods/vars_test.jl
@@ -6,6 +6,7 @@ using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods: nodal_init_state_auxiliary!
 using ClimateMachine.DGMethods.NumericalFluxes
 using Printf
 using LinearAlgebra
@@ -53,13 +54,27 @@ function init_state_prognostic!(
     state.coord = coord
 end
 
-function init_state_auxiliary!(
+function vars_nodal_init_state_auxiliary!(
     ::VarsTestModel{dim},
     aux::Vars,
+    tmp::Vars,
     g::LocalGeometry,
 ) where {dim}
     x, y, z = aux.coord = g.coord
     aux.polynomial = x * y + x * z + y * z
+end
+
+function init_state_auxiliary!(
+    m::VarsTestModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        vars_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 using Test

--- a/test/Utilities/SingleStackUtils/ssu_tests.jl
+++ b/test/Utilities/SingleStackUtils/ssu_tests.jl
@@ -34,10 +34,28 @@ vars_state(::EmptyBalLaw, ::Prognostic, FT) = @vars(ρ::FT)
 vars_state(::EmptyBalLaw, ::Gradient, FT) = @vars()
 vars_state(::EmptyBalLaw, ::GradientFlux, FT) = @vars()
 
-function init_state_auxiliary!(m::EmptyBalLaw, aux::Vars, geom::LocalGeometry)
+function empty_nodal_init_state_auxiliary!(
+    m::EmptyBalLaw,
+    aux::Vars,
+    tmp::Vars,
+    geom::LocalGeometry,
+)
     aux.x = geom.coord[1]
     aux.y = geom.coord[2]
     aux.z = geom.coord[3]
+end
+
+function init_state_auxiliary!(
+    m::EmptyBalLaw,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        empty_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end
 
 function init_state_prognostic!(

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -211,14 +211,29 @@ vars_state(::BurgersEquation, ::GradientFlux, FT) = @vars(
 # `init_state_prognostic!`. Note that
 # - this method is only called at `t=0`.
 # - `aux.coord` is available here because we've specified `coord` in `vars_state(m, aux, FT)`.
-# - `init_aux!` initializes the auxiliary gravitational potential field needed for vertical projections.
-function init_state_auxiliary!(
+function burgers_nodal_init_state_auxiliary!(
     m::BurgersEquation,
     aux::Vars,
+    tmp::Vars,
     geom::LocalGeometry,
 )
     aux.coord = geom.coord
-    init_aux!(m.orientation, m.param_set, aux)
+end;
+
+# `init_aux!` initializes the auxiliary gravitational potential field needed for vertical projections
+function init_state_auxiliary!(
+    m::BurgersEquation,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    init_aux!(m, m.orientation, state_auxiliary, grid)
+
+    nodal_init_state_auxiliary!(
+        m,
+        burgers_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end;
 
 # Specify the initial values in `state::Vars`. Note that

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -158,10 +158,29 @@ vars_state(::HeatModel, ::GradientFlux, FT) = @vars(α∇ρcT::SVector{3, FT});
 # - this method is only called at `t=0`
 # - `aux.z` and `aux.T` are available here because we've specified `z` and `T`
 # in `vars_state` given `Auxiliary`
-function init_state_auxiliary!(m::HeatModel, aux::Vars, geom::LocalGeometry)
+# in `vars_state`
+function heat_eq_nodal_init_state_auxiliary!(
+    m::HeatModel,
+    aux::Vars,
+    tmp::Vars,
+    geom::LocalGeometry,
+)
     aux.z = geom.coord[3]
     aux.T = m.initialT
 end;
+
+function init_state_auxiliary!(
+    m::HeatModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+)
+    nodal_init_state_auxiliary!(
+        m,
+        heat_eq_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
+end
 
 # Specify the initial values in `state::Vars`. Note that
 # - this method is only called at `t=0`

--- a/tutorials/Numerics/DGMethods/Box1D.jl
+++ b/tutorials/Numerics/DGMethods/Box1D.jl
@@ -53,8 +53,22 @@ vars_state(::Box1D, ::Prognostic, FT) = @vars(q::FT);
 vars_state(::Box1D, ::Gradient, FT) = @vars();
 vars_state(::Box1D, ::GradientFlux, FT) = @vars();
 
-function init_state_auxiliary!(m::Box1D, aux::Vars, geom::LocalGeometry)
+function box_nodal_init_state_auxiliary!(
+    m::Box1D,
+    aux::Vars,
+    tmp::Vars,
+    geom::LocalGeometry,
+)
     aux.z_dim = geom.coord[3]
+end;
+
+function init_state_auxiliary!(m::Box1D, state_auxiliary::MPIStateArray, grid)
+    nodal_init_state_auxiliary!(
+        m,
+        box_nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+    )
 end;
 
 function init_state_prognostic!(


### PR DESCRIPTION
This PR enforces discrete hydrostatic balance of the reference state by computing its density from the balance equation.
For the discrete balance to be maintained using a numerical flux with the contact property is necessary. Currently in CLIMA only the central flux has this property, and it is likely to lead to unstable code. Another flux that has this property is the Roe flux which is getting implemented in #1339.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
