### PR TITLE
Make MPIStateArray AD Compatible

### DIFF
--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -148,7 +148,7 @@ function SolverConfiguration(
         end
 
         @info @sprintf("Initializing %s", driver_config.name,)
-        Q = init_ode_state(dg, FT(0), init_args...; init_on_cpu = init_on_cpu)
+        Q = init_ode_state(MPIStateArray, dg, FT(0), init_args...; init_on_cpu = init_on_cpu)
 
         if Settings.debug_init
             write_debug_init_vtk_and_pvtu(

--- a/src/Numerics/DGMethods/create_states.jl
+++ b/src/Numerics/DGMethods/create_states.jl
@@ -1,7 +1,7 @@
 #### Create states
 
 function create_state(
-    ArrayType::Type{Union{MPIStateArray,Array}},
+    ArrayType::Union{Type{MPIStateArray}, Type{Array}},
     balance_law,
     grid,
     st::AbstractStateType;
@@ -21,7 +21,7 @@ function create_state(
     ns = number_states(balance_law, st)
     st isa GradientLaplacian && (ns = 3ns)
     V = vars_state(balance_law, st, FT)
-    if ArrayType isa MPIStateArray
+    if ArrayType <: MPIStateArray
         state = MPIStateArray{FT, V}(
             topology.mpicomm,
             DA,
@@ -42,7 +42,7 @@ function create_state(
             undef,
             (
                 Np,
-                number_state(balance_law, st),
+                number_states(balance_law, st),
                 length(topology.elems),
             ),
         )


### PR DESCRIPTION
# Description

Small fixes as of now for the working of Array Changes by @simonbyrne , but we still need to figure out how to make `array_device` compatible with Duals.

cc: @charleskawczynski 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
