### PR TITLE
Add turbconv integral hooks to AtmosModel

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -319,6 +319,7 @@ end
 function vars_state(m::AtmosModel, st::UpwardIntegrals, FT)
     @vars begin
         radiation::vars_state(m.radiation, st, FT)
+        turbconv::vars_state(m.turbconv, st, FT)
     end
 end
 """
@@ -614,10 +615,12 @@ function integral_load_auxiliary_state!(
     aux::Vars,
 )
     integral_load_auxiliary_state!(m.radiation, integ, state, aux)
+    integral_load_auxiliary_state!(m.turbconv, m, integ, state, aux)
 end
 
 function integral_set_auxiliary_state!(m::AtmosModel, aux::Vars, integ::Vars)
     integral_set_auxiliary_state!(m.radiation, aux, integ)
+    integral_set_auxiliary_state!(m.turbconv, m, aux, integ)
 end
 
 function reverse_integral_load_auxiliary_state!(

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -21,7 +21,9 @@ import ..BalanceLaws:
     flux_second_order!,
     boundary_state!,
     compute_gradient_argument!,
-    compute_gradient_flux!
+    compute_gradient_flux!,
+    integral_load_auxiliary_state!,
+    integral_set_auxiliary_state!
 
 using ..MPIStateArrays: MPIStateArray
 using ..DGMethods: nodal_update_auxiliary_state!
@@ -111,6 +113,25 @@ function flux_second_order!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+)
+    return nothing
+end
+
+function integral_load_auxiliary_state!(
+    m::TurbulenceConvectionModel,
+    bl::BalanceLaw,
+    integ::Vars,
+    state::Vars,
+    aux::Vars,
+)
+    return nothing
+end
+
+function integral_set_auxiliary_state!(
+    m::TurbulenceConvectionModel,
+    bl::BalanceLaw,
+    aux::Vars,
+    integ::Vars,
 )
     return nothing
 end


### PR DESCRIPTION
# Description

The EDMF model needs to estimate the updraft top, which requires computing an integral. This PR adds the `turbconv` integral hooks to the AtmosModel.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
