### PR TITLE
Add UpDownIntegrals, unify Upward and reverse_ integral methods

### DIFF
--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -48,11 +48,8 @@ source!
 
 ```@docs
 indefinite_stack_integral!
-reverse_indefinite_stack_integral!
 integral_load_auxiliary_state!
 integral_set_auxiliary_state!
-reverse_integral_load_auxiliary_state!
-reverse_integral_set_auxiliary_state!
 ```
 
 ## Gradient/Laplacian kernels

--- a/docs/src/HowToGuides/Numerics/DGMethods/how_to_make_a_balance_law.md
+++ b/docs/src/HowToGuides/Numerics/DGMethods/how_to_make_a_balance_law.md
@@ -52,8 +52,6 @@ The `vars_state` method is used to specify the names of the variables for the fo
 | [`compute_gradient_flux!`](@ref) | specify how to compute gradient fluxes. can be a functions of the gradient state, the prognostic state, and auxiliary variables.|
 | [`integral_load_auxiliary_state!`](@ref) | specify how to compute integrands. can be functions of the prognostic state and auxiliary variables. |
 | [`integral_set_auxiliary_state!`](@ref) | specify which auxiliary variables are used to store the output of the integrals. |
-| [`reverse_integral_load_auxiliary_state!`](@ref) | specify auxiliary variables need their integrals reversed. |
-| [`reverse_integral_set_auxiliary_state!`](@ref) | specify which auxiliary variables are used to store the output of the reversed integrals. |
 | [`update_auxiliary_state!`](@ref) | perform any updates to the auxiliary variables needed at the beginning of each time-step. Can be used to solve non-linear equations, calculate integrals, and apply filters. |
 | [`update_auxiliary_state_gradient!`](@ref) | same as above, but after computing gradients and gradient fluxes in case these variables are needed during the update. |
 

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -32,11 +32,8 @@ const param_set = EarthParameterSet()
 import ClimateMachine.BalanceLaws:
     vars_state,
     indefinite_stack_integral!,
-    reverse_indefinite_stack_integral!,
     integral_load_auxiliary_state!,
-    integral_set_auxiliary_state!,
-    reverse_integral_load_auxiliary_state!,
-    reverse_integral_set_auxiliary_state!
+    integral_set_auxiliary_state!
 
 import ClimateMachine.BalanceLaws: boundary_state!
 import ClimateMachine.Atmos: flux_second_order!
@@ -57,18 +54,13 @@ function integral_load_auxiliary_state!(
     integ::Vars,
     state::Vars,
     aux::Vars,
+    ::IntegralType,
 ) end
