### PR TITLE
Add `flattened_tup_chain ` and chained getproperty/getindex methods

### DIFF
--- a/docs/src/APIs/Utilities/VariableTemplates.md
+++ b/docs/src/APIs/Utilities/VariableTemplates.md
@@ -14,6 +14,7 @@ Vars
 ## Index methods
 
 ```@docs
+flattened_tup_chain
 varsize
 varsindices
 varsindex

--- a/src/Utilities/VariableTemplates/flattened_tup_chain.jl
+++ b/src/Utilities/VariableTemplates/flattened_tup_chain.jl
@@ -1,0 +1,35 @@
+export flattened_tup_chain
+
+flattened_tup_chain(::Type{NamedTuple{(), Tuple{}}}; prefix = (Symbol(),)) = ()
+flattened_tup_chain(::Type{T}; prefix = (Symbol(),)) where {T <: Real} =
+    (prefix,)
+flattened_tup_chain(::Type{T}; prefix = (Symbol(),)) where {T <: SVector} =
+    (prefix,)
+flattened_tup_chain(
+    ::Type{T};
+    prefix = (Symbol(),),
+) where {T <: SHermitianCompact} = (prefix,)
+
+"""
+    flattened_tup_chain(::Type{T}) where {T <: Union{NamedTuple,NTuple}}
+
+An array of tuples, containing symbols
+and integers for every combination of
+each field in the `Vars` array.
+"""
+function flattened_tup_chain(
+    ::Type{T};
+    prefix = (Symbol(),),
+) where {T <: Union{NamedTuple, NTuple}}
+    map(1:fieldcount(T)) do i
+        Ti = fieldtype(T, i)
+        name = fieldname(T, i)
+        sname = name isa Int ? name : Symbol(name)
+        flattened_tup_chain(
+            Ti,
+            prefix = prefix == (Symbol(),) ? (sname,) : (prefix..., sname),
+        )
+    end |>
+    Iterators.flatten |>
+    collect
+end

--- a/test/Utilities/VariableTemplates/runtests.jl
+++ b/test/Utilities/VariableTemplates/runtests.jl
@@ -99,4 +99,5 @@ using ClimateMachine.VariableTemplates
 
     include("varsindex.jl")
     include("ntuple_type.jl")
+    include("test_complex_models.jl")
 end

--- a/test/Utilities/VariableTemplates/test_complex_models.jl
+++ b/test/Utilities/VariableTemplates/test_complex_models.jl
@@ -1,0 +1,158 @@
+using Test
+using StaticArrays
+using ClimateMachine.VariableTemplates
+
+@testset "Complex models" begin
+
+    abstract type OneLayerModel end
+
+    struct EmptyModel <: OneLayerModel end
+    vars_state(m::EmptyModel, T) = @vars()
+
+    struct ScalarModel <: OneLayerModel end
+    vars_state(m::ScalarModel, T) = @vars(x::T)
+
+    struct VectorModel{N} <: OneLayerModel end
+    vars_state(m::VectorModel{N}, T) where {N} = @vars(x::SVector{N, T})
+
+    struct MatrixModel{N, M} <: OneLayerModel end
+    vars_state(m::MatrixModel{N, M}, T) where {N, M} =
+        @vars(x::SHermitianCompact{N, T, M})
+
+    abstract type TwoLayerModel end
+
+    Base.@kwdef struct CompositModel{Nv, N, M} <: TwoLayerModel
+        empty_model = EmptyModel()
+        scalar_model = ScalarModel()
+        vector_model = VectorModel{Nv}()
+        matrix_model = MatrixModel{N, M}()
+    end
+    function vars_state(m::CompositModel, T)
+        @vars begin
+            empty_model::vars_state(m.empty_model, T)
+            scalar_model::vars_state(m.scalar_model, T)
+            vector_model::vars_state(m.vector_model, T)
+            matrix_model::vars_state(m.matrix_model, T)
+        end
+    end
+
+    Base.@kwdef struct NTupleModel <: OneLayerModel
+        scalar_model = ScalarModel()
+    end
+
+    function vars_state(m::NTupleModel, T)
+        @vars begin
+            scalar_model::vars_state(m.scalar_model, T)
+        end
+    end
+
+    vars_state(m::NTuple{N, NTupleModel}, FT) where {N} =
+        Tuple{ntuple(i -> vars_state(m[i], FT), N)...}
+
+    Base.@kwdef struct NTupleContainingModel{N, Nv} <: TwoLayerModel
+        ntuple_model = ntuple(i -> NTupleModel(), N)
+        vector_model = VectorModel{Nv}()
+        scalar_model = ScalarModel()
+    end
+
+    function vars_state(m::NTupleContainingModel, T)
+        @vars begin
+            ntuple_model::vars_state(m.ntuple_model, T)
+            vector_model::vars_state(m.vector_model, T)
+            scalar_model::vars_state(m.scalar_model, T)
+        end
+    end
+
+    FT = Float32
+
+    # ------------------------------- Test getproperty
+    m = ScalarModel()
+    st = vars_state(m, FT)
+    vs = varsize(st)
+    a_global = collect(1:vs)
+    v = Vars{st}(a_global)
+    @test v.x == FT(1)
+
+    Nv = 3
+    m = VectorModel{Nv}()
+    st = vars_state(m, FT)
+    vs = varsize(st)
+    a_global = collect(1:vs)
+    v = Vars{st}(a_global)
+    @test v.x == SVector{Nv, FT}(FT[1, 2, 3])
+
+    N = 3
+    M = 6
+    m = MatrixModel{N, M}()
+    st = vars_state(m, FT)
+    vs = varsize(st)
+    a_global = collect(1:vs)
+    v = Vars{st}(a_global)
+    @test v.x == SHermitianCompact{N, FT, M}(collect(1:(1 + M - 1)))
+
+    Nv = 3
+    N = 3
+    M = 6
+    m = CompositModel{Nv, N, M}()
+    st = vars_state(m, FT)
+    vs = varsize(st)
+    a_global = collect(1:vs)
+    v = Vars{st}(a_global)
+
+    scalar_model = v.scalar_model
+    @test v.scalar_model.x == FT(1)
+
+    vector_model = v.vector_model
+    @test v.vector_model.x == SVector{Nv, FT}([2, 3, 4])
+
+    matrix_model = v.matrix_model
+    @test v.matrix_model.x ==
+          SHermitianCompact{N, FT, M}(collect(5:(5 + M - 1)))
+
+    Nv = 3
+    N = 3
+    m = NTupleContainingModel{N, Nv}()
+    st = vars_state(m, FT)
+    vs = varsize(st)
+    a_global = collect(1:vs)
+    v = Vars{st}(a_global)
+
+    @test v.vector_model.x == SVector{Nv, FT}([4, 5, 6])
+    @test v.scalar_model.x == FT(7)
+
+    for i in 1:N
+        @test m.ntuple_model[i] isa NTupleModel
+        @test m.ntuple_model[i].scalar_model isa ScalarModel
+        @test v.ntuple_model[i].scalar_model.x == FT(i)
+        @test v.vector_model.x == SVector{Nv, FT}((N + 1):(N + Nv))
+        @test v.scalar_model.x == FT(N + Nv + 1)
+    end
+
+    fn = flattenednames(st)
+    @test fn[1] === "ntuple_model[1].scalar_model.x"
+    @test fn[2] === "ntuple_model[2].scalar_model.x"
+    @test fn[3] === "ntuple_model[3].scalar_model.x"
+    @test fn[4] === "vector_model.x[1]"
+    @test fn[5] === "vector_model.x[2]"
+    @test fn[6] === "vector_model.x[3]"
+    @test fn[7] === "scalar_model.x"
+
+    ftc = flattened_tup_chain(st)
+    @test ftc[1] === (:ntuple_model, 1, :scalar_model, :x)
+    @test ftc[2] === (:ntuple_model, 2, :scalar_model, :x)
+    @test ftc[3] === (:ntuple_model, 3, :scalar_model, :x)
+    @test ftc[4] === (:vector_model, :x)
+    @test ftc[5] === (:scalar_model, :x)
+
+    # getproperty with tup-chain
+    for i in 1:N
+        @test v.scalar_model.x == getproperty(v, (:scalar_model, :x))
+        @test v.vector_model.x == getproperty(v, (:vector_model, :x))
+        @test v.ntuple_model[i] == getproperty(v, (:ntuple_model, i))
+        @test v.ntuple_model[i].scalar_model ==
+              getproperty(v, (:ntuple_model, i, :scalar_model))
+        @test v.ntuple_model[i].scalar_model.x ==
+              getproperty(v, (:ntuple_model, i, :scalar_model, :x))
+    end
+
+end


### PR DESCRIPTION
# Description

Debugging highly nested models (e.g., EDMF) is difficult because, at the moment, checking fields in all sub-models requires manually writing out all fields/subfields, or writing recursive `getproperty`/`getindex` methods, which is painful/overkill just for debugging. This PR adds a method `flattened_tup_chain`, along with a recursive and interleaved `getindex`/`getproperty`, to `VariableTemplates` so that users can iterate through every field in compute kernels in a convenient way, as demonstrated in a new test in the test suite:

```julia
    ftc = flattened_tup_chain(st)
    @test ftc[1] === (:ntuple_model, 1, :scalar_model, :x)
    @test ftc[2] === (:ntuple_model, 2, :scalar_model, :x)
    @test ftc[3] === (:ntuple_model, 3, :scalar_model, :x)
    @test ftc[4] === (:vector_model, :x)
    @test ftc[5] === (:scalar_model, :x)

    # getproperty with tup-chain
    for i in 1:N
        @test v.scalar_model.x == getproperty(v, (:scalar_model, :x))
        @test v.vector_model.x == getproperty(v, (:vector_model, :x))
        @test v.ntuple_model[i] == getproperty(v, (:ntuple_model, i))
        @test v.ntuple_model[i].scalar_model == getproperty(v, (:ntuple_model, i, :scalar_model))
        @test v.ntuple_model[i].scalar_model.x == getproperty(v, (:ntuple_model, i, :scalar_model, :x))
    end
```

If we change our initialization, as suggested by @trontrytel and discussed with @kpamnany, to initializing fields to `NaN`s, a very practical use-case of this might look like:

```julia
function init_heldsuarez!(balance_law, state::Vars{st}, aux::Vars{au}, coords, t) where {st,au}

    # Initialize fields...

    for tc in flattened_tup_chain(st)
        @assert getproperty(state, tc) ≠ NaN
    end
    for tc in flattened_tup_chain(au)
        @assert getproperty(aux, tc) ≠ NaN
    end
    # All fields in all balance_law submodels are now gauranteed to be initialized
end
```

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
