### PR TITLE
Bugfix: remove old driver syntax

### DIFF
--- a/src/Driver/SolverTypes/IMEXSolverType.jl
+++ b/src/Driver/SolverTypes/IMEXSolverType.jl
@@ -177,17 +177,19 @@ function solversetup(
     )
 
     if ode_solver.split_explicit_implicit
-        remainder_kwargs = (
+        if ode_solver.discrete_splitting
             numerical_flux_first_order = (
-                ode_solver.discrete_splitting ?
-                        (
-                    dg.numerical_flux_first_order,
-                    (dg.numerical_flux_first_order,),
-                ) :
-                        dg.numerical_flux_first_order
-            ),
+                dg.numerical_flux_first_order,
+                (dg.numerical_flux_first_order,),
+            )
+        else
+            numerical_flux_first_order = dg.numerical_flux_first_order
+        end
+        rem_dg = remainder_DGModel(
+            dg,
+            (vdg,);
+            numerical_flux_first_order = numerical_flux_first_order,
         )
-        rem_dg = remainder_DGModel(dg, (vdg,); remainder_kwargs...)
         solver = ode_solver.solver_method(
             rem_dg,
             vdg,

--- a/src/Driver/SolverTypes/MISSolverType.jl
+++ b/src/Driver/SolverTypes/MISSolverType.jl
@@ -146,17 +146,17 @@ function solversetup(
     # Using the RemainderModel, we subtract away the
     # fast processes and define a DG model for the
     # slower processes (advection and diffusion)
-    remainder_kwargs = (
-        numerical_flux_first_order = (
-            ode_solver.discrete_splitting ?
-                    (
-                dg.numerical_flux_first_order,
-                (dg.numerical_flux_first_order,),
-            ) :
-                    dg.numerical_flux_first_order
-        ),
+    if ode_solver.discrete_splitting
+        numerical_flux_first_order =
+            (dg.numerical_flux_first_order, (dg.numerical_flux_first_order,))
+    else
+        numerical_flux_first_order = dg.numerical_flux_first_order
+    end
+    slow_dg = remainder_DGModel(
+        dg,
+        (fast_dg,);
+        numerical_flux_first_order = numerical_flux_first_order,
     )
-    slow_dg = remainder_DGModel(dg, (fast_dg,); remainder_kwargs...)
 
     solver = ode_solver.mis_method(
         slow_dg,

--- a/src/Driver/SolverTypes/MultirateSolverType.jl
+++ b/src/Driver/SolverTypes/MultirateSolverType.jl
@@ -333,20 +333,17 @@ function solversetup(
     # Finally, we subtract away the
     # fast processes and define a DG model for the
     # slower processes (advection and diffusion)
-    slow_model = RemainderModel(dg.balance_law, (fast_model,))
-    slow_dg = DGModel(
-        slow_model,
-        dg.grid,
-        dg.numerical_flux_first_order,
-        dg.numerical_flux_second_order,
-        dg.numerical_flux_gradient,
-        state_auxiliary = dg.state_auxiliary,
-        state_gradient_flux = dg.state_gradient_flux,
-        states_higher_order = dg.states_higher_order,
-        # Ensure diffusion direction is passed to the correct
-        # DG model
-        diffusion_direction = diffusion_direction,
+    remainder_kwargs = (
+        numerical_flux_first_order = (
+            ode_solver.discrete_splitting ?
+                    (
+                dg.numerical_flux_first_order,
+                (dg.numerical_flux_first_order,),
+            ) :
+                    dg.numerical_flux_first_order
+        ),
     )
+    slow_dg = remainder_DGModel(dg, (acoustic_dg_full,); remainder_kwargs...)
 
     slow_solver = ode_solver.slow_method(slow_dg, Q; dt = dt, t0 = t0)
 

--- a/src/Driver/SolverTypes/MultirateSolverType.jl
+++ b/src/Driver/SolverTypes/MultirateSolverType.jl
@@ -194,17 +194,17 @@ function solversetup(
     # Using the RemainderModel, we subtract away the
     # fast processes and define a DG model for the
     # slower processes (advection and diffusion)
-    remainder_kwargs = (
-        numerical_flux_first_order = (
-            ode_solver.discrete_splitting ?
-                    (
-                dg.numerical_flux_first_order,
-                (dg.numerical_flux_first_order,),
-            ) :
-                    dg.numerical_flux_first_order
-        ),
+    if ode_solver.discrete_splitting
+        numerical_flux_first_order =
+            (dg.numerical_flux_first_order, (dg.numerical_flux_first_order,))
+    else
+        numerical_flux_first_order = dg.numerical_flux_first_order
+    end
+    slow_dg = remainder_DGModel(
+        dg,
+        (fast_dg,);
+        numerical_flux_first_order = numerical_flux_first_order,
     )
-    slow_dg = remainder_DGModel(dg, (fast_dg,); remainder_kwargs...)
 
     slow_solver = ode_solver.slow_method(slow_dg, Q; dt = dt)
     fast_dt = dt / ode_solver.timestep_ratio
@@ -333,17 +333,17 @@ function solversetup(
     # Finally, we subtract away the
     # fast processes and define a DG model for the
     # slower processes (advection and diffusion)
-    remainder_kwargs = (
-        numerical_flux_first_order = (
-            ode_solver.discrete_splitting ?
-                    (
-                dg.numerical_flux_first_order,
-                (dg.numerical_flux_first_order,),
-            ) :
-                    dg.numerical_flux_first_order
-        ),
+    if ode_solver.discrete_splitting
+        numerical_flux_first_order =
+            (dg.numerical_flux_first_order, (dg.numerical_flux_first_order,))
+    else
+        numerical_flux_first_order = dg.numerical_flux_first_order
+    end
+    slow_dg = remainder_DGModel(
+        dg,
+        (acoustic_dg_full,);
+        numerical_flux_first_order = numerical_flux_first_order,
     )
-    slow_dg = remainder_DGModel(dg, (acoustic_dg_full,); remainder_kwargs...)
 
     slow_solver = ode_solver.slow_method(slow_dg, Q; dt = dt, t0 = t0)
 

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -63,9 +63,9 @@ function main()
     resolution = (nelem_horz, nelem_vert)
 
     t0 = FT(0)
-    timeend = FT(1800)
+    timeend = FT(3600)
     # Timestep size (s)
-    dt = FT(600)
+    dt = FT(1800)
 
     setup = AcousticWaveSetup{FT}()
     T_profile = IsothermalProfile(param_set, setup.T_ref)
@@ -84,10 +84,12 @@ function main()
     )
 
     ode_solver = ClimateMachine.MultirateSolverType(
+        splitting_type = ClimateMachine.HEVISplitting(),
         fast_model = AtmosAcousticGravityLinearModel,
-        slow_method = LSRK144NiegemannDiehlBusch,
-        fast_method = LSRK144NiegemannDiehlBusch,
-        timestep_ratio = 180,
+        implicit_solver_adjustable = true,
+        slow_method = LSRK54CarpenterKennedy,
+        fast_method = ARK2ImplicitExplicitMidpoint,
+        timestep_ratio = 300,
     )
     driver_config = ClimateMachine.AtmosGCMConfiguration(
         "GCM Driver test",


### PR DESCRIPTION
# Description

A particular code path in the multirate solver driver was never tested, so this particular problem wasn't caught. Basically some stale code in the driver setup wasn't updated. This PR fixes the bug and updates a unit test.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
