### PR TITLE
Add bulk surface flux to boundaryconditions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -912,6 +912,16 @@ steps:
     agents:
       config: gpu
       queue: central
+      slurm_ntasks: 1  
+      slurm_gres: "gpu:1"
+
+  - label: "gpu_bomex_bulk_sfc_flux" 
+    key: "gpu_bomex_bulk_sfc_flux"
+    command:
+      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex_bulk_sfc_flux.jl --diagnostics=default --fix-rng-seed"
+    agents:
+      config: gpu
+      queue: central
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 

--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -41,11 +41,14 @@ ClimateMachine.Atmos.AtmosBC
 ClimateMachine.Atmos.DragLaw
 ClimateMachine.Atmos.Impermeable
 ClimateMachine.Atmos.PrescribedMoistureFlux
+ClimateMachine.Atmos.BulkFormulaMoisture
 ClimateMachine.Atmos.FreeSlip
 ClimateMachine.Atmos.PrescribedTemperature
 ClimateMachine.Atmos.PrescribedEnergyFlux
+ClimateMachine.Atmos.BulkFormulaEnergy
 ClimateMachine.Atmos.ImpermeableTracer
 ClimateMachine.Atmos.Impenetrable
 ClimateMachine.Atmos.Insulating
 ClimateMachine.Atmos.NoSlip
