### PR TITLE
Kd/agl/soil water tutorials

### DIFF
--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -29,14 +29,13 @@ if generate_tutorials
         ],
         "Ocean" => [],
         "Land" => [
-            "Heat" => [
-                "Heat Equation" => "Land/Heat/heat_equation.jl",
-            ],
+            "Heat" => ["Heat Equation" => "Land/Heat/heat_equation.jl"],
             "Water" => [
                 "Richard's Equation" => "Land/Soil/Water/equilibrium_test.jl",
-                "Hydraulics Functions" => "Land/Soil/Water/hydraulic_functions.jl",
+                "Hydraulics Functions" =>
+                    "Land/Soil/Water/hydraulic_functions.jl",
                 "Infiltration test" => "Land/Soil/Water/infiltration_test.jl",
-            ]
+            ],
         ],
         "Numerics" => [
             "System Solvers" => [

--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -32,6 +32,7 @@ if generate_tutorials
             "Heat" => ["Heat Equation" => "Land/Heat/heat_equation.jl"],
             "Water" => [
                 "Richard's Equation" => "Land/Soil/Water/equilibrium_test.jl",
+                "Infiltration Test" => "Land/Soil/Water/infiltration_test.jl",
                 "Hydraulics Functions" =>
                     "Land/Soil/Water/hydraulic_functions.jl",
             ],

--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -28,7 +28,15 @@ if generate_tutorials
                 "Atmos/agnesi_nh_lin.jl",
         ],
         "Ocean" => [],
-        "Land" => ["Heat" => ["Heat Equation" => "Land/Heat/heat_equation.jl"]],
+        "Land" => [
+            "Heat" => [
+                "Heat Equation" => "Land/Heat/heat_equation.jl",
+            ],
+            "Water" => [
+                "Richard's Equation" => "Land/Soil/Water/equilibrium_test.jl",
+                "Hydraulics Functions" => "Land/Soil/Water/hydraulic_functions.jl",
+            ]
+        ],
         "Numerics" => [
             "System Solvers" => [
                 "Conjugate Gradient" => "Numerics/SystemSolvers/cg.jl",

--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -35,6 +35,7 @@ if generate_tutorials
             "Water" => [
                 "Richard's Equation" => "Land/Soil/Water/equilibrium_test.jl",
                 "Hydraulics Functions" => "Land/Soil/Water/hydraulic_functions.jl",
+                "Infiltration test" => "Land/Soil/Water/infiltration_test.jl",
             ]
         ],
         "Numerics" => [

--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -34,7 +34,6 @@ if generate_tutorials
                 "Richard's Equation" => "Land/Soil/Water/equilibrium_test.jl",
                 "Hydraulics Functions" =>
                     "Land/Soil/Water/hydraulic_functions.jl",
-                "Infiltration test" => "Land/Soil/Water/infiltration_test.jl",
             ],
         ],
         "Numerics" => [

--- a/src/Land/Model/SoilWaterParameterizations.jl
+++ b/src/Land/Model/SoilWaterParameterizations.jl
@@ -539,7 +539,7 @@ function matric_potential(model::BrooksCorey{FT}, S_l::FT) where {FT}
     ψb = model.ψb
     m = model.m
 
-    ψ_m = -ψb * S_l^(-FT(1) / m)
+    ψ_m = ψb * S_l^(-FT(1) / m)
     return ψ_m
 end
 

--- a/src/Land/Model/soil_water.jl
+++ b/src/Land/Model/soil_water.jl
@@ -104,8 +104,8 @@ function SoilWaterModel(
     hydraulics::AbstractHydraulicsModel{FT} = vanGenuchten{FT}(),
     initialϑ_l::Function = (aux) -> eltype(aux)(NaN),
     initialθ_ice::Function = (aux) -> eltype(aux)(0.0),
-    dirichlet_bc::AbstractBoundaryFunctions = nothing,
-    neumann_bc::AbstractBoundaryFunctions = nothing,
+    dirichlet_bc::AbstractBoundaryFunctions = Dirichlet(),
+    neumann_bc::AbstractBoundaryFunctions = Neumann(),
 ) where {FT}
     args = (
         impedance_factor,

--- a/test/Land/Model/test_water_parameterizations.jl
+++ b/test/Land/Model/test_water_parameterizations.jl
@@ -80,6 +80,6 @@ using ClimateMachine.Land.SoilWaterParameterizations
 
     m = FT(0.5)
     ψb = FT(0.1656)
-    @test pressure_head(bc_model, 1.0, 0.001, 0.5) ≈ -ψb * 0.5^(-1 / m)
+    @test pressure_head(bc_model, 1.0, 0.001, 0.5) ≈ ψb * 0.5^(-1 / m)
     @test volumetric_liquid_fraction.([0.5, 1.5], Ref(0.75)) ≈ [0.5, 0.75]
 end

--- a/tutorials/Land/Soil/Water/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Water/equilibrium_test.jl
@@ -8,9 +8,14 @@
 # pressure head is equal and opposite the gradient of the
 # gravitational head.
 
-# Note that by default we only support liquid water in this example.
-# If you would like to include ice in a dynamical water model, phase transitions
-# must be turned on by including freezing and thawing as a source term.
+# A word about ice: the dynamic water model includes as state
+# variables `ϑ_l` and `θ_ice`. However, the right hand side of the ice
+# equation is zero unless freeze/thaw source terms are explicitly turned on.
+# In this case, liquid water and ice can be transformed into each other while
+# conserving the total water mass. If freezing and thawing are not turned on
+# (the default), the amount of ice in the model is zero for all space and time
+# (again by default). *It does not make sense to change this default*, since the
+# liquid water equation would have no knowledge of the amount of ice in the soil.
 
 # # Preliminary setup
 

--- a/tutorials/Land/Soil/Water/hydraulic_functions.jl
+++ b/tutorials/Land/Soil/Water/hydraulic_functions.jl
@@ -234,6 +234,14 @@ plot(
 plot!(S_l, log10.(K_T), label = "Temperature Dependent Viscosity")
 plot!(S_l_accounting_for_ice, log10.(K_ice), label = "Ice Impedance")
 
+# A word about ice - if the user is not considering phase transitions
+# and does not add in Freeze/Thaw source terms, the default is for zero
+# ice in the model, for all time and space. The ice impedance factor is
+# one if the volumetric ice fraction is zero, so even if one chose
+# `IceImpedance{FT}` as the `impedance_factor`, without freezing and thawing,
+# this factor would still be unity. 
+
+
 # We can also look and see how the Brooks and Corey moisture factor differs from the
 # van Genuchten moisture factor by changing the `hydraulics` model passed:
 T = FT(0.0)

--- a/tutorials/Land/Soil/Water/hydraulic_functions.jl
+++ b/tutorials/Land/Soil/Water/hydraulic_functions.jl
@@ -134,6 +134,8 @@ plot(
     label = "van Genuchten",
 )
 plot!(S_l, log10.(-ψ_bc), label = "Brooks and Corey")
+savefig("./bc_vg_matric_potential.png")
+# ![](bc_vg_matric_potential.png)
 # The huge range in `ψ` as `S_l` varies, as well as the steep slope in
 # `ψ` near saturation and completely dry soil, are part of the reason
 # why Richard's equation is such a challenging numerical problem.
@@ -185,14 +187,6 @@ K =
         Ref(T),
         S_l,
     )
-plot(
-    S_l,
-    log10.(K),
-    xlabel = "effective saturation",
-    ylabel = "Log10(K)",
-    label = "K",
-)
-
 # Let's see how the curves change when we include the effects of temperature
 # and ice on the hydraulic conductivity.
 viscosity_choice_T = TemperatureDependentViscosity{FT}()
@@ -233,7 +227,8 @@ plot(
 )
 plot!(S_l, log10.(K_T), label = "Temperature Dependent Viscosity")
 plot!(S_l_accounting_for_ice, log10.(K_ice), label = "Ice Impedance")
-
+savefig("./T_ice_K.png")
+# ![](T_ice_K.png)
 # A word about ice - if the user is not considering phase transitions
 # and does not add in Freeze/Thaw source terms, the default is for zero
 # ice in the model, for all time and space. The ice impedance factor is
@@ -273,7 +268,8 @@ plot!(
     ylabel = "Log10(K)",
     label = "Brooks and Corey",
 )
-
+savefig("./bc_vg_k.png")
+# ![](bc_vg_k.png)
 # # Other features
 # The user also has the choice of making the conductivity constant by choosing
 # `MoistureIndependent{FT}()`. This is useful for debugging!

--- a/tutorials/Land/Soil/Water/hydraulic_functions.jl
+++ b/tutorials/Land/Soil/Water/hydraulic_functions.jl
@@ -1,0 +1,150 @@
+# # Hydraulic functions and soil parameters
+
+# This tutorial shows how to specify and explore the hydraulic functions
+# used in Richard's equation and how to choose a soil type. In particular,
+# we show how to choose the formalism for matric potential and hydraulic
+# conductivity, and how to make the hydraulic conductivity account for
+# the presence of ice as well as how the temperature dependence of the
+# viscosity of liquid water.
+
+# # Preliminary setup
+
+# - load external packages
+
+using Plots
+
+# - load ClimateMachine modules
+
+using ClimateMachine
+using ClimateMachine.Land
+using ClimateMachine.Land.SoilWaterParameterizations
+
+FT = Float32
+# # Choose general soil parameters for your soil type.
+# For the water equation, the user needs to choose a porosity,
+#  and a specific storage. All values
+# are given in SI/mks units. Note that we neglect the residual pore
+# space in the ClimateMachine model. Below we choose parameters for
+# sandy loam (Bonan, 2019, Chapter 8, page 120), except for that of
+# specific storage.
+ν = FT(0.41)
+S_s = FT(1e-3)
+
+# # van Genuchten formalism
+# ClimateMachine's Land model use a constrained van Genuchten (1980)
+# formalism with two free parameters, `α` and `n`. The third parameter
+# is computed from `n`. Of these, only `α` carries units, of inverse meters.
+# These choices govern both the moisture dependency
+# of the hydraulic conductivity and the expression for the matric potential.
+# Note that they also are a function of the soil type!
+# Here we also choose to make the conductivity independent of the volumetric
+# ice fraction and temperature.
+vg_α = FT(7.5)
+vg_n = FT(1.89)
+Ksat_vg = FT(4.42 / (3600 * 100))
+
+viscosity_factor = ConstantViscosity{FT}()
+impedance_factor = NoImpedance{FT}()
+moisture_factor = MoistureDependent{FT}()
+hydraulics = vanGenuchten{FT}(α = vg_α, n = vg_n)
+
+# In the Climate Machine code, we make use of a feature of Julia called
+# multiple dispatch. With multiple dispatch, a function  can have
+# multiple methods (ways of executing), depending on the type of the
+# variables passed in. Which method is executed is decided in the moment,
+# when a particular set of arugments is passed and the function is called.
+# For example, we have defined a new type of object
+# in the ClimateMachine code for the `viscosity_factor`, the `impedance_factor`,
+# the `hydraulics` model, and the `moisture_factor`, and based on the
+# choices the user makes for these, the correct conductivity and matric potential
+# value will be returned - for that choice of types.
+
+# As one concrete example:
+# `hydraulics` is of type vanGenuchten{Float32} based on our choice of FT:
+#    `julia> typeof(hydraulics)`
+#    `vanGenuchten{Float32}`
+# and the supertype of vanGenucthen{Float32} is
+#    `julia> supertype(vanGenuchten{FT})`
+#    `AbstractHydraulicsModel{Float32}`
+# The function `matric_potential` will execute different methods
+# depending on if we pass a hydraulics model of type vanGenuchten or
+# e.g. BrooksCorey! In both cases, it will return the correct value
+# for `ψ`. The same is true for the `hydraulic_conductivity` function,
+# except it also dispatches on the type of the impedance factor and
+# viscosity factor supplied. It returns `K`,
+# aside from the factor of `Ksat`, which we need to multiply by.
+
+# This feature is nice because it allows us to have a single function call
+# execute different behaviors base on choices the user makes at the
+# driver level, without changing any source code.
+# One byproduct of this flexibility is that the function `hydraulic_conductivity`
+# requires all the arguments it could possibly need passed to it, which is
+# why here we must supply a value `T` and `θ_ice`, even though they are not used.
+T = FT(0.0)
+θ_ice = FT(0.0)
+# an array of values for the effective liquid saturation
+S_l = FT.(0.01:0.01:0.99)
+
+K = Ksat_vg .* hydraulic_conductivity.(Ref(impedance_factor), Ref(viscosity_factor), Ref(moisture_factor), Ref(hydraulics), Ref(θ_ice), Ref(ν), Ref(T), S_l)
+# The matric potential, on the other hand, only depends on the hydraulics model choice and the
+# effective saturation. However, it does use multiple dispatch on the `hydraulics` type.
+ψ = matric_potential.(Ref(hydraulics), S_l)
+
+# Let's plot these functions.
+plot(S_l, log10.(K), xlabel = "effective saturation", ylabel = "Log10(K)", label = "K")
+plot(S_l, log10.(-ψ), xlabel = "effective saturation", ylabel = "Log10(|ψ|)", label = "|ψ|")
+# The huge range in both `K` and `ψ` as `S_l`, as well as the steep slope in
+# `ψ` near saturation and completely dry soil, are the reason why Richard's equation
+# is such a challenging numerical problem.
+
+# # van Genuchten formalism with icy impedance and temperature effects
+# Let's see how the curves change when we include the effects of temperature
+# and ice on the hydraulic conductivity.
+viscosity_factor_T = TemperatureDependentViscosity{FT}()
+T = FT(300.0)
+K_T = Ksat .* hydraulic_conductivity.(Ref(impedance_factor), Ref(viscosity_factor_T), Ref(moisture_factor), Ref(hydraulics), Ref(θ_ice), Ref(ν), Ref(T), S_l)
+ice_impedance_I = IceImpedance{FT}()
+θ_ice = FT(0.3)
+S_l_accounting_for_ice = FT.(0.01:0.01:0.7) # note that the total volumetric water fraction cannot exceed unity.
+K_ice = Ksat .* hydraulic_conductivity.(Ref(ice_impedance_I), Ref(viscosity_factor), Ref(moisture_factor), Ref(hydraulics), Ref(θ_ice), Ref(ν), Ref(T), S_l_accounting_for_ice)
+plot(S_l, log10.(K), xlabel = "effective saturation", ylabel = "Log10(K)", label = "Base case")
+plot!(S_l, log10.(K_T), label = "Temperature Dependent Viscosity")
+plot!(S_l_accounting_for_ice, log10.(K_ice), label = "Ice Impedance")
+
+
+# # Brooks and Corey formalism
+# To choose a Brooks and Corey formalism for the hydraulics model,
+# the user needs to specify `ψ_b`, the matric potential at saturation,
+# a value for `Ksat`, and a constant `m`. Both `ψ_b` and `Ksat` carry units!
+# The parameters below are also for sandy loam.
+# This would also be used in the matric potential.
+ψ_sat = -0.09
+mval = 0.228
+Ksat_bc = FT(56.28 / (3600 * 100))
+
+hydraulics_bc = BrooksCorey{FT}(ψb = ψ_sat, m = mval)
+T = FT(0.0)
+θ_ice = FT(0.0)
+# an array of values for the effective liquid saturation
+S_l = FT.(0.01:0.01:0.99)
+
+K_bc = Ksat_bc .* hydraulic_conductivity.(Ref(impedance_factor), Ref(viscosity_factor), Ref(moisture_factor), Ref(hydraulics_bc), Ref(θ_ice), Ref(ν), Ref(T), S_l)
+plot(S_l, log10.(K), xlabel = "effective saturation", ylabel = "Log10(K)", label = "van Genuchten")
+plot!(S_l, log10.(K_bc), xlabel = "effective saturation", ylabel = "Log10(K)", label = "Brooks and Corey")
+
+# # Other features
+# The user also has the choice of making the conductivity constant by choosing
+# a `MoistureIndependent{FT}()` moisture factor. This is useful for debugging!
+moisture_factor_nothing = MoistureIndependent{FT}()
+K_constant = Ksat .* hydraulic_conductivity.(Ref(impedance_factor), Ref(viscosity_factor), Ref(moisture_factor_nothing), Ref(hydraulics), Ref(θ_ice), Ref(ν), Ref(T), S_l)
+#    `julia> unique(K_constant)`
+#    `1-element Array{Float32,1}:`
+#    ` 1.2277777f-5`
+# Note that choosing this option does not meant the matric potential
+# is constant, as a hydraulics model is still required and employed.
+
+
+# And, lastly, you might be wondering why we left `Ksat` out of the function
+# for `hydraulic_conductivity`. It turns out it is also useful for debugging
+# to be able to turn off the diffusion of water, by setting `K_sat = 0`.
+

--- a/tutorials/Land/Soil/Water/hydraulic_functions.jl
+++ b/tutorials/Land/Soil/Water/hydraulic_functions.jl
@@ -1,11 +1,59 @@
-# # Hydraulic functions and soil parameters
+# # Hydraulic functions
 
-# This tutorial shows how to specify and explore the hydraulic functions
-# used in Richard's equation and how to choose a soil type. In particular,
+# This tutorial shows how to specify the hydraulic functions
+# used in Richard's equation. In particular,
 # we show how to choose the formalism for matric potential and hydraulic
 # conductivity, and how to make the hydraulic conductivity account for
-# the presence of ice as well as how the temperature dependence of the
+# the presence of ice as well as the temperature dependence of the
 # viscosity of liquid water.
+
+# # Multiple dispatch
+# Before diving into the hydraulics, let's go over a feature of Julia called
+# multiple dispatch. This will make things simpler moving forwards!
+
+# In the Climate Machine code, we make use of multiple dispatch.
+# With multiple dispatch, a function can have many
+# ways of executing (called methods), depending on the *type* of the
+# variables passed in. A simple example of multiple dispatch is the division operation.
+# Integer division takes two numbers as input, and returns an integer - ignoring the decimal.
+# Float division takes two numbers as input, and returns a floating point number, including the decimal.
+# In Julia, we might write these as:
+# ```
+#    function division(a::Int, b::Int)
+#         return floor(Int, a/b)
+#     end
+#
+#    function division(a::Float64, b::Float64)
+#         return a/b
+#     end
+#  ```
+# We can see that `division` is now a function with two methods.
+# ```
+#     julia> division
+#     division (generic function with 2 methods)
+# ```
+# Now, using the same function signature, we can carry out integer
+# division or floating point division, depending on the types of the
+# arguments:
+# ```
+#     julia> division(1,2)
+#     0
+#
+#     julia> division(1.0,2.0)
+#     0.5
+# ```
+
+
+# One benefit of this is that a function like `matric_potential`, which
+# should return different answers depending on what type of hydraulics
+# model (e.g. van Genchten, or Brooks and Corey) the user chooses,
+# is always called in the same way. If not, we would need to have a
+# `matric_potential_van_genuchten` function, and a `matric_potential_brooks_and_corey`
+# function, for example, and we would need to change the source code
+# whenever the user wished to changed hydraulics model. Or, we could
+# have a single function with a branch in it, (the choice made based on a flag passed in),
+# but this slows things down on the GPU.
+# Multiple dispatch provides a nice solution.
 
 # # Preliminary setup
 
@@ -20,126 +68,225 @@ using ClimateMachine.Land
 using ClimateMachine.Land.SoilWaterParameterizations
 
 FT = Float32
-# # Choose general soil parameters for your soil type.
-# For the water equation, the user needs to choose a porosity,
-#  and a specific storage. All values
-# are given in SI/mks units. Note that we neglect the residual pore
-# space in the ClimateMachine model. Below we choose parameters for
-# sandy loam (Bonan, 2019, Chapter 8, page 120), except for that of
-# specific storage.
-ν = FT(0.41)
-S_s = FT(1e-3)
 
-# # van Genuchten formalism
-# ClimateMachine's Land model use a constrained van Genuchten (1980)
-# formalism with two free parameters, `α` and `n`. The third parameter
-# is computed from `n`. Of these, only `α` carries units, of inverse meters.
-# These choices govern both the moisture dependency
-# of the hydraulic conductivity and the expression for the matric potential.
-# Note that they also are a function of the soil type!
-# Here we also choose to make the conductivity independent of the volumetric
-# ice fraction and temperature.
+# # Choose general soil parameters for your soil type.
+# For the water equation, the user needs to choose a porosity `ν`,
+# saturated hydraulic conductivity `Ksat` (and a specific storage `S_s`,
+# though that is not needed here).
+# Note that the two hydraulic models included in ClimateMachine -
+# that of Brooks and Corey (1964, 1977) and van Genuchten (1980) - use the same
+# value of `Ksat`. All values are given in SI/mks units. We
+# neglect the residual pore space in the ClimateMachine model. Below
+# we choose parameters for sandy loam (Bonan, 2019, Chapter 8, page 120).
+ν = FT(0.41)
+Ksat = FT(4.42 / (3600 * 100))
+
+# # Matric Potential
+# The matric potential represents how much water clings to soil. Drier soil
+# holds onto water more tightly, making diffusion more difficult. As soil becomes
+# wetter, the matric potential decreases in magnitude, making diffusion easier.
+# ClimateMachine's Land model allows for two `hydraulics` models for matric potential
+# (and hydraulic conductivity), that of van Genuchten (1980), and Brooks and Corey (1967, 1970).
+
+# The van Genucthen model requires two free parameters, `α` and `n`.
+# The third parameter is computed from `n`. Of these, only `α` carries
+# units, of inverse meters. The Brooks and Corey model also uses
+# two free parameters, `ψ_b`, the matric potential at saturation,
+#  and a constant `m`. `ψ_b` carries units of meters.
+
+# Below we show how to create two concrete examples of these hydraulics models,
+# for sandy loam. Importantly - the parameters chosen are a function of soil type!
 vg_α = FT(7.5)
 vg_n = FT(1.89)
-Ksat_vg = FT(4.42 / (3600 * 100))
-
-viscosity_factor = ConstantViscosity{FT}()
-impedance_factor = NoImpedance{FT}()
-moisture_factor = MoistureDependent{FT}()
 hydraulics = vanGenuchten{FT}(α = vg_α, n = vg_n)
 
-# In the Climate Machine code, we make use of a feature of Julia called
-# multiple dispatch. With multiple dispatch, a function  can have
-# multiple methods (ways of executing), depending on the type of the
-# variables passed in. Which method is executed is decided in the moment,
-# when a particular set of arugments is passed and the function is called.
-# For example, we have defined a new type of object
-# in the ClimateMachine code for the `viscosity_factor`, the `impedance_factor`,
-# the `hydraulics` model, and the `moisture_factor`, and based on the
-# choices the user makes for these, the correct conductivity and matric potential
-# value will be returned - for that choice of types.
+ψ_sat = -0.09
+mval = 0.228
+hydraulics_bc = BrooksCorey{FT}(ψb = ψ_sat, m = mval)
 
-# As one concrete example:
+# As alluded to above, we use multiple dispatch.
+# As a concrete example:
 # `hydraulics` is of type vanGenuchten{Float32} based on our choice of FT:
-#    `julia> typeof(hydraulics)`
-#    `vanGenuchten{Float32}`
-# and the supertype of vanGenucthen{Float32} is
-#    `julia> supertype(vanGenuchten{FT})`
-#    `AbstractHydraulicsModel{Float32}`
+# ```
+#     julia> typeof(hydraulics)
+#     vanGenuchten{Float32}
+# ```
+# but meanwhile,
+# ```
+#     julia> typeof(hydraulics_bc)
+#     BrooksCorey{Float32}
+# ```
 # The function `matric_potential` will execute different methods
 # depending on if we pass a hydraulics model of type vanGenuchten or
 # e.g. BrooksCorey! In both cases, it will return the correct value
-# for `ψ`. The same is true for the `hydraulic_conductivity` function,
-# except it also dispatches on the type of the impedance factor and
-# viscosity factor supplied. It returns `K`,
-# aside from the factor of `Ksat`, which we need to multiply by.
+# for `ψ`.
 
-# This feature is nice because it allows us to have a single function call
-# execute different behaviors base on choices the user makes at the
-# driver level, without changing any source code.
-# One byproduct of this flexibility is that the function `hydraulic_conductivity`
+# Let's plot the matric potential as a function of the effective saturation `S_l`.
+
+S_l = FT.(0.01:0.01:0.99)
+ψ = matric_potential.(Ref(hydraulics), S_l)
+ψ_bc = matric_potential.(Ref(hydraulics_bc), S_l)
+plot(
+    S_l,
+    log10.(-ψ),
+    xlabel = "effective saturation",
+    ylabel = "Log10(|ψ|)",
+    label = "van Genuchten",
+)
+plot!(S_l, log10.(-ψ_bc), label = "Brooks and Corey")
+# The huge range in `ψ` as `S_l` varies, as well as the steep slope in
+# `ψ` near saturation and completely dry soil, are part of the reason
+# why Richard's equation is such a challenging numerical problem.
+
+
+# # Hydraulic conductivity
+# The hydraulic conductivity is a more complex function than the matric potential,
+# as it depends on the temperature of the water, the volumetric ice fraction, and
+# the volumetric liquid water fraction. It also depends on the `hydraulics` model
+# chosen.
+
+# We represent the hydraulic conductivity `K` as the product of four factors:
+# `Ksat`, an `impedance_factor` (which accounts for the effect of ice)
+# a `viscosity_factor` (which accounts for the effect of temperature)
+# and a `moisture_factor` (which accounts for the effect of liquid water),
+#  Let's start with ice and temperature independence, but moisture dependence.
+# The `moisture_factor` will make use of the `hydraulics` model chosen above when we compute `K`. 
+
+moisture_choice = MoistureDependent{FT}()
+viscosity_choice = ConstantViscosity{FT}()
+impedance_choice = NoImpedance{FT}()
+
+# We are going to calculate `K = Ksat × 1 × 1 × moisture_factor`, but as alluded
+# to above, our functions will use multiple dispatch. Just like we defined new type
+# classes for vanGenuchten{FT} and BrooksCorey{FT}, we also created new type classes
+# for the `impedance_factor`, `viscosity_factor`, and `moisture_factor`. 
+# Based on the type choices the user makes for these, the correct conductivity 
+# value will be returned. For example, in the source code we have defined a function
+# called `viscosity_factor` with a method that, when passed `ConstantViscosity{FT}`, always
+# returns 1. The same is true for a method of `impedance_factor`, using the type
+# `NoImpedance{FT}`, and for `moisture_factor`, using the type `MoistureIndependent{FT}`.
+
+
+# One byproduct of this flexibility in functions is that `hydraulic_conductivity`
 # requires all the arguments it could possibly need passed to it, which is
 # why here we must supply a value `T` and `θ_ice`, even though they are not used.
 T = FT(0.0)
 θ_ice = FT(0.0)
-# an array of values for the effective liquid saturation
-S_l = FT.(0.01:0.01:0.99)
 
-K = Ksat_vg .* hydraulic_conductivity.(Ref(impedance_factor), Ref(viscosity_factor), Ref(moisture_factor), Ref(hydraulics), Ref(θ_ice), Ref(ν), Ref(T), S_l)
-# The matric potential, on the other hand, only depends on the hydraulics model choice and the
-# effective saturation. However, it does use multiple dispatch on the `hydraulics` type.
-ψ = matric_potential.(Ref(hydraulics), S_l)
+K =
+    Ksat .*
+    hydraulic_conductivity.(
+        Ref(impedance_choice),
+        Ref(viscosity_choice),
+        Ref(moisture_choice),
+        Ref(hydraulics),
+        Ref(θ_ice),
+        Ref(ν),
+        Ref(T),
+        S_l,
+    )
+plot(
+    S_l,
+    log10.(K),
+    xlabel = "effective saturation",
+    ylabel = "Log10(K)",
+    label = "K",
+)
 
-# Let's plot these functions.
-plot(S_l, log10.(K), xlabel = "effective saturation", ylabel = "Log10(K)", label = "K")
-plot(S_l, log10.(-ψ), xlabel = "effective saturation", ylabel = "Log10(|ψ|)", label = "|ψ|")
-# The huge range in both `K` and `ψ` as `S_l`, as well as the steep slope in
-# `ψ` near saturation and completely dry soil, are the reason why Richard's equation
-# is such a challenging numerical problem.
-
-# # van Genuchten formalism with icy impedance and temperature effects
 # Let's see how the curves change when we include the effects of temperature
 # and ice on the hydraulic conductivity.
-viscosity_factor_T = TemperatureDependentViscosity{FT}()
+viscosity_choice_T = TemperatureDependentViscosity{FT}()
 T = FT(300.0)
-K_T = Ksat .* hydraulic_conductivity.(Ref(impedance_factor), Ref(viscosity_factor_T), Ref(moisture_factor), Ref(hydraulics), Ref(θ_ice), Ref(ν), Ref(T), S_l)
+K_T =
+    Ksat .*
+    hydraulic_conductivity.(
+        Ref(impedance_choice),
+        Ref(viscosity_choice_T),
+        Ref(moisture_choice),
+        Ref(hydraulics),
+        Ref(θ_ice),
+        Ref(ν),
+        Ref(T),
+        S_l,
+    )
 ice_impedance_I = IceImpedance{FT}()
 θ_ice = FT(0.3)
 S_l_accounting_for_ice = FT.(0.01:0.01:0.7) # note that the total volumetric water fraction cannot exceed unity.
-K_ice = Ksat .* hydraulic_conductivity.(Ref(ice_impedance_I), Ref(viscosity_factor), Ref(moisture_factor), Ref(hydraulics), Ref(θ_ice), Ref(ν), Ref(T), S_l_accounting_for_ice)
-plot(S_l, log10.(K), xlabel = "effective saturation", ylabel = "Log10(K)", label = "Base case")
+K_ice =
+    Ksat .*
+    hydraulic_conductivity.(
+        Ref(ice_impedance_I),
+        Ref(viscosity_choice),
+        Ref(moisture_choice),
+        Ref(hydraulics),
+        Ref(θ_ice),
+        Ref(ν),
+        Ref(T),
+        S_l_accounting_for_ice,
+    )
+plot(
+    S_l,
+    log10.(K),
+    xlabel = "effective saturation",
+    ylabel = "Log10(K)",
+    label = "Base case",
+)
 plot!(S_l, log10.(K_T), label = "Temperature Dependent Viscosity")
 plot!(S_l_accounting_for_ice, log10.(K_ice), label = "Ice Impedance")
 
-
-# # Brooks and Corey formalism
-# To choose a Brooks and Corey formalism for the hydraulics model,
-# the user needs to specify `ψ_b`, the matric potential at saturation,
-# a value for `Ksat`, and a constant `m`. Both `ψ_b` and `Ksat` carry units!
-# The parameters below are also for sandy loam.
-# This would also be used in the matric potential.
-ψ_sat = -0.09
-mval = 0.228
-Ksat_bc = FT(56.28 / (3600 * 100))
-
-hydraulics_bc = BrooksCorey{FT}(ψb = ψ_sat, m = mval)
+# We can also look and see how the Brooks and Corey moisture factor differs from the
+# van Genuchten moisture factor by changing the `hydraulics` model passed:
 T = FT(0.0)
 θ_ice = FT(0.0)
-# an array of values for the effective liquid saturation
-S_l = FT.(0.01:0.01:0.99)
 
-K_bc = Ksat_bc .* hydraulic_conductivity.(Ref(impedance_factor), Ref(viscosity_factor), Ref(moisture_factor), Ref(hydraulics_bc), Ref(θ_ice), Ref(ν), Ref(T), S_l)
-plot(S_l, log10.(K), xlabel = "effective saturation", ylabel = "Log10(K)", label = "van Genuchten")
-plot!(S_l, log10.(K_bc), xlabel = "effective saturation", ylabel = "Log10(K)", label = "Brooks and Corey")
+K_bc =
+    Ksat .*
+    hydraulic_conductivity.(
+        Ref(impedance_choice),
+        Ref(viscosity_choice),
+        Ref(moisture_choice),
+        Ref(hydraulics_bc),
+        Ref(θ_ice),
+        Ref(ν),
+        Ref(T),
+        S_l,
+    )
+plot(
+    S_l,
+    log10.(K),
+    xlabel = "effective saturation",
+    ylabel = "Log10(K)",
+    label = "van Genuchten",
+)
+plot!(
+    S_l,
+    log10.(K_bc),
+    xlabel = "effective saturation",
+    ylabel = "Log10(K)",
+    label = "Brooks and Corey",
+)
 
 # # Other features
 # The user also has the choice of making the conductivity constant by choosing
-# a `MoistureIndependent{FT}()` moisture factor. This is useful for debugging!
-moisture_factor_nothing = MoistureIndependent{FT}()
-K_constant = Ksat .* hydraulic_conductivity.(Ref(impedance_factor), Ref(viscosity_factor), Ref(moisture_factor_nothing), Ref(hydraulics), Ref(θ_ice), Ref(ν), Ref(T), S_l)
-#    `julia> unique(K_constant)`
-#    `1-element Array{Float32,1}:`
-#    ` 1.2277777f-5`
+# `MoistureIndependent{FT}()`. This is useful for debugging!
+no_moisture_dependence = MoistureIndependent{FT}()
+K_constant =
+    Ksat .*
+    hydraulic_conductivity.(
+        Ref(impedance_choice),
+        Ref(viscosity_choice),
+        Ref(no_moisture_dependence),
+        Ref(hydraulics),
+        Ref(θ_ice),
+        Ref(ν),
+        Ref(T),
+        S_l,
+    )
+# ```
+#     julia> unique(K_constant)
+#     1-element Array{Float32,1}:
+#      1.2277777f-5
+# ```
 # Note that choosing this option does not meant the matric potential
 # is constant, as a hydraulics model is still required and employed.
 
@@ -147,4 +294,3 @@ K_constant = Ksat .* hydraulic_conductivity.(Ref(impedance_factor), Ref(viscosit
 # And, lastly, you might be wondering why we left `Ksat` out of the function
 # for `hydraulic_conductivity`. It turns out it is also useful for debugging
 # to be able to turn off the diffusion of water, by setting `K_sat = 0`.
-

--- a/tutorials/Land/Soil/Water/infiltration_test.jl
+++ b/tutorials/Land/Soil/Water/infiltration_test.jl
@@ -97,8 +97,8 @@ end
 # Create the SoilWaterModel. The defaults are a temperature independent
 # viscosity, and no impedance factor due to ice. We choose to make the
 # hydraulic conductivity a function of the moisture content `ϑ_l`,
-# and employ the vanGenuchten hydraulic model with `n` = 2.0. The van
-# Genuchten parameter `m` is calculated from `n`, and we use the default
+# and employ the vanGenuchten hydraulic model with `n = 1.89` and `α = 7.5`. The van
+# Genuchten parameter `m` is calculated from `n`.
 # value for `α`.
 soil_water_model = SoilWaterModel(
     FT;


### PR DESCRIPTION
# Description

This PR fixes two small bugs in the soil water code (a sign error in the Brooks and Corey formulation) and the default values for the Neumann and Dirichlet BC structure in the soil water model.

The main purpose of this PR is to add two new tutorials, and to fix up the existing one (equilibrium_test.jl) and add them all to the list_of_tutorials. 

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [X] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
