### PR TITLE
Fix GCM config BCs

### DIFF
--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -227,7 +227,12 @@ function AtmosGCMConfiguration(
         nelem = nelem_vert,
     )
 
-    topology = StackedCubedSphereTopology(mpicomm, nelem_horz, vert_range)
+    topology = StackedCubedSphereTopology(
+        mpicomm,
+        nelem_horz,
+        vert_range;
+        boundary = (1, 2),
+    )
 
     grid = DiscontinuousSpectralElementGrid(
         topology,


### PR DESCRIPTION
# Description

@LenkaNovak ran into some issues with not being able to specify different BCs for the inner and outer sphere for a GCM configuration. This PR fixes this, so that we can specify different BCs for the inner and outer spheres. Thanks @mwarusz and @jkozdon for help with this!

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