+ClimateMachine.Atmos.average_density_sfc_int
 ```

--- a/experiments/AtmosLES/bomex_bulk_sfc_flux.jl
+++ b/experiments/AtmosLES/bomex_bulk_sfc_flux.jl
@@ -1,0 +1,564 @@
+#!/usr/bin/env julia --project
+#=
+# This experiment file establishes the initial conditions, boundary conditions,
+# source terms and simulation parameters (domain size + resolution) for the
+# BOMEX LES case. The set of parameters presented in the `master` branch copy
+# include those that have passed offline tests at the full simulation time of
+# 6 hours. Suggested offline tests included plotting horizontal-domain averages
+# of key properties (see AtmosDiagnostics). The timestepper configuration is in
+# `src/Driver/solver_configs.jl` while the `AtmosModel` defaults can be found in
+# `src/Atmos/Model/AtmosModel.jl` and `src/Driver/driver_configs.jl`
+#
+# This setup works in both Float32 and Float64 precision. `FT`
+#
+# To simulate the full 6 hour experiment, change `timeend` to (3600*6) and type in
+#
+# julia --project experiments/AtmosLES/bomex.jl
+#
+# See `src/Driver/driver_configs.jl` for additional flags (e.g. VTK, diagnostics,
+# update-interval, output directory settings)
+#
+# Upcoming changes:
+# 1) Atomic sources
+# 2) Improved boundary conditions
+# 3) Collapsed experiment design
+# 4) Updates to generally keep this in sync with master
+
+@article{doi:10.1175/1520-0469(2003)60<1201:ALESIS>2.0.CO;2,
+author = {Siebesma, A. Pier and Bretherton,
+          Christopher S. and Brown,
+          Andrew and Chlond,
+          Andreas and Cuxart,
+          Joan and Duynkerke,
+          Peter G. and Jiang,
+          Hongli and Khairoutdinov,
+          Marat and Lewellen,
+          David and Moeng,
+          Chin-Hoh and Sanchez,
+          Enrique and Stevens,
+          Bjorn and Stevens,
+          David E.},
+title = {A Large Eddy Simulation Intercomparison Study of Shallow Cumulus Convection},
+journal = {Journal of the Atmospheric Sciences},
+volume = {60},
+number = {10},
+pages = {1201-1219},
+year = {2003},
+doi = {10.1175/1520-0469(2003)60<1201:ALESIS>2.0.CO;2},
+URL = {https://journals.ametsoc.org/doi/abs/10.1175/1520-0469%282003%2960%3C1201%3AALESIS%3E2.0.CO%3B2},
+eprint = {https://journals.ametsoc.org/doi/pdf/10.1175/1520-0469%282003%2960%3C1201%3AALESIS%3E2.0.CO%3B2}
+=#
+
+using ClimateMachine
+ClimateMachine.init(parse_clargs = true)
+
+using ClimateMachine.Atmos
+using ClimateMachine.Orientations
+using ClimateMachine.ConfigTypes
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.Diagnostics
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.Mesh.Filters
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.ODESolvers
+using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.VariableTemplates
+
+using Distributions
+using Random
+using StaticArrays
+using Test
+using DocStringExtensions
+using LinearAlgebra
+
+using CLIMAParameters
+using CLIMAParameters.Planet: e_int_v0, grav, day
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+import ClimateMachine.BalanceLaws: vars_state
+import ClimateMachine.Atmos: source!, atmos_source!, altitude
+import ClimateMachine.Atmos: flux_second_order!, thermo_state
+
+"""
+  Bomex Geostrophic Forcing (Source)
+"""
+struct BomexGeostrophic{FT} <: Source
+    "Coriolis parameter [s⁻¹]"
+    f_coriolis::FT
+    "Eastward geostrophic velocity `[m/s]` (Base)"
+    u_geostrophic::FT
+    "Eastward geostrophic velocity `[m/s]` (Slope)"
+    u_slope::FT
+    "Northward geostrophic velocity `[m/s]`"
+    v_geostrophic::FT
+end
+function atmos_source!(
+    s::BomexGeostrophic,
+    atmos::AtmosModel,
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
+
+    f_coriolis = s.f_coriolis
+    u_geostrophic = s.u_geostrophic
+    u_slope = s.u_slope
+    v_geostrophic = s.v_geostrophic
+
+    z = altitude(atmos, aux)
+    # Note z dependence of eastward geostrophic velocity
+    u_geo = SVector(u_geostrophic + u_slope * z, v_geostrophic, 0)
+    ẑ = vertical_unit_vector(atmos, aux)
+    fkvector = f_coriolis * ẑ
+    # Accumulate sources
+    source.ρu -= fkvector × (state.ρu .- state.ρ * u_geo)
+    return nothing
+end
+
+"""
+  Bomex Sponge (Source)
+"""
+struct BomexSponge{FT} <: Source
+    "Maximum domain altitude (m)"
+    z_max::FT
+    "Altitude at with sponge starts (m)"
+    z_sponge::FT
+    "Sponge Strength 0 ⩽ α_max ⩽ 1"
+    α_max::FT
+    "Sponge exponent"
+    γ::FT
+    "Eastward geostrophic velocity `[m/s]` (Base)"
+    u_geostrophic::FT
+    "Eastward geostrophic velocity `[m/s]` (Slope)"
+    u_slope::FT
+    "Northward geostrophic velocity `[m/s]`"
+    v_geostrophic::FT
+end
+function atmos_source!(
+    s::BomexSponge,
+    atmos::AtmosModel,
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
+
+    z_max = s.z_max
+    z_sponge = s.z_sponge
+    α_max = s.α_max
+    γ = s.γ
+    u_geostrophic = s.u_geostrophic
+    u_slope = s.u_slope
+    v_geostrophic = s.v_geostrophic
+
+    z = altitude(atmos, aux)
+    u_geo = SVector(u_geostrophic + u_slope * z, v_geostrophic, 0)
+    ẑ = vertical_unit_vector(atmos, aux)
+    # Accumulate sources
+    if z_sponge <= z
+        r = (z - z_sponge) / (z_max - z_sponge)
+        β_sponge = α_max * sinpi(r / 2)^s.γ
+        source.ρu -= β_sponge * (state.ρu .- state.ρ * u_geo)
+    end
+    return nothing
+end
+
+"""
+  BomexTendencies (Source)
+Moisture, Temperature and Subsidence tendencies
+"""
+struct BomexTendencies{FT} <: Source
+    "Advection tendency in total moisture `[s⁻¹]`"
+    ∂qt∂t_peak::FT
+    "Lower extent of piecewise profile (moisture term) `[m]`"
+    zl_moisture::FT
+    "Upper extent of piecewise profile (moisture term) `[m]`"
+    zh_moisture::FT
+    "Cooling rate `[K/s]`"
+    ∂θ∂t_peak::FT
+    "Lower extent of piecewise profile (subsidence term) `[m]`"
+    zl_sub::FT
+    "Upper extent of piecewise profile (subsidence term) `[m]`"
+    zh_sub::FT
+    "Subsidence peak velocity"
+    w_sub::FT
+    "Max height in domain"
+    z_max::FT
+end
+function atmos_source!(
+    s::BomexTendencies,
+    atmos::AtmosModel,
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
+    FT = eltype(state)
+    ρ = state.ρ
+    z = altitude(atmos, aux)
+    _e_int_v0 = FT(e_int_v0(atmos.param_set))
+
+    # Establish thermodynamic state
+    TS = thermo_state(atmos, state, aux)
+
+    # Moisture tendencey (sink term)
+    # Temperature tendency (Radiative cooling)
+    # Large scale subsidence
+    # Unpack struct
+    zl_moisture = s.zl_moisture
+    zh_moisture = s.zh_moisture
+    z_max = s.z_max
+    zl_sub = s.zl_sub
+    zh_sub = s.zh_sub
+    zl_temperature = zl_sub
+    w_sub = s.w_sub
+    ∂qt∂t_peak = s.∂qt∂t_peak
+    ∂θ∂t_peak = s.∂θ∂t_peak
+    k̂ = vertical_unit_vector(atmos, aux)
+
+    # Thermodynamic state identification
+    q_pt = PhasePartition(TS)
+    cvm = cv_m(TS)
+
+    # Piecewise term for moisture tendency
+    linscale_moisture = (z - zl_moisture) / (zh_moisture - zl_moisture)
+    if z <= zl_moisture
+        ρ∂qt∂t = ρ * ∂qt∂t_peak
+    elseif zl_moisture < z <= zh_moisture
+        ρ∂qt∂t = ρ * (∂qt∂t_peak - ∂qt∂t_peak * linscale_moisture)
+    else
+        ρ∂qt∂t = -zero(FT)
+    end
+
+    # Piecewise term for internal energy tendency
+    linscale_temp = (z - zl_sub) / (z_max - zl_sub)
+    if z <= zl_sub
+        ρ∂θ∂t = ρ * ∂θ∂t_peak
+    elseif zl_temperature < z <= z_max
+        ρ∂θ∂t = ρ * (∂θ∂t_peak - ∂θ∂t_peak * linscale_temp)
+    else
+        ρ∂θ∂t = -zero(FT)
+    end
+
+    # Piecewise terms for subsidence
+    linscale_sub = (z - zl_sub) / (zh_sub - zl_sub)
+    w_s = -zero(FT)
+    if z <= zl_sub
+        w_s = -zero(FT) + z * (w_sub) / (zl_sub)
+    elseif zl_sub < z <= zh_sub
+        w_s = w_sub - (w_sub) * linscale_sub
+    else
+        w_s = -zero(FT)
+    end
+
+    # Collect Sources
+    source.moisture.ρq_tot += ρ∂qt∂t
+    source.ρe += cvm * ρ∂θ∂t * exner(TS) + _e_int_v0 * ρ∂qt∂t
+    source.ρe -= ρ * w_s * dot(k̂, diffusive.∇h_tot)
+    source.moisture.ρq_tot -= ρ * w_s * dot(k̂, diffusive.moisture.∇q_tot)
+    return nothing
+end
+
+"""
+  Initial Condition for BOMEX LES
+"""
+function init_bomex!(bl, state, aux, (x, y, z), t)
+    # This experiment runs the BOMEX LES Configuration
+    # (Shallow cumulus cloud regime)
+    # x,y,z imply eastward, northward and altitude coordinates in `[m]`
+
+    # Problem floating point precision
+    FT = eltype(state)
+
+    P_sfc::FT = 1.015e5 # Surface air pressure
+    qg::FT = 22.45e-3 # Total moisture at surface
+    q_pt_sfc = PhasePartition(qg) # Surface moisture partitioning
+    Rm_sfc = gas_constant_air(bl.param_set, q_pt_sfc) # Moist gas constant
+    θ_liq_sfc = FT(299.1) # Prescribed θ_liq at surface
+    T_sfc = FT(300.4) # Surface temperature
+    _grav = FT(grav(bl.param_set))
+
+    # Initialise speeds [u = Eastward, v = Northward, w = Vertical]
+    u::FT = 0
+    v::FT = 0
+    w::FT = 0
+
+    # Prescribed altitudes for piece-wise profile construction
+    zl1::FT = 520
+    zl2::FT = 1480
+    zl3::FT = 2000
+    zl4::FT = 3000
+
+    # Assign piecewise quantities to θ_liq and q_tot
+    θ_liq::FT = 0
+    q_tot::FT = 0
+
+    # Piecewise functions for potential temperature and total moisture
+    if FT(0) <= z <= zl1
+        # Well mixed layer
+        θ_liq = 298.7
+        q_tot = 17.0 + (z / zl1) * (16.3 - 17.0)
+    elseif z > zl1 && z <= zl2
+        # Conditionally unstable layer
+        θ_liq = 298.7 + (z - zl1) * (302.4 - 298.7) / (zl2 - zl1)
+        q_tot = 16.3 + (z - zl1) * (10.7 - 16.3) / (zl2 - zl1)
+    elseif z > zl2 && z <= zl3
+        # Absolutely stable inversion
+        θ_liq = 302.4 + (z - zl2) * (308.2 - 302.4) / (zl3 - zl2)
+        q_tot = 10.7 + (z - zl2) * (4.2 - 10.7) / (zl3 - zl2)
+    else
+        θ_liq = 308.2 + (z - zl3) * (311.85 - 308.2) / (zl4 - zl3)
+        q_tot = 4.2 + (z - zl3) * (3.0 - 4.2) / (zl4 - zl3)
+    end
+
+    # Set velocity profiles - piecewise profile for u
+    zlv::FT = 700
+    if z <= zlv
+        u = -8.75
+    else
+        u = -8.75 + (z - zlv) * (-4.61 + 8.75) / (zl4 - zlv)
+    end
+
+    # Convert total specific humidity to kg/kg
+    q_tot /= 1000
+    # Scale height based on surface parameters
+    H = Rm_sfc * T_sfc / _grav
+    # Pressure based on scale height
+    P = P_sfc * exp(-z / H)
+
+    # Establish thermodynamic state and moist phase partitioning
+    TS = LiquidIcePotTempSHumEquil_given_pressure(bl.param_set, θ_liq, P, q_tot)
+    T = air_temperature(TS)
+    ρ = air_density(TS)
+    q_pt = PhasePartition(TS)
+
+    # Compute momentum contributions
+    ρu = ρ * u
+    ρv = ρ * v
+    ρw = ρ * w
+
+    # Compute energy contributions
+    e_kin = FT(1 // 2) * (u^2 + v^2 + w^2)
+    e_pot = _grav * z
+    ρe_tot = ρ * total_energy(e_kin, e_pot, TS)
+
+    # Assign initial conditions for prognostic state variables
+    state.ρ = ρ
+    state.ρu = SVector(ρu, ρv, ρw)
+    state.ρe = ρe_tot
+    state.moisture.ρq_tot = ρ * q_tot
+
+    if z <= FT(400) # Add random perturbations to bottom 400m of model
+        state.ρe += rand() * ρe_tot / 100
+        state.moisture.ρq_tot += rand() * ρ * q_tot / 100
+    end
+end
+
+function config_bomex(FT, N, resolution, xmax, ymax, zmax)
+
+    ics = init_bomex!     # Initial conditions
+
+    C_smag = FT(0.23)     # Smagorinsky coefficient
+
+    u_star = FT(0.28)     # Friction velocity
+    C_drag = FT(0.0011)   # Bulk transfer coefficient
+
+    T_sfc = FT(300.4)     # Surface temperature `[K]`
+    q_sfc = FT(22.45e-3)  # Surface specific humiity `[kg/kg]`
+    LHF = FT(147.2)       # Latent heat flux `[W/m²]`
+    SHF = FT(9.5)         # Sensible heat flux `[W/m²]`
+    moisture_flux = LHF / latent_heat_vapor(param_set, T_sfc)
+
+    ∂qt∂t_peak = FT(-1.2e-8)  # Moisture tendency (energy source)
+    zl_moisture = FT(300)     # Low altitude limit for piecewise function (moisture source)
+    zh_moisture = FT(500)     # High altitude limit for piecewise function (moisture source)
+    ∂θ∂t_peak = FT(-2 / FT(day(param_set)))  # Potential temperature tendency (energy source)
+
+    z_sponge = FT(2400)     # Start of sponge layer
+    α_max = FT(0.75)        # Strength of sponge layer (timescale)
+    γ = 2              # Strength of sponge layer (exponent)
+
+    u_geostrophic = FT(-10)        # Eastward relaxation speed
+    u_slope = FT(1.8e-3)     # Slope of altitude-dependent relaxation speed
+    v_geostrophic = FT(0)          # Northward relaxation speed
+
+    zl_sub = FT(1500)         # Low altitude for piecewise function (subsidence source)
+    zh_sub = FT(2100)         # High altitude for piecewise function (subsidence source)
+    w_sub = FT(-0.65e-2)     # Subsidence velocity peak value
+
+    f_coriolis = FT(0.376e-4) # Coriolis parameter
+
+    # Assemble source components
+    source = (
+        Gravity(),
+        BomexTendencies{FT}(
+            ∂qt∂t_peak,
+            zl_moisture,
+            zh_moisture,
+            ∂θ∂t_peak,
+            zl_sub,
+            zh_sub,
+            w_sub,
+            zmax,
+        ),
+        BomexSponge{FT}(
+            zmax,
+            z_sponge,
+            α_max,
+            γ,
+            u_geostrophic,
+            u_slope,
+            v_geostrophic,
+        ),
+        BomexGeostrophic{FT}(f_coriolis, u_geostrophic, u_slope, v_geostrophic),
+    )
+
+    # Choose default IMEX solver
+    ode_solver_type = ClimateMachine.IMEXSolverType()
+
+    # Assemble model components
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        param_set;
+        turbulence = SmagorinskyLilly{FT}(C_smag),
+        moisture = EquilMoist{FT}(; maxiter = 5, tolerance = FT(0.1)),
+        source = source,
+        boundarycondition = (
+            AtmosBC(
+                momentum = Impenetrable(DragLaw(
+                    # normPu_int is the internal horizontal speed
+                    # P represents the projection onto the horizontal
+                    (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
+                )),
+                energy = BulkFormulaEnergy(
+                    (state, aux, t, normPu_int) -> C_drag,
+                    (state, aux, t) -> T_sfc,
+                    (state, aux, t) -> q_sfc,
+                ),
+                moisture = BulkFormulaMoisture(
+                    (state, aux, t, normPu_int) -> C_drag,
+                    (state, aux, t) -> q_sfc,
+                ),
+            ),
+            AtmosBC(),
+        ),
+        init_state_prognostic = ics,
+    )
+
+    # Assemble configuration
+    config = ClimateMachine.AtmosLESConfiguration(
+        "BOMEX",
+        N,
+        resolution,
+        xmax,
+        ymax,
+        zmax,
+        param_set,
+        init_bomex!,
+        solver_type = ode_solver_type,
+        model = model,
+    )
+    return config
+end
+
+function config_diagnostics(driver_config)
+    default_dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
+        "2500steps",
+        driver_config.name,
+    )
+    core_dgngrp = setup_atmos_core_diagnostics(
+        AtmosLESConfigType(),
+        "2500steps",
+        driver_config.name,
+    )
+    return ClimateMachine.DiagnosticsConfiguration([
+        default_dgngrp,
+        core_dgngrp,
+    ])
+end
+
+function main()
+    FT = Float32
+
+    # DG polynomial order
+    N = 4
+    # Domain resolution and size
+    Δh = FT(100)
+    Δv = FT(40)
+
+    resolution = (Δh, Δh, Δv)
+
+    # Prescribe domain parameters
+    xmax = FT(6400)
+    ymax = FT(6400)
+    zmax = FT(3000)
+
+    t0 = FT(0)
+
+    # For a full-run, please set the timeend to 3600*6 seconds
+    # For the test we set this to == 30 minutes
+    timeend = FT(1800)
+    #timeend = FT(3600 * 6)
+    CFLmax = FT(0.90)
+
+    driver_config = config_bomex(FT, N, resolution, xmax, ymax, zmax)
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+    )
+    dgn_config = config_diagnostics(driver_config)
+
+    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            ("moisture.ρq_tot",),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
+        nothing
+    end
+
+    # State variable
+    Q = solver_config.Q
+    # Volume geometry information
+    vgeo = driver_config.grid.vgeo
+    M = vgeo[:, Grids._M, :]
+    # Unpack prognostic vars
+    ρ₀ = Q.ρ
+    ρe₀ = Q.ρe
+    # DG variable sums
+    Σρ₀ = sum(ρ₀ .* M)
+    Σρe₀ = sum(ρe₀ .* M)
+    cb_check_cons = GenericCallbacks.EveryXSimulationSteps(3000) do
+        Q = solver_config.Q
+        δρ = (sum(Q.ρ .* M) - Σρ₀) / Σρ₀
+        δρe = (sum(Q.ρe .* M) .- Σρe₀) ./ Σρe₀
+        @show (abs(δρ))
+        @show (abs(δρe))
+        @test (abs(δρ) <= 0.0001)
+        @test (abs(δρe) <= 0.0025)
+        nothing
+    end
+
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (cbtmarfilter, cb_check_cons),
+        check_euclidean_distance = true,
+    )
+end
+
+main()

--- a/src/Atmos/Model/bc_moisture.jl
+++ b/src/Atmos/Model/bc_moisture.jl
@@ -60,3 +60,57 @@ function atmos_moisture_normal_boundary_flux_second_order!(
     # assumes EquilMoist
     fluxᵀn.moisture.ρq_tot += nρd_q_tot
 end
+
+"""
+    BulkFormulaMoisture(fn) :: MoistureBC
+
+Calculate the net inward moisture flux across the boundary using
+the bulk formula.
+The drag coefficient is `C_q = fn_C_q(state, aux, t, normu_int_tan)`.
+The surface q_tot is `q_tot_sfc = fn_q_tot_sfc(state, aux, t)`.
+Return the flux (in kg m^-2 s^-1).
+"""
+struct BulkFormulaMoisture{FNX, FNM} <: MoistureBC
+    fn_C_q::FNX
+    fn_q_tot_sfc::FNM
+end
+function atmos_moisture_boundary_state!(
+    nf,
+    bc_moisture::BulkFormulaMoisture,
+    atmos,
+    args...,
+) end
+function atmos_moisture_normal_boundary_flux_second_order!(
+    nf,
+    bc_moisture::BulkFormulaMoisture,
+    atmos,
+    fluxᵀn,
+    n⁻,
+    state_sfc⁻,
+    diff_sfc⁻,
+    hyperdiff_sfc⁻,
+    aux_sfc⁻,
+    state_sfc⁺,
+    diff_sfc⁺,
+    hyperdiff_sfc⁺,
+    aux_sfc⁺,
+    bctype,
+    t,
+    state_int⁻,
+    diff_int⁻,
+    aux_int⁻,
+)
+
+    u_int⁻ = state_int⁻.ρu / state_int⁻.ρ
+    u_int⁻_tan = projection_tangential(atmos, aux_int⁻, u_int⁻)
+    normu_int⁻_tan = norm(u_int⁻_tan)
+    C_q = bc_moisture.fn_C_q(state_sfc⁻, aux_sfc⁻, t, normu_int⁻_tan)
+    q_tot_sfc = bc_moisture.fn_q_tot_sfc(state_sfc⁻, aux_sfc⁻, t)
+    q_tot_int = state_int⁻.moisture.ρq_tot / state_int⁻.ρ
+    ρ_avg = average_density_sfc_int(state_sfc⁻.ρ, state_int⁻.ρ)
+    # NOTE: difference from design docs since normal points outwards
+    fluxᵀn.moisture.ρq_tot -=
+        C_q * ρ_avg * normu_int⁻_tan * (q_tot_sfc - q_tot_int)
+    fluxᵀn.ρ -= C_q * ρ_avg * normu_int⁻_tan * (q_tot_sfc - q_tot_int)
+    fluxᵀn.ρu -= C_q * normu_int⁻_tan * (q_tot_sfc - q_tot_int) .* state_int⁻.ρu
+end

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -10,10 +10,14 @@ export AtmosBC,
     Insulating,
     PrescribedTemperature,
     PrescribedEnergyFlux,
+    BulkFormulaEnergy,
     Impermeable,
     ImpermeableTracer,
     PrescribedMoistureFlux,
+    BulkFormulaMoisture,
     PrescribedTracerFlux
+
+export average_density_sfc_int
 
 """
     AtmosBC(momentum = Impenetrable(FreeSlip())
@@ -202,6 +206,17 @@ function atmos_normal_boundary_flux_second_order!(
         args...,
     )
     turbconv_normal_boundary_flux_second_order!(nf, bc.turbconv, atmos, args...)
+end
+
+"""
+    average_density_sfc_int(ρ_sfc, ρ_int)
+
+Average density between the surface and the interior point, given
+ - `ρ_sfc` density at the surface
+ - `ρ_int` density at the interior point
+"""
+function average_density_sfc_int(ρ_sfc::FT, ρ_int::FT) where {FT <: Real}
+    return FT(0.5) * (ρ_sfc + ρ_int)
 end
 
 include("bc_momentum.jl")


### PR DESCRIPTION
# Description

Add bulk surface flux of moisture and energy to boundaryconditions.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
