### PR TITLE
Precipitation removal scheme for GCM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,7 +49,7 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 [compat]
 Adapt = "2.0.2"
 ArgParse = "1.1"
-CLIMAParameters = "0.1.6"
+CLIMAParameters = "0.1.8"
 CUDA = "1.2"
 Combinatorics = "1.0"
 Coverage = "1.0"

--- a/docs/list_of_apis.jl
+++ b/docs/list_of_apis.jl
@@ -7,6 +7,7 @@ apis = [
     "Driver" => "APIs/Driver/index.md",
     "Atmos" => [
         "AtmosModel" => "APIs/Atmos/AtmosModel.md",
+        "Microphysics_0M" => "APIs/Atmos/Microphysics_0M.md",
         "Microphysics" => "APIs/Atmos/Microphysics.md",
         "Temperature Profiles" => "APIs/Atmos/TemperatureProfiles.md",
     ],

--- a/docs/list_of_theory_docs.jl
+++ b/docs/list_of_theory_docs.jl
@@ -9,6 +9,7 @@ theory_docs = Any[
     ],
     "Atmos" => Any[
         "AtmosModel" => "Theory/Atmos/AtmosModel.md",
+        "Microphysics_0M" => "Theory/Atmos/Microphysics_0M.md",
         "Microphysics" => "Theory/Atmos/Microphysics.md",
         "EDMF equations" => "Theory/Atmos/EDMFEquations.md",
         "Tracers" => "Theory/Atmos/Model/tracers.md",

--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -58,3 +58,9 @@ ClimateMachine.Atmos.Insulating
 ClimateMachine.Atmos.NoSlip
 ClimateMachine.Atmos.average_density
 ```
+
+## Sources
+
+```@docs
+ClimateMachine.Atmos.RemovePrecipitation
+```

--- a/docs/src/APIs/Atmos/Microphysics_0M.md
+++ b/docs/src/APIs/Atmos/Microphysics_0M.md
@@ -1,0 +1,15 @@
+# Microphysics_0M
+
+```@meta
+CurrentModule = ClimateMachine
+```
+
+```@docs
+Microphysics_0M
+```
+
+## Methods
+
+```@docs
+Microphysics_0M.remove_precipitation
+```

--- a/docs/src/Theory/Atmos/Microphysics_0M.md
+++ b/docs/src/Theory/Atmos/Microphysics_0M.md
@@ -1,0 +1,81 @@
+# Microphysics_0M
+
+The `Microphysics_0M.jl` module defines a 0-moment bulk parameterization of
+  the moisture sink due to precipitation.
+It offers a simplified way of removing the excess water
+  without assuming anything about the size distributions of cloud
+  or precipitation particles.
+
+The ``q_{tot}`` (total water specific humidity) sink due to precipitation
+  is obtained by relaxation with a constant timescale
+  to a state with condensate exceeding a threshold value removed.
+The threshold for removing excess ``q_{tot}`` is defined either by the
+  condensate specific humidity or supersaturation.
+The thresholds and the relaxation timescale are defined in
+  `CLIMAParameters.jl`.
+
+!!! note
+
+    To remove precipitation instantly, the relaxation timescale should be
+    equal to the timestep length.
+
+## Moisture sink due to precipitation
+
+If based on maximum condensate specific humidity, the sink is defined as:
+``` math
+\begin{equation}
+  \left. \mathcal{S}_{q_{tot}} \right|_{precip} =-
+    \frac{max(0, q_{liq} + q_{ice} - q_{c0})}{\tau_{precip}}
+\end{equation}
+```
+where:
+  - ``q_{liq}``, ``q_{ice}`` are cloud liquid water and cloud ice specific humidities,
+  - ``q_{c0}`` is the condensate specific humidity threshold above which water is removed,
+  - ``\tau_{precip}`` is the relaxation timescale.
+
+If based on saturation excess, the sink is defined as:
+```math
+\begin{equation}
+  \left. \mathcal{S}_{q_{tot}} \right|_{precip} =-
+    \frac{max(0, q_{liq} + q_{ice} - S_{0} \, q_{vap}^{sat})}{\tau_{precip}}
+\end{equation}
+```
+where:
+  - ``q_{liq}``, ``q_{ice}`` are cloud liquid water and cloud ice specific humidities,
+  - ``S_{0}`` is the supersaturation threshold above which water is removed,
+  - ``q_{vap}^{sat}`` is the saturation specific humidity,
+  - ``\tau_{precip}`` is the relaxation timescale.
+
+## Coupling to the state variables
+
+Following the conservation equations for
+[moisture](https://clima.github.io/ClimateMachine.jl/latest/Theory/Atmos/AtmosModel/#Moisture)
+and [mass](https://clima.github.io/ClimateMachine.jl/latest/Theory/Atmos/AtmosModel/#Mass),
+the ``\mathcal{S}_{q_{tot}}`` sink has to be multiplied by ``\rho`` before
+  adding it as one of the sink terms to both moisture and mass state variables.
+For the conservation equation for
+[total energy](https://clima.github.io/ClimateMachine.jl/latest/Theory/Atmos/AtmosModel/#Energy),
+  no additional source/sink terms $M$ are considered, and the
+  the sink due to removing ``q_{tot}`` is computed as:
+```math
+\begin{equation}
+\left. \sum_{j\in\{v,l,i\}}(I_j + \Phi)  \rho C(q_j \rightarrow q_p) \right|_{precip} =
+  \left[\lambda I_l + (1 - \lambda) I_i + \Phi \right]
+  \rho \, \left.\mathcal{S}_{q_{tot}} \right|_{precip}
+\end{equation}
+```
+where:
+ - ``\lambda`` is the liquid fraction
+ - ``I_l = c_{vl} (T - T_0)`` is the internal energy of liquid water
+ - ``I_i = c_{vi} (T - T_0) - I_{i0}`` is the internal energy of ice
+ - ``T`` is the temperature,
+ - ``T_0`` is the thermodynamic reference temperature (which is unrelated to the reference temperature used in hydrostatic reference states used in the momentum equations),
+ - ``I_{i0}`` is the specific internal energy of ice at ``T_0``
+ - ``c_{vl}`` and ``c_{vi}`` are the isochoric specific heats
+     of liquid water, and ice.
+ - ``\Phi`` is the effective gravitational potential.
+
+This assumes that the ``\mathcal{S}_{q_{tot}}`` sink is partitioned between the
+  cloud liquid water and cloud ice sinks
+  ``\mathcal{S}_{q_{liq}}`` and ``\mathcal{S}_{q_{ice}}`` based on the
+  cloud liquid water and cloud ice fractions.

--- a/experiments/AtmosGCM/baroclinic-wave.jl
+++ b/experiments/AtmosGCM/baroclinic-wave.jl
@@ -168,9 +168,14 @@ function config_baroclinic_wave(FT, poly_order, resolution, with_moisture)
     if with_moisture
         hyperdiffusion = EquilMoistBiharmonic(FT(8 * 3600))
         moisture = EquilMoist{FT}()
+        # TODO - switch to line below if you want to start removing q_tot
+        #        due to precipitation
+        source = (Gravity(), Coriolis())
+        #source = (Gravity(), Coriolis(), RemovePrecipitation(true))
     else
         hyperdiffusion = DryBiharmonic(FT(8 * 3600))
         moisture = DryModel()
+        source = (Gravity(), Coriolis())
     end
     model = AtmosModel{FT}(
         AtmosGCMConfigType,
@@ -180,7 +185,7 @@ function config_baroclinic_wave(FT, poly_order, resolution, with_moisture)
         turbulence = ConstantViscosityWithDivergence(FT(0)),
         hyperdiffusion = hyperdiffusion,
         moisture = moisture,
-        source = (Gravity(), Coriolis()),
+        source = source,
     )
 
     config = ClimateMachine.AtmosGCMConfiguration(

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -1,5 +1,13 @@
-using CLIMAParameters.Planet: Omega
-export Source, Gravity, RayleighSponge, Subsidence, GeostrophicForcing, Coriolis
+using ..Microphysics_0M
+using CLIMAParameters.Planet: Omega, e_int_i0, cv_d, cv_l, cv_i, T_0
+
+export Source,
+    Gravity,
+    RayleighSponge,
+    Subsidence,
+    GeostrophicForcing,
+    Coriolis,
+    RemovePrecipitation
 
 # kept for compatibility
 # can be removed if no functions are using this
@@ -171,5 +179,64 @@ function atmos_source!(
         r = (z - s.z_sponge) / (s.z_max - s.z_sponge)
         β_sponge = s.α_max * sinpi(r / 2)^s.γ
         source.ρu -= β_sponge * (state.ρu .- state.ρ * s.u_relaxation)
+    end
+end
+
+"""
+    RemovePrecipitation{FT} <: Source
+
+A sink to `q_tot` when cloud condensate is exceeding a threshold.
+The threshold is defined either in terms of condensate or supersaturation.
+The removal rate is implemented as a relaxation term
+in the Microphysics_0M module.
+The default thresholds and timescale are defined in CLIMAParameters.jl.
+"""
+struct RemovePrecipitation <: Source
+    " Set to true if using qc based threshold"
+    use_qc_thr::Bool
+end
+function atmos_source!(
+    s::RemovePrecipitation,
+    atmos::AtmosModel,
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
+    FT = eltype(state)
+    ts = thermo_state(atmos, state, aux)
+    if has_condensate(ts)
+
+        q = PhasePartition(ts)
+        T::FT = air_temperature(ts)
+        λ::FT = liquid_fraction(ts)
+
+        _e_int_i0::FT = e_int_i0(atmos.param_set)
+        _cv_l::FT = cv_l(atmos.param_set)
+        _cv_i::FT = cv_i(atmos.param_set)
+        _T_0::FT = T_0(atmos.param_set)
+
+        S_qt::FT = 0
+        if s.use_qc_thr
+            S_qt = remove_precipitation(atmos.param_set, q)
+        else
+            q_vap_sat = q_vap_saturation(ts)
+            S_qt = remove_precipitation(atmos.param_set, q, q_vap_sat)
+        end
+
+        source.moisture.ρq_tot += state.ρ * S_qt
+
+        source.ρ += state.ρ * S_qt
+
+        source.ρe +=
+            (
+                λ * _cv_l * (T - _T_0) +
+                (1 - λ) * (_cv_i * (T - _T_0) - _e_int_i0) +
+                gravitational_potential(atmos.orientation, aux)
+            ) *
+            state.ρ *
+            S_qt
     end
 end

--- a/src/Atmos/Parameterizations/CloudPhysics/Microphysics_0M.jl
+++ b/src/Atmos/Parameterizations/CloudPhysics/Microphysics_0M.jl
@@ -1,0 +1,59 @@
+"""
+    Microphysics_0M
+
+Zero-moment bulk microphysics scheme that instantly removes
+moisture above certain threshold.
+This is equivalent to instanteneous conversion of cloud condensate
+into precipitation and precipitation fallout with infinite
+terminal velocity.
+
+"""
+module Microphysics_0M
+
+using ..Thermodynamics
+
+using CLIMAParameters
+using CLIMAParameters.Atmos.Microphysics_0M
+
+const APS = AbstractParameterSet
+
+export remove_precipitation
+
+"""
+    remove_precipitation(param_set::APS, q; q_vap_sat)
+
+ - `param_set` - abstract parameter set
+ - `q` - current PhasePartition
+ - `q_vap_sat` - water vapor specific humidity at saturation
+
+Returns the `q_tot` tendency due to the removal of precipitation.
+The tendency is obtained assuming a relaxation with a constant timescale
+to a state with precipitable water removed.
+The threshold for when to remove `q_tot` is defined either by the
+condensate specific humidity or supersaturation.
+The thresholds and the relaxation timescale are defined in
+CLIMAParameters.
+"""
+function remove_precipitation(
+    param_set::APS,
+    q::PhasePartition{FT},
+) where {FT <: Real}
+
+    _τ_precip::FT = τ_precip(param_set)
+    _qc_0::FT = qc_0(param_set)
+
+    return -max(0, (q.liq + q.ice - _qc_0)) / _τ_precip
+end
+function remove_precipitation(
+    param_set::APS,
+    q::PhasePartition{FT},
+    q_vap_sat::FT,
+) where {FT <: Real}
+
+    _τ_precip::FT = τ_precip(param_set)
+    _S_0::FT = S_0(param_set)
+
+    return -max(0, (q.liq + q.ice - _S_0 * q_vap_sat)) / _τ_precip
+end
+
+end #module Microphysics_0M.jl

--- a/src/ClimateMachine.jl
+++ b/src/ClimateMachine.jl
@@ -18,6 +18,12 @@ include(joinpath(
     "CloudPhysics",
     "Microphysics.jl",
 ))
+include(joinpath(
+    "Atmos",
+    "Parameterizations",
+    "CloudPhysics",
+    "Microphysics_0M.jl",
+))
 include(joinpath("Common", "SurfaceFluxes", "SurfaceFluxes.jl"))
 include(joinpath("Arrays", "MPIStateArrays.jl"))
 include(joinpath("Numerics", "Mesh", "Mesh.jl"))


### PR DESCRIPTION
# Description

This is a draft of precipitation removal scheme for the GCM (aka the 0-moment microphysics scheme).

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
