### PR TITLE
Add `--debug-init`

### DIFF
--- a/docs/src/GettingStarted/RunningClimateMachine.md
+++ b/docs/src/GettingStarted/RunningClimateMachine.md
@@ -129,6 +129,8 @@ ClimateMachine:
   --log-level <level>   set the log level to one of
                         debug/info/warn/error (default: "info")
   --output-dir <path>   directory for output data (default: "output")
+  --debug-init          fill state arrays with NaNs and dump them
+                        post-initialization"
   --integration-testing
                         enable integration testing
 

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -34,7 +34,7 @@ vars_state(::BalanceLaw, ::AbstractStateType, FT) = @vars()
       coords,
       args...)
 
-Initialize the conservative state variables at ``t = 0``
+Initialize the prognostic state variables at ``t = 0``
 """
 function init_state_prognostic! end
 
@@ -101,7 +101,8 @@ function source! end
         t::Real
     )
 
-transformation of state variables to variables of which gradients are computed
+transformation of state variables to variables of which gradients are
+computed
 """
 compute_gradient_argument!(::BalanceLaw, args...) = nothing
 
@@ -222,14 +223,16 @@ function update_auxiliary_state_gradient! end
 """
     integral_load_auxiliary_state!
 
-Specify how to compute integrands. Can be functions of the conservative state and auxiliary variables.
+Specify how to compute integrands. Can be functions of the prognostic
+state and auxiliary variables.
 """
 function integral_load_auxiliary_state! end
 
 """
     integral_set_auxiliary_state!
 
-Specify which auxiliary variables are used to store the output of the integrals.
+Specify which auxiliary variables are used to store the output of the
+integrals.
 """
 function integral_set_auxiliary_state! end
 
@@ -250,7 +253,8 @@ function reverse_integral_load_auxiliary_state! end
 """
     reverse_integral_set_auxiliary_state!
 
-Specify which auxiliary variables are used to store the output of the reversed integrals.
+Specify which auxiliary variables are used to store the output of the
+reversed integrals.
 """
 function reverse_integral_set_auxiliary_state! end
 

--- a/src/Diagnostics/diagnostic_fields.jl
+++ b/src/Diagnostics/diagnostic_fields.jl
@@ -87,7 +87,7 @@ This constructor computes the spatial gradients of the velocity field.
 
 # Arguments
  - `dg`: DGModel
- - `Q`: MPIStateArray containing the conservative state variables
+ - `Q`: MPIStateArray containing the prognostic state variables
 """
 function VectorGradients(dg::DGModel, Q::MPIStateArray)
     bl = dg.balance_law

--- a/src/Diagnostics/dump_aux.jl
+++ b/src/Diagnostics/dump_aux.jl
@@ -15,9 +15,7 @@ function dump_aux_collect(dgngrp, currtime)
         number_states(bl, Auxiliary()),
     )
 
-
     interpolate_local!(interpol, dg.state_auxiliary.data, iaux)
-
 
     all_aux_data = accumulate_interpolated_data(mpicomm, interpol, iaux)
 

--- a/src/Diagnostics/groups.jl
+++ b/src/Diagnostics/groups.jl
@@ -268,7 +268,7 @@ include("dump_state.jl")
     )
 
 Create and return a `DiagnosticsGroup` containing a diagnostic that
-simply dumps the conservative state variables at the specified
+simply dumps the prognostic state variables at the specified
 `interval` after being interpolated, into NetCDF files prefixed by
 `out_prefix`.
 """

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -17,7 +17,7 @@ using ..SystemSolvers
 using ..ConfigTypes
 using ..Diagnostics
 using ..DGMethods
-using ..BalanceLaws: BalanceLaw, vars_state, update_auxiliary_state!
+using ..BalanceLaws
 using ..DGMethods: remainder_DGModel
 using ..DGMethods.NumericalFluxes
 using ..Ocean.HydrostaticBoussinesq
@@ -28,6 +28,7 @@ using ..MPIStateArrays
 using ..ODESolvers
 using ..TicToc
 using ..VariableTemplates
+using ..VTK
 
 function _init_array(::Type{CuArray})
     comm = MPI.COMM_WORLD
@@ -66,6 +67,7 @@ Base.@kwdef mutable struct ClimateMachine_Settings
     log_level::String = "INFO"
     disable_custom_logger::Bool = false
     output_dir::String = "output"
+    debug_init::Bool = false
     integration_testing::Bool = false
     array_type::Type = Array
 end
@@ -257,6 +259,11 @@ function parse_commandline(
                 get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", Settings.output_dir)
             end
         end
+        "--debug-init"
+        help = "fill state arrays with NaNs and dump them post-initialization"
+        action = :store_const
+        constant = true
+        default = get_setting(:debug_init, defaults, global_defaults)
         "--integration-testing"
         help = "enable integration testing"
         action = :store_const
@@ -328,6 +335,8 @@ Recognized keyword arguments are:
         disable using a global custom logger for ClimateMachine
 - `output_dir::String = "output"`: (path)
         absolute or relative path to output data directory
+- `debug_init::Bool = false`:
+        fill state arrays with NaNs and dump them post-initialization
 - `integration_testing::Bool = false`:
         enable integration_testing
 

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -21,7 +21,13 @@ function DGModel(
     numerical_flux_first_order,
     numerical_flux_second_order,
     numerical_flux_gradient;
-    state_auxiliary = create_state(balance_law, grid, Auxiliary()),
+    fill_nan = false,
+    state_auxiliary = create_state(
+        balance_law,
+        grid,
+        Auxiliary(),
+        fill_nan = fill_nan,
+    ),
     state_gradient_flux = create_state(balance_law, grid, GradientFlux()),
     states_higher_order = (
         create_state(balance_law, grid, GradientLaplacian()),
@@ -99,7 +105,6 @@ function (dg::DGModel)(tendency, state_prognostic, param, t; increment = false)
 end
 
 function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
-
 
     balance_law = dg.balance_law
     device = array_device(state_prognostic)
@@ -577,13 +582,19 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
     wait(device, comp_stream)
 end
 
-function init_ode_state(dg::DGModel, args...; init_on_cpu = false)
+function init_ode_state(
+    dg::DGModel,
+    args...;
+    init_on_cpu = false,
+    fill_nan = false,
+)
     device = arraytype(dg.grid) <: Array ? CPU() : CUDADevice()
 
     balance_law = dg.balance_law
     grid = dg.grid
 
-    state_prognostic = create_state(balance_law, grid, Prognostic())
+    state_prognostic =
+        create_state(balance_law, grid, Prognostic(), fill_nan = fill_nan)
 
     topology = grid.topology
     Np = dofs_per_element(grid)

--- a/src/Numerics/DGMethods/create_states.jl
+++ b/src/Numerics/DGMethods/create_states.jl
@@ -1,6 +1,11 @@
 #### Create states
 
-function create_state(balance_law, grid, st::AbstractStateType)
+function create_state(
+    balance_law,
+    grid,
+    st::AbstractStateType;
+    fill_nan = false,
+)
     topology = grid.topology
     Np = dofs_per_element(grid)
 
@@ -30,6 +35,7 @@ function create_state(balance_law, grid, st::AbstractStateType)
         nabrtovmapsend = grid.nabrtovmapsend,
         weights = weights,
     )
+    fill_nan && fill!(state, NaN)
     return state
 end
 


### PR DESCRIPTION
# Description

If this is specified, fill state arrays with NaNs on creation and write auxiliary and prognostic state arrays to VTK files immediately after they are initialized.

Closes #1213. Closes #1343.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [X] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
