### PR TITLE
Remove unused arg in number_states calls

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -551,7 +551,7 @@ end
     ss = soundspeed(m, m.moisture, state, aux)
 
     FT = typeof(state.ρ)
-    ws = fill(uN + ss, MVector{number_states(m, Prognostic(), FT), FT})
+    ws = fill(uN + ss, MVector{number_states(m, Prognostic()), FT})
     vars_ws = Vars{vars_state(m, Prognostic(), FT)}(ws)
 
     wavespeed_tracers!(m.tracers, vars_ws, nM, state, aux, t)
@@ -570,7 +570,7 @@ function update_auxiliary_state!(
     FT = eltype(Q)
     state_auxiliary = dg.state_auxiliary
 
-    if number_states(m, UpwardIntegrals(), FT) > 0
+    if number_states(m, UpwardIntegrals()) > 0
         indefinite_stack_integral!(dg, m, Q, state_auxiliary, t, elems)
         reverse_indefinite_stack_integral!(dg, m, Q, state_auxiliary, t, elems)
     end

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -244,11 +244,8 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
 
     # Interpolate the state, thermo and dyn vars to sphere (u and vorticity
     # need projection to zonal, merid). All this may happen on the GPU.
-    istate = ArrayType{FT}(
-        undef,
-        interpol.Npl,
-        number_states(atmos, Prognostic(), FT),
-    )
+    istate =
+        ArrayType{FT}(undef, interpol.Npl, number_states(atmos, Prognostic()))
     interpolate_local!(interpol, Q.realdata, istate)
 
     ithermo = ArrayType{FT}(undef, interpol.Npl, num_thermo(atmos, FT))

--- a/src/Diagnostics/atmos_refstate_perturbations.jl
+++ b/src/Diagnostics/atmos_refstate_perturbations.jl
@@ -182,11 +182,8 @@ function atmos_refstate_perturbations_collect(
 
     # Interpolate the state and thermo variables.
     interpol = dgngrp.interpol
-    istate = ArrayType{FT}(
-        undef,
-        interpol.Npl,
-        number_states(atmos, Prognostic(), FT),
-    )
+    istate =
+        ArrayType{FT}(undef, interpol.Npl, number_states(atmos, Prognostic()))
     interpolate_local!(interpol, Q.realdata, istate)
 
     if interpol isa InterpolationCubedSphere
@@ -195,11 +192,7 @@ function atmos_refstate_perturbations_collect(
         project_cubed_sphere!(interpol, istate, (_ρu, _ρv, _ρw))
     end
 
-    iaux = ArrayType{FT}(
-        undef,
-        interpol.Npl,
-        number_states(atmos, Auxiliary(), FT),
-    )
+    iaux = ArrayType{FT}(undef, interpol.Npl, number_states(atmos, Auxiliary()))
     interpolate_local!(interpol, dg.state_auxiliary.realdata, iaux)
 
     ithermo = ArrayType{FT}(undef, interpol.Npl, num_thermo(atmos, FT))

--- a/src/Diagnostics/dump_aux.jl
+++ b/src/Diagnostics/dump_aux.jl
@@ -12,7 +12,7 @@ function dump_aux_collect(dgngrp, currtime)
     iaux = similar(
         dg.state_auxiliary.data,
         interpol.Npl,
-        number_states(bl, Auxiliary(), FT),
+        number_states(bl, Auxiliary()),
     )
 
 

--- a/src/Diagnostics/dump_state.jl
+++ b/src/Diagnostics/dump_state.jl
@@ -9,7 +9,7 @@ function dump_state_collect(dgngrp, currtime)
     bl = dg.balance_law
     mpirank = MPI.Comm_rank(mpicomm)
 
-    istate = similar(Q.data, interpol.Npl, number_states(bl, Prognostic(), FT))
+    istate = similar(Q.data, interpol.Npl, number_states(bl, Prognostic()))
     interpolate_local!(interpol, Q.data, istate)
 
     if interpol isa InterpolationCubedSphere

--- a/src/Diagnostics/helpers.jl
+++ b/src/Diagnostics/helpers.jl
@@ -41,7 +41,7 @@ end
 function extract_state(dg, state, ijk, e, st::AbstractStateType)
     bl = dg.balance_law
     FT = eltype(state)
-    num_state = number_states(bl, st, FT)
+    num_state = number_states(bl, st)
     local_state = MArray{Tuple{num_state}, FT}(undef)
     for s in 1:num_state
         local_state[s] = state[ijk, s, e]

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -119,9 +119,9 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
     state_auxiliary = dg.state_auxiliary
 
     FT = eltype(state_prognostic)
-    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-    num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
-    nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
+    num_state_prognostic = number_states(balance_law, Prognostic())
+    num_state_gradient_flux = number_states(balance_law, GradientFlux())
+    nhyperviscstate = number_states(balance_law, Hyperdiffusive())
     num_state_tendency = size(tendency, 2)
 
     @assert num_state_prognostic ≤ num_state_tendency

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -53,12 +53,12 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
     @uniform begin
         N = polyorder
         FT = eltype(state_prognostic)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        num_state_gradient_flux = number_states(balance_law, GradientFlux())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
 
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
-        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive())
 
         Nq = N + 1
 
@@ -333,12 +333,12 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(state_prognostic)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        num_state_gradient_flux = number_states(balance_law, GradientFlux())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
 
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
-        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive())
 
         Nq = N + 1
 
@@ -557,11 +557,11 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
     @uniform begin
         N = polyorder
         FT = eltype(state_prognostic)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
-        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        num_state_gradient_flux = number_states(balance_law, GradientFlux())
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
 
         if dim == 1
             Np = (N + 1)
@@ -851,11 +851,11 @@ end
         N = polyorder
 
         FT = eltype(state_prognostic)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        ngradstate = number_states(balance_law, Gradient(), FT)
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
-        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        ngradstate = number_states(balance_law, Gradient())
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
+        num_state_gradient_flux = number_states(balance_law, GradientFlux())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
 
         Nq = N + 1
 
@@ -1029,11 +1029,11 @@ end
         N = polyorder
 
         FT = eltype(state_prognostic)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        ngradstate = number_states(balance_law, Gradient(), FT)
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
-        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        ngradstate = number_states(balance_law, Gradient())
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
+        num_state_gradient_flux = number_states(balance_law, GradientFlux())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
 
         Nq = N + 1
 
@@ -1209,11 +1209,11 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(state_prognostic)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        ngradstate = number_states(balance_law, Gradient(), FT)
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
-        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        ngradstate = number_states(balance_law, Gradient())
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
+        num_state_gradient_flux = number_states(balance_law, GradientFlux())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
 
         if dim == 1
             Np = (N + 1)
@@ -1485,8 +1485,8 @@ end
 ) where {dim, polyorder}
     N = polyorder
     FT = eltype(state_auxiliary)
