### PR TITLE
Fix missed `conservative` -> `prognostic` rename in docs.

### DIFF
--- a/docs/src/GettingStarted/RunningClimateMachine.md
+++ b/docs/src/GettingStarted/RunningClimateMachine.md
@@ -35,7 +35,7 @@ Output takes the form of various [groups of diagnostic variables](@ref
 Diagnostics-groups) that are written to NetCDF files at user-specified
 intervals by the `ClimateMachine` when configured to do so by a driver.
 
-The `ClimateMachine` can also output conservative and auxiliary state variables
+The `ClimateMachine` can also output prognostic and auxiliary state variables
 to VTK files at specified intervals.
 
 Whether or not output is generated, and if so, at what interval, is a

--- a/docs/src/HowToGuides/Numerics/DGMethods/how_to_make_a_balance_law.md
+++ b/docs/src/HowToGuides/Numerics/DGMethods/how_to_make_a_balance_law.md
@@ -16,9 +16,9 @@ Defining the set of solved PDEs in ClimateMachine revolve around defining a
 Here, `Y`, `Σ`, `F_{first_order}`, `F_{second_order}`, and
 `S_{non_conservative}` can be thought of column vectors[^1] expressing:
 
- - `Y` the conservative state variables, or unknowns of the PDEs to be solved
+ - `Y` the prognostic state variables, or unknowns of the PDEs to be solved
 
- - `Σ` the gradients of functions of the conservative state variables
+ - `Σ` the gradients of functions of the prognostic state variables
 
  - `F_{first-order}` contains all first-order fluxes (e.g. **not** functions
  of gradients of any variables)
@@ -33,21 +33,24 @@ spatial discretization, users must provide their own implementations of
 the following methods, which are computed locally at each nodal point:
 
 ## Variable name specification methods
-| **Method** | Necessary | Purpose |
-|:-----|:---|:----|
-| [`vars_state`](@ref)         | **YES** |  specify the names of the variables in the conservative state vector, typically mass, momentum, and various tracers. |
-| [`vars_state`](@ref)           | **YES** |  specify the names of any variables required for the balance law that aren't related to derivatives of the state variables (e.g. spatial coordinates or various integrals) or those needed to solve expensive auxiliary equations (e.g., temperature via a non-linear equation solve)     |
-| [`vars_state`](@ref)         | **YES** |  specify the names of the gradients of functions of the conservative state variables. used to represent values before **and** after differentiation |
-| [`vars_state`](@ref)         | **YES** |  specify the names of the gradient fluxes necessary to impose Neumann boundary conditions. typically the product of a diffusivity tensor with a gradient state variable, potentially equivalent to the second-order flux for a conservative state variable |
-| [`vars_state`](@ref)         | **NO** |  specify the names of any one-dimensional vertical integrals from **bottom to top** of the domain required for the balance law. used to represent both the integrand **and** the resulting indefinite integral |
-| [`vars_state`](@ref)         | **NO** |  specify the names of any one-dimensional vertical integral from **top to bottom** of the domain required for the balance law. each variable here must also exist in `vars_state` since the reverse integral kernels use subtraction to reverse the integral instead of performing a new integral. use to represent the value before **and** after reversing direction |
+
+The `vars_state` method is used to specify the names of the variables for the following state variable types:
+
+| **Type** | Purpose |
+|:-----|:----|
+| [`Prognostic`](@ref) | the variables in the prognostic state vector, typically mass, momentum, and various tracers. |
+| [`Auxiliary`](@ref) | any variables required for the balance law that aren't related to derivatives of the state variables (e.g. spatial coordinates or various integrals) or those needed to solve expensive auxiliary equations (e.g., temperature via a non-linear equation solve)     |
+| [`Gradient`](@ref) | the gradients of functions of the prognostic state variables. used to represent values before **and** after differentiation |
+| [`GradientFlux`](@ref) | the gradient fluxes necessary to impose Neumann boundary conditions. typically the product of a diffusivity tensor with a gradient state variable, potentially equivalent to the second-order flux for a prognostic state variable |
+| [`UpwardIntegrals`](@ref) | any one-dimensional vertical integrals from **bottom to top** of the domain required for the balance law. used to represent both the integrand **and** the resulting indefinite integral |
+| [`DownwardIntegrals`](@ref) | any one-dimensional vertical integral from **top to bottom** of the domain required for the balance law. each variable here must also exist in `vars_state` since the reverse integral kernels use subtraction to reverse the integral instead of performing a new integral. use to represent the value before **and** after reversing direction |
 
 ## Methods to compute gradients and integrals
 | **Method** |  Purpose |
 |:-----|:-----|
