### PR TITLE
Add `ODESolvers.getsteps()`

### DIFF
--- a/docs/src/APIs/Numerics/ODESolvers/ODESolvers.md
+++ b/docs/src/APIs/Numerics/ODESolvers/ODESolvers.md
@@ -90,8 +90,9 @@ ODESolvers.DiffEqJLSolver
 
 ```@docs
 ODESolvers.solve!
-ODESolvers.gettime
 ODESolvers.updatedt!
+ODESolvers.gettime
+ODESolvers.getsteps
 ```
 
 ## Generic Callbacks

--- a/src/Numerics/ODESolvers/AdditiveRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/AdditiveRungeKuttaMethod.jl
@@ -76,6 +76,8 @@ mutable struct AdditiveRungeKutta{
     dt::RT
     "time"
     t::RT
+    "elapsed time steps"
+    steps::Int
     "rhs function"
     rhs!
     "rhs linear operator"
@@ -152,6 +154,7 @@ mutable struct AdditiveRungeKutta{
         new{T, RT, AT, BE, V, VS, Nstages, Nstages^2, Nstages - 1}(
             RT(dt),
             RT(t0),
+            0,
             rhs!,
             rhs_implicit!,
             besolver!,

--- a/src/Numerics/ODESolvers/DifferentialEquations.jl
+++ b/src/Numerics/ODESolvers/DifferentialEquations.jl
@@ -18,6 +18,7 @@ for OrdinaryDiffEq.jl, Sundials.jl, and more.
 """
 mutable struct DiffEqJLSolver{I} <: AbstractDiffEqJLSolver
     integ::I
+    steps::Int
 
     function DiffEqJLSolver(
         rhs!,
@@ -44,7 +45,7 @@ mutable struct DiffEqJLSolver{I} <: AbstractDiffEqJLSolver
             save_end = false,
             kwargs...,
         )
-        new{typeof(integ)}(integ)
+        new{typeof(integ)}(integ, 0)
     end
 end
 
@@ -63,6 +64,7 @@ for OrdinaryDiffEq.jl, Sundials.jl, and more.
 """
 mutable struct DiffEqJLIMEXSolver{I} <: AbstractDiffEqJLSolver
     integ::I
+    steps::Int
 
     function DiffEqJLIMEXSolver(
         rhs!,
@@ -92,7 +94,7 @@ mutable struct DiffEqJLIMEXSolver{I} <: AbstractDiffEqJLSolver
             kwargs...,
         )
 
-        new{typeof(integ)}(integ)
+        new{typeof(integ)}(integ, 0)
     end
 end
 

--- a/src/Numerics/ODESolvers/LowStorageRungeKutta3NMethod.jl
+++ b/src/Numerics/ODESolvers/LowStorageRungeKutta3NMethod.jl
@@ -61,6 +61,8 @@ mutable struct LowStorageRungeKutta3N{T, RT, AT, Nstages} <: AbstractODESolver
     dt::RT
     "time"
     t::RT
+    "elapsed time steps"
+    steps::Int
     "rhs function"
     rhs!
     "Storage for RHS during the `LowStorageRungeKutta3N` update"
@@ -98,6 +100,7 @@ mutable struct LowStorageRungeKutta3N{T, RT, AT, Nstages} <: AbstractODESolver
         new{T, RT, AT, length(RKC)}(
             RT(dt),
             RT(t0),
+            0,
             rhs!,
             dQ,
             dR,

--- a/src/Numerics/ODESolvers/LowStorageRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/LowStorageRungeKuttaMethod.jl
@@ -28,6 +28,8 @@ mutable struct LowStorageRungeKutta2N{T, RT, AT, Nstages} <: AbstractODESolver
     dt::RT
     "time"
     t::RT
+    "elapsed time steps"
+    steps::Int
     "rhs function"
     rhs!
     "Storage for RHS during the LowStorageRungeKutta update"
@@ -55,7 +57,7 @@ mutable struct LowStorageRungeKutta2N{T, RT, AT, Nstages} <: AbstractODESolver
         dQ = similar(Q)
         fill!(dQ, 0)
 
-        new{T, RT, AT, length(RKA)}(RT(dt), RT(t0), rhs!, dQ, RKA, RKB, RKC)
+        new{T, RT, AT, length(RKA)}(RT(dt), RT(t0), 0, rhs!, dQ, RKA, RKB, RKC)
     end
 end
 

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalGARKDecoupledImplicit.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalGARKDecoupledImplicit.jl
@@ -72,6 +72,8 @@ mutable struct MRIGARKDecoupledImplicit{
     dt::RT
     "time"
     t::RT
+    "elapsed time steps"
+    steps::Int
     "rhs function"
     slowrhs!
     "backwark Euler solver"
@@ -144,6 +146,7 @@ mutable struct MRIGARKDecoupledImplicit{
         new{T, RT, AT, Nstages, NΓ, FS, Nx, Ny, Nx * Ny, BE}(
             RT(dt),
             RT(t0),
+            0,
             slowrhs!,
             besolver!,
             Rstages,

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalGARKExplicit.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalGARKExplicit.jl
@@ -103,6 +103,8 @@ mutable struct MRIGARKExplicit{T, RT, AT, Nstages, NΓ, FS, Nstages_sq} <:
     dt::RT
     "time"
     t::RT
+    "elapsed time steps"
+    steps::Int
     "rhs function"
     slowrhs!
     "Storage for RHS during the `MRIGARKExplicit` update"
@@ -147,6 +149,7 @@ mutable struct MRIGARKExplicit{T, RT, AT, Nstages, NΓ, FS, Nstages_sq} <:
         new{T, RT, AT, Nstages, NΓ, FS, Nstages^2}(
             RT(dt),
             RT(t0),
+            0,
             slowrhs!,
             Rstages,
             Γs,

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalStepMethod.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalStepMethod.jl
@@ -60,6 +60,8 @@ mutable struct MultirateInfinitesimalStep{
     dt::RT
     "time"
     t::RT
+    "elapsed time steps"
+    steps::Int
     "storage for y_n"
     yn::AT
     "Storage for ``Y_nj - y_n``"
@@ -130,6 +132,7 @@ mutable struct MultirateInfinitesimalStep{
         }(
             RT(dt),
             RT(t0),
+            0,
             yn,
             ΔYnj,
             fYnj,

--- a/src/Numerics/ODESolvers/MultirateRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/MultirateRungeKuttaMethod.jl
@@ -44,6 +44,8 @@ mutable struct MultirateRungeKutta{SS, FS, RT} <: AbstractODESolver
     dt::RT
     "time"
     t::RT
+    "elapsed time steps"
+    steps::Int
 
     function MultirateRungeKutta(
         slow_solver::LSRK2N,
@@ -55,7 +57,7 @@ mutable struct MultirateRungeKutta{SS, FS, RT} <: AbstractODESolver
         SS = typeof(slow_solver)
         FS = typeof(fast_solver)
         RT = real(eltype(slow_solver.dQ))
-        new{SS, FS, RT}(slow_solver, fast_solver, RT(dt), RT(t0))
+        new{SS, FS, RT}(slow_solver, fast_solver, RT(dt), RT(t0), 0)
     end
 end
 

--- a/src/Numerics/ODESolvers/ODESolvers.jl
+++ b/src/Numerics/ODESolvers/ODESolvers.jl
@@ -12,9 +12,10 @@ using ..SystemSolvers
 using ..MPIStateArrays: array_device, realview
 using ..GenericCallbacks
 
-export solve!, updatedt!, gettime
+export solve!, updatedt!, gettime, getsteps
 
 abstract type AbstractODESolver end
+
 """
     gettime(solver::AbstractODESolver)
 
@@ -28,6 +29,13 @@ gettime(solver::AbstractODESolver) = solver.t
 Returns the current simulation time step of the ODE solver `solver`
 """
 getdt(solver::AbstractODESolver) = solver.dt
+
+"""
+    getsteps(solver::AbstractODESolver)
+
+Returns the number of completed time steps of the ODE solver `solver`
+"""
+getsteps(solver::AbstractODESolver) = solver.steps
 
 """
     ODESolvers.general_dostep!(Q, solver::AbstractODESolver, p,
@@ -65,6 +73,13 @@ function general_dostep!(
 end
 
 """
+    updatetime!(solver::AbstractODESolver, time)
+
+Change the current time to `time` for the ODE solver `solver`.
+"""
+updatetime!(solver::AbstractODESolver, time) = (solver.t = time)
+
+"""
     updatedt!(solver::AbstractODESolver, dt)
 
 Change the time step size to `dt` for the ODE solver `solver`.
@@ -72,11 +87,11 @@ Change the time step size to `dt` for the ODE solver `solver`.
 updatedt!(solver::AbstractODESolver, dt) = (solver.dt = dt)
 
 """
-    updatetime!(solver::AbstractODESolver, time)
+    updatesteps!(solver::AbstractODESolver, dt)
 
-Change the current time to `time` for the ODE solver `solver`.
+Set the number of elapsed time steps for the ODE solver `solver`.
 """
-updatetime!(solver::AbstractODESolver, time) = (solver.t = time)
+updatesteps!(solver::AbstractODESolver, steps) = (solver.steps = steps)
 
 isadjustable(solver::AbstractODESolver) = true
 
@@ -114,6 +129,7 @@ function solve!(
     time = t0
     while time < timeend
         step += 1
+        updatesteps!(solver, step)
 
         time = general_dostep!(
             Q,

--- a/src/Numerics/ODESolvers/SplitExplicitMethod.jl
+++ b/src/Numerics/ODESolvers/SplitExplicitMethod.jl
@@ -36,6 +36,8 @@ mutable struct SplitExplicitSolver{SS, FS, RT, MSA} <: AbstractODESolver
     dt::RT
     "time"
     t::RT
+    "elapsed time steps"
+    steps::Int
     "storage for transfer tendency"
     dQ2fast::MSA
 
@@ -59,6 +61,7 @@ mutable struct SplitExplicitSolver{SS, FS, RT, MSA} <: AbstractODESolver
             fast_solver,
             RT(dt),
             RT(t0),
+            0,
             dQ2fast,
         )
     end

--- a/src/Numerics/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
@@ -28,6 +28,8 @@ mutable struct StrongStabilityPreservingRungeKutta{T, RT, AT, Nstages} <:
     dt::RT
     "time"
     t::RT
+    "elapsed time steps"
+    steps::Int
     "rhs function"
     rhs!
     "Storage for RHS during the `StrongStabilityPreservingRungeKutta` update"
@@ -55,6 +57,7 @@ mutable struct StrongStabilityPreservingRungeKutta{T, RT, AT, Nstages} <:
         new{T, RT, AT, length(RKB)}(
             RT(dt),
             RT(t0),
+            0,
             rhs!,
             similar(Q),
             similar(Q),

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -180,6 +180,7 @@ function run(
         t0 = 0,
         split_explicit_implicit = split_explicit_implicit,
     )
+    @test getsteps(odesolver) == 0
 
     filterorder = 18
     filter = ExponentialFilter(grid, 0, filterorder)
@@ -247,6 +248,8 @@ function run(
         adjustfinalstep = false,
         callbacks = callbacks,
     )
+
+    @test getsteps(odesolver) == nsteps
 
     # final statistics
     engf = norm(Q)

--- a/test/Numerics/ODESolvers/callbacks.jl
+++ b/test/Numerics/ODESolvers/callbacks.jl
@@ -5,7 +5,7 @@ using ClimateMachine.GenericCallbacks
 
 mutable struct PseudoSolver <: AbstractODESolver
     t::Float64
-    step::Int
+    steps::Int
     PseudoSolver() = new(42.0, 0)
 end
 gettime(ps::PseudoSolver) = ps.t


### PR DESCRIPTION
# Description

An alternative way to do this that isn't invasive of the `ODESolver` types is to make [this `step`](https://github.com/CliMA/ClimateMachine.jl/blob/master/src/Numerics/ODESolvers/ODESolvers.jl#L113) a global `const Ref`. Thoughts?

Closes #1419. 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
