### PR TITLE
Fix integral kernel args in `RadiationModel `

### DIFF
--- a/src/Atmos/Model/radiation.jl
+++ b/src/Atmos/Model/radiation.jl
@@ -11,27 +11,23 @@ function atmos_nodal_update_auxiliary_state!(
     aux::Vars,
     t::Real,
 ) end
-function integral_set_auxiliary_state!(
+function integral_set_auxiliary_state!(::RadiationModel, integ::Vars, aux::Vars) end
+function integral_load_auxiliary_state!(
     ::RadiationModel,
     integ::Vars,
     state::Vars,
     aux::Vars,
-) end
-function integral_load_auxiliary_state!(
-    ::RadiationModel,
-    aux::Vars,
-    integ::Vars,
 ) end
 function reverse_integral_set_auxiliary_state!(
     ::RadiationModel,
     integ::Vars,
-    state::Vars,
     aux::Vars,
 ) end
 function reverse_integral_load_auxiliary_state!(
     ::RadiationModel,
-    aux::Vars,
     integ::Vars,
+    state::Vars,
+    aux::Vars,
 ) end
 function flux_radiation!(
     ::RadiationModel,


### PR DESCRIPTION
# Description

In the EDMF branch, we found that the upward/downward calls to [integral_load_auxiliary_state! and integral_set_auxiliary_state!](https://github.com/CliMA/ClimateMachine.jl/blob/master/src/Atmos/Model/AtmosModel.jl#L611-L641) do not match the [method signature for the default radiation model](https://github.com/CliMA/ClimateMachine.jl/blob/master/src/Atmos/Model/radiation.jl#L14-L35). This PR corrects this bug. We haven't had any issues because, currently, no models that use the `RadiationModel` have integrals (i.e., [num_states](https://github.com/CliMA/ClimateMachine.jl/blob/master/src/Atmos/Model/AtmosModel.jl#L573) is always false), and so we've not yet hit this problem.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
