### PR TITLE
Add fixed_number_of_steps option to driver

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -70,6 +70,7 @@ Base.@kwdef mutable struct ClimateMachine_Settings
     debug_init::Bool = false
     integration_testing::Bool = false
     array_type::Type = Array
+    fixed_number_of_steps::Int = -1
 end
 
 const Settings = ClimateMachine_Settings()
@@ -269,6 +270,11 @@ function parse_commandline(
         action = :store_const
         constant = true
         default = get_setting(:integration_testing, defaults, global_defaults)
+        "--fixed-number-of-steps"
+        help = "if `≥0` perform specified number of steps"
+        metavar = "<number>"
+        arg_type = Int
+        default = get_setting(:fixed_number_of_steps, defaults, global_defaults)
     end
     # add custom cli argparse settings if provided
     if !isnothing(custom_clargs)

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -86,6 +86,7 @@ function SolverConfiguration(
     diffdir = EveryDirection(),
     timeend_dt_adjust = true,
     CFL_direction = EveryDirection(),
+    fixed_number_of_steps = Settings.fixed_number_of_steps,
 ) where {FT <: AbstractFloat}
     @tic SolverConfiguration
 
@@ -201,8 +202,13 @@ function SolverConfiguration(
             CFL_direction,
         )
     end
-    numberofsteps = convert(Int, cld(timeend - t0, ode_dt))
-    timeend_dt_adjust && (ode_dt = (timeend - t0) / numberofsteps)
+    if fixed_number_of_steps < 0
+        numberofsteps = convert(Int, cld(timeend - t0, ode_dt))
+        timeend_dt_adjust && (ode_dt = (timeend - t0) / numberofsteps)
+    else
+        numberofsteps = fixed_number_of_steps
+        timeend = fixed_number_of_steps * ode_dt
+    end
 
     # create the solver
     solver = solversetup(ode_solver_type, dg, Q, ode_dt, t0, diffdir)

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -158,6 +158,25 @@ function main()
         solver_config,
     )
     @test CFL_nondiff ≈ CFL
+
+    # Test that if dt is not adjusted based on final time the CFL is correct
+    for fixed_number_of_steps in (-1, 0, 10)
+        solver_config = ClimateMachine.SolverConfiguration(
+            t0,
+            timeend,
+            driver_config,
+            Courant_number = CFL,
+            fixed_number_of_steps = fixed_number_of_steps,
+        )
+
+        if fixed_number_of_steps < 0
+            @test solver_config.timeend == timeend
+        else
+            @test solver_config.timeend ==
+                  solver_config.dt * fixed_number_of_steps
+            @test solver_config.numberofsteps == fixed_number_of_steps
+        end
+    end
 end
 
 main()


### PR DESCRIPTION
For performance analysis runs and testing it is often useful to force a fixed
number of time steps. To achieve this is the addition of the keyword
argument `fixed_number_of_steps` to `SolverConfiguration`; this can also
be set with the command line argument `--fixed-number-of-steps`.

If `fixed_number_of_steps < 0` then the original number of steps
(inferred from `tend`) is used, otherwise the number of specified by
`fixed_number_of_steps` is used.