### PR TITLE
Fix plot legend in plothelpers.jl

### DIFF
--- a/docs/plothelpers.jl
+++ b/docs/plothelpers.jl
@@ -28,6 +28,7 @@ function export_plot(
     xlabel,
     ylabel,
     time_data,
+    round_digits = 2,
 )
     ϕ_all isa Tuple || (ϕ_all = (ϕ_all,))
     single_var = ϕ_all[1] == xlabel && length(ϕ_all) == 1
@@ -37,7 +38,8 @@ function export_plot(
             ϕ_string = String(ϕ)
             ϕ_name = plot_friendly_name(ϕ_string)
             ϕ_data = data[ϕ_string][:]
-            label = single_var ? "t=$t" : "$(ϕ_string), t=$t"
+            label = single_var ? "t=$(round(t, digits=2))" :
+                "$(ϕ_string), t=$(round(t, digits=2))"
             plot!(ϕ_data, z; xlabel = xlabel, ylabel = ylabel, label = label)
         end
     end

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -593,7 +593,7 @@ callback = GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
     push!(data_var, state_vars_var)
     push!(data_avg, state_vars_avg)
     push!(data_nodal, state_vars)
-    push!(time_data, round(gettime(solver_config.solver), digits = 3))
+    push!(time_data, gettime(solver_config.solver))
     nothing
 end;
 


### PR DESCRIPTION
# Description

This PR fixes the legend of the _solution_vs_time.png_ plot, rounding the time shown to two digits.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