-    num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
-    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
+    num_state_auxiliary = number_states(balance_law, Auxiliary())
+    num_state_prognostic = number_states(balance_law, Prognostic())
 
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
@@ -1540,7 +1540,7 @@ See [`BalanceLaw`](@ref) for usage.
 ) where {dim, polyorder}
     N = polyorder
     FT = eltype(state_auxiliary)
-    num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+    num_state_auxiliary = number_states(balance_law, Auxiliary())
 
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
@@ -1589,8 +1589,8 @@ Update the auxiliary state array
     activedofs,
 ) where {dim, N}
     FT = eltype(state_prognostic)
-    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-    num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+    num_state_prognostic = number_states(balance_law, Prognostic())
+    num_state_auxiliary = number_states(balance_law, Auxiliary())
 
     Nq = N + 1
 
@@ -1650,9 +1650,9 @@ end
     activedofs,
 ) where {dim, N}
     FT = eltype(state_prognostic)
-    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-    num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
-    num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+    num_state_prognostic = number_states(balance_law, Prognostic())
+    num_state_gradient_flux = number_states(balance_law, GradientFlux())
+    num_state_auxiliary = number_states(balance_law, Auxiliary())
 
     Nq = N + 1
 
@@ -1728,9 +1728,9 @@ See [`BalanceLaw`](@ref) for usage.
 ) where {dim, N, nvertelem}
     @uniform begin
         FT = eltype(state_prognostic)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