-| [`compute_gradient_argument!`](@ref) | specify how to compute the arguments to the gradients. can be functions of conservative state  and auxiliary variables. |
-| [`compute_gradient_flux!`](@ref) | specify how to compute gradient fluxes. can be a functions of the gradient state, the conservative state, and auxiliary variables.|
-| [`integral_load_auxiliary_state!`](@ref) | specify how to compute integrands. can be functions of the conservative state and auxiliary variables. |
+| [`compute_gradient_argument!`](@ref) | specify how to compute the arguments to the gradients. can be functions of prognostic state  and auxiliary variables. |
+| [`compute_gradient_flux!`](@ref) | specify how to compute gradient fluxes. can be a functions of the gradient state, the prognostic state, and auxiliary variables.|
+| [`integral_load_auxiliary_state!`](@ref) | specify how to compute integrands. can be functions of the prognostic state and auxiliary variables. |
 | [`integral_set_auxiliary_state!`](@ref) | specify which auxiliary variables are used to store the output of the integrals. |
 | [`reverse_integral_load_auxiliary_state!`](@ref) | specify auxiliary variables need their integrals reversed. |
 | [`reverse_integral_set_auxiliary_state!`](@ref) | specify which auxiliary variables are used to store the output of the reversed integrals. |
@@ -58,20 +61,20 @@ the following methods, which are computed locally at each nodal point:
 ## Methods to compute fluxes and sources
 | **Method** | Purpose |
 |:-----|:-----|
-| [`flux_first_order!`](@ref) |  specify `F_{first_order}` for each conservative state variable. can be functions of the conservative state and auxiliary variables. |
-| [`flux_second_order!`](@ref)    |  specify `F_{second_order}` for each conservative state variable. can be functions of the conservative state, gradient flux state, and auxiliary variables. |
-| [`source!`](@ref)            |  specify `S_{non_conservative}`  for each conservative state variable. can be functions of the conservative state, gradient flux state, and auxiliary variables. |
+| [`flux_first_order!`](@ref) |  specify `F_{first_order}` for each prognostic state variable. can be functions of the prognostic state and auxiliary variables. |
+| [`flux_second_order!`](@ref)    |  specify `F_{second_order}` for each prognostic state variable. can be functions of the prognostic state, gradient flux state, and auxiliary variables. |
+| [`source!`](@ref)            |  specify `S_{non_conservative}`  for each prognostic state variable. can be functions of the prognostic state, gradient flux state, and auxiliary variables. |
 
 ## Methods to compute numerical fluxes
 | **Method** | Purpose |
 |:-----|:-----|
 | [`wavespeed`](@ref) | specify how to compute the local wavespeed if using the `RusanovNumericalFlux`. |
-| [`boundary_state!`](@ref) | define exterior nodal values of the conservative state and gradient flux state used to compute the numerical boundary fluxes. |
+| [`boundary_state!`](@ref) | define exterior nodal values of the prognostic state and gradient flux state used to compute the numerical boundary fluxes. |
 
 ## Methods to set initial conditions
 | **Method** | Purpose |
 |:-----|:-----|
-| [`init_state_prognostic!`](@ref) | provide initial values for the conservative state as a function of time and space. |
+| [`init_state_prognostic!`](@ref) | provide initial values for the prognostic state as a function of time and space. |
 | [`init_state_auxiliary!`](@ref) | provide initial values for the auxiliary variables as a function of the geometry. |
 
 


### PR DESCRIPTION
# Description

Fix some missed name change from `conservative` to `prognostic` in docs.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
