### PR TITLE
docs: fix subscripts on math equations in Driver/SolverTypes/

### DIFF
--- a/src/Driver/SolverTypes/MISSolverType.jl
+++ b/src/Driver/SolverTypes/MISSolverType.jl
@@ -17,7 +17,7 @@ Infinitesimal Step (MIS) method, this solver solves ODEs with
 the partitioned form:
 
 ```math
-    \\dot{Q} = f_fast(Q, t) + f_slow(Q, t)
+    \\dot{Q} = f_{fast}(Q, t) + f_{slow}(Q, t)
 ```
 
 where the right-hand-side functions `f_fast` and `f_slow` denote

--- a/src/Driver/SolverTypes/MultirateSolverType.jl
+++ b/src/Driver/SolverTypes/MultirateSolverType.jl
@@ -18,7 +18,7 @@ Runge-Kutta implementation. This solver computes solutions to ODEs with
 the partitioned form:
 
 ```math
-    \\dot{Q} = f_fast(Q, t) + f_slow(Q, t)
+    \\dot{Q} = f_{fast}(Q, t) + f_{slow}(Q, t)
 ```
 
 where the right-hand-side functions `f_fast` and `f_slow` denote


### PR DESCRIPTION
# Description

Add curly brackets to equation text that should be subscript. See the [relevant docs](https://clima.github.io/ClimateMachine.jl/latest/APIs/Driver/#ClimateMachine.MISSolverType) for current behavior.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
