### PR TITLE
Hack in writing and reading checkpoint files for split-explicit method

### DIFF
--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -46,6 +46,7 @@ cpu_gpu = [
   { file = "test/Ocean/HydrostaticBoussinesq/test_3D_spindown.jl", slurmargs = ["--ntasks=1"], args = [] },
   { file = "test/Ocean/SplitExplicit/test_vertical_integral_model.jl", slurmargs = ["--ntasks=1"], args = [] },
   { file = "test/Ocean/SplitExplicit/test_spindown_long.jl", slurmargs = ["--ntasks=1"], args = [] },
+  { file = "test/Ocean/SplitExplicit/test_restart.jl", slurmargs = ["--ntasks=1"], args = [] },
   { file = "tutorials/Numerics/DGMethods/nonnegative.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl", slurmargs = ["--ntasks=3"], args = [] },

--- a/test/Ocean/SplitExplicit/test_restart.jl
+++ b/test/Ocean/SplitExplicit/test_restart.jl
@@ -1,0 +1,73 @@
+#!/usr/bin/env julia --project
+using Test
+
+include("hydrostatic_spindown.jl")
+ClimateMachine.init()
+
+const FT = Float64
+
+#################
+# RUN THE TESTS #
+#################
+@testset "$(@__FILE__)" begin
+
+    include("../refvals/hydrostatic_spindown_refvals.jl")
+
+    # simulation time
+    timeend = FT(24 * 3600) # s
+    tout = FT(3 * 3600) # s
+    timespan = (tout, timeend)
+
+    # DG polynomial order
+    N = Int(4)
+
+    # Domain resolution
+    Nˣ = Int(5)
+    Nʸ = Int(5)
+    Nᶻ = Int(8)
+    resolution = (N, Nˣ, Nʸ, Nᶻ)
+
+    # Domain size
+    Lˣ = 1e6  # m
+    Lʸ = 1e6  # m
+    H = 400  # m
+    dimensions = (Lˣ, Lʸ, H)
+
+    @testset "single run" begin
+        run_hydrostatic_spindown(
+            "vtk_split",
+            resolution,
+            dimensions,
+            timespan,
+            coupling = Coupled(),
+            dt_slow = 90 * 60,
+            refDat = refVals.ninety_minutes,
+        )
+    end
+
+    @testset "restart run" begin
+        midpoint = timeend / 2
+        timespan = (tout, midpoint)
+
+        run_hydrostatic_spindown(
+            "vtk_split",
+            resolution,
+            dimensions,
+            timespan,
+            coupling = Coupled(),
+            dt_slow = 90 * 60,
+        )
+
+        run_hydrostatic_spindown(
+            "vtk_split",
+            resolution,
+            dimensions,
+            timespan,
+            coupling = Coupled(),
+            dt_slow = 90 * 60,
+            refDat = refVals.ninety_minutes,
+            restart = Int(midpoint / tout) - 1,
+        )
+    end
+
+end


### PR DESCRIPTION
# Description

The split-explicit solver used for the Ocean requires two sets of state and aux variables to be stored in order to restart properly. We extended `write_checkpoint()` to enable this and then put in a simple version of what is done in the Driver to our script. (This method will be added as a driver once all parts have been ported over). 

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
