### PR TITLE
Added divergence damping and model orientation

### DIFF
--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -1,11 +1,24 @@
 # # Single stack tutorial based on the 3D Burgers + tracer equations
 
+# This tutorial implements the Burgers equations with a tracer field
+# in a single element stack. The flow is initialized with a horizontally
+# uniform profile of horizontal velocity and uniform initial temperature. The fluid
+# is heated from the bottom surface. Gaussian noise is imposed to the horizontal
+# velocity field at each node at the start of the simulation. The tutorial demonstrates how to
+#
+#   * Initialize a [`BalanceLaw`](@ref ClimateMachine.BalanceLaws.BalanceLaw) in a single stack configuration;
+#   * Return the horizontal velocity field to a given profile (e.g., large-scale advection);
+#   * Remove any horizontal inhomogeneities or noise from the flow.
+#
+# The second and third bullet points are demonstrated imposing Rayleigh friction, horizontal
+# diffusion and 2D divergence damping to the horizontal momentum prognostic equation.
+
 # Equations solved in balance law form:
 
 # ```math
 # \begin{align}
 # \frac{∂ ρ}{∂ t} =& - ∇ ⋅ (ρ\mathbf{u}) \\
-# \frac{∂ ρ\mathbf{u}}{∂ t} =& - ∇ ⋅ (-μ ∇\mathbf{u}) - ∇ ⋅ (ρ\mathbf{u} \mathbf{u}') - γ[ (ρ\mathbf{u}-ρ̄\mathbf{ū}) - (ρ\mathbf{u}-ρ̄\mathbf{ū})⋅ẑ ẑ] \\
+# \frac{∂ ρ\mathbf{u}}{∂ t} =& - ∇ ⋅ (-μ ∇\mathbf{u}) - ∇ ⋅ (ρ\mathbf{u} \mathbf{u}') - γ[ (ρ\mathbf{u}-ρ̄\mathbf{ū}) - (ρ\mathbf{u}-ρ̄\mathbf{ū})⋅ẑ ẑ] - ν_d ∇_h (∇_h ⋅ ρ\mathbf{u}) \\
 # \frac{∂ ρcT}{∂ t} =& - ∇ ⋅ (-α ∇ρcT) - ∇ ⋅ (\mathbf{u} ρcT)
 # \end{align}
 # ```
@@ -29,8 +42,9 @@
 #  - ``\mathbf{ū}`` is the horizontally averaged velocity (vector)
 #  - ``μ`` is the dynamic viscosity tensor
 #  - ``γ`` is the Rayleigh friction frequency
+#  - ``ν_d`` is the horizontal divergence damping coefficient
 #  - ``T`` is the temperature
-#  - ``α`` is the thermal diffusivity
+#  - ``α`` is the thermal diffusivity tensor
 #  - ``c`` is the heat capacity
 #  - ``ρcT`` is the thermal energy
 
@@ -54,7 +68,7 @@ using Distributions
 using OrderedCollections
 using Plots
 using StaticArrays
-using LinearAlgebra: Diagonal
+using LinearAlgebra: Diagonal, tr
 
 #  - load CLIMAParameters and set up to use it:
 using CLIMAParameters
@@ -68,6 +82,9 @@ using ClimateMachine.Mesh.Grids
 using ClimateMachine.Writers
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux
+
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.GenericCallbacks
@@ -77,7 +94,13 @@ using ClimateMachine.SingleStackUtils
 
 #  - import necessary ClimateMachine modules: (`import`ing enables us to
 #  provide implementations of these structs/methods)
-using ClimateMachine.BalanceLaws
+using ClimateMachine.Orientations:
+    Orientation,
+    FlatOrientation,
+    init_aux!,
+    vertical_unit_vector,
+    projection_tangential
+
 import ClimateMachine.BalanceLaws:
     vars_state,
     source!,
@@ -85,8 +108,6 @@ import ClimateMachine.BalanceLaws:
     flux_first_order!,
     compute_gradient_argument!,
     compute_gradient_flux!,
-    update_auxiliary_state!,
-    nodal_update_auxiliary_state!,
     init_state_auxiliary!,
     init_state_prognostic!,
     boundary_state!
@@ -110,21 +131,25 @@ include(joinpath(clima_dir, "docs", "plothelpers.jl"));
 # Model parameters can be stored in the particular [`BalanceLaw`](@ref
 # ClimateMachine.BalanceLaws.BalanceLaw), in this case, the `BurgersEquation`:
 
