### PR TITLE
Fixed Boyd_Vandeven filter bug

### DIFF
--- a/src/Numerics/Mesh/Filters.jl
+++ b/src/Numerics/Mesh/Filters.jl
@@ -172,7 +172,7 @@ the form:
 whenever s ≤ i ≤ N, and 1 otherwise. The function `χ(η)` is defined
 as
 ```math
-χ(x) = sqrt(-log(1-4*(abs(x)-0.5)^2)/4*(abs(x)-0.5)^2)
+χ(η) = sqrt(-log(1-4*(abs(η)-0.5)^2)/(4*(abs(η)-0.5)^2))
 ```
 if `x != 0.5` and `1` otherwise. Here, `s` is the filter order,
 the filter starts with polynomial order `Nc`, and `alpha` is a parameter
@@ -200,19 +200,14 @@ struct BoydVandevenFilter <: AbstractSpectralFilter
 
         @assert iseven(s)
         @assert 0 <= Nc <= N
-
-        σ(η) = 0.5 * erfc(2 * sqrt(s) * χ(η) * (abs(η) - 0.5))
+        function σ(η)
+            a = 2 * abs(η) - 1
+            χ = iszero(a) ? one(a) : sqrt(-log1p(-a^2) / a^2)
+            return erfc(sqrt(s) * χ * a) / 2
+        end
         filter = spectral_filter_matrix(ξ, Nc, σ)
 
         new(AT(filter))
-    end
-end
-
-function χ(x)
-    if (x == 0.5)
-        return 1
-    else
-        return sqrt(-log(1 - 4 * (abs(x) - 0.5)^2) / 4 * (abs(x) - 0.5)^2)
     end
 end
 


### PR DESCRIPTION
# Description

Fix suggested by @jiahe23 in issue #1391.

<!--- Please fill out the following section --->

I have implemented the correction suggested by @jiahe23 in issue #1391 

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
