### PR TITLE
Add turbulence statistics diagnostics

### DIFF
--- a/docs/src/APIs/Diagnostics/Diagnostics.md
+++ b/docs/src/APIs/Diagnostics/Diagnostics.md
@@ -25,6 +25,7 @@ Diagnostics.setup_atmos_default_diagnostics
 Diagnostics.setup_atmos_core_diagnostics
 Diagnostics.setup_atmos_default_perturbations
 Diagnostics.setup_atmos_refstate_perturbations
+Diagnostics.setup_atmos_turbulence_stats
 Diagnostics.setup_dump_state_diagnostics
 Diagnostics.setup_dump_aux_diagnostics
 ```

--- a/src/ClimateMachine.jl
+++ b/src/ClimateMachine.jl
@@ -41,5 +41,4 @@ include(joinpath("Utilities", "Checkpoint", "Checkpoint.jl"))
 include(joinpath("Driver", "Callbacks", "Callbacks.jl"))
 include(joinpath("Driver", "Driver.jl"))
 
-
 end

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -10,6 +10,7 @@ export DiagnosticsGroup,
     setup_atmos_core_diagnostics,
     setup_atmos_default_perturbations,
     setup_atmos_refstate_perturbations,
+    setup_atmos_turbulence_stats,
     setup_dump_state_diagnostics,
     setup_dump_aux_diagnostics
 

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -26,6 +26,43 @@ using ..Atmos
 using ..Atmos: thermo_state
 using ..TurbulenceClosures: turbulence_tensors
 
+"""
+    setup_atmos_default_diagnostics(
+        ::AtmosGCMConfigType,
+        interval::String,
+        out_prefix::String;
+        writer::AbstractWriter,
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing the "AtmosDefault"
+diagnostics for GCM configurations. All the diagnostics in the group will run
+at the specified `interval`, be interpolated to the specified boundaries and
+resolution, and will be written to files prefixed by `out_prefix` using
+`writer`.
+"""
+function setup_atmos_default_diagnostics(
+    ::AtmosGCMConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    # TODO: remove this
+    @assert !isnothing(interpol)
+
+    return DiagnosticsGroup(
+        "AtmosGCMDefault",
+        Diagnostics.atmos_gcm_default_init,
+        Diagnostics.atmos_gcm_default_fini,
+        Diagnostics.atmos_gcm_default_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
 include("diagnostic_fields.jl")
 
 # 3D variables

--- a/src/Diagnostics/atmos_les_core.jl
+++ b/src/Diagnostics/atmos_les_core.jl
@@ -5,6 +5,43 @@ using ..Mesh.Grids
 using ..Thermodynamics
 using LinearAlgebra
 
+"""
+    setup_atmos_core_diagnostics(
+        ::AtmosLESConfigType,
+        interval::String,
+        out_prefix::String;
+        writer::AbstractWriter,
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing the "AtmosLESCore"
+diagnostics for LES configurations. All the diagnostics in the group
+will run at the specified `interval`, be interpolated to the specified
+boundaries and resolution, and will be written to files prefixed by
+`out_prefix` using `writer`.
+"""
+function setup_atmos_core_diagnostics(
+    ::AtmosLESConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    # TODO: remove this
+    @assert isnothing(interpol)
+
+    return DiagnosticsGroup(
+        "AtmosLESCore",
+        Diagnostics.atmos_les_core_init,
+        Diagnostics.atmos_les_core_fini,
+        Diagnostics.atmos_les_core_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
 # Simple horizontal averages
 function vars_atmos_les_core_simple(m::AtmosModel, FT)
     @vars begin

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -6,6 +6,43 @@ using ..Thermodynamics
 using ..TurbulenceClosures
 using LinearAlgebra
 
+"""
+    setup_atmos_default_diagnostics(
+        ::AtmosLESConfigType,
+        interval::String,
+        out_prefix::String;
+        writer = NetCDFWriter(),
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing the "AtmosDefault"
+diagnostics for LES configurations. All the diagnostics in the group will
+run at the specified `interval`, be interpolated to the specified boundaries
+and resolution, and will be written to files prefixed by `out_prefix` using
+`writer`.
+"""
+function setup_atmos_default_diagnostics(
+    ::AtmosLESConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    # TODO: remove this
+    @assert isnothing(interpol)
+
+    return DiagnosticsGroup(
+        "AtmosLESDefault",
+        Diagnostics.atmos_les_default_init,
+        Diagnostics.atmos_les_default_fini,
+        Diagnostics.atmos_les_default_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
 # Simple horizontal averages
 function vars_atmos_les_default_simple(m::AtmosModel, FT)
     @vars begin

--- a/src/Diagnostics/atmos_les_default_perturbations.jl
+++ b/src/Diagnostics/atmos_les_default_perturbations.jl
@@ -8,6 +8,42 @@ using ..Mesh.Topologies
 using ..Mesh.Grids
 using ..Thermodynamics
 
+"""
+    setup_atmos_default_perturbations(
+        ::AtmosLESConfigType,
+        interval::String,
+        out_prefix::String;
+        writer::AbstractWriter,
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing the
+"AtmosLESDefaultPerturbations" diagnostics for the LES configuration.
+All the diagnostics in the group will run at the specified `interval`,
+and written to files prefixed by `out_prefix` using `writer`.
+"""
+function setup_atmos_default_perturbations(
+    ::AtmosLESConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    # TODO: remove this
+    @assert !isnothing(interpol)
+
+    return DiagnosticsGroup(
+        "AtmosLESDefaultPerturbations",
+        Diagnostics.atmos_les_default_perturbations_init,
+        Diagnostics.atmos_les_default_perturbations_fini,
+        Diagnostics.atmos_les_default_perturbations_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
 # Compute sums for density-averaged horizontal averages
 #
 # These are trimmed down versions of `atmos_les_default_simple_sums!()`:

--- a/src/Diagnostics/atmos_refstate_perturbations.jl
+++ b/src/Diagnostics/atmos_refstate_perturbations.jl
@@ -9,6 +9,44 @@ using ..Mesh.Topologies
 using ..Mesh.Grids
 using ..Thermodynamics
 
+"""
+    setup_atmos_refstate_perturbations(
+        ::ClimateMachineConfigType,
+        interval::String,
+        out_prefix::String;
+        writer = NetCDFWriter(),
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing the
+"AtmosRefStatePerturbations" diagnostics for both LES and GCM
+configurations. All the diagnostics in the group will run at the
+specified `interval`, be interpolated to the specified boundaries
+and resolution, and written to files prefixed by `out_prefix`
+using `writer`.
+"""
+function setup_atmos_refstate_perturbations(
+    ::ClimateMachineConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    # TODO: remove this
+    @assert !isnothing(interpol)
+
+    return DiagnosticsGroup(
+        "AtmosRefStatePerturbations",
+        Diagnostics.atmos_refstate_perturbations_init,
+        Diagnostics.atmos_refstate_perturbations_fini,
+        Diagnostics.atmos_refstate_perturbations_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
 function vars_atmos_refstate_perturbations(m::AtmosModel, FT)
     @vars begin
         ref_state::vars_atmos_refstate_perturbations(m.ref_state, FT)

--- a/src/Diagnostics/atmos_turbulence_stats.jl
+++ b/src/Diagnostics/atmos_turbulence_stats.jl
@@ -1,0 +1,148 @@
+# AtmosTurbulenceStats
+#
+# Computes average kinetic energy and dissipation.
+
+using ..Atmos
+using ..Mesh.Topologies
+using ..Mesh.Grids
+
+struct TurbulenceStatsParams <: DiagnosticsGroupParams
+    nor::Float64
+    iter::Float64
+end
+
+"""
+    setup_atmos_turbulence_stats(
+        ::ClimateMachineConfigType,
+        interval::String,
+        out_prefix::String,
+        nor::Float64;
+        iter::Float64,
+        writer = NetCDFWriter(),
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing the
+"AtmosTurbulenceStats" diagnostics for both LES and GCM
+configurations. All the diagnostics in the group will run at the
+specified `interval`, be interpolated to the specified boundaries
+and resolution, and written to files prefixed by `out_prefix`
+using `writer`.
+"""
+function setup_atmos_turbulence_stats(
+    ::ClimateMachineConfigType,
+    interval::String,
+    out_prefix::String,
+    nor::Float64,
+    iter::Float64;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    @assert isnothing(interpol)
+
+    return DiagnosticsGroup(
+        "AtmosTurbulenceStats",
+        Diagnostics.atmos_turbulence_stats_init,
+        Diagnostics.atmos_turbulence_stats_fini,
+        Diagnostics.atmos_turbulence_stats_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+        TurbulenceStatsParams(nor, iter),
+    )
+end
+
+# store average kinetic energy and dissipation
+Base.@kwdef mutable struct AtmosTurbulenceStats{FT}
+    E_k::FT = 0.0
+end
+const AtmosTurbulenceStatsCollected = AtmosTurbulenceStats()
+
+function atmos_turbulence_stats_init(dgngrp, currtime)
+    FT = eltype(Settings.Q)
+    mpicomm = Settings.mpicomm
+    mpirank = MPI.Comm_rank(mpicomm)
+
+    if mpirank == 0
+        # outputs are scalars
+        dims = OrderedDict()
+
+        # set up the variables we're going to be writing
+        vars = OrderedDict(
+            "E_k" => ((), FT, Variables["E_k"].attrib),
+            "dE" => ((), FT, Variables["dE"].attrib),
+        )
+
+        # create the output file
+        dprefix = @sprintf(
+            "%s_%s_%s",
+            dgngrp.out_prefix,
+            dgngrp.name,
+            Settings.starttime,
+        )
+        dfilename = joinpath(Settings.output_dir, dprefix)
+        init_data(dgngrp.writer, dfilename, dims, vars)
+    end
+
+    return nothing
+end
+
+function average_kinetic_energy_and_dissipation(
+    Q,
+    vgeo,
+    E_0,
+    nor,
+    iter,
+    mpicomm,
+)
+    u₀ = Q.ρu ./ Q.ρ
+    u_0 = u₀[:, 1, :] ./ nor
+    v_0 = u₀[:, 2, :] ./ nor
+    w_0 = u₀[:, 3, :] ./ nor
+
+    M = vgeo[:, Grids._M, 1:size(u_0, 2)]
+    SM = sum(M)
+
+    E_k = 0.5 * sum((u_0 .^ 2 .+ v_0 .^ 2 .+ w_0 .^ 2) .* M) / SM
+    E_k = MPI.Reduce(E_k, +, 0, mpicomm)
+
+    mpirank = MPI.Comm_rank(mpicomm)
+    nranks = MPI.Comm_size(mpicomm)
+    if mpirank == 0
+        E_k /= nranks
+        dE = -(E_k - E_0) / iter
+        return (E_k, dE)
+    end
+
+    return (0.0, 0.0)
+end
+
+function atmos_turbulence_stats_collect(dgngrp, currtime)
+    mpicomm = Settings.mpicomm
+    dg = Settings.dg
+    Q = Settings.Q
+    mpirank = MPI.Comm_rank(mpicomm)
+    nranks = MPI.Comm_size(mpicomm)
+
+    E_k, dE = average_kinetic_energy_and_dissipation(
+        Q,
+        dg.grid.vgeo,
+        AtmosTurbulenceStatsCollected.E_k,
+        dgngrp.params.nor,
+        dgngrp.params.iter,
+        mpicomm,
+    )
+
+    if mpirank == 0
+        AtmosTurbulenceStatsCollected.E_k = E_k
+
+        varvals = OrderedDict("E_k" => E_k, "dE" => dE)
+
+        # write output
+        append_data(dgngrp.writer, varvals, currtime)
+    end
+
+end
+
+function atmos_turbulence_stats_fini(dgngrp, currtime) end

--- a/src/Diagnostics/dump_aux.jl
+++ b/src/Diagnostics/dump_aux.jl
@@ -1,3 +1,39 @@
+"""
+    setup_dump_aux_diagnostics(
+        ::ClimateMachineConfigType,
+        interval::String,
+        out_prefix::String;
+        writer = NetCDFWriter(),
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing a diagnostic that
+simply dumps the auxiliary state variables at the specified
+`interval` after being interpolated, into NetCDF files prefixed by
+`out_prefix`.
+"""
+function setup_dump_aux_diagnostics(
+    ::ClimateMachineConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    # TODO: remove this
+    @assert !isnothing(interpol)
+
+    return DiagnosticsGroup(
+        "DumpAux",
+        Diagnostics.dump_aux_init,
+        Diagnostics.dump_aux_fini,
+        Diagnostics.dump_aux_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
 dump_aux_init(dgngrp, currtime) = dump_init(dgngrp, currtime, Auxiliary())
 
 function dump_aux_collect(dgngrp, currtime)

--- a/src/Diagnostics/dump_state.jl
+++ b/src/Diagnostics/dump_state.jl
@@ -1,3 +1,39 @@
+"""
+    setup_dump_state_diagnostics(
+        ::ClimateMachineConfigType,
+        interval::String,
+        out_prefix::String;
+        writer = NetCDFWriter(),
+        interpol = nothing,
+    )
+
+Create and return a `DiagnosticsGroup` containing a diagnostic that
+simply dumps the conservative state variables at the specified
+`interval` after being interpolated, into NetCDF files prefixed by
+`out_prefix`.
+"""
+function setup_dump_state_diagnostics(
+    ::ClimateMachineConfigType,
+    interval::String,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+)
+    # TODO: remove this
+    @assert !isnothing(interpol)
+
+    return DiagnosticsGroup(
+        "DumpState",
+        Diagnostics.dump_state_init,
+        Diagnostics.dump_state_fini,
+        Diagnostics.dump_state_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+    )
+end
+
 dump_state_init(dgngrp, currtime) = dump_init(dgngrp, currtime, Prognostic())
 
 function dump_state_collect(dgngrp, currtime)

--- a/src/Diagnostics/groups.jl
+++ b/src/Diagnostics/groups.jl
@@ -1,12 +1,12 @@
+abstract type DiagnosticsGroupParams end
+
 """
     DiagnosticsGroup
 
 Holds a set of diagnostics that share a collection interval, a filename
-prefix, and an interpolation.
-
-TODO: will be restructured to be defined as groups of `DiagnosticVariable`s.
+prefix, an output writer, an interpolation, and any extra parameters.
 """
-mutable struct DiagnosticsGroup
+mutable struct DiagnosticsGroup{DGP <: Union{Nothing, DiagnosticsGroupParams}}
     name::String
     init::Function
     fini::Function
@@ -15,6 +15,7 @@ mutable struct DiagnosticsGroup
     out_prefix::String
     writer::AbstractWriter
     interpol::Union{Nothing, InterpolationTopology}
+    params::DGP
 
     DiagnosticsGroup(
         name,
@@ -25,7 +26,18 @@ mutable struct DiagnosticsGroup
         out_prefix,
         writer,
         interpol,
-    ) = new(name, init, fini, collect, interval, out_prefix, writer, interpol)
+        params = nothing,
+    ) = new{typeof(params)}(
+        name,
+        init,
+        fini,
+        collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+        params,
+    )
 end
 
 function GenericCallbacks.init!(dgngrp::DiagnosticsGroup, solver, Q, param, t)
@@ -67,266 +79,11 @@ function GenericCallbacks.fini!(dgngrp::DiagnosticsGroup, solver, Q, param, t)
 end
 
 include("atmos_les_default.jl")
-"""
-    setup_atmos_default_diagnostics(
-        ::AtmosLESConfigType,
-        interval::String,
-        out_prefix::String;
-        writer = NetCDFWriter(),
-        interpol = nothing,
-    )
-
-Create and return a `DiagnosticsGroup` containing the "AtmosDefault"
-diagnostics for LES configurations. All the diagnostics in the group will
-run at the specified `interval`, be interpolated to the specified boundaries
-and resolution, and will be written to files prefixed by `out_prefix` using
-`writer`.
-"""
-function setup_atmos_default_diagnostics(
-    ::AtmosLESConfigType,
-    interval::String,
-    out_prefix::String;
-    writer = NetCDFWriter(),
-    interpol = nothing,
-)
-    # TODO: remove this
-    @assert isnothing(interpol)
-
-    return DiagnosticsGroup(
-        "AtmosLESDefault",
-        Diagnostics.atmos_les_default_init,
-        Diagnostics.atmos_les_default_fini,
-        Diagnostics.atmos_les_default_collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-    )
-end
-
 include("atmos_gcm_default.jl")
-"""
-    setup_atmos_default_diagnostics(
-        ::AtmosGCMConfigType,
-        interval::String,
-        out_prefix::String;
-        writer::AbstractWriter,
-        interpol = nothing,
-    )
-
-Create and return a `DiagnosticsGroup` containing the "AtmosDefault"
-diagnostics for GCM configurations. All the diagnostics in the group will run
-at the specified `interval`, be interpolated to the specified boundaries and
-resolution, and will be written to files prefixed by `out_prefix` using
-`writer`.
-"""
-function setup_atmos_default_diagnostics(
-    ::AtmosGCMConfigType,
-    interval::String,
-    out_prefix::String;
-    writer = NetCDFWriter(),
-    interpol = nothing,
-)
-    # TODO: remove this
-    @assert !isnothing(interpol)
-
-    return DiagnosticsGroup(
-        "AtmosGCMDefault",
-        Diagnostics.atmos_gcm_default_init,
-        Diagnostics.atmos_gcm_default_fini,
-        Diagnostics.atmos_gcm_default_collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-    )
-end
-
 include("atmos_les_core.jl")
-"""
-    setup_atmos_core_diagnostics(
-        ::AtmosLESConfigType,
-        interval::String,
-        out_prefix::String;
-        writer::AbstractWriter,
-        interpol = nothing,
-    )
-
-Create and return a `DiagnosticsGroup` containing the "AtmosLESCore"
-diagnostics for LES configurations. All the diagnostics in the group
-will run at the specified `interval`, be interpolated to the specified
-boundaries and resolution, and will be written to files prefixed by
-`out_prefix` using `writer`.
-"""
-function setup_atmos_core_diagnostics(
-    ::AtmosLESConfigType,
-    interval::String,
-    out_prefix::String;
-    writer = NetCDFWriter(),
-    interpol = nothing,
-)
-    # TODO: remove this
-    @assert isnothing(interpol)
-
-    return DiagnosticsGroup(
-        "AtmosLESCore",
-        Diagnostics.atmos_les_core_init,
-        Diagnostics.atmos_les_core_fini,
-        Diagnostics.atmos_les_core_collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-    )
-end
-
 include("atmos_les_default_perturbations.jl")
-"""
-    setup_atmos_default_perturbations(
-        ::AtmosLESConfigType,
-        interval::String,
-        out_prefix::String;
-        writer::AbstractWriter,
-        interpol = nothing,
-    )
-
-Create and return a `DiagnosticsGroup` containing the
-"AtmosLESDefaultPerturbations" diagnostics for the LES configuration.
-All the diagnostics in the group will run at the specified `interval`,
-and written to files prefixed by `out_prefix` using `writer`.
-"""
-function setup_atmos_default_perturbations(
-    ::AtmosLESConfigType,
-    interval::String,
-    out_prefix::String;
-    writer = NetCDFWriter(),
-    interpol = nothing,
-)
-    # TODO: remove this
-    @assert !isnothing(interpol)
-
-    return DiagnosticsGroup(
-        "AtmosLESDefaultPerturbations",
-        Diagnostics.atmos_les_default_perturbations_init,
-        Diagnostics.atmos_les_default_perturbations_fini,
-        Diagnostics.atmos_les_default_perturbations_collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-    )
-end
-
 include("atmos_refstate_perturbations.jl")
-"""
-    setup_atmos_refstate_perturbations(
-        ::ClimateMachineConfigType,
-        interval::String,
-        out_prefix::String;
-        writer = NetCDFWriter(),
-        interpol = nothing,
-    )
-
-Create and return a `DiagnosticsGroup` containing the
-"AtmosRefStatePerturbations" diagnostics for both LES and GCM
-configurations. All the diagnostics in the group will run at the
-specified `interval`, be interpolated to the specified boundaries
-and resolution, and written to files prefixed by `out_prefix`
-using `writer`.
-"""
-function setup_atmos_refstate_perturbations(
-    ::ClimateMachineConfigType,
-    interval::String,
-    out_prefix::String;
-    writer = NetCDFWriter(),
-    interpol = nothing,
-)
-    # TODO: remove this
-    @assert !isnothing(interpol)
-
-    return DiagnosticsGroup(
-        "AtmosRefStatePerturbations",
-        Diagnostics.atmos_refstate_perturbations_init,
-        Diagnostics.atmos_refstate_perturbations_fini,
-        Diagnostics.atmos_refstate_perturbations_collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-    )
-end
-
+include("atmos_turbulence_stats.jl")
 include("dump_init.jl")
 include("dump_state.jl")
-"""
-    setup_dump_state_diagnostics(
-        ::ClimateMachineConfigType,
-        interval::String,
-        out_prefix::String;
-        writer = NetCDFWriter(),
-        interpol = nothing,
-    )
-
-Create and return a `DiagnosticsGroup` containing a diagnostic that
-simply dumps the prognostic state variables at the specified
-`interval` after being interpolated, into NetCDF files prefixed by
-`out_prefix`.
-"""
-function setup_dump_state_diagnostics(
-    ::ClimateMachineConfigType,
-    interval::String,
-    out_prefix::String;
-    writer = NetCDFWriter(),
-    interpol = nothing,
-)
-    # TODO: remove this
-    @assert !isnothing(interpol)
-
-    return DiagnosticsGroup(
-        "DumpState",
-        Diagnostics.dump_state_init,
-        Diagnostics.dump_state_fini,
-        Diagnostics.dump_state_collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-    )
-end
-
 include("dump_aux.jl")
-"""
-    setup_dump_aux_diagnostics(
-        ::ClimateMachineConfigType,
-        interval::String,
-        out_prefix::String;
-        writer = NetCDFWriter(),
-        interpol = nothing,
-    )
-
-Create and return a `DiagnosticsGroup` containing a diagnostic that
-simply dumps the auxiliary state variables at the specified
-`interval` after being interpolated, into NetCDF files prefixed by
-`out_prefix`.
-"""
-function setup_dump_aux_diagnostics(
-    ::ClimateMachineConfigType,
-    interval::String,
-    out_prefix::String;
-    writer = NetCDFWriter(),
-    interpol = nothing,
-)
-    # TODO: remove this
-    @assert !isnothing(interpol)
-
-    return DiagnosticsGroup(
-        "DumpAux",
-        Diagnostics.dump_aux_init,
-        Diagnostics.dump_aux_fini,
-        Diagnostics.dump_aux_collect,
-        interval,
-        out_prefix,
-        writer,
-        interpol,
-    )
-end

--- a/src/Diagnostics/variables.jl
+++ b/src/Diagnostics/variables.jl
@@ -444,4 +444,20 @@ function setup_variables()
             "",
         ),
     )
+    Variables["E_k"] = DiagnosticVariable(
+        "E_k",
+        var_attrib(
+            "",
+            "volumetrically-averaged dimensionless kinetic energy",
+            "",
+        ),
+    )
+    Variables["dE"] = DiagnosticVariable(
+        "dE",
+        var_attrib(
+            "",
+            "volumetrically-averaged kinetic energy dissipation",
+            "",
+        ),
+    )
 end

--- a/src/Driver/diagnostics_configs.jl
+++ b/src/Driver/diagnostics_configs.jl
@@ -11,7 +11,9 @@ Container for all the `DiagnosticsGroup`s to be used for a simulation.
 mutable struct DiagnosticsConfiguration
     groups::Array{DiagnosticsGroup, 1}
 
-    DiagnosticsConfiguration(groups::Array{DiagnosticsGroup, 1}) = new(groups)
+    DiagnosticsConfiguration(
+        groups::Array{DG, 1},
+    ) where {DG <: DiagnosticsGroup} = new(groups)
 end
 
 """

--- a/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
+++ b/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
@@ -201,6 +201,7 @@ function run_hydrostatic_spindown(
         dg_2D,
         model_2D,
         Q_2D,
+        timeendlocal,
     )
 
     eng0 = norm(Q_3D)
@@ -246,6 +247,7 @@ function make_callbacks(
     dg_fast,
     model_fast,
     Q_fast,
+    timeend,
 )
     if isdir(vtkpath)
         rm(vtkpath, recursive = true)


### PR DESCRIPTION
# Description

Defines a callback for calculating volumetrically averaged dimensionless kinetic energy and dissipation

<!--- Please fill out the following section --->

I have built a module that allows for a callback to calculate volumetrically averaged dimensionless kinetic energy and kinetic energy dissipation. This will be useful as it replaces the tedious procedure of calculating these during post-processing. These represent useful insight into certain turbulence dominated cases like the Taylor-Green vortex.

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