-Base.@kwdef struct BurgersEquation{FT, APS} <: BalanceLaw
+Base.@kwdef struct BurgersEquation{FT, APS, O} <: BalanceLaw
     "Parameters"
     param_set::APS
+    "Orientation model"
+    orientation::O
     "Heat capacity"
     c::FT = 1
     "Vertical dynamic viscosity"
     μv::FT = 1e-4
     "Horizontal dynamic viscosity"
-    μh::FT = 1e-2
-    "Thermal diffusivity"
-    α::FT = 0.01
+    μh::FT = 1
+    "Vertical thermal diffusivity"
+    αv::FT = 1e-2
+    "Horizontal thermal diffusivity"
+    αh::FT = 1
     "IC Gaussian noise standard deviation"
-    σ::FT = 1e-1
+    σ::FT = 5e-2
     "Rayleigh damping"
-    γ::FT = μh / 0.08 / 1e-2 / 1e-2
+    γ::FT = 5
     "Domain height"
     zmax::FT = 1
     "Initial conditions for temperature"
@@ -133,10 +158,17 @@ Base.@kwdef struct BurgersEquation{FT, APS} <: BalanceLaw
     T_bottom::FT = 300.0
     "Top flux (α∇ρcT) at top boundary (Neumann boundary conditions)"
     flux_top::FT = 0.0
+    "Divergence damping coefficient (horizontal)"
+    νd::FT = 1
 end
 
 # Create an instance of the `BurgersEquation`:
-m = BurgersEquation{FT, typeof(param_set)}(; param_set = param_set);
+orientation = FlatOrientation()
+
+m = BurgersEquation{FT, typeof(param_set), typeof(orientation)}(
+    param_set = param_set,
+    orientation = orientation,
+);
 
 # This model dictates the flow control, using [Dynamic Multiple
 # Dispatch](https://en.wikipedia.org/wiki/Multiple_dispatch), for which
@@ -150,7 +182,12 @@ m = BurgersEquation{FT, typeof(param_set)}(; param_set = param_set);
 # by the solver.
 
 # Specify auxiliary variables for `BurgersEquation`
-vars_state(::BurgersEquation, ::Auxiliary, FT) = @vars(z::FT, T::FT);
+function vars_state(m::BurgersEquation, st::Auxiliary, FT)
+    @vars begin
+        coord::SVector{3, FT}
+        orientation::vars_state(m.orientation, st, FT)
+    end
+end
 
 # Specify prognostic variables, the variables solved for in the PDEs, for
 # `BurgersEquation`
@@ -159,32 +196,34 @@ vars_state(::BurgersEquation, ::Prognostic, FT) =
 
 # Specify state variables whose gradients are needed for `BurgersEquation`
 vars_state(::BurgersEquation, ::Gradient, FT) =
-    @vars(u::SVector{3, FT}, ρcT::FT);
+    @vars(u::SVector{3, FT}, ρcT::FT, ρu::SVector{3, FT});
 
 # Specify gradient variables for `BurgersEquation`
-vars_state(::BurgersEquation, ::GradientFlux, FT) =
-    @vars(μ∇u::SMatrix{3, 3, FT, 9}, α∇ρcT::SVector{3, FT});
+vars_state(::BurgersEquation, ::GradientFlux, FT) = @vars(
+    μ∇u::SMatrix{3, 3, FT, 9},
+    α∇ρcT::SVector{3, FT},
+    νd∇D::SMatrix{3, 3, FT, 9}
+);
 
 # ## Define the compute kernels
 
 # Specify the initial values in `aux::Vars`, which are available in
 # `init_state_prognostic!`. Note that
-# - this method is only called at `t=0`
-# - `aux.z` and `aux.T` are available here because we've specified `z` and `T`
-# in `vars_state` given `Auxiliary`
+# - this method is only called at `t=0`.
+# - `aux.coord` is available here because we've specified `coord` in `vars_state(m, aux, FT)`.
+# - `init_aux!` initializes the auxiliary gravitational potential field needed for vertical projections.
 function init_state_auxiliary!(
     m::BurgersEquation,
     aux::Vars,
     geom::LocalGeometry,
 )
-    aux.z = geom.coord[3]
-    aux.T = m.initialT
+    aux.coord = geom.coord
+    init_aux!(m.orientation, m.param_set, aux)
 end;
 
 # Specify the initial values in `state::Vars`. Note that