-        nout = number_states(balance_law, UpwardIntegrals(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
+        nout = number_states(balance_law, UpwardIntegrals())
 
         Nq = N + 1
         Nqj = dim == 2 ? 1 : Nq
@@ -1850,7 +1850,7 @@ end
 
         Nq = N + 1
         Nqj = dim == 2 ? 1 : Nq
-        nout = number_states(balance_law, DownwardIntegrals(), FT)
+        nout = number_states(balance_law, DownwardIntegrals())
 
         # note that k is the second not 4th index (since this is scratch memory and k
         # needs to be persistent across threads)
@@ -1935,7 +1935,7 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
 
         Nq = N + 1
 
@@ -2026,7 +2026,7 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
 
         Nq = N + 1
 
@@ -2107,7 +2107,7 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
 
         if dim == 1
             Np = (N + 1)
@@ -2219,10 +2219,10 @@ end
         N = polyorder
 
         FT = eltype(Qhypervisc_grad)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
-        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
         ngradtransformstate = num_state_prognostic
 
         Nq = N + 1
@@ -2347,10 +2347,10 @@ end
         N = polyorder
 
         FT = eltype(Qhypervisc_grad)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
-        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
         ngradtransformstate = num_state_prognostic
 
         Nq = N + 1
@@ -2457,10 +2457,10 @@ end
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        ngradlapstate = number_states(balance_law, GradientLaplacian(), FT)
-        nhyperviscstate = number_states(balance_law, Hyperdiffusive(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        ngradlapstate = number_states(balance_law, GradientLaplacian())
+        nhyperviscstate = number_states(balance_law, Hyperdiffusive())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
         ngradtransformstate = num_state_prognostic
 
         if dim == 1
@@ -2619,9 +2619,9 @@ end
 ) where {dim, N}
     @uniform begin
         FT = eltype(state_prognostic)
-        num_state_prognostic = number_states(balance_law, Prognostic(), FT)
-        num_state_gradient_flux = number_states(balance_law, GradientFlux(), FT)
-        num_state_auxiliary = number_states(balance_law, Auxiliary(), FT)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        num_state_gradient_flux = number_states(balance_law, GradientFlux())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
 
         Nq = N + 1
 

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -278,7 +278,7 @@ function numerical_flux_first_order!(
 ) where {S, A}
 
     FT = eltype(fluxᵀn)
-    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
+    num_state_prognostic = number_states(balance_law, Prognostic())
     fluxᵀn = parent(fluxᵀn)
 
     flux⁻ = similar(fluxᵀn, Size(3, num_state_prognostic))
@@ -364,7 +364,7 @@ function numerical_flux_second_order!(
 ) where {S, D, HD, A}
 
     FT = eltype(fluxᵀn)
-    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
+    num_state_prognostic = number_states(balance_law, Prognostic())
     fluxᵀn = parent(fluxᵀn)
 
     flux⁻ = similar(fluxᵀn, Size(3, num_state_prognostic))
@@ -563,7 +563,7 @@ function normal_boundary_flux_second_order!(
     aux1⁻,
 ) where {S}
     FT = eltype(fluxᵀn)
-    num_state_prognostic = number_states(balance_law, Prognostic(), FT)
+    num_state_prognostic = number_states(balance_law, Prognostic())
     fluxᵀn = parent(fluxᵀn)
 
     flux = similar(fluxᵀn, Size(3, num_state_prognostic))

--- a/src/Numerics/DGMethods/create_states.jl
+++ b/src/Numerics/DGMethods/create_states.jl
@@ -12,7 +12,7 @@ function create_state(balance_law, grid, st::AbstractStateType)
     weights = reshape(weights, size(weights, 1), 1, size(weights, 2))
 
     # TODO: Clean up this MPIStateArray interface...
-    ns = number_states(balance_law, st, FT)
+    ns = number_states(balance_law, st)
     st isa GradientLaplacian && (ns = 3ns)
     V = vars_state(balance_law, st, FT)
     state = MPIStateArray{FT, V}(

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -106,25 +106,25 @@ function remainder_DGModel(
     # If any of these asserts fail, the remainder model will need to be extended
     # to allow for it; see `flux_first_order!` and `source!` below.
     for subdg in subsdg
-        @assert number_states(subdg.balance_law, Prognostic(), FT) <=
-                number_states(maindg.balance_law, Prognostic(), FT)
+        @assert number_states(subdg.balance_law, Prognostic()) <=
+                number_states(maindg.balance_law, Prognostic())
 
-        @assert number_states(subdg.balance_law, Auxiliary(), FT) ==
-                number_states(maindg.balance_law, Auxiliary(), FT)
+        @assert number_states(subdg.balance_law, Auxiliary()) ==
+                number_states(maindg.balance_law, Auxiliary())
 
-        @assert number_states(subdg.balance_law, Gradient(), FT) == 0
-        @assert number_states(subdg.balance_law, GradientFlux(), FT) == 0
+        @assert number_states(subdg.balance_law, Gradient()) == 0
+        @assert number_states(subdg.balance_law, GradientFlux()) == 0
 
-        @assert number_states(subdg.balance_law, GradientLaplacian(), FT) == 0
-        @assert number_states(subdg.balance_law, Hyperdiffusive(), FT) == 0
+        @assert number_states(subdg.balance_law, GradientLaplacian()) == 0
+        @assert number_states(subdg.balance_law, Hyperdiffusive()) == 0
 
         # Do not currenlty support nested remainder models
         # For this to work the way directions and numerical fluxes are handled
         # would need to be updated.
         @assert !(subdg.balance_law isa RemBL)
 
-        @assert number_states(subdg.balance_law, UpwardIntegrals(), FT) == 0
-        @assert number_states(subdg.balance_law, DownwardIntegrals(), FT) == 0
+        @assert number_states(subdg.balance_law, UpwardIntegrals()) == 0
+        @assert number_states(subdg.balance_law, DownwardIntegrals()) == 0
 
         # The remainder model requires that the subcomponent direction be
         # included in the main model directions
@@ -353,11 +353,11 @@ function wavespeed(
 
     ws = fill(
         -zero(FT),
-        MVector{number_states(rem_balance_law.main, Prognostic(), FT), FT},
+        MVector{number_states(rem_balance_law.main, Prognostic()), FT},
     )
     rs = fill(
         -zero(FT),
-        MVector{number_states(rem_balance_law.main, Prognostic(), FT), FT},
+        MVector{number_states(rem_balance_law.main, Prognostic()), FT},
     )
 
     # Compute the main components wavespeed
@@ -375,7 +375,7 @@ function wavespeed(
     # Compute the sub components wavespeed
     for (sub, subdir) in zip(rem_balance_law.subs, rem_balance_law.subsdir)
         @inbounds if subdir isa Union{Dirs.types...}
-            num_state = static(number_states(sub, Prognostic(), Float32))
+            num_state = static(number_states(sub, Prognostic()))
             rs[static(1):num_state] .+=
                 wavespeed(sub, nM, state, aux, t, (subdir,))
         end
@@ -460,13 +460,13 @@ function numerical_flux_first_order!(
             nf = numerical_fluxes[2][k]
 
             FT = eltype(a_fluxᵀn)
-            num_state_prognostic = number_states(sub, Prognostic(), FT)
+            num_state_prognostic = number_states(sub, Prognostic())
 
             a_sub_fluxᵀn = MVector{num_state_prognostic, FT}(undef)
             a_sub_state_prognostic⁻ = MVector{num_state_prognostic, FT}(undef)
             a_sub_state_prognostic⁺ = MVector{num_state_prognostic, FT}(undef)
 
-            state_rng = static(1):static(number_states(sub, Prognostic(), FT))
+            state_rng = static(1):static(number_states(sub, Prognostic()))
             a_sub_fluxᵀn .= a_fluxᵀn[state_rng]
             a_sub_state_prognostic⁻ .= parent(state_prognostic⁻)[state_rng]
             a_sub_state_prognostic⁺ .= parent(state_prognostic⁺)[state_rng]
@@ -584,14 +584,14 @@ function numerical_boundary_flux_first_order!(
             a_state_auxiliary⁺ .= a_back_state_auxiliary⁺
 
             FT = eltype(a_fluxᵀn)
-            num_state_prognostic = number_states(sub, Prognostic(), FT)
+            num_state_prognostic = number_states(sub, Prognostic())
 
             a_sub_fluxᵀn = MVector{num_state_prognostic, FT}(undef)
             a_sub_state_prognostic⁻ = MVector{num_state_prognostic, FT}(undef)
             a_sub_state_prognostic⁺ = MVector{num_state_prognostic, FT}(undef)
             a_sub_state_prognostic1⁻ = MVector{num_state_prognostic, FT}(undef)
 
-            state_rng = static(1):static(number_states(sub, Prognostic(), FT))
+            state_rng = static(1):static(number_states(sub, Prognostic()))
             a_sub_fluxᵀn .= a_fluxᵀn[state_rng]
             a_sub_state_prognostic⁻ .= parent(state_prognostic⁻)[state_rng]
             a_sub_state_prognostic⁺ .= parent(state_prognostic⁺)[state_rng]

--- a/src/Numerics/SystemSolvers/columnwise_lu_solver.jl
+++ b/src/Numerics/SystemSolvers/columnwise_lu_solver.jl
@@ -269,13 +269,13 @@ function banded_matrix(
     FT = eltype(Q.data)
     device = array_device(Q)
 
-    nstate = number_states(bl, Prognostic(), FT)
+    nstate = number_states(bl, Prognostic())
     N = polynomialorder(grid)
     Nq = N + 1
 
     # p is lower bandwidth
     # q is upper bandwidth
-    eband = number_states(bl, GradientFlux(), FT) == 0 ? 1 : 2
+    eband = number_states(bl, GradientFlux()) == 0 ? 1 : 2
     p = q = nstate * Nq * eband - 1
 
     nrealelem = length(topology.realelems)

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -674,7 +674,7 @@ function update_auxiliary_state_gradient!(
     # We are unable to use vars (ie A.w) for this because this operation will
     # return a SubArray, and adapt (used for broadcasting along reshaped arrays)
     # has a limited recursion depth for the types allowed.
-    number_aux = number_states(m, Auxiliary(), FT)
+    number_aux = number_states(m, Auxiliary())
     index_w = varsindex(vars_state(m, Auxiliary(), FT), :w)
     index_wz0 = varsindex(vars_state(m, Auxiliary(), FT), :wz0)
     Nq, Nqk, _, _, nelemv, nelemh, nhorzrealelem, _ = basic_grid_info(dg)

--- a/src/Ocean/SplitExplicit/Communication.jl
+++ b/src/Ocean/SplitExplicit/Communication.jl
@@ -29,15 +29,15 @@ end
     update_auxiliary_state!(model_int, integral, forcing_tendency, 0)
 
     ### properly shape MPIStateArrays
-    num_aux_int = number_states(integral, Auxiliary(), FT)
+    num_aux_int = number_states(integral, Auxiliary())
     data_int = model_int.state_auxiliary.data
     data_int = reshape(data_int, Nq^2, Nqk, num_aux_int, nelemv, nelemh)
 
-    num_aux_bt = number_states(barotropic, Auxiliary(), FT)
+    num_aux_bt = number_states(barotropic, Auxiliary())
     data_bt = model_bt.state_auxiliary.data
     data_bt = reshape(data_bt, Nq^2, num_aux_bt, nelemh)
 
-    num_aux_bc = number_states(baroclinic, Auxiliary(), FT)
+    num_aux_bc = number_states(baroclinic, Auxiliary())
     data_bc = model_bc.state_auxiliary.data
     data_bc = reshape(data_bc, Nq^2, Nqk, num_aux_bc, nelemv, nelemh)
 
@@ -93,19 +93,19 @@ end
     update_auxiliary_state!(model_int, integral, state_bc, 0)
 
     ### properly shape MPIStateArrays
-    num_aux_int = number_states(integral, Auxiliary(), FT)
+    num_aux_int = number_states(integral, Auxiliary())
     data_int = model_int.state_auxiliary.data
     data_int = reshape(data_int, Nq^2, Nqk, num_aux_int, nelemv, nelemh)
 
-    num_aux_bt = number_states(barotropic, Auxiliary(), FT)
+    num_aux_bt = number_states(barotropic, Auxiliary())
     data_bt_aux = model_bt.state_auxiliary.data
     data_bt_aux = reshape(data_bt_aux, Nq^2, num_aux_bt, nelemh)
 
-    num_state_bt = number_states(barotropic, Prognostic(), FT)
+    num_state_bt = number_states(barotropic, Prognostic())
     data_bt_state = state_bt.data
     data_bt_state = reshape(data_bt_state, Nq^2, num_state_bt, nelemh)
 
-    num_state_bc = number_states(baroclinic, Prognostic(), FT)
+    num_state_bc = number_states(baroclinic, Prognostic())
     data_bc_state = state_bc.data
     data_bc_state =
         reshape(data_bc_state, Nq^2, Nqk, num_state_bc, nelemv, nelemh)

--- a/src/Ocean/SplitExplicit/HydrostaticBoussinesqCoupling.jl
+++ b/src/Ocean/SplitExplicit/HydrostaticBoussinesqCoupling.jl
@@ -52,15 +52,15 @@ end
     update_auxiliary_state!(model_int, integral, Q, 0)
 
     ### properly shape MPIStateArrays
-    num_int = number_states(integral, Auxiliary(), FT)
+    num_int = number_states(integral, Auxiliary())
     data_int = model_int.state_auxiliary.data
     data_int = reshape(data_int, Nq^2, Nqk, num_int, nelemv, nelemh)
 
-    num_aux = number_states(m, Auxiliary(), FT)
+    num_aux = number_states(m, Auxiliary())
     data_aux = dg.state_auxiliary.data
     data_aux = reshape(data_aux, Nq^2, Nqk, num_aux, nelemv, nelemh)
 
-    num_state = number_states(m, Prognostic(), FT)
+    num_state = number_states(m, Prognostic())
     data_state = reshape(Q.data, Nq^2, Nqk, num_state, nelemv, nelemh)
 
     ### get vars indices

--- a/test/Atmos/Model/ref_state.jl
+++ b/test/Atmos/Model/ref_state.jl
@@ -32,7 +32,7 @@ using Test
         vgeo = SArray{Tuple{3, 16, 3}, FT}(zeros(3, 16, 3)) # dummy, not used
         local_geom = LocalGeometry(Val(5), vgeo, 1, 1) # dummy, not used
         st = vars_state(atmos, Auxiliary(), FT)
-        nst = number_states(atmos, Auxiliary(), FT)
+        nst = number_states(atmos, Auxiliary())
         arr = MArray{Tuple{nst}, FT}(undef)
         fill!(arr, 0)
         aux = Vars{st}(arr)

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -299,7 +299,7 @@ function boundary_state!(
         diff⁺.σ = diff⁻.σ
     elseif bctype == 2 # Neumann with data
         FT = eltype(diff⁺)
-        ngrad = number_states(m, Gradient(), FT)
+        ngrad = number_states(m, Gradient())
         ∇state = Grad{vars_state(m, Gradient(), FT)}(similar(
             parent(diff⁺),
             Size(3, ngrad),
@@ -310,7 +310,7 @@ function boundary_state!(
         # compute the diffusive flux using the boundary state
     elseif bctype == 4 # zero Neumann
         FT = eltype(diff⁺)
-        ngrad = number_states(m, Gradient(), FT)
+        ngrad = number_states(m, Gradient())
         ∇state = Grad{vars_state(m, Gradient(), FT)}(similar(
             parent(diff⁺),
             Size(3, ngrad),
@@ -361,7 +361,7 @@ function boundary_flux_second_order!(
         flux_second_order!(m, F, state⁻, diff⁻, hyperdiff⁻, aux⁻, t)
     elseif bctype == 2 # Neumann data
         FT = eltype(diff⁺)
-        ngrad = number_states(m, Gradient(), FT)
+        ngrad = number_states(m, Gradient())
         ∇state = Grad{vars_state(m, Gradient(), FT)}(similar(
             parent(diff⁺),
             Size(3, ngrad),

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -158,11 +158,11 @@ function run(
     nM /= norm(nM)
     state_prognostic = Vars{vars_state(dg.balance_law, Prognostic(), FT)}(rand(
         FT,
-        number_states(dg.balance_law, Prognostic(), FT),
+        number_states(dg.balance_law, Prognostic()),
     ))
     state_auxiliary = Vars{vars_state(dg.balance_law, Auxiliary(), FT)}(rand(
         FT,
-        number_states(dg.balance_law, Auxiliary(), FT),
+        number_states(dg.balance_law, Auxiliary()),
     ))
     full_wavespeed = wavespeed(
         dg.balance_law,


### PR DESCRIPTION
# Description

@jkozdon pointed out that `number_states` doesn't actually need the float type. So, this PR does some house-cleaning and removes `FT` in calls to `number_states`.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
