### PR TITLE
Remove q_tot reference state when filtering

### DIFF
--- a/src/Atmos/Model/filters.jl
+++ b/src/Atmos/Model/filters.jl
@@ -14,7 +14,7 @@ vars_state_filtered(target::AtmosFilterPerturbations, FT) =
     vars_state_conservative(target.atmos, FT)
 
 function compute_filter_argument!(
-    ::AtmosFilterPerturbations,
+    target::AtmosFilterPerturbations,
     filter_state::Vars,
     state::Vars,
     aux::Vars,
@@ -24,9 +24,12 @@ function compute_filter_argument!(
     # remove reference state
     filter_state.ρ -= aux.ref_state.ρ
     filter_state.ρe -= aux.ref_state.ρe
+    if !(target.atmos.moisture isa DryModel)
+        filter_state.moisture.ρq_tot -= aux.ref_state.ρq_tot
+    end
 end
 function compute_filter_result!(
-    ::AtmosFilterPerturbations,
+    target::AtmosFilterPerturbations,
     state::Vars,
     filter_state::Vars,
     aux::Vars,
@@ -36,4 +39,7 @@ function compute_filter_result!(
     # add reference state
     state.ρ += aux.ref_state.ρ
     state.ρe += aux.ref_state.ρe
+    if !(target.atmos.moisture isa DryModel)
+        state.moisture.ρq_tot += aux.ref_state.ρq_tot
+    end
 end


### PR DESCRIPTION
# Description

This PR implements subtraction of specific humidity reference state in the `AtmosFilterPerturbations` target.

Closes #1348.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
