### PR TITLE
Adding soil heat model into soil model

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -417,6 +417,15 @@ steps:
       queue: central
       slurm_ntasks: 1
 
+  - label: "cpu_heat_analytic_unit_test"
+    key: "cpu_heat_analytic_unit_test"
+    command:
+      - "mpiexec julia --color=yes --project test/Land/Model/heat_analytic_unit_test.jl "
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: "cpu_soil_test_bc"
     key: "cpu_soil_test_bc"
     command:
@@ -959,6 +968,16 @@ steps:
     key: "gpu_haverkamp_test"
     command:
       - "mpiexec julia --color=yes --project test/Land/Model/haverkamp_test.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
+  - label: "gpu_heat_analytic_unit_test"
+    key: "gpu_heat_analytic_unit_test"
+    command:
+      - "mpiexec julia --color=yes --project test/Land/Model/heat_analytic_unit_test.jl "
     agents:
       config: gpu
       queue: central

--- a/docs/list_of_apis.jl
+++ b/docs/list_of_apis.jl
@@ -15,6 +15,8 @@ apis = [
         "Land Model" => "APIs/Land/LandModel.md",
         "Soil Water Parameterizations" =>
             "APIs/Land/SoilWaterParameterizations.md",
+        "Soil Heat Parameterizations" =>
+            "APIs/Land/SoilHeatParameterizations.md",
     ],
     "Common" => [
         "Orientations" => "APIs/Common/Orientations.md",

--- a/docs/src/APIs/Land/LandModel.md
+++ b/docs/src/APIs/Land/LandModel.md
@@ -17,7 +17,9 @@ ClimateMachine.Land.PrescribedWaterModel
 ClimateMachine.Land.SoilHeatModel
 ClimateMachine.Land.PrescribedTemperatureModel
 ClimateMachine.Land.SoilWaterParameterizations
+ClimateMachine.Land.SoilHeatParameterizations
 ClimateMachine.Land.SoilParamFunctions
+ClimateMachine.Land.get_water_content
 ```
 
 ## Boundary Conditions

--- a/docs/src/APIs/Land/SoilHeatParameterizations.md
+++ b/docs/src/APIs/Land/SoilHeatParameterizations.md
@@ -1,0 +1,17 @@
+# Soil Heat Parameterizations
+
+```@meta
+CurrentModule = ClimateMachine.Land.SoilHeatParameterizations
+```
+
+## Heat functions
+```@docs
+volumetric_heat_capacity
+volumetric_internal_energy
+saturated_thermal_conductivity
+thermal_conductivity
+relative_saturation
+kersten_number
+volumetric_internal_energy_liq
+temperature_from_ρe_int
+```

--- a/src/Land/Model/LandModel.jl
+++ b/src/Land/Model/LandModel.jl
@@ -1,11 +1,13 @@
 module Land
 
-using CLIMAParameters
 using DocStringExtensions
 using LinearAlgebra, StaticArrays
+
+using CLIMAParameters
+using CLIMAParameters.Planet: ρ_cloud_liq, ρ_cloud_ice, cp_l, cp_i, T_0, LH_f0
+
 using ..VariableTemplates
 using ..MPIStateArrays
-
 using ..BalanceLaws
 import ..BalanceLaws:
     BalanceLaw,
@@ -19,9 +21,7 @@ import ..BalanceLaws:
     nodal_init_state_auxiliary!,
     init_state_prognostic!,
     nodal_update_auxiliary_state!
-
 using ..DGMethods: LocalGeometry, DGModel
-
 export LandModel
 
 """
@@ -212,6 +212,8 @@ end
 include("land_bc.jl")
 include("SoilWaterParameterizations.jl")
 using .SoilWaterParameterizations
+include("SoilHeatParameterizations.jl")
+using .SoilHeatParameterizations
 include("soil_model.jl")
 include("soil_water.jl")
 include("soil_heat.jl")

--- a/src/Land/Model/SoilHeatParameterizations.jl
+++ b/src/Land/Model/SoilHeatParameterizations.jl
@@ -1,0 +1,206 @@
+"""
+    SoilHeatParameterizations
+
+Functions for volumetric heat capacity, temperature as a function
+of volumetric internal energy, saturated thermal conductivity, thermal
+conductivity, relative saturation and the Kersten number are included.
+Heat capacities denoted by `ρc_` are volumetric, while `cp_` denotes an isobaric
+specific heat capacity.
+"""
+module SoilHeatParameterizations
+
+using CLIMAParameters
+using CLIMAParameters.Planet: ρ_cloud_liq, ρ_cloud_ice, cp_l, cp_i, T_0, LH_f0
+using DocStringExtensions
+
+export volumetric_heat_capacity,
+    volumetric_internal_energy,
+    saturated_thermal_conductivity,
+    thermal_conductivity,
+    relative_saturation,
+    kersten_number,
+    volumetric_internal_energy_liq,
+    temperature_from_ρe_int
+
+
+"""
+    function temperature_from_ρe_int(
+        ρe_int::FT,
+        θ_i::FT,
+        ρcs::FT,
+        param_set::AbstractParameterSet
+    ) where {FT}
+
+Computes the temperature of soil given `θ_i` and volumetric
+internal energy `ρe_int`.
+"""
+function temperature_from_ρe_int(
+    ρe_int::FT,
+    θ_i::FT,
+    ρcs::FT,
+    param_set::AbstractParameterSet,
+) where {FT}
+
+    _ρ_i = FT(ρ_cloud_ice(param_set))
+    _T_ref = FT(T_0(param_set))
+    _LH_f0 = FT(LH_f0(param_set))
+    T = _T_ref + (ρe_int + θ_i * _ρ_i * _LH_f0) / ρcs
+    return T
+end
+
+"""
+    volumetric_heat_capacity(
+        θ_l::FT,
+        θ_i::FT,
+        ρc_ds::FT,
+        param_set::AbstractParameterSet
+    ) where {FT}
+
+Compute the expression for volumetric heat capacity.
+"""
+function volumetric_heat_capacity(
+    θ_l::FT,
+    θ_i::FT,
+    ρc_ds::FT,
+    param_set::AbstractParameterSet,
+) where {FT}
+
+    _ρ_i = FT(ρ_cloud_ice(param_set))
+    ρcp_i = FT(cp_i(param_set) * _ρ_i)
+
+    _ρ_l = FT(ρ_cloud_liq(param_set))
+    ρcp_l = FT(cp_l(param_set) * _ρ_l)
+
+    ρc_s = ρc_ds + θ_l * ρcp_l + θ_i * ρcp_i
+    return ρc_s
+end
+
+"""
+    volumetric_internal_energy(
+        θ_i::FT,
+        ρc_s::FT,
+        T::FT,
+        param_set::AbstractParameterSet
+    ) where {FT}
+Compute the expression for volumetric internal energy.
+"""
+function volumetric_internal_energy(
+    θ_i::FT,
+    ρc_s::FT,
+    T::FT,
+    param_set::AbstractParameterSet,
+) where {FT}
+
+    _ρ_i = FT(ρ_cloud_ice(param_set))
+    _LH_f0 = FT(LH_f0(param_set))
+    _T_ref = FT(T_0(param_set))
+    ρe_int = ρc_s * (T - _T_ref) - θ_i * _ρ_i * _LH_f0
+    return ρe_int
+end
+
+"""
+    saturated_thermal_conductivity(
+        θ_l::FT,
+        θ_i::FT,
+        κ_sat_unfrozen::FT,
+        κ_sat_frozen::FT
+    ) where {FT}
+Compute the expression for saturated thermal conductivity of soil matrix.
+"""
+function saturated_thermal_conductivity(
+    θ_l::FT,
+    θ_i::FT,
+    κ_sat_unfrozen::FT,
+    κ_sat_frozen::FT,
+) where {FT}
+
+    θ_w = θ_l + θ_i
+    if θ_w < eps(FT)
+        κ_sat = FT(0.0)
+    else
+        κ_sat = FT(κ_sat_unfrozen^(θ_l / θ_w) * κ_sat_frozen^(θ_i / θ_w))
+    end
+
+    return κ_sat
+end
+
+"""
+    relative_saturation(
+            θ_l::FT,
+            θ_i::FT,
+            porosity::FT
+    ) where {FT}
+Compute the expression for relative saturation.
+"""
+function relative_saturation(θ_l::FT, θ_i::FT, porosity::FT) where {FT}
+    S_r = (θ_l + θ_i) / porosity
+    return S_r
+end
+"""
+    kersten_number(
+        θ_i::FT,
+        S_r::FT,
+        soil_param_functions::PS
+    ) where {FT, PS}
+
+Compute the expression for the Kersten number.
+"""
+function kersten_number(
+    θ_i::FT,
+    S_r::FT,
+    soil_param_functions::PS,
+) where {FT, PS}
+    a = soil_param_functions.a
+    b = soil_param_functions.b
+    ν_om = soil_param_functions.ν_om
+    ν_sand = soil_param_functions.ν_sand
+    ν_gravel = soil_param_functions.ν_gravel
+
+    if θ_i < eps(FT)
+        K_e =
+            S_r^((FT(1) + ν_om - a * ν_sand - ν_gravel) / FT(2)) *
+            (
+                (FT(1) + exp(-b * S_r))^(-FT(3)) -
+                ((FT(1) - S_r) / FT(2))^FT(3)
+            )^(FT(1) - ν_om)
+    else
+        K_e = S_r^(FT(1) + ν_om)
+    end
+    return K_e
+end
+
+"""
+    thermal_conductivity(
+        κ_dry::FT,
+        K_e::FT,
+        κ_sat::FT
+    ) where {FT}
+Compute the expression for thermal conductivity of soil matrix.
+"""
+function thermal_conductivity(κ_dry::FT, K_e::FT, κ_sat::FT) where {FT}
+    κ = K_e * κ_sat + (FT(1) - K_e) * κ_dry
+    return κ
+end
+
+"""
+    volumetric_internal_energy_liq(
+        cp_l::FT,
+        T::FT,
+        T_ref::FT,
+    ) where {FT}
+Compute the expression for the volumetric internal energy of liquid water.
+Here, cp_l is the volumetric heat capacity of liquid water.
+"""
+function volumetric_internal_energy_liq(
+    T::FT,
+    param_set::AbstractParameterSet,
+) where {FT}
+
+    _T_ref = FT(T_0(param_set))
+    _ρ_l = FT(ρ_cloud_liq(param_set))
+    ρcp_l = FT(cp_l(param_set) * _ρ_l)
+    ρe_int_l = ρcp_l * (T - _T_ref)
+    return ρe_int_l
+end
+
+end # Module

--- a/src/Land/Model/SoilWaterParameterizations.jl
+++ b/src/Land/Model/SoilWaterParameterizations.jl
@@ -343,7 +343,7 @@ end
 """
     impedance_factor(
         imp::NoImpedance{FT},
-        θ_ice::FT,
+        θ_i::FT,
         porosity::FT,
     ) where {FT}
 
@@ -354,7 +354,7 @@ The other arguments are included to unify the function call.
 """
 function impedance_factor(
     imp::NoImpedance{FT},
-    θ_ice::FT,
+    θ_i::FT,
     porosity::FT,
 ) where {FT}
     gamma = FT(1.0)
@@ -364,7 +364,7 @@ end
 """
     impedance_factor(
         imp::IceImpedance{FT},
-        θ_ice::FT,
+        θ_i::FT,
         porosity::FT,
     ) where {FT}
 
@@ -373,11 +373,11 @@ ice is desired.
 """
 function impedance_factor(
     imp::IceImpedance{FT},
-    θ_ice::FT,
+    θ_i::FT,
     porosity::FT,
 ) where {FT}
     Ω = imp.Ω
-    S_ice = θ_ice / porosity
+    S_ice = θ_i / porosity
     gamma = FT(10.0^(-Ω * S_ice))
     return gamma
 end
@@ -388,7 +388,7 @@ end
         viscosity::AbstractViscosityFactor{FT},
         moisture::AbstractMoistureFactor{FT},
         hydraulics::AbstractHydraulicsModel{FT},
-        θ_ice::FT,
+        θ_i::FT,
         porosity::FT,
         T::FT,
         S_l::FT,
@@ -401,14 +401,14 @@ function hydraulic_conductivity(
     viscosity::AbstractViscosityFactor{FT},
     moisture::AbstractMoistureFactor{FT},
     hydraulics::AbstractHydraulicsModel{FT},
-    θ_ice::FT,
+    θ_i::FT,
     porosity::FT,
     T::FT,
     S_l::FT,
 ) where {FT}
     K = FT(
         viscosity_factor(viscosity, T) *
-        impedance_factor(impedance, θ_ice, porosity) *
+        impedance_factor(impedance, θ_i, porosity) *
         moisture_factor(moisture, hydraulics, S_l),
     )
     return K

--- a/src/Land/Model/land_bc.jl
+++ b/src/Land/Model/land_bc.jl
@@ -15,8 +15,8 @@ function boundary_state!(
     _...,
 )
     args = (state⁺, diff⁺, aux⁺, n̂, state⁻, diff⁻, aux⁻, bctype, t)
-    soil_boundary_state!(nf, land.soil.water, args...)
-    soil_boundary_state!(nf, land.soil.heat, args...)
+    soil_boundary_state!(nf, land, land.soil, land.soil.water, args...)
+    soil_boundary_state!(nf, land, land.soil, land.soil.heat, args...)
 end
 
 
@@ -33,8 +33,8 @@ function boundary_state!(
     _...,
 )
     args = (state⁺, aux⁺, n̂, state⁻, aux⁻, bctype, t)
-    soil_boundary_state!(nf, land.soil.water, args...)
-    soil_boundary_state!(nf, land.soil.heat, args...)
+    soil_boundary_state!(nf, land, land.soil, land.soil.water, args...)
+    soil_boundary_state!(nf, land, land.soil, land.soil.heat, args...)
 end
 
 abstract type AbstractBoundaryFunctions end

--- a/src/Land/Model/soil_bc.jl
+++ b/src/Land/Model/soil_bc.jl
@@ -1,6 +1,8 @@
 
 function soil_boundary_state!(
     nf,
+    land::LandModel,
+    soil::SoilModel,
     m::AbstractSoilComponentModel,
     state⁺::Vars,
     diff⁺::Vars,
@@ -19,6 +21,8 @@ end
 
 function soil_boundary_state!(
     nf,
+    land::LandModel,
+    soil::SoilModel,
     m::AbstractSoilComponentModel,
     state⁺::Vars,
     aux⁺::Vars,
@@ -36,6 +40,8 @@ end
 
 function soil_boundary_state!(
     nf,
+    land::LandModel,
+    soil::SoilModel,
     water::SoilWaterModel,
     state⁺::Vars,
     aux⁺::Vars,
@@ -48,9 +54,21 @@ function soil_boundary_state!(
 )
     water_bc = water.dirichlet_bc
     if bctype == 2
-        top_boundary_conditions!(water, water_bc, state⁺, aux⁺, state⁻, aux⁻, t)
+        top_boundary_conditions!(
+            land,
+            soil,
+            water,
+            water_bc,
+            state⁺,
+            aux⁺,
+            state⁻,
+            aux⁻,
+            t,
+        )
     elseif bctype == 1
         bottom_boundary_conditions!(
+            land,
+            soil,
             water,
             water_bc,
             state⁺,
@@ -65,6 +83,8 @@ end
 
 function soil_boundary_state!(
     nf,
+    land::LandModel,
+    soil::SoilModel,
     water::SoilWaterModel,
     state⁺::Vars,
     diff⁺::Vars,
@@ -80,6 +100,8 @@ function soil_boundary_state!(
     water_bc = water.neumann_bc
     if bctype == 2
         top_boundary_conditions!(
+            land,
+            soil,
             water,
             water_bc,
             state⁺,
@@ -93,6 +115,8 @@ function soil_boundary_state!(
         )
     elseif bctype == 1
         bottom_boundary_conditions!(
+            land,
+            soil,
             water,
             water_bc,
             state⁺,
@@ -107,11 +131,105 @@ function soil_boundary_state!(
     end
 end
 
+# Heat
+function soil_boundary_state!(
+    nf,
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    state⁺::Vars,
+    aux⁺::Vars,
+    nM,
+    state⁻::Vars,
+    aux⁻::Vars,
+    bctype,
+    t,
+    _...,
+)
+    heat_bc = heat.dirichlet_bc
+    if bctype == 2
+        top_boundary_conditions!(
+            land,
+            soil,
+            heat,
+            heat_bc,
+            state⁺,
+            aux⁺,
+            state⁻,
+            aux⁻,
+            t,
+        )
+    elseif bctype == 1
+        bottom_boundary_conditions!(
+            land,
+            soil,
+            heat,
+            heat_bc,
+            state⁺,
+            aux⁺,
+            state⁻,
+            aux⁻,
+            t,
+        )
+    end
+end
+
+function soil_boundary_state!(
+    nf,
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    state⁺::Vars,
+    diff⁺::Vars,
+    aux⁺::Vars,
+    n̂,
+    state⁻::Vars,
+    diff⁻::Vars,
+    aux⁻::Vars,
+    bctype,
+    t,
+    _...,
+)
+    heat_bc = heat.neumann_bc
+    if bctype == 2
+        top_boundary_conditions!(
+            land,
+            soil,
+            heat,
+            heat_bc,
+            state⁺,
+            diff⁺,
+            aux⁺,
+            n̂,
+            state⁻,
+            diff⁻,
+            aux⁻,
+            t,
+        )
+    elseif bctype == 1
+        bottom_boundary_conditions!(
+            land,
+            soil,
+            heat,
+            heat_bc,
+            state⁺,
+            diff⁺,
+            aux⁺,
+            n̂,
+            state⁻,
+            diff⁻,
+            aux⁻,
+            t,
+        )
+    end
+end
 
 
-
+# Water
 """
     top_boundary_conditions!(
+        land::LandModel,
+        soil::SoilModel,
         water::SoilWaterModel,
         bc::Neumann,
         state⁺::Vars,
@@ -127,6 +245,8 @@ end
 Specify Neumann boundary conditions for the top of the soil, if given.
 """
 function top_boundary_conditions!(
+    land::LandModel,
+    soil::SoilModel,
     water::SoilWaterModel,
     bc::Neumann,
     state⁺::Vars,
@@ -147,6 +267,8 @@ end
 
 """
     top_boundary_conditions!(
+        land::LandModel,
+        soil::SoilModel,
         water::SoilWaterModel,
         bc::Dirichlet,
         state⁺::Vars,
@@ -159,6 +281,8 @@ end
 Specify Dirichlet boundary conditions for the top of the soil, if given.
 """
 function top_boundary_conditions!(
+    land::LandModel,
+    soil::SoilModel,
     water::SoilWaterModel,
     bc::Dirichlet,
     state⁺::Vars,
@@ -176,6 +300,8 @@ end
 
 """
     bottom_boundary_conditions!(
+        land::LandModel,
+        soil::SoilModel,
         water::SoilWaterModel,
         bc::Neumann,
         state⁺::Vars,
@@ -191,6 +317,8 @@ end
 Specify Neumann boundary conditions for the bottom of the soil, if given.
 """
 function bottom_boundary_conditions!(
+    land::LandModel,
+    soil::SoilModel,
     water::SoilWaterModel,
     bc::Neumann,
     state⁺::Vars,
@@ -212,6 +340,8 @@ end
 
 """
     bottom_boundary_conditions!(
+        land::LandModel,
+        soil::SoilModel,
         water::SoilWaterModel,
         bc::Dirichlet,
         state⁺::Vars,
@@ -224,6 +354,8 @@ end
 Specify Dirichlet boundary conditions for the bottom of the soil, if given.
 """
 function bottom_boundary_conditions!(
+    land::LandModel,
+    soil::SoilModel,
     water::SoilWaterModel,
     bc::Dirichlet,
     state⁺::Vars,
@@ -234,6 +366,186 @@ function bottom_boundary_conditions!(
 )
     if bc.bottom_state != nothing
         state⁺.soil.water.ϑ_l = bc.bottom_state(aux⁻, t)
+    else
+        nothing
+    end
+end
+
+## Heat
+"""
+    top_boundary_conditions!(
+        land::LandModel,
+        soil::SoilModel,
+        heat::SoilHeatModel,
+        bc::Neumann,
+        state⁺::Vars,
+        diff⁺::Vars,
+        aux⁺::Vars,
+        n̂,
+        state⁻::Vars,
+        diff⁻::Vars,
+        aux⁻::Vars,
+        t,
+    )
+
+Specify Neumann boundary conditions for the top of the soil, if given.
+"""
+function top_boundary_conditions!(
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    bc::Neumann,
+    state⁺::Vars,
+    diff⁺::Vars,
+    aux⁺::Vars,
+    n̂,
+    state⁻::Vars,
+    diff⁻::Vars,
+    aux⁻::Vars,
+    t,
+)
+    if bc.surface_flux != nothing
+        diff⁺.soil.heat.κ∇T = n̂ * bc.surface_flux(aux⁻, t)
+    else
+        nothing
+    end
+end
+
+"""
+    top_boundary_conditions!(
+        land::LandModel,
+        soil::SoilModel,
+        water::SoilWaterModel,
+        bc::Dirichlet,
+        state⁺::Vars,
+        aux⁺::Vars,
+        state⁻::Vars,
+        aux⁻::Vars,
+        t,
+    )
+
+Specify Dirichlet boundary conditions for the top of the soil, if given.
+"""
+function top_boundary_conditions!(
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    bc::Dirichlet,
+    state⁺::Vars,
+    aux⁺::Vars,
+    state⁻::Vars,
+    aux⁻::Vars,
+    t,
+)
+    if bc.surface_state != nothing
+        ϑ_l, θ_i = get_water_content(land.soil.water, aux⁻, state⁻, t)
+        θ_l =
+            volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
+        ρc_s = volumetric_heat_capacity(
+            θ_l,
+            θ_i,
+            land.soil.param_functions.ρc_ds,
+            land.param_set,
+        )
+
+        ρe_int_bc = volumetric_internal_energy(
+            θ_i,
+            ρc_s,
+            bc.surface_state(aux⁻, t),
+            land.param_set,
+        )
+
+        state⁺.soil.heat.ρe_int = ρe_int_bc
+    else
+        nothing
+    end
+end
+
+"""
+    bottom_boundary_conditions!(
+        land::LandModel,
+        soil::SoilModel,
+        heat::SoilHeatModel,
+        bc::Neumann,
+        state⁺::Vars,
+        diff⁺::Vars,
+        aux⁺::Vars,
+        n̂,
+        state⁻::Vars,
+        diff⁻::Vars,
+        aux⁻::Vars,
+        t,
+    )
+
+Specify Neumann boundary conditions for the bottom of the soil, if given.
+"""
+function bottom_boundary_conditions!(
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    bc::Neumann,
+    state⁺::Vars,
+    diff⁺::Vars,
+    aux⁺::Vars,
+    n̂,
+    state⁻::Vars,
+    diff⁻::Vars,
+    aux⁻::Vars,
+    t,
+)
+    if bc.bottom_flux != nothing
+        diff⁺.soil.heat.κ∇T = -n̂ * bc.bottom_flux(aux⁻, t)
+    else
+        nothing
+    end
+end
+
+
+"""
+    bottom_boundary_conditions!(
+        land::LandModel,
+        soil::SoilModel,
+        heat::SoilHeatModel,
+        bc::Dirichlet,
+        state⁺::Vars,
+        aux⁺::Vars,
+        state⁻::Vars,
+        aux⁻::Vars,
+        t,
+    )
+
+Specify Dirichlet boundary conditions for the bottom of the soil, if given.
+"""
+function bottom_boundary_conditions!(
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    bc::Dirichlet,
+    state⁺::Vars,
+    aux⁺::Vars,
+    state⁻::Vars,
+    aux⁻::Vars,
+    t,
+)
+    if bc.bottom_state != nothing
+        ϑ_l, θ_i = get_water_content(land.soil.water, aux⁻, state⁻, t)
+        θ_l =
+            volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
+        ρc_s = volumetric_heat_capacity(
+            θ_l,
+            θ_i,
+            land.soil.param_functions.ρc_ds,
+            land.param_set,
+        )
+
+        ρe_int_bc = volumetric_internal_energy(
+            θ_i,
+            ρc_s,
+            bc.bottom_state(aux⁻, t),
+            land.param_set,
+        )
+
+        state⁺.soil.heat.ρe_int = ρe_int_bc
     else
         nothing
     end

--- a/src/Land/Model/soil_heat.jl
+++ b/src/Land/Model/soil_heat.jl
@@ -1,35 +1,230 @@
 ### Soil heat model
+
 export SoilHeatModel, PrescribedTemperatureModel
 
 abstract type AbstractHeatModel <: AbstractSoilComponentModel end
 
 """
-    PrescribedTemperatureModel{FT} <: AbstractHeatModel
+    PrescribedTemperatureModel{F1} <: AbstractHeatModel
 
-A model where the temperature is set by the user and not dynamically determined.
-
-This is useful for driving Richard's equation without a back reaction on temperature.
-# Fields
-$(DocStringExtensions.FIELDS)
+Model structure for a prescribed temperature model.
 """
-Base.@kwdef struct PrescribedTemperatureModel{FT} <: AbstractHeatModel
-    "Prescribed function for temperature"
-    T::FT = FT(0.0)
+struct PrescribedTemperatureModel{F1} <: AbstractHeatModel
+    "Temperature"
+    T::F1
 end
 
 """
-    get_temperature(m::PrescribedTemperatureModel)
+    PrescribedTemperatureModel(
+        T::Function = (aux,t) -> eltype(aux)(0.0)
+    )
+
+Outer constructor for the PrescribedTemperatureModel defining default values.
+
+The functions supplied by the user are point-wise evaluated and are
+evaluated in the Balance Law functions compute_gradient_argument,
+ nodal_update, etc. whenever the prescribed temperature content variables are
+needed by the water model.
 """
-get_temperature(m::PrescribedTemperatureModel) = m.T
+function PrescribedTemperatureModel(T::Function = (aux, t) -> eltype(aux)(0.0))
+    return PrescribedTemperatureModel{typeof(T)}(T)
+end
 
+"""
+    SoilHeatModel{FT, FiT, BCD, BCN} <: AbstractHeatModel
+
+The necessary components for the Heat Equation in a soil water matrix.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct SoilHeatModel{FT, FiT, BCD, BCN} <: AbstractHeatModel
+    "Initial conditions for temperature"
+    initialT::FiT
+    "Dirichlet BC structure"
+    dirichlet_bc::BCD
+    "Neumann BC structure"
+    neumann_bc::BCN
+end
+
+"""
+    SoilHeatModel(
+        ::Type{FT};
+        initialT::FT = FT(NaN),
+        dirichlet_bc::AbstractBoundaryFunctions = nothing,
+        neumann_bc::AbstractBoundaryFunctions = nothing
+    ) where {FT}
+
+Constructor for the SoilHeatModel.
+"""
+function SoilHeatModel(
+    ::Type{FT};
+    initialT = (aux) -> FT(NaN),
+    dirichlet_bc::AbstractBoundaryFunctions = nothing,
+    neumann_bc::AbstractBoundaryFunctions = nothing,
+) where {FT}
+    args = (initialT, dirichlet_bc, neumann_bc)
+    return SoilHeatModel{FT, typeof.(args)...}(args...)
+end
+
+"""
+    function get_temperature(
+        heat::SoilHeatModel
+        aux::Vars,
+        t::Real
+    )
+Returns the temperature when the heat model chosen is the dynamical SoilHeatModel.
+This is necessary for fully coupling heat and water.
+"""
+function get_temperature(heat::SoilHeatModel, aux::Vars, t::Real)
+    T = aux.soil.heat.T
+    return T
+end
+
+"""
+    function get_temperature(
+        heat::PrescribedTemperatureModel,
+        aux::Vars,
+        t::Real
+    )
+Returns the temperature when the heat model chosen is a user prescribed one.
+This is useful for driving Richard's equation without a back reaction on temperature.
+"""
+function get_temperature(heat::PrescribedTemperatureModel, aux::Vars, t::Real)
+    T = heat.T(aux, t)
+    return T
+end
+
+"""
+    function get_initial_temperature(
+        m::SoilHeatModel
+        aux::Vars,
+        t::Real
+    )    
+Returns the temperature from the SoilHeatModel.
+Needed for soil_init_aux! of SoilWaterModel.
+"""
+function get_initial_temperature(m::SoilHeatModel, aux::Vars, t::Real)
+    return m.initialT(aux)
+end
 
 
 """
-    SoilHeatModel <: AbstractHeatModel
-
-The balance law for internal energy in soil.
-
-To be used when the user wants to dynamically determine internal energy and temperature.
-
+    function get_initial_temperature(
+        m::PrescribedTemperatureModel,
+        aux::Vars,
+        t::Real
+    )    
+Returns the temperature from the prescribed model.
+Needed for soil_init_aux! of SoilWaterModel.
 """
-struct SoilHeatModel <: AbstractHeatModel end
+function get_initial_temperature(
+    m::PrescribedTemperatureModel,
+    aux::Vars,
+    t::Real,
+)
+    return m.T(aux, t)
+end
+
+vars_state(heat::SoilHeatModel, st::Prognostic, FT) = @vars(ρe_int::FT)
+vars_state(heat::SoilHeatModel, st::Auxiliary, FT) = @vars(T::FT)
+vars_state(heat::SoilHeatModel, st::Gradient, FT) = @vars(T::FT)
+vars_state(heat::SoilHeatModel, st::GradientFlux, FT) =
+    @vars(κ∇T::SVector{3, FT})
+
+function soil_init_aux!(
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    aux.soil.heat.T = heat.initialT(aux)
+end
+
+function land_nodal_update_auxiliary_state!(
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+
+    ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, t)
+    θ_l = volumetric_liquid_fraction(ϑ_l, soil.param_functions.porosity)
+    ρc_ds = soil.param_functions.ρc_ds
+    ρcs = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, land.param_set)
+    aux.soil.heat.T = temperature_from_ρe_int(
+        state.soil.heat.ρe_int,
+        θ_i,
+        ρcs,
+        land.param_set,
+    )
+end
+
+function compute_gradient_argument!(
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    transform::Vars,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+
+    ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, t)
+    θ_l = volumetric_liquid_fraction(ϑ_l, soil.param_functions.porosity)
+    ρc_ds = soil.param_functions.ρc_ds
+    ρcs = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, land.param_set)
+    transform.soil.heat.T = temperature_from_ρe_int(
+        state.soil.heat.ρe_int,
+        θ_i,
+        ρcs,
+        land.param_set,
+    )
+end
+
+function compute_gradient_flux!(
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    diffusive::Vars,
+    ∇transform::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+
+    ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, t)
+    θ_l = volumetric_liquid_fraction(ϑ_l, soil.param_functions.porosity)
+    κ_dry = soil.param_functions.κ_dry
+    S_r = relative_saturation(θ_l, θ_i, soil.param_functions.porosity)
+    kersten = kersten_number(θ_i, S_r, soil.param_functions)
+    κ_sat = saturated_thermal_conductivity(
+        θ_l,
+        θ_i,
+        soil.param_functions.κ_sat_unfrozen,
+        soil.param_functions.κ_sat_frozen,
+    )
+    diffusive.soil.heat.κ∇T =
+        thermal_conductivity(κ_dry, kersten, κ_sat) * ∇transform.soil.heat.T
+end
+
+function flux_second_order!(
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    flux::Grad,
+    state::Vars,
+    diffusive::Vars,
+    hyperdiffusive::Vars,
+    aux::Vars,
+    t::Real,
+)
+    ρe_int_l = volumetric_internal_energy_liq(aux.soil.heat.T, land.param_set)
+    diffusive_water_flux =
+        -ρe_int_l .* get_diffusive_water_flux(soil.water, diffusive)
+    diffusive_heat_flux = -diffusive.soil.heat.κ∇T
+    flux.soil.heat.ρe_int += diffusive_heat_flux + diffusive_water_flux
+end

--- a/src/Land/Model/soil_model.jl
+++ b/src/Land/Model/soil_model.jl
@@ -8,7 +8,7 @@ export SoilModel, SoilParamFunctions
 abstract type AbstractSoilParameterFunctions{FT <: AbstractFloat} end
 
 """
-    struct SoilParamFunctions{FT} <: AbstractSoilParameterFunctions{FT}
+    SoilParamFunctions{FT} <: AbstractSoilParameterFunctions{FT}
 
 Necessary parameters for the soil model. These will eventually be prescribed
 functions of space (and time).
@@ -18,10 +18,28 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct SoilParamFunctions{FT} <: AbstractSoilParameterFunctions{FT}
     "Aggregate porosity of the soil"
     porosity::FT = FT(NaN)
-    "Hydraulic conductivity at saturation"
+    "Hydraulic conductivity at saturation. Units of m s-1."
     Ksat::FT = FT(NaN)
-    "Specific storage of the soil"
+    "Specific storage of the soil. Units of m s-1."
     S_s::FT = FT(NaN)
+    "Volume fraction of gravels. Units of m-3 m-3."
+    ν_gravel::FT = FT(NaN)
+    "Volume fraction of SOM. Units of m-3 m-3."
+    ν_om::FT = FT(NaN)
+    "Volume fraction of sand. Units of m-3 m-3."
+    ν_sand::FT = FT(NaN)
+    "Bulk volumetric heat capacity of dry soil. Units of J m-3 K-1."
+    ρc_ds::FT = FT(NaN)
+    "Dry thermal conductivity. Units of W m-1 K-1."
+    κ_dry::FT = FT(NaN)
+    "Saturated thermal conductivity for unfrozen soil. Units of W m-1 K-1."
+    κ_sat_unfrozen::FT = FT(NaN)
+    "Saturated thermal conductivity for frozen soil. Units of W m-1 K-1."
+    κ_sat_frozen::FT = FT(NaN)
+    "Adjustable scale parameter for determining Kersten number. Unitless."
+    a::FT = FT(NaN)
+    "Adjustable scale parameter for determining Kersten number. Unitless."
+    b::FT = FT(NaN)
 end
 
 

--- a/src/Land/Model/soil_water.jl
+++ b/src/Land/Model/soil_water.jl
@@ -1,48 +1,48 @@
-export SoilWaterModel, PrescribedWaterModel
+export SoilWaterModel, PrescribedWaterModel, get_water_content
 
 abstract type AbstractWaterModel <: AbstractSoilComponentModel end
 
 """
-    struct PrescribedWaterModel{F1, F2} <: AbstractWaterModel
+    PrescribedWaterModel{F1, F2} <: AbstractWaterModel
 
 Model structure for a prescribed water content model.
 
 The user supplies functions of space and time for both `ϑ_l` and
-`θ_ice`. No auxiliary or state variables are added, no PDE is solved. 
+`θ_i`. No auxiliary or state variables are added, no PDE is solved. 
 The defaults are no moisture anywhere, for all time. 
 
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct PrescribedWaterModel{F1, F2} <: AbstractWaterModel
+struct PrescribedWaterModel{FN1, FN2} <: AbstractWaterModel
     "Augmented liquid fraction"
-    ϑ_l::F1
+    ϑ_l::FN1
     "Volumetric fraction of ice"
-    θ_ice::F2
+    θ_i::FN2
 end
 
 """
-    PrescribedWaterModel(
-        ϑ_l::Function = (aux,t) -> eltype(aux)(0.0),
-        θ_ice::Function = (aux,t) -> eltype(aux)(0.0),
-    ) where {FT}
-
-Outer constructor for the PrescribedWaterModel defining default values, and
-making it so changes to those defaults are supplied via keyword args.
+    function PrescribedWaterModel(
+        ϑ_l::Function = (aux, t) -> eltype(aux)(0.0),
+        θ_i::Function = (aux, t) -> eltype(aux)(0.0),
+    )
+        args = (ϑ_l, θ_i)
+        return PrescribedWaterModel{typeof.(args)...}(args...)
+    end
+Outer constructor for the PrescribedWaterModel defining default values.
 
 The functions supplied by the user are point-wise evaluated and are 
-evaluated in the Balance Law functions (kernels?) compute_gradient_argument,
- nodal_update, etc. whenever the prescribed water content variables are 
+evaluated in the Balance Law functions compute_gradient_argument,
+nodal_update, etc. whenever the prescribed water content variables are 
 needed by the heat model.
 """
 function PrescribedWaterModel(
     ϑ_l::Function = (aux, t) -> eltype(aux)(0.0),
-    θ_ice::Function = (aux, t) -> eltype(aux)(0.0),
-) where {FT}
-    args = (ϑ_l, θ_ice)
+    θ_i::Function = (aux, t) -> eltype(aux)(0.0),
+)
+    args = (ϑ_l, θ_i)
     return PrescribedWaterModel{typeof.(args)...}(args...)
 end
-
 
 """
     SoilWaterModel{FT, IF, VF, MF, HM, Fiϑl, Fiθi, BCD, BCN} <: AbstractWaterModel
@@ -50,7 +50,7 @@ end
 The necessary components for solving the equations for water (liquid or ice) in soil. 
 
 Without freeze/thaw source terms added (separately), this model reduces to
-Richard's equation for liquid water. Note that the default for `θ_ice` is zero. 
+Richard's equation for liquid water. Note that the default for `θ_i` is zero. 
 Without freeze/thaw source terms added to both the liquid and ice equations, 
 the default should never be changed, because we do not enforce that the total 
 volumetric water fraction is less than or equal to porosity otherwise.
@@ -74,7 +74,7 @@ struct SoilWaterModel{FT, IF, VF, MF, HM, Fiϑl, Fiθi, BCD, BCN} <:
     "Initial condition: augmented liquid fraction"
     initialϑ_l::Fiϑl
     "Initial condition: volumetric ice fraction"
-    initialθ_ice::Fiθi
+    initialθ_i::Fiθi
     "Dirichlet boundary condition structure"
     dirichlet_bc::BCD
     "Neumann boundary condition  structure"
@@ -89,7 +89,7 @@ end
         moisture_factor::AbstractMoistureFactor{FT} = MoistureIndependent{FT}(),
         hydraulics::AbstractHydraulicsModel{FT} = vanGenuchten{FT}(),
         initialϑ_l = (aux) -> FT(NaN),
-        initialθ_ice = (aux) -> FT(NaN),
+        initialθ_i = (aux) -> FT(0.0),
         dirichlet_bc::AbstractBoundaryFunctions = nothing,
         neumann_bc::AbstractBoundaryFunctions = nothing,
     ) where {FT}
@@ -103,7 +103,7 @@ function SoilWaterModel(
     moisture_factor::AbstractMoistureFactor{FT} = MoistureIndependent{FT}(),
     hydraulics::AbstractHydraulicsModel{FT} = vanGenuchten{FT}(),
     initialϑ_l::Function = (aux) -> eltype(aux)(NaN),
-    initialθ_ice::Function = (aux) -> eltype(aux)(0.0),
+    initialθ_i::Function = (aux) -> eltype(aux)(0.0),
     dirichlet_bc::AbstractBoundaryFunctions = nothing,
     neumann_bc::AbstractBoundaryFunctions = nothing,
 ) where {FT}
@@ -113,7 +113,7 @@ function SoilWaterModel(
         moisture_factor,
         hydraulics,
         initialϑ_l,
-        initialθ_ice,
+        initialθ_i,
         dirichlet_bc,
         neumann_bc,
     )
@@ -123,49 +123,76 @@ end
 
 """
     get_water_content(
+        water::SoilWaterModel,
         aux::Vars,
         state::Vars,
-        t::Real,
-        water::SoilWaterModel,
+        t::Real
     )
 
 Return the moisture variables for the balance law soil water model.
 """
 function get_water_content(
+    water::SoilWaterModel,
     aux::Vars,
     state::Vars,
     t::Real,
-    water::SoilWaterModel,
 )
-    return state.soil.water.ϑ_l, state.soil.water.θ_ice
+    FT = eltype(state)
+    return FT(state.soil.water.ϑ_l), FT(state.soil.water.θ_i)
 end
 
 
 
 """
     get_water_content(
+        water::PrescribedWaterModel,
         aux::Vars,
         state::Vars,
-        t::Real,
-        water::PrescribedWaterModel,
+        t::Real
     )
 
 Return the moisture variables for the prescribed soil water model.
 """
 function get_water_content(
+    water::PrescribedWaterModel,
     aux::Vars,
     state::Vars,
     t::Real,
-    water::PrescribedWaterModel,
 )
+    FT = eltype(aux)
     ϑ_l = water.ϑ_l(aux, t)
-    θ_ice = water.θ_ice(aux, t)
-    return ϑ_l, θ_ice
+    θ_i = water.θ_i(aux, t)
+    return FT(ϑ_l), FT(θ_i)
 end
 
 
-vars_state(water::SoilWaterModel, st::Prognostic, FT) =
-    @vars(ϑ_l::FT, θ_ice::FT)
+"""
+    function get_diffusive_water_flux(
+        water::SoilWaterModel,
+        diffusive::Vars
+    )
+
+Returns the diffusive water flux from the `diffusive` vector.
+"""
+function get_diffusive_water_flux(water::SoilWaterModel, diffusive::Vars)
+    return diffusive.soil.water.K∇h
+end
+
+"""
+    function get_diffusive_water_flux(
+        water::PrescribedWaterModel,
+        diffusive::Vars
+    )
+
+Returns zero diffusive water flux under the PrescribedWaterModel.
+"""
+function get_diffusive_water_flux(water::PrescribedWaterModel, diffusive::Vars)
+    FT = eltype(diffusive)
+    return SVector{3, FT}(0, 0, 0)
+end
+
+
+vars_state(water::SoilWaterModel, st::Prognostic, FT) = @vars(ϑ_l::FT, θ_i::FT)
 
 
 vars_state(water::SoilWaterModel, st::Auxiliary, FT) = @vars(h::FT, K::FT)
@@ -183,7 +210,9 @@ function soil_init_aux!(
     aux::Vars,
     geom::LocalGeometry,
 )
-    T = get_temperature(land.soil.heat)
+
+    FT = eltype(aux)
+    T = get_initial_temperature(land.soil.heat, aux, FT(0.0))
     S_l = effective_saturation(
         soil.param_functions.porosity,
         water.initialϑ_l(aux),
@@ -201,7 +230,7 @@ function soil_init_aux!(
             water.viscosity_factor,
             water.moisture_factor,
             water.hydraulics,
-            water.initialθ_ice(aux),
+            water.initialθ_i(aux),
             soil.param_functions.porosity,
             T,
             S_l,
@@ -217,7 +246,7 @@ function land_nodal_update_auxiliary_state!(
     aux::Vars,
     t::Real,
 )
-    T = get_temperature(land.soil.heat)
+    T = get_temperature(land.soil.heat, aux, t)
     S_l = effective_saturation(
         soil.param_functions.porosity,
         state.soil.water.ϑ_l,
@@ -235,7 +264,7 @@ function land_nodal_update_auxiliary_state!(
             water.viscosity_factor,
             water.moisture_factor,
             water.hydraulics,
-            state.soil.water.θ_ice,
+            state.soil.water.θ_i,
             soil.param_functions.porosity,
             T,
             S_l,

--- a/test/Land/Model/haverkamp_test.jl
+++ b/test/Land/Model/haverkamp_test.jl
@@ -47,10 +47,10 @@ haverkamp_dataset_path = get_data_folder(haverkamp_dataset)
     function init_soil_water!(land, state, aux, coordinates, time)
         myfloat = eltype(aux)
         state.soil.water.ϑ_l = myfloat(land.soil.water.initialϑ_l(aux))
-        state.soil.water.θ_ice = myfloat(land.soil.water.initialθ_ice(aux))
+        state.soil.water.θ_i = myfloat(land.soil.water.initialθ_i(aux))
     end
 
-    soil_heat_model = PrescribedTemperatureModel{FT}()
+    soil_heat_model = PrescribedTemperatureModel()
 
     soil_param_functions = SoilParamFunctions{FT}(
         porosity = 0.495,

--- a/test/Land/Model/heat_analytic_unit_test.jl
+++ b/test/Land/Model/heat_analytic_unit_test.jl
@@ -1,0 +1,167 @@
+# Test heat equation agrees with analytic solution to problem 55 on page 28 in https://ocw.mit.edu/courses/mathematics/18-303-linear-partial-differential-equations-fall-2006/lecture-notes/heateqni.pdf
+using MPI
+using OrderedCollections
+using StaticArrays
+using Statistics
+using Dierckx
+using Test
+
+using CLIMAParameters
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using ClimateMachine
+using ClimateMachine.Land
+using ClimateMachine.Land.SoilWaterParameterizations
+using ClimateMachine.Land.SoilHeatParameterizations
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.DGMethods: BalanceLaw, LocalGeometry
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.ODESolvers
+using ClimateMachine.VariableTemplates
+using ClimateMachine.SingleStackUtils
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, vars_state
+import ClimateMachine.DGMethods: calculate_dt
+
+function calculate_dt(dg, model::LandModel, Q, Courant_number, t, direction)
+    Δt = one(eltype(Q))
+    CFL = DGMethods.courant(diffusive_courant, dg, model, Q, Δt, t, direction)
+    return Courant_number / CFL
+end
+function diffusive_courant(
+    m::LandModel,
+    state::Vars,
+    aux::Vars,
+    diffusive::Vars,
+    Δx,
+    Δt,
+    t,
+    direction,
+)
+    return Δt * m.soil.param_functions.κ_dry / (Δx * Δx)
+end
+
+@testset "Heat analytic unit test" begin
+    ClimateMachine.init()
+    FT = Float32
+
+    function init_soil!(land, state, aux, coordinates, time)
+        myFT = eltype(state)
+
+        ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, time)
+        θ_l =
+            volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
+        ρc_s = volumetric_heat_capacity(
+            θ_l,
+            θ_i,
+            land.soil.param_functions.ρc_ds,
+            land.param_set,
+        )
+
+        state.soil.heat.ρe_int = myFT(volumetric_internal_energy(
+            θ_i,
+            ρc_s,
+            land.soil.heat.initialT(aux),
+            land.param_set,
+        ))
+    end
+
+    soil_param_functions = SoilParamFunctions{FT}(
+        porosity = 0.495,
+        ν_gravel = 0.1,
+        ν_om = 0.1,
+        ν_sand = 0.1,
+        ρc_ds = 1,
+        κ_dry = 1,
+        κ_sat_unfrozen = 0.57,
+        κ_sat_frozen = 2.29,
+        a = 0.24,
+        b = 18.1,
+    )
+
+    heat_surface_state = (aux, t) -> eltype(aux)(0.0)
+
+    tau = FT(1) # period (sec)
+    A = FT(5) # ampltitude (T)
+    ω = FT(2 * pi / tau)
+    heat_bottom_state = (aux, t) -> A * cos(ω * t)
+    T_init = (aux) -> eltype(aux)(0.0)
+
+    soil_water_model = PrescribedWaterModel(
+        (aux, t) -> eltype(aux)(0.0),
+        (aux, t) -> eltype(aux)(0.0),
+    )
+
+    soil_heat_model = SoilHeatModel(
+        FT;
+        initialT = T_init,
+        dirichlet_bc = Dirichlet(
+            surface_state = heat_surface_state,
+            bottom_state = heat_bottom_state,
+        ),
+        neumann_bc = Neumann(surface_flux = nothing, bottom_flux = nothing),
+    )
+
+    m_soil = SoilModel(soil_param_functions, soil_water_model, soil_heat_model)
+    sources = ()
+    m = LandModel(
+        param_set,
+        m_soil;
+        source = sources,
+        init_state_prognostic = init_soil!,
+    )
+
+    N_poly = 5
+    nelem_vert = 10
+
+    # Specify the domain boundaries
+    zmax = FT(1)
+    zmin = FT(0)
+
+    driver_config = ClimateMachine.SingleStackConfiguration(
+        "LandModel",
+        N_poly,
+        nelem_vert,
+        zmax,
+        param_set,
+        m;
+        zmin = zmin,
+        numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
+    )
+
+    t0 = FT(0)
+    timeend = FT(5)
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config;
+        Courant_number = FT(0.7),
+        CFL_direction = VerticalDirection(),
+    )
+    mygrid = solver_config.dg.grid
+    aux = solver_config.dg.state_auxiliary
+
+    ClimateMachine.invoke!(solver_config)
+    t = ODESolvers.gettime(solver_config.solver)
+
+    z_ind = varsindex(vars_state(m, Auxiliary(), FT), :z)
+    z = Array(aux[:, z_ind, :][:])
+
+    T_ind = varsindex(vars_state(m, Auxiliary(), FT), :soil, :heat, :T)
+    T = Array(aux[:, T_ind, :][:])
+
+    num =
+        exp.(sqrt(ω / 2) * (1 + im) * (1 .- z)) .-
+        exp.(-sqrt(ω / 2) * (1 + im) * (1 .- z))
+    denom = exp(sqrt(ω / 2) * (1 + im)) - exp.(-sqrt(ω / 2) * (1 + im))
+    analytic_soln = real(num .* A * exp(im * ω * timeend) / denom)
+    MSE = mean((analytic_soln .- T) .^ 2.0)
+    @test eltype(aux) == FT
+    @test MSE < 1e-5
+end

--- a/test/Land/Model/prescribed_twice.jl
+++ b/test/Land/Model/prescribed_twice.jl
@@ -4,6 +4,7 @@
 using MPI
 using OrderedCollections
 using StaticArrays
+using Test
 
 using CLIMAParameters
 struct EarthParameterSet <: AbstractEarthParameterSet end
@@ -31,9 +32,8 @@ using ClimateMachine.BalanceLaws:
 
     function init_soil_water!(land, state, aux, coordinates, time) end
 
-    #Eventually, these can be called in the same way.
     soil_water_model = PrescribedWaterModel()
-    soil_heat_model = PrescribedTemperatureModel{FT}()
+    soil_heat_model = PrescribedTemperatureModel()
     soil_param_functions = nothing
     m_soil = SoilModel(soil_param_functions, soil_water_model, soil_heat_model)
     sources = ()

--- a/test/Land/Model/runtests.jl
+++ b/test/Land/Model/runtests.jl
@@ -1,7 +1,6 @@
 using Test, Pkg
 @testset "Land" begin
+    include("test_heat_parameterizations.jl")
     include("test_water_parameterizations.jl")
-    #    include("haverkamp_test.jl")
-    #    include("test_bc.jl")
     include("prescribed_twice.jl")
 end

--- a/test/Land/Model/test_bc.jl
+++ b/test/Land/Model/test_bc.jl
@@ -33,7 +33,7 @@ using ClimateMachine.BalanceLaws:
     function init_soil_water!(land, state, aux, coordinates, time)
         myfloat = eltype(state)
         state.soil.water.ϑ_l = myfloat(land.soil.water.initialϑ_l(aux))
-        state.soil.water.θ_ice = myfloat(land.soil.water.initialθ_ice(aux))
+        state.soil.water.θ_i = myfloat(land.soil.water.initialθ_i(aux))
     end
 
     soil_param_functions =
@@ -59,8 +59,7 @@ using ClimateMachine.BalanceLaws:
             bottom_flux = bottom_flux,
         ),
     )
-
-    soil_heat_model = PrescribedTemperatureModel{FT}()
+    soil_heat_model = PrescribedTemperatureModel()
 
     m_soil = SoilModel(soil_param_functions, soil_water_model, soil_heat_model)
     sources = ()

--- a/test/Land/Model/test_heat_parameterizations.jl
+++ b/test/Land/Model/test_heat_parameterizations.jl
@@ -1,0 +1,72 @@
+using MPI
+using OrderedCollections
+using StaticArrays
+using Test
+
+using CLIMAParameters
+using CLIMAParameters.Planet: ρ_cloud_liq, ρ_cloud_ice, cp_l, cp_i, T_0, LH_f0
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using ClimateMachine
+using ClimateMachine.Land.SoilHeatParameterizations
+using ClimateMachine.Land
+
+@testset "Land heat parameterizations" begin
+    FT = Float64
+    # Density of liquid water (kg/m``^3``)
+    _ρ_l = FT(ρ_cloud_liq(param_set))
+    # Density of ice water (kg/m``^3``)
+    _ρ_i = FT(ρ_cloud_ice(param_set))
+    # Volum. isobaric heat capacity liquid water (J/m3/K)
+    _ρcp_l = FT(cp_l(param_set) * _ρ_l)
+    # Volumetric isobaric heat capacity ice (J/m3/K)
+    _ρcp_i = FT(cp_i(param_set) * _ρ_i)
+    # Reference temperature (K)
+    _T_ref = FT(T_0(param_set))
+    # Latent heat of fusion at ``T_0`` (J/kg)
+    _LH_f0 = FT(LH_f0(param_set))
+
+    @test temperature_from_ρe_int(5.4e7, 0.05, 2.1415e6, param_set) ==
+          FT(_T_ref + (5.4e7 + 0.05 * _ρ_i * _LH_f0) / 2.1415e6)
+
+    @test volumetric_heat_capacity(0.25, 0.05, 1e6, param_set) ==
+          FT(1e6 + 0.25 * _ρcp_l + 0.05 * _ρcp_i)
+
+    @test volumetric_internal_energy(0.05, 2.1415e6, 300.0, param_set) ==
+          FT(2.1415e6 * (300.0 - _T_ref) - 0.05 * _ρ_i * _LH_f0)
+
+    @test saturated_thermal_conductivity(0.25, 0.05, 0.57, 2.29) ==
+          FT(0.57^(0.25 / (0.05 + 0.25)) * 2.29^(0.05 / (0.05 + 0.25)))
+
+    @test saturated_thermal_conductivity(0.0, 0.0, 0.57, 2.29) == FT(0.0)
+
+    @test relative_saturation(0.25, 0.05, 0.4) == FT((0.25 + 0.05) / 0.4)
+
+    # Test branching in kersten_number
+    soil_param_functions = SoilParamFunctions{FT}(
+        ν_gravel = 0.1,
+        ν_om = 0.1,
+        ν_sand = 0.1,
+        a = 0.24,
+        b = 18.1,
+    )
+    # ice fraction = 0
+    @test kersten_number(0.0, 0.75, soil_param_functions) == FT(
+        0.75^((FT(1) + 0.1 - 0.24 * 0.1 - 0.1) / FT(2)) *
+        (
+            (FT(1) + exp(-18.1 * 0.75))^(-FT(3)) -
+            ((FT(1) - 0.75) / FT(2))^FT(3)
+        )^(FT(1) - 0.1),
+    )
+
+    # ice fraction ~= 0
+    @test kersten_number(0.05, 0.75, soil_param_functions) ==
+          FT(0.75^(FT(1) + 0.1))
+
+    @test thermal_conductivity(1.5, 0.7287, 0.7187) ==
+          FT(0.7287 * 0.7187 + (FT(1) - 0.7287) * 1.5)
+
+    @test volumetric_internal_energy_liq(300.0, param_set) ==
+          FT(_ρcp_l * (300.0 - _T_ref))
+end

--- a/tutorials/Land/Soil/Water/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Water/equilibrium_test.jl
@@ -1,15 +1,6 @@
-# # Hydrostatic Equilibirum test for Richard's Equation
-
-# This tutorial shows how to use ClimateMachine code to solve
-# Richard's equation in a column of soil. We choose boundary
-# conditions of zero flux at the top and bottom of the column,
-# and then run the simulation long enough to see that the system
-# is approach hydrostatic equilibrium, where the gradient of the
-# pressure head is equal and opposite the gradient of the
-# gravitational head.
-
+# # Hydrostatic Equilibrium test for Richard's Equation
 # Note that freezing and thawing are turned off in this example. That
-# means that `θ_ice`, initialized to zero by default, will remain zero.
+# means that `θ_i`, initialized to zero by default, will remain zero.
 
 # # Preliminary setup
 
@@ -45,7 +36,7 @@ using ClimateMachine.BalanceLaws:
 
 
 # - define the float type desired (`Float64` or `Float32`)
-FT = Float64;
+const FT = Float64;
 
 # - initialize ClimateMachine for CPU
 ClimateMachine.init(; disable_gpu = true);
@@ -53,16 +44,16 @@ ClimateMachine.init(; disable_gpu = true);
 
 # # Set up the soil model
 
-# We want to solveRichard's equation alone, i.e. do not solve
+# We want to solve Richard's equation alone, i.e. do not solve
 # the heat equation. The default is a constant temperature, but this
 # only affects Richard's equation if one chooses a temperature dependent
 # viscosity of water (see below).
 
-soil_heat_model = PrescribedTemperatureModel{FT}()
+soil_heat_model = PrescribedTemperatureModel()
 
 # Define the porosity, Ksat, and specific storage values for the soil. Note
 # that all values must be givne in mks.
-soil_param_functions = SoilParamFunctions(
+soil_param_functions = SoilParamFunctions{FT}(
     porosity = 0.495,
     Ksat = 0.0443 / (3600 * 100),
     S_s = 1e-3,
@@ -74,13 +65,13 @@ soil_param_functions = SoilParamFunctions(
 # scalars, inside the code they are multiplied by ẑ. The two conditions
 # not supplied must be set to `nothing`.
 
-surface_flux = (aux, t) -> FT(0.0)
-bottom_flux = (aux, t) -> FT(0.0)
+surface_flux = (aux, t) -> eltype(aux)(0.0)
+bottom_flux = (aux, t) -> eltype(aux)(0.0)
 surface_state = nothing
 bottom_state = nothing
 
 # Define the initial state function.
-ϑ_l0 = (aux) -> FT(0.494)
+ϑ_l0 = (aux) -> eltype(aux)(0.494)
 
 # Create the SoilWaterModel. The defaults are a temperature independent
 # viscosity, and no impedance factor due to ice. We choose to make the
@@ -116,9 +107,8 @@ sources = ()
 function init_soil_water!(land, state, aux, coordinates, time)
     FT = eltype(state)
     state.soil.water.ϑ_l = FT(land.soil.water.initialϑ_l(aux))
-    state.soil.water.θ_ice = FT(land.soil.water.initialθ_ice(aux))
-end;
-
+    state.soil.water.θ_i = FT(land.soil.water.initialθ_i(aux))
+end
 
 
 # Create the land model - in this tutorial, it only includes the soil.
@@ -290,4 +280,4 @@ plot!(
     label = "porosity",
 )
 # save the output.
-savefig("./equilibrium_test_ϑ_l_vG.png")
+savefig("equilibrium_test_ϑ_l_vG.png")


### PR DESCRIPTION
# Description

This PR builds on PR 1342 which added the balance law components and boundary condition interface for the soil water model. 

PR 1442 adds the SoilHeatModel to soil_heat.jl, and the functions needed for the balance law for heat conduction and diffusion in the soil (SoilHeatParameterizations.jl). It adds an internal test (test_heat_parameterizations.jl) to test these functions, and a unit test (heat_analytic_unit_test) to verify the analytic solution to the heat equation in dry soil with dirichlet boundary conditions matches CLiMA's numerical solution, using a PrescribedWaterModel, with no ice and no liquid water. No water implies K and C are constant. We also changed the names of certain state variables and parameters to be consistent with variables used across CliMA, and to follow the Design Doc (internal energy I is now ρe_int_, θ_ice is now θ_i , etc.). We also changed the way CliMA Parameters are accessed for consistency / ease of use.

Testing the SoilHeatModel and SoilWaterModel together (no prescribed model) will come in a following pr. 

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