-# - this method is only called at `t=0`
-# - `state.ρ`, `state.ρu` and`state.ρcT` are available here because
-# we've specified `ρ`, `ρu` and `ρcT` in `vars_state` given `Prognostic`
+# - this method is only called at `t=0`.
+# - `state.ρ`, `state.ρu` and`state.ρcT` are available here because we've specified `ρ`, `ρu` and `ρcT` in `vars_state(m, state, FT)`.
 function init_state_prognostic!(
     m::BurgersEquation,
     state::Vars,
@@ -192,7 +231,7 @@ function init_state_prognostic!(
     coords,
     t::Real,
 )
-    z = aux.z
+    z = aux.coord[3]
     ε1 = rand(Normal(0, m.σ))
     ε2 = rand(Normal(0, m.σ))
     state.ρ = 1
@@ -201,42 +240,16 @@ function init_state_prognostic!(
     ρw = 0
     state.ρu = SVector(ρu, ρv, ρw)
 
-    state.ρcT = state.ρ * m.c * aux.T
+    state.ρcT = state.ρ * m.c * m.initialT
 end;
 
 # The remaining methods, defined in this section, are called at every
 # time-step in the solver by the [`BalanceLaw`](@ref
 # ClimateMachine.BalanceLaws.BalanceLaw) framework.
 
-# Overload `update_auxiliary_state!` to call `heat_eq_nodal_update_aux!`, or
-# any other auxiliary methods
-function update_auxiliary_state!(
-    dg::DGModel,
-    m::BurgersEquation,
-    Q::MPIStateArray,
-    t::Real,
-    elems::UnitRange,
-)
-    nodal_update_auxiliary_state!(heat_eq_nodal_update_aux!, dg, m, Q, t, elems)
-    return true # TODO: remove return true
-end;
-
-# Compute/update all auxiliary variables at each node. Note that
-# - `aux.T` is available here because we've specified `T` in
-# `vars_state` given `Auxiliary`
-function heat_eq_nodal_update_aux!(
-    m::BurgersEquation,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-)
-    aux.T = state.ρcT / (state.ρ * m.c)
-end;
-
 # Since we have second-order fluxes, we must tell `ClimateMachine` to compute
-# the gradient of `ρcT` and `u`. Here, we specify how `ρcT`, `u` are computed. Note that
-# `transform.ρcT` and `transform.u` are available here because we've specified `ρcT`
-# and `u`in `vars_state` given `Gradient`
+# the gradient of `ρcT`, `u` and `ρu`. Here, we specify how `ρcT`, `u` and `ρu` are computed. Note that
+# e.g. `transform.ρcT` is available here because we've specified `ρcT` in `vars_state(m, ::Gradient, FT)`.
 function compute_gradient_argument!(
     m::BurgersEquation,
     transform::Vars,
@@ -246,31 +259,36 @@ function compute_gradient_argument!(
 )
     transform.ρcT = state.ρcT
     transform.u = state.ρu / state.ρ
+    transform.ρu = state.ρu
 end;
 
 # Specify where in `diffusive::Vars` to store the computed gradient from
 # `compute_gradient_argument!`. Note that:
-#  - `diffusive.μ∇u` is available here because we've specified `μ∇u` in
-#  `vars_state` given `GradientFlux`
-#  - `∇transform.u` is available here because we've specified `u` in
-#  `vars_state` given `Gradient`
-#  - `diffusive.μ∇u` is built using an anisotropic diffusivity tensor
+#  - `diffusive.μ∇u` is available here because we've specified `μ∇u` in `vars_state(m, ::GradientFlux, FT)`.
+#  - `∇transform.u` is available here because we've specified `u` in `vars_state(m, ::Gradient, FT)`.
+#  - `diffusive.μ∇u` is built using an anisotropic diffusivity tensor.
+#  - The `divergence` may be computed from the trace of tensor `∇ρu`.
 function compute_gradient_flux!(
-    m::BurgersEquation,
+    m::BurgersEquation{FT},
     diffusive::Vars,
     ∇transform::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
-)
-    diffusive.α∇ρcT = m.α * ∇transform.ρcT
+) where {FT}
+    ∇ρu = ∇transform.ρu
+    ẑ = vertical_unit_vector(m.orientation, m.param_set, aux)
+    divergence = tr(∇ρu) - ẑ' * ∇ρu * ẑ
+    diffusive.α∇ρcT = Diagonal(SVector(m.αh, m.αh, m.αv)) * ∇transform.ρcT
     diffusive.μ∇u = Diagonal(SVector(m.μh, m.μh, m.μv)) * ∇transform.u
+    diffusive.νd∇D =
+        Diagonal(SVector(m.νd, m.νd, FT(0))) *
+        Diagonal(SVector(divergence, divergence, FT(0)))
 end;
 
 # Introduce Rayleigh friction towards a target profile as a source.
 # Note that:
-# - Rayleigh damping is only applied in the horizontal by subtracting
-#  the vertical component of momentum from the momentum vector.
+# - Rayleigh damping is only applied in the horizontal using the `projection_tangential` method.
 function source!(
     m::BurgersEquation{FT},
     source::Vars,
@@ -279,21 +297,22 @@ function source!(
     aux::Vars,
     args...,
 ) where {FT}
-    ẑ = SVector{3, FT}(0, 0, 1)
+    ẑ = vertical_unit_vector(m.orientation, m.param_set, aux)
+    z = aux.coord[3]
     ρ̄ū =
         state.ρ * SVector{3, FT}(
-            0.5 - 2 * (aux.z - m.zmax / 2)^2,
-            0.5 - 2 * (aux.z - m.zmax / 2)^2,
+            0.5 - 2 * (z - m.zmax / 2)^2,
+            0.5 - 2 * (z - m.zmax / 2)^2,
             0.0,
         )
     ρu_p = state.ρu - ρ̄ū
-    source.ρu -= m.γ * (ρu_p - ẑ' * ρu_p * ẑ)
+    source.ρu -=
+        m.γ * projection_tangential(m.orientation, m.param_set, aux, ρu_p)
 end;
 
 # Compute advective flux.
 # Note that:
-# - `state.ρu` is available here because we've specified `ρu` in
-# `vars_state` given `Prognostic`
+# - `state.ρu` is available here because we've specified `ρu` in `vars_state(m, state, FT)`.
 function flux_first_order!(
     m::BurgersEquation,
     flux::Grad,
@@ -311,8 +330,8 @@ end;
 
 # Compute diffusive flux (e.g. ``F(μ, \mathbf{u}, t) = -μ∇\mathbf{u}`` in the original PDE).
 # Note that:
-# - `diffusive.μ∇u` is available here because we've specified `μ∇u` in
-# `vars_state` given `GradientFlux`
+# - `diffusive.μ∇u` is available here because we've specified `μ∇u` in `vars_state(m, ::GradientFlux, FT)`.
+# - The divergence gradient can be written as a diffusive flux using a divergence diagonal tensor.
 function flux_second_order!(
     m::BurgersEquation,
     flux::Grad,
@@ -324,6 +343,7 @@ function flux_second_order!(
 )
     flux.ρcT -= diffusive.α∇ρcT
     flux.ρu -= diffusive.μ∇u
+    flux.ρu -= diffusive.νd∇D
 end;
 
 # ### Boundary conditions
@@ -333,7 +353,7 @@ end;
 # Boundary conditions must be specified for all unknowns, both first-order and
 # second-order unknowns which have been reformulated.
 
-# The boundary conditions for `ρ`, `ρu` and `ρcT` (first order unknown)
+# The boundary conditions for `ρ`, `ρu` and `ρcT` (first order unknowns)
 function boundary_state!(
     nf,
     m::BurgersEquation,
@@ -389,7 +409,7 @@ end;
 N_poly = 5;
 
 # Specify the number of vertical elements
-nelem_vert = 20;
+nelem_vert = 10;
 
 # Specify the domain height
 zmax = m.zmax;
@@ -408,16 +428,17 @@ driver_config = ClimateMachine.SingleStackConfiguration(
 # # Time discretization
 
 # Specify simulation time (SI units)
-t0 = FT(0)
-timeend = FT(10)
+t0 = FT(0);
+timeend = FT(1);
 
-# We'll define the time-step based on the [Fourier
-# number] and the [Courant number] of the flow
+# We'll define the time-step based on the Fourier
+# number and the [Courant number](https://en.wikipedia.org/wiki/Courant–Friedrichs–Lewy_condition)
+# of the flow
 Δ = min_node_distance(driver_config.grid)
 
-given_Fourier = FT(0.08);
-Fourier_bound = given_Fourier * Δ^2 / max(m.α, m.μh);
-Courant_bound = FT(0.1) * Δ
+given_Fourier = FT(0.5);
+Fourier_bound = given_Fourier * Δ^2 / max(m.αh, m.μh, m.νd);
+Courant_bound = FT(0.5) * Δ;
 dt = min(Fourier_bound, Courant_bound)
 
 # # Configure a `ClimateMachine` solver.
@@ -432,9 +453,9 @@ dt = min(Fourier_bound, Courant_bound)
 solver_config =
     ClimateMachine.SolverConfiguration(t0, timeend, driver_config, ode_dt = dt);
 
-# ## Inspect the initial conditions for a single node (e.g. the southwest node)
+# ## Inspect the initial conditions for a single nodal stack
 
-# Let's export a plot of the initial state
+# Let's export plots of the initial state
 output_dir = @__DIR__;
 
 mkpath(output_dir);
@@ -448,45 +469,44 @@ state_vars = get_vars_from_nodal_stack(
     solver_config.Q,
     vars_state(m, Prognostic(), FT),
 );
-aux_vars = get_vars_from_nodal_stack(
-    driver_config.grid,
-    solver_config.dg.state_auxiliary,
-    vars_state(m, Auxiliary(), FT),
-    exclude = [z_key],
-);
-all_vars = [OrderedDict(state_vars..., aux_vars...)];
-time_data = FT[0]; # store time data
 
-# Generate plots of initial conditions
+# Create an array to store the solution:
+state_data = Dict[state_vars]  # store initial condition at ``t=0``
+time_data = FT[0]                                      # store time data
+
+# Generate plots of initial conditions for the southwest nodal stack
 export_plot(
     z,
-    all_vars,
+    state_data,
     ("ρcT",),
-    joinpath(output_dir, "initial_condition_T.png");
-    xlabel = "ρcT",
+    joinpath(output_dir, "initial_condition_T_nodal.png"),
+    xlabel = "ρcT at southwest node",
     ylabel = z_label,
     time_data = time_data,
 );
 export_plot(
     z,
-    all_vars,
+    state_data,
     ("ρu[1]",),
-    joinpath(output_dir, "initial_condition_u.png");
-    xlabel = "ρu[1]",
+    joinpath(output_dir, "initial_condition_u_nodal.png"),
+    xlabel = "ρu at southwest node",
     ylabel = z_label,
     time_data = time_data,
 );
 export_plot(
     z,
-    all_vars,
+    state_data,
     ("ρu[2]",),
-    joinpath(output_dir, "initial_condition_v.png"),
-    xlabel = "ρu[2]",
+    joinpath(output_dir, "initial_condition_v_nodal.png"),
+    xlabel = "ρv at southwest node",
     ylabel = z_label,
     time_data = time_data,
 );
 
-# ## Inspect the initial conditions for the horizontal average
+# ![](initial_condition_T_nodal.png)
+# ![](initial_condition_u_nodal.png)
+
+# ## Inspect the initial conditions for the horizontal averages
 
 # Horizontal statistics of variables
 
@@ -510,7 +530,7 @@ export_plot(
     data_avg,
     ("ρu[1]",),
     joinpath(output_dir, "initial_condition_avg_u.png");
-    xlabel = "ρu[1]",
+    xlabel = "Horizontal mean of ρu",
     ylabel = z_label,
     time_data = time_data,
 );
@@ -519,7 +539,7 @@ export_plot(
     data_var,
     ("ρu[1]",),
     joinpath(output_dir, "initial_condition_variance_u.png"),
-    xlabel = "ρu[1]",
+    xlabel = "Horizontal variance of ρu",
     ylabel = z_label,
     time_data = time_data,
 );
@@ -531,15 +551,26 @@ export_plot(
 
 # Define the number of outputs from `t0` to `timeend`
 const n_outputs = 5;
+const every_x_simulation_time = timeend / n_outputs;
 
-# This equates to exports every ceil(Int, timeend/n_outputs) time-step:
-const every_x_simulation_time = ceil(Int, timeend / n_outputs);
+# Create a dictionary for `z` coordinate (and convert to cm) NCDatasets IO:
+dims = OrderedDict(z_key => collect(z));
+
+# Create dictionaries to store outputs:
+data_var = Dict[Dict([k => Dict() for k in 0:n_outputs]...),]
+data_var[1] = state_vars_var
+
+data_avg = Dict[Dict([k => Dict() for k in 0:n_outputs]...),]
+data_avg[1] = state_vars_avg
+
+data_nodal = Dict[Dict([k => Dict() for k in 0:n_outputs]...),]
+data_nodal[1] = state_vars
 
 # The `ClimateMachine`'s time-steppers provide hooks, or callbacks, which
 # allow users to inject code to be executed at specified intervals. In this
-# callback, a dictionary of variables are appended to `all_data` for time
-# the callback is executed. In addition, time is collected and appended to
-# `time_data`.
+# callback, the state variables are collected, combined into a single
+# `OrderedDict` and written to a NetCDF file (for each output step `step`).
+step = [0];
 callback = GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
     state_vars_var = get_horizontal_variance(
         driver_config.grid,
@@ -551,9 +582,18 @@ callback = GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
         solver_config.Q,
         vars_state(m, Prognostic(), FT),
     )
+    state_vars = get_vars_from_nodal_stack(
+        driver_config.grid,
+        solver_config.Q,
+        vars_state(m, Prognostic(), FT),
+        i = 1,
+        j = 1,
+    )
+    step[1] += 1
     push!(data_var, state_vars_var)
     push!(data_avg, state_vars_avg)
-    push!(time_data, gettime(solver_config.solver))
+    push!(data_nodal, state_vars)
+    push!(time_data, round(gettime(solver_config.solver), digits = 3))
     nothing
 end;
 
@@ -569,13 +609,14 @@ ClimateMachine.invoke!(solver_config; user_callbacks = (callback,))
 # Our solution has now been calculated and exported to NetCDF files in
 # `output_dir`.
 
-# Let's plot the horizontal statistics of the solution:
+# Let's plot the horizontal statistics of `ρu` and `ρcT`, as well as the evolution of
+# `ρu` for the southwest nodal stack:
 export_plot(
     z,
     data_avg,
     ("ρu[1]"),
-    joinpath(output_dir, "solution_vs_time_u.png");
-    xlabel = "Horizontal mean rho*u",
+    joinpath(output_dir, "solution_vs_time_u_avg.png"),
+    xlabel = "Horizontal mean of ρu",
     ylabel = z_label,
     time_data = time_data,
 );
@@ -583,8 +624,8 @@ export_plot(
     z,
     data_var,
     ("ρu[1]"),
-    joinpath(output_dir, "variance_vs_time_u.png");
-    xlabel = "Horizontal variance rho*u",
+    joinpath(output_dir, "variance_vs_time_u.png"),
+    xlabel = "Horizontal variance of ρu",
     ylabel = z_label,
     time_data = time_data,
 );
@@ -592,26 +633,43 @@ export_plot(
     z,
     data_avg,
     ("ρcT"),
-    joinpath(output_dir, "solution_vs_time_T.png");
-    xlabel = "Horizontal mean rho*c*T",
+    joinpath(output_dir, "solution_vs_time_T_avg.png"),
+    xlabel = "Horizontal mean of ρcT",
     ylabel = z_label,
     time_data = time_data,
 );
 export_plot(
     z,
     data_var,
-    ("ρu[3]"),
-    joinpath(output_dir, "variance_vs_time_w.png");
-    xlabel = "Horizontal variance rho*w",
+    ("ρcT"),
+    joinpath(output_dir, "variance_vs_time_T.png"),
+    xlabel = "Horizontal variance of ρcT",
     ylabel = z_label,
     time_data = time_data,
 );
-# ![](solution_vs_time_u.png)
+export_plot(
+    z,
+    data_nodal,
+    ("ρu[1]"),
+    joinpath(output_dir, "solution_vs_time_u_nodal.png"),
+    xlabel = "ρu at southwest node",
+    ylabel = z_label,
+    time_data = time_data,
+);
+# ![](solution_vs_time_u_avg.png)
 # ![](variance_vs_time_u.png)
+# ![](solution_vs_time_T_avg.png)
+# ![](variance_vs_time_T.png)
+# ![](solution_vs_time_u_nodal.png)
 
-# The results look as we would expect: they Rayleigh friction damps the
-# horizontal velocity to the objective profile and the horizontal
-# diffusivity damps the horizontal variance. To run this file, and
+# Rayleigh friction returns the horizontal velocity to the objective
+# profile on the timescale of the simulation (1 second), since `γ`∼1. The horizontal viscosity
+# and 2D divergence damping act to reduce the horizontal variance over the same timescale.
+# The initial Gaussian noise is propagated to the temperature field through advection.
+# The horizontal diffusivity acts to reduce this `ρcT` variance in time, although in a longer
+# timescale.
+
+# To run this file, and
 # inspect the solution, include this tutorial in the Julia REPL
 # with:
 


### PR DESCRIPTION
Added divergence damping and model orientation

# Description

Added 2D divergence damping horizontal flow, model orientation for correct projections and changed the timescale of the problem for more relevant output.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [X] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