-function integral_set_auxiliary_state!(::RadiationModel, aux::Vars, integ::Vars) end
-function reverse_integral_load_auxiliary_state!(
-    ::RadiationModel,
-    integ::Vars,
-    state::Vars,
-    aux::Vars,
-) end
-function reverse_integral_set_auxiliary_state!(
+function integral_set_auxiliary_state!(
     ::RadiationModel,
     aux::Vars,
     integ::Vars,
+    ::IntegralType,
 ) end
 function flux_radiation!(
     ::RadiationModel,
@@ -113,6 +105,7 @@ function integral_load_auxiliary_state!(
     integrand::Vars,
     state::Vars,
     aux::Vars,
+    ::UpwardIntegrals,
 )
     FT = eltype(state)
     integrand.radiation.attenuation_coeff = state.ρ * m.κ * aux.moisture.q_liq
@@ -121,6 +114,7 @@ function integral_set_auxiliary_state!(
     m::DYCOMSRadiation,
     aux::Vars,
     integral::Vars,
+    ::UpwardIntegrals,
 )
     integral = integral.radiation.attenuation_coeff
     aux.∫dz.radiation.attenuation_coeff = integral
@@ -128,19 +122,21 @@ end
 
 vars_state(m::DYCOMSRadiation, ::DownwardIntegrals, FT) =
     @vars(attenuation_coeff::FT)
-function reverse_integral_load_auxiliary_state!(
+function integral_load_auxiliary_state!(
     m::DYCOMSRadiation,
     integrand::Vars,
     state::Vars,
     aux::Vars,
+    ::DownwardIntegrals,
 )
     FT = eltype(state)
     integrand.radiation.attenuation_coeff = aux.∫dz.radiation.attenuation_coeff
 end
-function reverse_integral_set_auxiliary_state!(
+function integral_set_auxiliary_state!(
     m::DYCOMSRadiation,
     aux::Vars,
     integral::Vars,
+    ::DownwardIntegrals,
 )
     aux.∫dnz.radiation.attenuation_coeff = integral.radiation.attenuation_coeff
 end

--- a/experiments/AtmosLES/taylor_green.jl
+++ b/experiments/AtmosLES/taylor_green.jl
@@ -29,11 +29,8 @@ const param_set = EarthParameterSet()
 import ClimateMachine.BalanceLaws:
     vars_state,
     indefinite_stack_integral!,
-    reverse_indefinite_stack_integral!,
     integral_load_auxiliary_state!,
-    integral_set_auxiliary_state!,
-    reverse_integral_load_auxiliary_state!,
-    reverse_integral_set_auxiliary_state!
+    integral_set_auxiliary_state!
 
 import ClimateMachine.BalanceLaws: boundary_state!
 import ClimateMachine.Atmos: flux_second_order!

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -52,11 +52,8 @@ import ClimateMachine.BalanceLaws:
     init_state_prognostic!,
     update_auxiliary_state!,
     indefinite_stack_integral!,
-    reverse_indefinite_stack_integral!,
     integral_load_auxiliary_state!,
-    integral_set_auxiliary_state!,
-    reverse_integral_load_auxiliary_state!,
-    reverse_integral_set_auxiliary_state!
+    integral_set_auxiliary_state!
 
 import ClimateMachine.DGMethods:
     LocalGeometry,
@@ -570,9 +567,15 @@ function update_auxiliary_state!(
     FT = eltype(Q)
     state_auxiliary = dg.state_auxiliary
 
-    if number_states(m, UpwardIntegrals()) > 0
-        indefinite_stack_integral!(dg, m, Q, state_auxiliary, t, elems)
-        reverse_indefinite_stack_integral!(dg, m, Q, state_auxiliary, t, elems)
+    ui = UpwardIntegrals()
+    di = DownwardIntegrals()
+    nsu = number_states(m, ui)
+    nsd = number_states(m, di)
+    if nsu > 0
+        indefinite_stack_integral!(dg, m, Q, state_auxiliary, t, ui, elems)
+    end
+    if nsu > 0
+        indefinite_stack_integral!(dg, m, Q, state_auxiliary, t, di, elems)
     end
 
     nodal_update_auxiliary_state!(
@@ -613,31 +616,39 @@ function integral_load_auxiliary_state!(
     integ::Vars,
     state::Vars,
     aux::Vars,
+    i::UpwardIntegrals,
 )
-    integral_load_auxiliary_state!(m.radiation, integ, state, aux)
-    integral_load_auxiliary_state!(m.turbconv, m, integ, state, aux)
+    integral_load_auxiliary_state!(m.radiation, integ, state, aux, i)
+    integral_load_auxiliary_state!(m.turbconv, m, integ, state, aux, i)
 end
 
-function integral_set_auxiliary_state!(m::AtmosModel, aux::Vars, integ::Vars)
-    integral_set_auxiliary_state!(m.radiation, aux, integ)
-    integral_set_auxiliary_state!(m.turbconv, m, aux, integ)
+function integral_set_auxiliary_state!(
+    m::AtmosModel,
+    aux::Vars,
+    integ::Vars,
+    i::UpwardIntegrals,
+)
+    integral_set_auxiliary_state!(m.radiation, aux, integ, i)
+    integral_set_auxiliary_state!(m.turbconv, m, aux, integ, i)
 end
 
-function reverse_integral_load_auxiliary_state!(
+function integral_load_auxiliary_state!(
     m::AtmosModel,
     integ::Vars,
     state::Vars,
     aux::Vars,
+    i::DownwardIntegrals,
 )
-    reverse_integral_load_auxiliary_state!(m.radiation, integ, state, aux)
+    integral_load_auxiliary_state!(m.radiation, integ, state, aux, i)
 end
 
-function reverse_integral_set_auxiliary_state!(
+function integral_set_auxiliary_state!(
     m::AtmosModel,
     aux::Vars,
     integ::Vars,
+    i::DownwardIntegrals,
 )
-    reverse_integral_set_auxiliary_state!(m.radiation, aux, integ)
+    integral_set_auxiliary_state!(m.radiation, aux, integ, i)
 end
 
 

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -104,19 +104,13 @@ integral_load_auxiliary_state!(
     integ::Vars,
     state::Vars,
     aux::Vars,
+    ::IntegralType,
 ) = nothing
-integral_set_auxiliary_state!(lm::AtmosLinearModel, aux::Vars, integ::Vars) =
-    nothing
-reverse_integral_load_auxiliary_state!(
-    lm::AtmosLinearModel,
-    integ::Vars,
-    state::Vars,
-    aux::Vars,
-) = nothing
-reverse_integral_set_auxiliary_state!(
+integral_set_auxiliary_state!(
     lm::AtmosLinearModel,
     aux::Vars,
     integ::Vars,
+    ::IntegralType,
 ) = nothing
 flux_second_order!(
     lm::AtmosLinearModel,

--- a/src/Atmos/Model/radiation.jl
+++ b/src/Atmos/Model/radiation.jl
@@ -11,23 +11,31 @@ function atmos_nodal_update_auxiliary_state!(
     aux::Vars,
     t::Real,
 ) end
-function integral_set_auxiliary_state!(::RadiationModel, integ::Vars, aux::Vars) end
+function integral_set_auxiliary_state!(
+    ::RadiationModel,
+    integ::Vars,
+    aux::Vars,
+    ::UpwardIntegrals,
+) end
 function integral_load_auxiliary_state!(
     ::RadiationModel,
     integ::Vars,
     state::Vars,
     aux::Vars,
+    ::UpwardIntegrals,
 ) end
-function reverse_integral_set_auxiliary_state!(
+function integral_set_auxiliary_state!(
     ::RadiationModel,
     integ::Vars,
     aux::Vars,
+    ::DownwardIntegrals,
 ) end
-function reverse_integral_load_auxiliary_state!(
+function integral_load_auxiliary_state!(
     ::RadiationModel,
     integ::Vars,
     state::Vars,
     aux::Vars,
+    ::DownwardIntegrals,
 ) end
 function flux_radiation!(
     ::RadiationModel,

--- a/src/BalanceLaws/BalanceLaws.jl
+++ b/src/BalanceLaws/BalanceLaws.jl
@@ -29,10 +29,7 @@ export BalanceLaw,
     nodal_update_auxiliary_state!,
     integral_load_auxiliary_state!,
     integral_set_auxiliary_state!,
-    indefinite_stack_integral!,
-    reverse_indefinite_stack_integral!,
-    reverse_integral_load_auxiliary_state!,
-    reverse_integral_set_auxiliary_state!
+    indefinite_stack_integral!
 
 include("state_types.jl")
 include("interface.jl")

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -243,28 +243,6 @@ Compute indefinite integral along stack.
 """
 function indefinite_stack_integral! end
 
-"""
-    reverse_integral_load_auxiliary_state!
-
-Specify auxiliary variables need their integrals reversed.
-"""
-function reverse_integral_load_auxiliary_state! end
-
-"""
-    reverse_integral_set_auxiliary_state!
-
-Specify which auxiliary variables are used to store the output of the
-reversed integrals.
-"""
-function reverse_integral_set_auxiliary_state! end
-
-"""
-    reverse_indefinite_stack_integral!
-
-Compute reverse indefinite integral along stack.
-"""
-function reverse_indefinite_stack_integral! end
-
 # Internal methods
 number_states(m::BalanceLaw, st::AbstractStateType, FT = Int) =
     varsize(vars_state(m, st, FT))

--- a/src/BalanceLaws/state_types.jl
+++ b/src/BalanceLaws/state_types.jl
@@ -7,6 +7,7 @@ export AbstractStateType,
     GradientFlux,
     GradientLaplacian,
     Hyperdiffusive,
+    IntegralType,
     UpwardIntegrals,
     DownwardIntegrals
 
@@ -62,15 +63,22 @@ Hyper-diffusive variables
 struct Hyperdiffusive <: AbstractStateType end
 
 """
-    UpwardIntegrals <: AbstractStateType
+    IntegralType <: AbstractStateType
+
+Super-type for UpwardIntegrals and DownwardIntegrals
+"""
+abstract type IntegralType <: AbstractStateType end
+
+"""
+    UpwardIntegrals <: IntegralType
 
 Variables computed in upward integrals
 """
-struct UpwardIntegrals <: AbstractStateType end
+struct UpwardIntegrals <: IntegralType end
 
 """
-    DownwardIntegrals <: AbstractStateType
+    DownwardIntegrals <: IntegralType
 
 Variables computed in downward integrals
 """
-struct DownwardIntegrals <: AbstractStateType end
+struct DownwardIntegrals <: IntegralType end

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -58,11 +58,8 @@ import ClimateMachine.BalanceLaws:
     update_auxiliary_state!,
     nodal_update_auxiliary_state!,
     indefinite_stack_integral!,
-    reverse_indefinite_stack_integral!,
     integral_load_auxiliary_state!,
-    integral_set_auxiliary_state!,
-    reverse_integral_load_auxiliary_state!,
-    reverse_integral_set_auxiliary_state!
+    integral_set_auxiliary_state!
 
 
 export TurbulenceClosureModel,

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -6,7 +6,7 @@ the Eddy-Diffusivity Mass-Flux model
 """
 module TurbulenceConvection
 
-using ..BalanceLaws: BalanceLaw, AbstractStateType
+using ..BalanceLaws: BalanceLaw, AbstractStateType, UpwardIntegrals
 using ..VariableTemplates: @vars, Vars, Grad
 
 export TurbulenceConvectionModel, NoTurbConv
@@ -123,6 +123,7 @@ function integral_load_auxiliary_state!(
     integ::Vars,
     state::Vars,
     aux::Vars,
+    i::UpwardIntegrals,
 )
     return nothing
 end
@@ -132,6 +133,7 @@ function integral_set_auxiliary_state!(
     bl::BalanceLaw,
     aux::Vars,
     integ::Vars,
+    i::UpwardIntegrals,
 )
     return nothing
 end

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -41,10 +41,7 @@ import ..BalanceLaws:
     nodal_update_auxiliary_state!,
     integral_load_auxiliary_state!,
     integral_set_auxiliary_state!,
-    indefinite_stack_integral!,
-    reverse_indefinite_stack_integral!,
-    reverse_integral_load_auxiliary_state!,
-    reverse_integral_set_auxiliary_state!
+    indefinite_stack_integral!
 
 export DGModel,
     init_ode_state, restart_ode_state, restart_auxiliary_state, basic_grid_info

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -696,6 +696,7 @@ function indefinite_stack_integral!(
     state_prognostic::MPIStateArray,
     state_auxiliary::MPIStateArray,
     t::Real,
+    ::UpwardIntegrals,
     elems::UnitRange = dg.grid.topology.elems,
 )
 
@@ -733,12 +734,13 @@ function indefinite_stack_integral!(
     wait(device, event)
 end
 
-function reverse_indefinite_stack_integral!(
+function indefinite_stack_integral!(
     dg::DGModel,
     m::BalanceLaw,
     state_prognostic::MPIStateArray,
     state_auxiliary::MPIStateArray,
     t::Real,
+    ::DownwardIntegrals,
     elems::UnitRange = dg.grid.topology.elems,
 )
 

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -1791,6 +1791,7 @@ See [`BalanceLaw`](@ref) for usage.
                     Vars{vars_state(balance_law, Auxiliary(), FT)}(
                         local_state_auxiliary,
                     ),
+                    UpwardIntegrals()
                 )
 
                 # multiply in the curve jacobian
@@ -1827,6 +1828,7 @@ See [`BalanceLaw`](@ref) for usage.
                         :,
                         k,
                     )),
+                    UpwardIntegrals()
                 )
                 @unroll for ind_out in 1:nout
                     local_integral[ind_out, k] = local_integral[ind_out, Nq]
@@ -1867,7 +1869,7 @@ end
         # Initialize the constant state at zero
         ijk = i + Nq * ((j - 1) + Nqj * (Nq - 1))
         et = nvertelem + (eh - 1) * nvertelem
-        reverse_integral_load_auxiliary_state!(
+        integral_load_auxiliary_state!(
             balance_law,
             Vars{vars_state(balance_law, DownwardIntegrals(), FT)}(l_T),
             Vars{vars_state(balance_law, Prognostic(), FT)}(view(
@@ -1882,6 +1884,7 @@ end
                 :,
                 et,
             )),
+            DownwardIntegrals()
         )
 
         # Loop up the stack of elements
@@ -1889,7 +1892,7 @@ end
             e = ev + (eh - 1) * nvertelem
             @unroll for k in 1:Nq
                 ijk = i + Nq * ((j - 1) + Nqj * (k - 1))
-                reverse_integral_load_auxiliary_state!(
+                integral_load_auxiliary_state!(
                     balance_law,
                     Vars{vars_state(balance_law, DownwardIntegrals(), FT)}(l_V),
                     Vars{vars_state(balance_law, Prognostic(), FT)}(view(
@@ -1904,9 +1907,10 @@ end
                         :,
                         e,
                     )),
+                    DownwardIntegrals()
                 )
                 l_V .= l_T .- l_V
-                reverse_integral_set_auxiliary_state!(
+                integral_set_auxiliary_state!(
                     balance_law,
                     Vars{vars_state(balance_law, Auxiliary(), FT)}(view(
                         state_auxiliary,
@@ -1915,6 +1919,7 @@ end
                         e,
                     )),
                     Vars{vars_state(balance_law, DownwardIntegrals(), FT)}(l_V),
+                    DownwardIntegrals(),
                 )
             end
         end

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -15,9 +15,7 @@ import ..BalanceLaws:
     boundary_state!,
     update_auxiliary_state!,
     integral_load_auxiliary_state!,
-    integral_set_auxiliary_state!,
-    reverse_integral_load_auxiliary_state!,
-    reverse_integral_set_auxiliary_state!
+    integral_set_auxiliary_state!
 
 """
     RemBL(
@@ -171,12 +169,6 @@ integral_load_auxiliary_state!(rem_balance_law::RemBL, args...) =
 
 integral_set_auxiliary_state!(rem_balance_law::RemBL, args...) =
     integral_set_auxiliary_state!(rem_balance_law.main, args...)
-
-reverse_integral_load_auxiliary_state!(rem_balance_law::RemBL, args...) =
-    reverse_integral_load_auxiliary_state!(rem_balance_law.main, args...)
-
-reverse_integral_set_auxiliary_state!(rem_balance_law::RemBL, args...) =
-    reverse_integral_set_auxiliary_state!(rem_balance_law.main, args...)
 
 transform_post_gradient_laplacian!(rem_balance_law::RemBL, args...) =
     transform_post_gradient_laplacian!(rem_balance_law.main, args...)

--- a/src/Ocean/SplitExplicit/VerticalIntegralModel.jl
+++ b/src/Ocean/SplitExplicit/VerticalIntegralModel.jl
@@ -71,7 +71,7 @@ function update_auxiliary_state!(
     nodal_update_auxiliary_state!(f!, dg, tm, x, t)
 
     # compute integral for Gᵁ
-    indefinite_stack_integral!(dg, tm, x, A, t) # bottom -> top
+    indefinite_stack_integral!(dg, tm, x, A, t, UpwardIntegrals()) # bottom -> top
 
     return true
 end

--- a/test/Numerics/DGMethods/integral_test.jl
+++ b/test/Numerics/DGMethods/integral_test.jl
@@ -24,11 +24,8 @@ import ClimateMachine.BalanceLaws:
     init_state_prognostic!,
     update_auxiliary_state!,
     indefinite_stack_integral!,
-    reverse_indefinite_stack_integral!,
     integral_load_auxiliary_state!,
-    integral_set_auxiliary_state!,
-    reverse_integral_load_auxiliary_state!,
-    reverse_integral_set_auxiliary_state!
+    integral_set_auxiliary_state!
 
 import ClimateMachine.DGMethods: init_ode_state
 using ClimateMachine.Mesh.Geometry: LocalGeometry
@@ -91,8 +88,24 @@ function update_auxiliary_state!(
     t::Real,
     elems::UnitRange,
 )
-    indefinite_stack_integral!(dg, m, Q, dg.state_auxiliary, t, elems)
-    reverse_indefinite_stack_integral!(dg, m, Q, dg.state_auxiliary, t, elems)
+    indefinite_stack_integral!(
+        dg,
+        m,
+        Q,
+        dg.state_auxiliary,
+        t,
+        UpwardIntegrals(),
+        elems,
+    )
+    indefinite_stack_integral!(
+        dg,
+        m,
+        Q,
+        dg.state_auxiliary,
+        t,
+        DownwardIntegrals(),
+        elems,
+    )
 
     return true
 end
@@ -102,6 +115,7 @@ end
     integrand::Vars,
     state::Vars,
     aux::Vars,
+    ::UpwardIntegrals,
 )
     x, y, z = aux.coord
     integrand.a = x + z
@@ -112,25 +126,28 @@ end
     m::IntegralTestModel,
     aux::Vars,
     integral::Vars,
+    ::UpwardIntegrals,
 )
     aux.int.a = integral.a
     aux.int.b = integral.b
 end
 
-@inline function reverse_integral_load_auxiliary_state!(
+@inline function integral_load_auxiliary_state!(
     m::IntegralTestModel,
     integral::Vars,
     state::Vars,
     aux::Vars,
+    ::DownwardIntegrals,
 )
     integral.a = aux.int.a
     integral.b = aux.int.b
 end
 
-@inline function reverse_integral_set_auxiliary_state!(
+@inline function integral_set_auxiliary_state!(
     m::IntegralTestModel,
     aux::Vars,
     integral::Vars,
+    ::DownwardIntegrals,
 )
     aux.rev_int.a = integral.a
     aux.rev_int.b = integral.b


### PR DESCRIPTION
# Description

 - Adds `UpdDownIntegrals`
 - Adds a `UpDownIntegrals` argument to both `integral_` and `reverse_integral` methods
 - Fixes the radiation argument list in `ClimateMachine.jl/src/Atmos/Model/radiation.jl`

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
