### PR TITLE
Make `export_plot` use `round_digits` kwarg

### DIFF
--- a/docs/plothelpers.jl
+++ b/docs/plothelpers.jl
@@ -38,8 +38,8 @@ function export_plot(
             ϕ_string = String(ϕ)
             ϕ_name = plot_friendly_name(ϕ_string)
             ϕ_data = data[ϕ_string][:]
-            label = single_var ? "t=$(round(t, digits=2))" :
-                "$(ϕ_string), t=$(round(t, digits=2))"
+            label = single_var ? "t=$(round(t, digits=round_digits))" :
+                "$(ϕ_string), t=$(round(t, digits=round_digits))"
             plot!(ϕ_data, z; xlabel = xlabel, ylabel = ylabel, label = label)
         end
     end


### PR DESCRIPTION
# Description

`round_digits` is not actually used in `export_plot`. This PR makes `export_plot` use the `round_digits` input kwarg.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
