### PR TITLE
Add kernel vars wrappers

### DIFF
--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -57,6 +57,7 @@ export DGModel,
 include("NumericalFluxes.jl")
 include("DGModel.jl")
 include("DGModel_kernels.jl")
+include("kernel_vars_wrappers.jl")
 include("create_states.jl")
 
 """

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -1,14 +1,14 @@
 using .NumericalFluxes:
-    numerical_flux_gradient!,
-    numerical_flux_first_order!,
-    numerical_flux_second_order!,
-    numerical_flux_divergence!,
-    numerical_flux_higher_order!,
-    numerical_boundary_flux_gradient!,
-    numerical_boundary_flux_first_order!,
-    numerical_boundary_flux_second_order!,
-    numerical_boundary_flux_divergence!,
-    numerical_boundary_flux_higher_order!
+    wrapper_numerical_flux_gradient!,
+    wrapper_numerical_flux_first_order!,
+    wrapper_numerical_flux_second_order!,
+    wrapper_numerical_flux_divergence!,
+    wrapper_numerical_flux_higher_order!,
+    wrapper_numerical_boundary_flux_gradient!,
+    wrapper_numerical_boundary_flux_first_order!,
+    wrapper_numerical_boundary_flux_second_order!,
+    wrapper_numerical_boundary_flux_divergence!,
+    wrapper_numerical_boundary_flux_higher_order!
 
 using ..Mesh.Geometry
 
@@ -129,15 +129,11 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
             end
 
             fill!(local_flux, -zero(eltype(local_flux)))
-            flux_first_order!(
+            wrapper_flux_first_order!(
                 balance_law,
-                Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                local_flux,
+                local_state_prognostic,
+                local_state_auxiliary,
                 t,
                 (direction,),
             )
@@ -149,21 +145,13 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
             end
 
             fill!(local_flux, -zero(eltype(local_flux)))
-            flux_second_order!(
+            wrapper_flux_second_order!(
                 balance_law,
-                Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux,
-                ),
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                local_flux,
+                local_state_prognostic,
+                local_state_gradient_flux,
+                local_state_hyperdiffusion,
+                local_state_auxiliary,
                 t,
             )
 
@@ -195,17 +183,11 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
             if direction isa EveryDirection && balance_law isa RemBL
                 if rembl_has_subs_direction(HorizontalDirection(), balance_law)
                     fill!(local_flux, -zero(eltype(local_flux)))
-                    flux_first_order!(
+                    wrapper_flux_first_order!(
                         balance_law,
-                        Grad{vars_state(balance_law, Prognostic(), FT)}(
-                            local_flux,
-                        ),
-                        Vars{vars_state(balance_law, Prognostic(), FT)}(
-                            local_state_prognostic,
-                        ),
-                        Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                            local_state_auxiliary,
-                        ),
+                        local_flux,
+                        local_state_prognostic,
+                        local_state_auxiliary,
                         t,
                         (HorizontalDirection(),),
                     )
@@ -222,17 +204,11 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
                 end
                 if rembl_has_subs_direction(VerticalDirection(), balance_law)
                     fill!(local_flux, -zero(eltype(local_flux)))
-                    flux_first_order!(
+                    wrapper_flux_first_order!(
                         balance_law,
-                        Grad{vars_state(balance_law, Prognostic(), FT)}(
-                            local_flux,
-                        ),
-                        Vars{vars_state(balance_law, Prognostic(), FT)}(
-                            local_state_prognostic,
-                        ),
-                        Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                            local_state_auxiliary,
-                        ),
+                        local_flux,
+                        local_state_prognostic,
+                        local_state_auxiliary,
                         t,
                         (VerticalDirection(),),
                     )
@@ -260,18 +236,12 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
             end
 
             fill!(local_source, -zero(eltype(local_source)))
-            source!(
+            wrapper_source!(
                 balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_source),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                local_source,
+                local_state_prognostic,
+                local_state_gradient_flux,
+                local_state_auxiliary,
                 t,
                 (direction,),
             )
@@ -408,15 +378,11 @@ end
             end
 
             fill!(local_flux, -zero(eltype(local_flux)))
-            flux_first_order!(
+            wrapper_flux_first_order!(
                 balance_law,
-                Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                local_flux,
+                local_state_prognostic,
+                local_state_auxiliary,
                 t,
                 (direction,),
             )
@@ -428,21 +394,13 @@ end
             end
 
             fill!(local_flux, -zero(eltype(local_flux)))
-            flux_second_order!(
+            wrapper_flux_second_order!(
                 balance_law,
-                Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux,
-                ),
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                local_flux,
+                local_state_prognostic,
+                local_state_gradient_flux,
+                local_state_hyperdiffusion,
+                local_state_auxiliary,
                 t,
             )
 
@@ -476,18 +434,12 @@ end
             end
 
             fill!(local_source, -zero(eltype(local_source)))
-            source!(
+            wrapper_source!(
                 balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_source),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                local_source,
+                local_state_prognostic,
+                local_state_gradient_flux,
+                local_state_auxiliary,
                 t,
                 (direction,),
             )
@@ -685,55 +637,31 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
         bctype = elemtobndy[f, e⁻]
         fill!(local_flux, -zero(eltype(local_flux)))
         if bctype == 0
-            numerical_flux_first_order!(
+            wrapper_numerical_flux_first_order!(
                 numerical_flux_first_order,
                 balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                SVector(normal_vector),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺nondiff,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺nondiff,
-                ),
+                local_flux,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺nondiff,
+                local_state_auxiliary⁺nondiff,
                 t,
                 face_direction,
             )
-            numerical_flux_second_order!(
+            wrapper_numerical_flux_second_order!(
                 numerical_flux_second_order,
                 balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
+                local_flux,
                 normal_vector,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux⁻,
-                ),
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺diff,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux⁺,
-                ),
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion⁺,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺diff,
-                ),
+                local_state_prognostic⁻,
+                local_state_gradient_flux⁻,
+                local_state_hyperdiffusion⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺diff,
+                local_state_gradient_flux⁺,
+                local_state_hyperdiffusion⁺,
+                local_state_auxiliary⁺diff,
                 t,
             )
         else
@@ -752,73 +680,39 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
                         state_auxiliary[n + Nqk^2, s, e⁻]
                 end
             end
-            numerical_boundary_flux_first_order!(
+            wrapper_numerical_boundary_flux_first_order!(
                 numerical_flux_first_order,
                 balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                SVector(normal_vector),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺nondiff,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺nondiff,
-                ),
+                local_flux,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺nondiff,
+                local_state_auxiliary⁺nondiff,
                 bctype,
                 t,
                 face_direction,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic_bottom1,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary_bottom1,
-                ),
+                local_state_prognostic_bottom1,
+                local_state_auxiliary_bottom1,
             )
-            numerical_boundary_flux_second_order!(
+            wrapper_numerical_boundary_flux_second_order!(
                 numerical_flux_second_order,
                 balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
+                local_flux,
                 normal_vector,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux⁻,
-                ),
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺diff,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux⁺,
-                ),
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion⁺,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺diff,
-                ),
+                local_state_prognostic⁻,
+                local_state_gradient_flux⁻,
+                local_state_hyperdiffusion⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺diff,
+                local_state_gradient_flux⁺,
+                local_state_hyperdiffusion⁺,
+                local_state_auxiliary⁺diff,
                 bctype,
                 t,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic_bottom1,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux_bottom1,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary_bottom1,
-                ),
+                local_state_prognostic_bottom1,
+                local_state_gradient_flux_bottom1,
+                local_state_auxiliary_bottom1,
             )
         end
 
@@ -900,17 +794,11 @@ end
 
         @unroll for k in 1:Nqk
             fill!(local_transform, -zero(eltype(local_transform)))
-            compute_gradient_argument!(
+            wrapper_compute_gradient_argument!(
                 balance_law,
-                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[
-                    :,
-                    k,
-                ]),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[
-                    :,
-                    k,
-                ]),
+                local_transform,
+                local_state_prognostic[:, k],
+                local_state_auxiliary[:, k],
                 t,
             )
             @unroll for s in 1:ngradstate
@@ -980,24 +868,12 @@ end
                     local_state_gradient_flux,
                     -zero(eltype(local_state_gradient_flux)),
                 )
-                compute_gradient_flux!(
+                wrapper_compute_gradient_flux!(
                     balance_law,
-                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                        local_state_gradient_flux,
-                    ),
-                    Grad{vars_state(balance_law, Gradient(), FT)}(local_transform_gradient[
-                        :,
-                        :,
-                        k,
-                    ]),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[
-                        :,
-                        k,
-                    ]),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[
-                        :,
-                        k,
-                    ]),
+                    local_state_gradient_flux,
+                    local_transform_gradient[:, :, k],
+                    local_state_prognostic[:, k],
+                    local_state_auxiliary[:, k],
                     t,
                 )
 
@@ -1092,17 +968,11 @@ end
 
         @unroll for k in 1:Nqk
             fill!(local_transform, -zero(eltype(local_transform)))
-            compute_gradient_argument!(
+            wrapper_compute_gradient_argument!(
                 balance_law,
-                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[
-                    :,
-                    k,
-                ]),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[
-                    :,
-                    k,
-                ]),
+                local_transform,
+                local_state_prognostic[:, k],
+                local_state_auxiliary[:, k],
                 t,
             )
             @unroll for s in 1:ngradstate
@@ -1157,24 +1027,12 @@ end
                     local_state_gradient_flux,
                     -zero(eltype(local_state_gradient_flux)),
                 )
-                compute_gradient_flux!(
+                wrapper_compute_gradient_flux!(
                     balance_law,
-                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                        local_state_gradient_flux,
-                    ),
-                    Grad{vars_state(balance_law, Gradient(), FT)}(local_transform_gradient[
-                        :,
-                        :,
-                        k,
-                    ]),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[
-                        :,
-                        k,
-                    ]),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[
-                        :,
-                        k,
-                    ]),
+                    local_state_gradient_flux,
+                    local_transform_gradient[:, :, k],
+                    local_state_prognostic[:, k],
+                    local_state_auxiliary[:, k],
                     t,
                 )
 
@@ -1291,15 +1149,11 @@ end
         end
 
         fill!(local_transform⁻, -zero(eltype(local_transform⁻)))
-        compute_gradient_argument!(
+        wrapper_compute_gradient_argument!(
             balance_law,
-            Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁻),
-            Vars{vars_state(balance_law, Prognostic(), FT)}(
-                local_state_prognostic⁻,
-            ),
-            Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                local_state_auxiliary⁻,
-            ),
+            local_transform⁻,
+            local_state_prognostic⁻,
+            local_state_auxiliary⁻,
             t,
         )
 
@@ -1313,15 +1167,11 @@ end
         end
 
         fill!(local_transform⁺, -zero(eltype(local_transform⁺)))
-        compute_gradient_argument!(
+        wrapper_compute_gradient_argument!(
             balance_law,
-            Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁺),
-            Vars{vars_state(balance_law, Prognostic(), FT)}(
-                local_state_prognostic⁺,
-            ),
-            Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                local_state_auxiliary⁺,
-            ),
+            local_transform⁺,
+            local_state_prognostic⁺,
+            local_state_auxiliary⁺,
             t,
         )
 
@@ -1331,42 +1181,26 @@ end
             -zero(eltype(local_state_gradient_flux)),
         )
         if bctype == 0
-            numerical_flux_gradient!(
+            wrapper_numerical_flux_gradient!(
                 numerical_flux_gradient,
                 balance_law,
                 local_transform_gradient,
-                SVector(normal_vector),
-                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁻),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁺),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺,
-                ),
+                normal_vector,
+                local_transform⁻,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_transform⁺,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
                 t,
             )
             if num_state_gradient_flux > 0
-                compute_gradient_flux!(
+                wrapper_compute_gradient_flux!(
                     balance_law,
-                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                        local_state_gradient_flux,
-                    ),
-                    Grad{vars_state(balance_law, Gradient(), FT)}(
-                        local_transform_gradient,
-                    ),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic⁻,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary⁻,
-                    ),
+                    local_state_gradient_flux,
+                    local_transform_gradient,
+                    local_state_prognostic⁻,
+                    local_state_auxiliary⁻,
                     t,
                 )
             end
@@ -1382,49 +1216,29 @@ end
                         state_auxiliary[n + Nqk^2, s, e⁻]
                 end
             end
-            numerical_boundary_flux_gradient!(
+            wrapper_numerical_boundary_flux_gradient!(
                 numerical_flux_gradient,
                 balance_law,
                 local_transform_gradient,
-                SVector(normal_vector),
-                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁻),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁺),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺,
-                ),
+                normal_vector,
+                local_transform⁻,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_transform⁺,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
                 bctype,
                 t,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic_bottom1,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary_bottom1,
-                ),
+                local_state_prognostic_bottom1,
+                local_state_auxiliary_bottom1,
             )
             if num_state_gradient_flux > 0
-                compute_gradient_flux!(
+                wrapper_compute_gradient_flux!(
                     balance_law,
-                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                        local_state_gradient_flux,
-                    ),
-                    Grad{vars_state(balance_law, Gradient(), FT)}(
-                        local_transform_gradient,
-                    ),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic⁻,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary⁻,
-                    ),
+                    local_state_gradient_flux,
+                    local_transform_gradient,
+                    local_state_prognostic⁻,
+                    local_state_auxiliary⁻,
                     t,
                 )
             end
@@ -1446,18 +1260,12 @@ end
                 vMI * sM * (local_transform_gradient[3, j] - l_nG⁻[3, j])
         end
 
-        compute_gradient_flux!(
+        wrapper_compute_gradient_flux!(
             balance_law,
-            Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                local_state_prognostic⁻visc,
-            ),
-            Grad{vars_state(balance_law, Gradient(), FT)}(l_nG⁻),
-            Vars{vars_state(balance_law, Prognostic(), FT)}(
-                local_state_prognostic⁻,
-            ),
-            Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                local_state_auxiliary⁻,
-            ),
+            local_state_prognostic⁻visc,
+            l_nG⁻,
+            local_state_prognostic⁻,
+            local_state_auxiliary⁻,
             t,
         )
 
@@ -1507,12 +1315,10 @@ end
         @unroll for s in 1:num_state_prognostic
             l_state[s] = state[n, s, e]
         end
-        init_state_prognostic!(
+        wrapper_init_state_prognostic!(
             balance_law,
-            Vars{vars_state(balance_law, Prognostic(), FT)}(l_state),
-            Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                local_state_auxiliary,
-            ),
+            l_state,
+            local_state_auxiliary,
             coords,
             args...,
         )
@@ -1603,6 +1409,8 @@ Update the auxiliary state array
     FT = eltype(state_prognostic)
     num_state_prognostic = number_states(balance_law, Prognostic())
     num_state_auxiliary = number_states(balance_law, Auxiliary())
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
 
     Nq = N + 1
 
@@ -1633,12 +1441,8 @@ Update the auxiliary state array
 
             f!(
                 balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                Vars{vs_prognostic}(local_state_prognostic),
+                Vars{vs_auxiliary}(local_state_auxiliary),
                 t,
             )
 
@@ -1665,6 +1469,9 @@ end
     num_state_prognostic = number_states(balance_law, Prognostic())
     num_state_gradient_flux = number_states(balance_law, GradientFlux())
     num_state_auxiliary = number_states(balance_law, Auxiliary())
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_grad_flux = vars_state(balance_law, GradientFlux(), FT)
 
     Nq = N + 1
 
@@ -1701,15 +1508,9 @@ end
 
             f!(
                 balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux,
-                ),
+                Vars{vs_prognostic}(local_state_prognostic),
+                Vars{vs_auxiliary}(local_state_auxiliary),
+                Vars{vs_grad_flux}(local_state_gradient_flux),
                 t,
             )
 
@@ -1790,19 +1591,11 @@ See [`BalanceLaw`](@ref) for usage.
                     local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
                 end
 
-                integral_load_auxiliary_state!(
+                wrapper_integral_load_auxiliary_state!(
                     balance_law,
-                    Vars{vars_state(balance_law, UpwardIntegrals(), FT)}(view(
-                        local_kernel,
-                        :,
-                        k,
-                    )),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary,
-                    ),
+                    view(local_kernel, :, k),
+                    local_state_prognostic,
+                    local_state_auxiliary,
                 )
 
                 # multiply in the curve jacobian
@@ -1826,19 +1619,10 @@ See [`BalanceLaw`](@ref) for usage.
                     local_kernel[s, k] = local_integral[s, k]
                 end
                 ijk = i + Nq * ((j - 1) + Nqj * (k - 1))
-                integral_set_auxiliary_state!(
+                wrapper_integral_set_auxiliary_state!(
                     balance_law,
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(view(
-                        state_auxiliary,
-                        ijk,
-                        :,
-                        e,
-                    )),
-                    Vars{vars_state(balance_law, UpwardIntegrals(), FT)}(view(
-                        local_kernel,
-                        :,
-                        k,
-                    )),
+                    view(state_auxiliary, ijk, :, e),
+                    view(local_kernel, :, k),
                 )
                 @unroll for ind_out in 1:nout
                     local_integral[ind_out, k] = local_integral[ind_out, Nq]
@@ -1879,21 +1663,11 @@ end
         # Initialize the constant state at zero
         ijk = i + Nq * ((j - 1) + Nqj * (Nq - 1))
         et = nvertelem + (eh - 1) * nvertelem
-        reverse_integral_load_auxiliary_state!(
+        wrapper_reverse_integral_load_auxiliary_state!(
             balance_law,
-            Vars{vars_state(balance_law, DownwardIntegrals(), FT)}(l_T),
-            Vars{vars_state(balance_law, Prognostic(), FT)}(view(
-                state,
-                ijk,
-                :,
-                et,
-            )),
-            Vars{vars_state(balance_law, Auxiliary(), FT)}(view(
-                state_auxiliary,
-                ijk,
-                :,
-                et,
-            )),
+            l_T,
+            view(state, ijk, :, et),
+            view(state_auxiliary, ijk, :, et),
         )
 
         # Loop up the stack of elements
@@ -1901,32 +1675,17 @@ end
             e = ev + (eh - 1) * nvertelem
             @unroll for k in 1:Nq
                 ijk = i + Nq * ((j - 1) + Nqj * (k - 1))
-                reverse_integral_load_auxiliary_state!(
+                wrapper_reverse_integral_load_auxiliary_state!(
                     balance_law,
-                    Vars{vars_state(balance_law, DownwardIntegrals(), FT)}(l_V),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(view(
-                        state,
-                        ijk,
-                        :,
-                        e,
-                    )),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(view(
-                        state_auxiliary,
-                        ijk,
-                        :,
-                        e,
-                    )),
+                    l_V,
+                    view(state, ijk, :, e),
+                    view(state_auxiliary, ijk, :, e),
                 )
                 l_V .= l_T .- l_V
-                reverse_integral_set_auxiliary_state!(
+                wrapper_reverse_integral_set_auxiliary_state!(
                     balance_law,
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(view(
-                        state_auxiliary,
-                        ijk,
-                        :,
-                        e,
-                    )),
-                    Vars{vars_state(balance_law, DownwardIntegrals(), FT)}(l_V),
+                    view(state_auxiliary, ijk, :, e),
+                    l_V,
                 )
             end
         end
@@ -2184,22 +1943,22 @@ end
 
         bctype = elemtobndy[f, e⁻]
         if bctype == 0
-            numerical_flux_divergence!(
+            wrapper_numerical_flux_divergence!(
                 divgradnumpenalty,
                 balance_law,
-                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_div),
+                l_div,
                 normal_vector,
-                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad⁻),
-                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad⁺),
+                l_grad⁻,
+                l_grad⁺,
             )
         else
-            numerical_boundary_flux_divergence!(
+            wrapper_numerical_boundary_flux_divergence!(
                 divgradnumpenalty,
                 balance_law,
-                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_div),
+                l_div,
                 normal_vector,
-                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad⁻),
-                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad⁺),
+                l_grad⁻,
+                l_grad⁺,
                 bctype,
             )
         end
@@ -2323,14 +2082,12 @@ end
             local_state_hyperdiffusion,
             -zero(eltype(local_state_hyperdiffusion)),
         )
-        transform_post_gradient_laplacian!(
+        wrapper_transform_post_gradient_laplacian!(
             balance_law,
-            Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                local_state_hyperdiffusion,
-            ),
-            Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad_lap),
-            Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[:]),
-            Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:]),
+            local_state_hyperdiffusion,
+            l_grad_lap,
+            local_state_prognostic,
+            local_state_auxiliary,
             t,
         )
         @unroll for s in 1:nhyperviscstate
@@ -2431,14 +2188,12 @@ end
             local_state_hyperdiffusion,
             -zero(eltype(local_state_hyperdiffusion)),
         )
-        transform_post_gradient_laplacian!(
+        wrapper_transform_post_gradient_laplacian!(
             balance_law,
-            Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                local_state_hyperdiffusion,
-            ),
-            Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad_lap),
-            Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[:]),
-            Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:]),
+            local_state_hyperdiffusion,
+            l_grad_lap,
+            local_state_prognostic,
+            local_state_auxiliary,
             t,
         )
         @unroll for s in 1:nhyperviscstate
@@ -2556,51 +2311,31 @@ end
 
         bctype = elemtobndy[f, e⁻]
         if bctype == 0
-            numerical_flux_higher_order!(
+            wrapper_numerical_flux_higher_order!(
                 hyperviscnumflux,
                 balance_law,
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion,
-                ),
+                local_state_hyperdiffusion,
                 normal_vector,
-                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_lap⁻),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_lap⁺),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺,
-                ),
+                l_lap⁻,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                l_lap⁺,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
                 t,
             )
         else
-            numerical_boundary_flux_higher_order!(
+            wrapper_numerical_boundary_flux_higher_order!(
                 hyperviscnumflux,
                 balance_law,
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion,
-                ),
+                local_state_hyperdiffusion,
                 normal_vector,
-                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_lap⁻),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_lap⁺),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺,
-                ),
+                l_lap⁻,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                l_lap⁺,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
                 bctype,
                 t,
             )
@@ -2634,6 +2369,9 @@ end
         num_state_prognostic = number_states(balance_law, Prognostic())
         num_state_gradient_flux = number_states(balance_law, GradientFlux())
         num_state_auxiliary = number_states(balance_law, Auxiliary())
+        vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+        vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+        vs_grad_flux = vars_state(balance_law, GradientFlux(), FT)
 
         Nq = N + 1
 
@@ -2667,15 +2405,9 @@ end
         Δx = pointwise_courant[n, e]
         c = local_courant(
             balance_law,
-            Vars{vars_state(balance_law, Prognostic(), FT)}(
-                local_state_prognostic,
-            ),
-            Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                local_state_auxiliary,
-            ),
-            Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                local_state_gradient_flux,
-            ),
+            Vars{vs_prognostic}(local_state_prognostic),
+            Vars{vs_auxiliary}(local_state_auxiliary),
+            Vars{vs_grad_flux}(local_state_gradient_flux),
             Δx,
             Δt,
             simtime,

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -638,4 +638,6 @@ function boundary_flux_second_order!(
     )
 end
 
+include("num_flux_vars_wrappers.jl")
+
 end

--- a/src/Numerics/DGMethods/kernel_vars_wrappers.jl
+++ b/src/Numerics/DGMethods/kernel_vars_wrappers.jl
@@ -1,0 +1,222 @@
+#### Interface kernels
+
+function wrapper_flux_first_order!(
+    balance_law::BalanceLaw,
+    local_flux::AbstractArray{FT, 2},
+    local_state_prognostic::AbstractArray{FT, 1},
+    local_state_auxiliary::AbstractArray{FT, 1},
+    t::AbstractFloat,
+    direction,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    flux_first_order!(
+        balance_law,
+        Grad{vs_prognostic}(local_flux),
+        Vars{vs_prognostic}(local_state_prognostic),
+        Vars{vs_auxiliary}(local_state_auxiliary),
+        t,
+        direction,
+    )
+end
+
+function wrapper_flux_second_order!(
+    balance_law::BalanceLaw,
+    local_flux::AbstractArray{FT, 2},
+    local_state_prognostic::AbstractArray{FT, 1},
+    local_state_gradient_flux::AbstractArray{FT, 1},
+    local_state_hyperdiffusion::AbstractArray{FT, 1},
+    local_state_auxiliary::AbstractArray{FT, 1},
+    t::AbstractFloat,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_grad_flux = vars_state(balance_law, GradientFlux(), FT)
+    vs_hyperdiff = vars_state(balance_law, Hyperdiffusive(), FT)
+    flux_second_order!(
+        balance_law,
+        Grad{vs_prognostic}(local_flux),
+        Vars{vs_prognostic}(local_state_prognostic),
+        Vars{vs_grad_flux}(local_state_gradient_flux),
+        Vars{vs_hyperdiff}(local_state_hyperdiffusion),
+        Vars{vs_auxiliary}(local_state_auxiliary),
+        t,
+    )
+
+end
+
+function wrapper_source!(
+    balance_law::BalanceLaw,
+    local_source::AbstractArray{FT, 1},
+    local_state_prognostic::AbstractArray{FT, 1},
+    local_state_gradient_flux::AbstractArray{FT, 1},
+    local_state_auxiliary::AbstractArray{FT, 1},
+    t::AbstractFloat,
+    direction,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_grad_flux = vars_state(balance_law, GradientFlux(), FT)
+
+    source!(
+        balance_law,
+        Vars{vs_prognostic}(local_source),
+        Vars{vs_prognostic}(local_state_prognostic),
+        Vars{vs_grad_flux}(local_state_gradient_flux),
+        Vars{vs_auxiliary}(local_state_auxiliary),
+        t,
+        direction,
+    )
+
+end
+
+function wrapper_compute_gradient_argument!(
+    balance_law::BalanceLaw,
+    local_transform::AbstractArray{FT, 1},
+    local_state_prognostic::AbstractArray{FT, 1},
+    local_state_auxiliary::AbstractArray{FT, 1},
+    t::AbstractFloat,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_gradient = vars_state(balance_law, Gradient(), FT)
+    compute_gradient_argument!(
+        balance_law,
+        Vars{vs_gradient}(local_transform),
+        Vars{vs_prognostic}(local_state_prognostic),
+        Vars{vs_auxiliary}(local_state_auxiliary),
+        t,
+    )
+
+end
+
+function wrapper_compute_gradient_flux!(
+    balance_law::BalanceLaw,
+    local_state_gradient_flux::AbstractArray{FT, 1},
+    local_transform_gradient::AbstractArray{FT, 2},
+    local_state_prognostic::AbstractArray{FT, 1},
+    local_state_auxiliary::AbstractArray{FT, 1},
+    t::AbstractFloat,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_gradient = vars_state(balance_law, Gradient(), FT)
+    vs_grad_flux = vars_state(balance_law, GradientFlux(), FT)
+    compute_gradient_flux!(
+        balance_law,
+        Vars{vs_grad_flux}(local_state_gradient_flux),
+        Grad{vs_gradient}(local_transform_gradient),
+        Vars{vs_prognostic}(local_state_prognostic),
+        Vars{vs_auxiliary}(local_state_auxiliary),
+        t,
+    )
+
+end
+
+function wrapper_transform_post_gradient_laplacian!(
+    balance_law::BalanceLaw,
+    local_state_hyperdiffusion::AbstractArray{FT, 1},
+    l_grad_lap::AbstractArray{FT, 2},
+    local_state_prognostic,
+    local_state_auxiliary,
+    t,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_grad_lap = vars_state(balance_law, GradientLaplacian(), FT)
+    vs_hyperdiff = vars_state(balance_law, Hyperdiffusive(), FT)
+    transform_post_gradient_laplacian!(
+        balance_law,
+        Vars{vs_hyperdiff}(local_state_hyperdiffusion),
+        Grad{vs_grad_lap}(l_grad_lap),
+        Vars{vs_prognostic}(local_state_prognostic),
+        Vars{vs_auxiliary}(local_state_auxiliary),
+        t,
+    )
+end
+
+function wrapper_init_state_prognostic!(
+    balance_law::BalanceLaw,
+    l_state::AbstractArray{FT, 1},
+    local_state_auxiliary::AbstractArray{FT, 1},
+    coords,
+    args...,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    init_state_prognostic!(
+        balance_law,
+        Vars{vs_prognostic}(l_state),
+        Vars{vs_auxiliary}(local_state_auxiliary),
+        coords,
+        args...,
+    )
+end
+
+function wrapper_integral_load_auxiliary_state!(
+    balance_law::BalanceLaw,
+    local_kernel::AbstractArray{FT, 1},
+    local_state_prognostic::AbstractArray{FT, 1},
+    local_state_auxiliary::AbstractArray{FT, 1},
+) where {FT}
+
+    vs_up_integ = vars_state(balance_law, UpwardIntegrals(), FT)
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    integral_load_auxiliary_state!(
+        balance_law,
+        Vars{vs_up_integ}(local_kernel),
+        Vars{vs_prognostic}(local_state_prognostic),
+        Vars{vs_auxiliary}(local_state_auxiliary),
+    )
+
+end
+
+function wrapper_integral_set_auxiliary_state!(
+    balance_law::BalanceLaw,
+    state_auxiliary::AbstractArray{FT, 1},
+    local_kernel::AbstractArray{FT, 1},
+) where {FT}
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_up_integ = vars_state(balance_law, UpwardIntegrals(), FT)
+    integral_set_auxiliary_state!(
+        balance_law,
+        Vars{vs_auxiliary}(state_auxiliary),
+        Vars{vs_up_integ}(local_kernel),
+    )
+
+end
+
+function wrapper_reverse_integral_load_auxiliary_state!(
+    balance_law::BalanceLaw,
+    l_V::AbstractArray{FT, 1},
+    state::AbstractArray{FT, 1},
+    state_auxiliary::AbstractArray{FT, 1},
+) where {FT}
+
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_dn_integ = vars_state(balance_law, DownwardIntegrals(), FT)
+    reverse_integral_load_auxiliary_state!(
+        balance_law,
+        Vars{vs_dn_integ}(l_V),
+        Vars{vs_prognostic}(state),
+        Vars{vs_auxiliary}(state_auxiliary),
+    )
+
+end
+
+function wrapper_reverse_integral_set_auxiliary_state!(
+    balance_law::BalanceLaw,
+    state_auxiliary::AbstractArray{FT, 1},
+    l_V::AbstractArray{FT, 1},
+) where {FT}
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_dn_integ = vars_state(balance_law, DownwardIntegrals(), FT)
+    reverse_integral_set_auxiliary_state!(
+        balance_law,
+        Vars{vs_auxiliary}(state_auxiliary),
+        Vars{vs_dn_integ}(l_V),
+    )
+
+end

--- a/src/Numerics/DGMethods/num_flux_vars_wrappers.jl
+++ b/src/Numerics/DGMethods/num_flux_vars_wrappers.jl
@@ -1,0 +1,395 @@
+######
+###### Numerical fluxes
+######
+
+function wrapper_numerical_flux_gradient!(
+    numerical_flux_gradient::NumericalFluxGradient,
+    balance_law::BalanceLaw,
+    local_transform_gradient::AbstractArray{FT, 2},
+    normal_vector::AbstractArray{FT, 1},
+    local_transform⁻::AbstractArray{FT, 1},
+    local_state_prognostic⁻::AbstractArray{FT, 1},
+    local_state_auxiliary⁻::AbstractArray{FT, 1},
+    local_transform⁺::AbstractArray{FT, 1},
+    local_state_prognostic⁺::AbstractArray{FT, 1},
+    local_state_auxiliary⁺::AbstractArray{FT, 1},
+    t,
+) where {FT}
+
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_gradient = vars_state(balance_law, Gradient(), FT)
+    numerical_flux_gradient!(
+        numerical_flux_gradient,
+        balance_law,
+        local_transform_gradient,
+        normal_vector,
+        Vars{vs_gradient}(local_transform⁻),
+        Vars{vs_prognostic}(local_state_prognostic⁻),
+        Vars{vs_auxiliary}(local_state_auxiliary⁻),
+        Vars{vs_gradient}(local_transform⁺),
+        Vars{vs_prognostic}(local_state_prognostic⁺),
+        Vars{vs_auxiliary}(local_state_auxiliary⁺),
+        t,
+    )
+end
+
+function wrapper_numerical_flux_first_order!(
+    numerical_flux_first_order::NumericalFluxFirstOrder,
+    balance_law::BalanceLaw,
+    local_flux::AbstractArray{FT, 1},
+    normal_vector::AbstractArray{FT, 1},
+    local_state_prognostic⁻::AbstractArray{FT, 1},
+    local_state_auxiliary⁻::AbstractArray{FT, 1},
+    local_state_prognostic⁺nondiff::AbstractArray{FT, 1},
+    local_state_auxiliary⁺nondiff::AbstractArray{FT, 1},
+    t,
+    face_direction,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_grad_flux = vars_state(balance_law, GradientFlux(), FT)
+
+    numerical_flux_first_order!(
+        numerical_flux_first_order,
+        balance_law,
+        Vars{vs_prognostic}(local_flux),
+        normal_vector,
+        Vars{vs_prognostic}(local_state_prognostic⁻),
+        Vars{vs_auxiliary}(local_state_auxiliary⁻),
+        Vars{vs_prognostic}(local_state_prognostic⁺nondiff),
+        Vars{vs_auxiliary}(local_state_auxiliary⁺nondiff),
+        t,
+        face_direction,
+    )
+
+end
+
+function wrapper_numerical_flux_second_order!(
+    numerical_flux_second_order::NumericalFluxSecondOrder,
+    balance_law::BalanceLaw,
+    local_flux::AbstractArray{FT, 1},
+    normal_vector::AbstractArray{FT, 1},
+    local_state_prognostic⁻::AbstractArray{FT, 1},
+    local_state_gradient_flux⁻::AbstractArray{FT, 1},
+    local_state_hyperdiffusion⁻::AbstractArray{FT, 1},
+    local_state_auxiliary⁻::AbstractArray{FT, 1},
+    local_state_prognostic⁺diff::AbstractArray{FT, 1},
+    local_state_gradient_flux⁺::AbstractArray{FT, 1},
+    local_state_hyperdiffusion⁺::AbstractArray{FT, 1},
+    local_state_auxiliary⁺diff::AbstractArray{FT, 1},
+    t,
+) where {FT}
+
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_grad_flux = vars_state(balance_law, GradientFlux(), FT)
+    vs_hyperdiff = vars_state(balance_law, Hyperdiffusive(), FT)
+
+    numerical_flux_second_order!(
+        numerical_flux_second_order,
+        balance_law,
+        Vars{vs_prognostic}(local_flux),
+        normal_vector,
+        Vars{vs_prognostic}(local_state_prognostic⁻),
+        Vars{vs_grad_flux}(local_state_gradient_flux⁻),
+        Vars{vs_hyperdiff}(local_state_hyperdiffusion⁻),
+        Vars{vs_auxiliary}(local_state_auxiliary⁻),
+        Vars{vs_prognostic}(local_state_prognostic⁺diff),
+        Vars{vs_grad_flux}(local_state_gradient_flux⁺),
+        Vars{vs_hyperdiff}(local_state_hyperdiffusion⁺),
+        Vars{vs_auxiliary}(local_state_auxiliary⁺diff),
+        t,
+    )
+end
+
+function wrapper_numerical_flux_divergence!(
+    divgradnumpenalty::DivNumericalPenalty,
+    balance_law::BalanceLaw,
+    l_div::AbstractArray{FT, 1},
+    normal_vector::AbstractArray{FT, 1},
+    l_grad⁻::AbstractArray{FT, 2},
+    l_grad⁺::AbstractArray{FT, 2},
+) where {FT}
+    vs_grad_lap = vars_state(balance_law, GradientLaplacian(), FT)
+    numerical_flux_divergence!(
+        divgradnumpenalty,
+        balance_law,
+        Vars{vs_grad_lap}(l_div),
+        normal_vector,
+        Grad{vs_grad_lap}(l_grad⁻),
+        Grad{vs_grad_lap}(l_grad⁺),
+    )
+
+end
+
+function wrapper_numerical_flux_higher_order!(
+    hyperviscnumflux::GradNumericalFlux,
+    balance_law::BalanceLaw,
+    local_state_hyperdiffusion::AbstractArray{FT, 1},
+    normal_vector::AbstractArray{FT, 1},
+    l_lap⁻::AbstractArray{FT, 1},
+    local_state_prognostic⁻::AbstractArray{FT, 1},
+    local_state_auxiliary⁻::AbstractArray{FT, 1},
+    l_lap⁺::AbstractArray{FT, 1},
+    local_state_prognostic⁺::AbstractArray{FT, 1},
+    local_state_auxiliary⁺::AbstractArray{FT, 1},
+    t,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_grad_lap = vars_state(balance_law, GradientLaplacian(), FT)
+    vs_hyperdiff = vars_state(balance_law, Hyperdiffusive(), FT)
+    numerical_flux_higher_order!(
+        hyperviscnumflux,
+        balance_law,
+        Vars{vs_hyperdiff}(local_state_hyperdiffusion),
+        normal_vector,
+        Vars{vs_grad_lap}(l_lap⁻),
+        Vars{vs_prognostic}(local_state_prognostic⁻),
+        Vars{vs_auxiliary}(local_state_auxiliary⁻),
+        Vars{vs_grad_lap}(l_lap⁺),
+        Vars{vs_prognostic}(local_state_prognostic⁺),
+        Vars{vs_auxiliary}(local_state_auxiliary⁺),
+        t,
+    )
+end
+
+######
+###### Numerical boundary fluxes
+######
+
+function wrapper_numerical_boundary_flux_gradient!(
+    numerical_flux_gradient::NumericalFluxGradient,
+    balance_law::BalanceLaw,
+    local_transform_gradient,
+    normal_vector::AbstractArray{FT, 1},
+    local_transform⁻::AbstractArray{FT, 1},
+    local_state_prognostic⁻::AbstractArray{FT, 1},
+    local_state_auxiliary⁻::AbstractArray{FT, 1},
+    local_transform⁺::AbstractArray{FT, 1},
+    local_state_prognostic⁺::AbstractArray{FT, 1},
+    local_state_auxiliary⁺::AbstractArray{FT, 1},
+    bctype::Int,
+    t,
+    local_state_prognostic_bottom1::AbstractArray{FT, 1},
+    local_state_auxiliary_bottom1::AbstractArray{FT, 1},
+) where {FT}
+
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_gradient = vars_state(balance_law, Gradient(), FT)
+
+    numerical_boundary_flux_gradient!(
+        numerical_flux_gradient,
+        balance_law,
+        local_transform_gradient,
+        normal_vector,
+        Vars{vs_gradient}(local_transform⁻),
+        Vars{vs_prognostic}(local_state_prognostic⁻),
+        Vars{vs_auxiliary}(local_state_auxiliary⁻),
+        Vars{vs_gradient}(local_transform⁺),
+        Vars{vs_prognostic}(local_state_prognostic⁺),
+        Vars{vs_auxiliary}(local_state_auxiliary⁺),
+        bctype,
+        t,
+        Vars{vs_prognostic}(local_state_prognostic_bottom1),
+        Vars{vs_auxiliary}(local_state_auxiliary_bottom1),
+    )
+
+end
+
+function wrapper_numerical_boundary_flux_first_order!(
+    numerical_flux_first_order::NumericalFluxFirstOrder,
+    balance_law::BalanceLaw,
+    local_flux::AbstractArray{FT, 1},
+    normal_vector::AbstractArray{FT, 1},
+    local_state_prognostic⁻::AbstractArray{FT, 1},
+    local_state_auxiliary⁻::AbstractArray{FT, 1},
+    local_state_prognostic⁺nondiff::AbstractArray{FT, 1},
+    local_state_auxiliary⁺nondiff::AbstractArray{FT, 1},
+    bctype::Int,
+    t,
+    face_direction,
+    local_state_prognostic_bottom1::AbstractArray{FT, 1},
+    local_state_auxiliary_bottom1::AbstractArray{FT, 1},
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+
+    numerical_boundary_flux_first_order!(
+        numerical_flux_first_order,
+        balance_law,
+        Vars{vs_prognostic}(local_flux),
+        normal_vector,
+        Vars{vs_prognostic}(local_state_prognostic⁻),
+        Vars{vs_auxiliary}(local_state_auxiliary⁻),
+        Vars{vs_prognostic}(local_state_prognostic⁺nondiff),
+        Vars{vs_auxiliary}(local_state_auxiliary⁺nondiff),
+        bctype,
+        t,
+        face_direction,
+        Vars{vs_prognostic}(local_state_prognostic_bottom1),
+        Vars{vs_auxiliary}(local_state_auxiliary_bottom1),
+    )
+end
+
+function wrapper_numerical_boundary_flux_second_order!(
+    numerical_flux_second_order::NumericalFluxSecondOrder,
+    balance_law::BalanceLaw,
+    local_flux::AbstractArray{FT, 1},
+    normal_vector::AbstractArray{FT, 1},
+    local_state_prognostic⁻::AbstractArray{FT, 1},
+    local_state_gradient_flux⁻::AbstractArray{FT, 1},
+    local_state_hyperdiffusion⁻::AbstractArray{FT, 1},
+    local_state_auxiliary⁻::AbstractArray{FT, 1},
+    local_state_prognostic⁺diff::AbstractArray{FT, 1},
+    local_state_gradient_flux⁺::AbstractArray{FT, 1},
+    local_state_hyperdiffusion⁺::AbstractArray{FT, 1},
+    local_state_auxiliary⁺diff::AbstractArray{FT, 1},
+    bctype::Int,
+    t,
+    local_state_prognostic_bottom1::AbstractArray{FT, 1},
+    local_state_gradient_flux_bottom1::AbstractArray{FT, 1},
+    local_state_auxiliary_bottom1::AbstractArray{FT, 1},
+) where {FT}
+
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_grad_flux = vars_state(balance_law, GradientFlux(), FT)
+    vs_hyperdiff = vars_state(balance_law, Hyperdiffusive(), FT)
+    numerical_boundary_flux_second_order!(
+        numerical_flux_second_order,
+        balance_law,
+        Vars{vs_prognostic}(local_flux),
+        normal_vector,
+        Vars{vs_prognostic}(local_state_prognostic⁻),
+        Vars{vs_grad_flux}(local_state_gradient_flux⁻),
+        Vars{vs_hyperdiff}(local_state_hyperdiffusion⁻),
+        Vars{vs_auxiliary}(local_state_auxiliary⁻),
+        Vars{vs_prognostic}(local_state_prognostic⁺diff),
+        Vars{vs_grad_flux}(local_state_gradient_flux⁺),
+        Vars{vs_hyperdiff}(local_state_hyperdiffusion⁺),
+        Vars{vs_auxiliary}(local_state_auxiliary⁺diff),
+        bctype,
+        t,
+        Vars{vs_prognostic}(local_state_prognostic_bottom1),
+        Vars{vs_grad_flux}(local_state_gradient_flux_bottom1),
+        Vars{vs_auxiliary}(local_state_auxiliary_bottom1),
+    )
+end
+
+function wrapper_numerical_boundary_flux_divergence!(
+    divgradnumpenalty::DivNumericalPenalty,
+    balance_law::BalanceLaw,
+    l_div::AbstractArray{FT, 1},
+    normal_vector::AbstractArray{FT, 1},
+    l_grad⁻::AbstractArray{FT, 2},
+    l_grad⁺::AbstractArray{FT, 2},
+    bctype::Int,
+) where {FT}
+    vs_grad_lap = vars_state(balance_law, GradientLaplacian(), FT)
+    numerical_boundary_flux_divergence!(
+        divgradnumpenalty,
+        balance_law,
+        Vars{vs_grad_lap}(l_div),
+        normal_vector,
+        Grad{vs_grad_lap}(l_grad⁻),
+        Grad{vs_grad_lap}(l_grad⁺),
+        bctype,
+    )
+end
+
+function wrapper_numerical_boundary_flux_higher_order!(
+    hyperviscnumflux::GradNumericalFlux,
+    balance_law::BalanceLaw,
+    local_state_hyperdiffusion::AbstractArray{FT, 1},
+    normal_vector::AbstractArray{FT, 1},
+    l_lap⁻::AbstractArray{FT, 1},
+    local_state_prognostic⁻::AbstractArray{FT, 1},
+    local_state_auxiliary⁻::AbstractArray{FT, 1},
+    l_lap⁺::AbstractArray{FT, 1},
+    local_state_prognostic⁺::AbstractArray{FT, 1},
+    local_state_auxiliary⁺::AbstractArray{FT, 1},
+    bctype::Int,
+    t,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    vs_grad_lap = vars_state(balance_law, GradientLaplacian(), FT)
+    vs_hyperdiff = vars_state(balance_law, Hyperdiffusive(), FT)
+    numerical_boundary_flux_higher_order!(
+        hyperviscnumflux,
+        balance_law,
+        Vars{vs_hyperdiff}(local_state_hyperdiffusion),
+        normal_vector,
+        Vars{vs_grad_lap}(l_lap⁻),
+        Vars{vs_prognostic}(local_state_prognostic⁻),
+        Vars{vs_auxiliary}(local_state_auxiliary⁻),
+        Vars{vs_grad_lap}(l_lap⁺),
+        Vars{vs_prognostic}(local_state_prognostic⁺),
+        Vars{vs_auxiliary}(local_state_auxiliary⁺),
+        bctype,
+        t,
+    )
+
+end
+
+function wrapper_update_penalty!(
+    numerical_flux::NumericalFluxFirstOrder,
+    balance_law::BalanceLaw,
+    normal_vector::AbstractArray{FT, 1},
+    max_wavespeed,
+    penalty::AbstractArray{FT},
+    state_prognostic⁻::AbstractArray{FT, 1},
+    state_auxiliary⁻::AbstractArray{FT, 1},
+    state_prognostic⁺::AbstractArray{FT, 1},
+    state_auxiliary⁺::AbstractArray{FT, 1},
+    t,
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    update_penalty!(
+        numerical_flux,
+        balance_law,
+        normal_vector,
+        max_wavespeed,
+        Vars{vs_prognostic}(penalty),
+        Vars{vs_prognostic}(state_prognostic⁻),
+        Vars{vs_auxiliary}(state_auxiliary⁻),
+        Vars{vs_prognostic}(state_prognostic⁺),
+        Vars{vs_auxiliary}(state_auxiliary⁺),
+        t,
+    )
+
+end
+
+function wrapper_boundary_state!(
+    numerical_flux,
+    balance_law::BalanceLaw,
+    state_prognostic⁺::AbstractArray{FT, 1},
+    state_auxiliary⁺::AbstractArray{FT, 1},
+    normal_vector::AbstractArray{FT, 1},
+    state_prognostic⁻::AbstractArray{FT, 1},
+    state_auxiliary⁻::AbstractArray{FT, 1},
+    bctype::Int,
+    t,
+    state1⁻::AbstractArray{FT, 1},
+    aux1⁻::AbstractArray{FT, 1},
+) where {FT}
+    vs_prognostic = vars_state(balance_law, Prognostic(), FT)
+    vs_auxiliary = vars_state(balance_law, Auxiliary(), FT)
+    boundary_state!(
+        numerical_flux,
+        balance_law,
+        Vars{vs_prognostic}(state_prognostic⁺),
+        Vars{vs_auxiliary}(state_auxiliary⁺),
+        normal_vector,
+        Vars{vs_prognostic}(state_prognostic⁻),
+        Vars{vs_auxiliary}(state_auxiliary⁻),
+        bctype,
+        t,
+        Vars{vs_prognostic}(state1⁻),
+        Vars{vs_auxiliary}(aux1⁻),
+    )
+end


### PR DESCRIPTION
# Description

This PR adds kernel wrappers that wraps arrays with `Vars{}`. This, together with #1400, should help clean up some of the DG kernels (especially the numerical flux kernels), and thin the layer in which VariableTemplates is used.

Remaining pieces:

 - [ ] Add more type restrictions?

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
