### PR TITLE
reduce bors timeout from 24 to 3 hours

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -7,6 +7,6 @@ status = [
   "format"
 ]
 delete_merged_branches = true
-timeout_sec = 86400
+timeout_sec = 10800
 block_labels = [ "do-not-merge-yet" ]
 cut_body_after = "<!--"


### PR DESCRIPTION
<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
