### PR TITLE
Add implicit time marching to heat tutorial

### DIFF
--- a/docs/src/APIs/Driver/index.md
+++ b/docs/src/APIs/Driver/index.md
@@ -12,6 +12,7 @@ MultirateSolverType
 AbstractSolverType
 DiscreteSplittingType
 ExplicitSolverType
+ImplicitSolverType
 ConfigTypes
 IMEXSolverType
 ```

--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -748,6 +748,8 @@ array_device(::Union{Array, SArray, MArray}) = CPU()
 array_device(::CuArray) = CUDADevice()
 array_device(s::SubArray) = array_device(parent(s))
 array_device(Q::MPIStateArray) = array_device(Q.data)
+array_device(ra::Base.ReshapedArray{T, N, A}) where {T, N, A <: MPIStateArray} =
+    array_device(parent(ra))
 
 realview(Q::Union{Array, SArray, MArray}) = Q
 realview(Q::MPIStateArray) = Q.realdata

--- a/src/Driver/SolverTypes/ImplicitSolverType.jl
+++ b/src/Driver/SolverTypes/ImplicitSolverType.jl
@@ -1,0 +1,69 @@
+
+export ImplicitSolverType
+
+"""
+# Description
+    ImplicitSolverType(;
+        solver_method = KenCarp4,
+    )
+
+This solver type constructs an ODE solver using a _fully implicit_
+method.
+
+# Arguments
+- `solver_method` (Function): Function defining the implicit
+    solver.
+    Default: `KenCarp4`
+"""
+struct ImplicitSolverType <: AbstractSolverType
+    # Function for an implicit method
+    solver_method::Function
+
+    function ImplicitSolverType(
+        alg;
+        solver_method = ODESolvers.DiffEqJLConstructor(alg),
+    )
+
+        return new(solver_method)
+    end
+end
+
+"""
+    getdtmodel(ode_solver::AbstractSolverType, bl)
+
+A function which returns a model representing the dynamics
+with the most restrictive time-stepping requirements.
+"""
+function getdtmodel(ode_solver::ImplicitSolverType, bl)
+    # For implicit methods, the entire model itself
+    # contributes to the total stability of the time-integrator
+    return bl
+end
+
+
+"""
+# Description
+    function solversetup(
+        ode_solver::ImplicitSolverType,
+        dg,
+        Q,
+        dt,
+        t0,
+        diffusion_direction,
+    )
+
+Creates an implicit ODE solver.
+"""
+function solversetup(
+    ode_solver::ImplicitSolverType,
+    dg,
+    Q,
+    dt,
+    t0,
+    diffusion_direction,
+)
+
+    solver = ode_solver.solver_method(dg, Q; dt = dt, t0 = t0)
+
+    return solver
+end

--- a/src/Driver/SolverTypes/SolverTypes.jl
+++ b/src/Driver/SolverTypes/SolverTypes.jl
@@ -78,6 +78,7 @@ solversetup(
 ))
 
 include("ExplicitSolverType.jl")
+include("ImplicitSolverType.jl")
 include("IMEXSolverType.jl")
 include("MultirateSolverType.jl")
 include("MISSolverType.jl")

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -33,7 +33,7 @@
 # 1) Preliminary configuration
 # 2) PDEs
 # 3) Space discretization
-# 4) Time discretization
+# 4) Time discretization / solver
 # 5) Solver hooks / callbacks
 # 6) Solve
 # 7) Post-processing
@@ -48,6 +48,8 @@ using MPI
 using OrderedCollections
 using Plots
 using StaticArrays
+using OrdinaryDiffEq
+using DiffEqBase
 
 #  - load CLIMAParameters and set up to use it:
 
@@ -85,6 +87,8 @@ import ClimateMachine.BalanceLaws:
     init_state_auxiliary!,
     init_state_prognostic!,
     boundary_state!
+
+import ClimateMachine.DGMethods: calculate_dt
 
 # ## Initialization
 
@@ -326,31 +330,78 @@ driver_config = ClimateMachine.SingleStackConfiguration(
     numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
 );
 
-# # Time discretization
+# # Time discretization / solver
 
 # Specify simulation time (SI units)
 t0 = FT(0)
 timeend = FT(40)
 
-# We'll define the time-step based on the [Fourier
-# number](https://en.wikipedia.org/wiki/Fourier_number)
-Δ = min_node_distance(driver_config.grid)
-
-given_Fourier = FT(0.08);
-Fourier_bound = given_Fourier * Δ^2 / m.α;
-dt = Fourier_bound
-
-# # Configure a solver.
-
-# This initializes the state vector and allocates memory for the solution in
-# space (`dg` has the model `m`, which describes the PDEs as well as the
-# function used for initialization). This additionally initializes the ODE
-# solver, by default an explicit Low-Storage
+# In this section, we initialize the state vector and allocate memory for
+# the solution in space (`dg` has the model `m`, which describes the PDEs
+# as well as the function used for initialization). `SolverConfiguration`
+# initializes the ODE solver, by default an explicit Low-Storage
 # [Runge-Kutta](https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods)
-# method.
+# method. In this tutorial, we prescribe an option for an implicit
+# `Kvaerno3` method.
 
-solver_config =
-    ClimateMachine.SolverConfiguration(t0, timeend, driver_config, ode_dt = dt);
+# First, let's define how the time-step is computed, based on the
+# [Fourier number](https://en.wikipedia.org/wiki/Fourier_number)
+# (i.e., diffusive Courant number) is defined. Because
+# the `HeatModel` is a custom model, we must define how both are computed.
+# First, we must define our own implementation of `DGMethods.calculate_dt`,
+# (which we imported):
+function calculate_dt(dg, model::HeatModel, Q, Courant_number, t, direction)
+    Δt = one(eltype(Q))
+    CFL = DGMethods.courant(diffusive_courant, dg, model, Q, Δt, t, direction)
+    return Courant_number / CFL
+end
+
+# Next, we'll define our implementation of `diffusive_courant`:
+function diffusive_courant(
+    m::HeatModel,
+    state::Vars,
+    aux::Vars,
+    diffusive::Vars,
+    Δx,
+    Δt,
+    t,
+    direction,
+)
+    return Δt * m.α / (Δx * Δx)
+end
+
+# Finally, we initialize the state vector and solver
+# configuration based on the given Fourier number.
+# Note that, we can use a much larger Fourier number
+# for implicit solvers as compared to explicit solvers.
+use_implicit_solver = false
+if use_implicit_solver
+    given_Fourier = FT(30)
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config;
+        ode_solver_type = ImplicitSolverType(OrdinaryDiffEq.Kvaerno3(
+            autodiff = false,
+            linsolve = LinSolveGMRES(),
+        )),
+        Courant_number = given_Fourier,
+        CFL_direction = VerticalDirection(),
+    )
+else
+    given_Fourier = FT(0.7)
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config;
+        Courant_number = given_Fourier,
+        CFL_direction = VerticalDirection(),
+    )
+end;
+
+
 grid = solver_config.dg.grid;
 Q = solver_config.Q;
 aux = solver_config.dg.state_auxiliary;


### PR DESCRIPTION
# Description

This PR makes the heat tutorial use an implicit time marching method (`Kvaerno3`) from the DiffEq library and adds an implicit solver type to the driver configuration.

At the moment, we cannot use ForwardDiff to approximate the Jacobians. Instead, DiffEq is falling back on finite difference method, which results in more kernel calls. Next, we'd like to see how this implicit method fairs with explicit for a range of thermal conductivities (which varies the stiffness). While I'm working on a preliminary comparison PR, @kanav99 will be trying to get ForwardDiff working with #1291 to reduce the number of kernel calls. Thanks @kanav99 and @thomasgibson for all of your help with time marching!

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
