### PR TITLE
add q_ice to Aux in EquilMoist

### DIFF
--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -138,7 +138,7 @@ vars_state(::EquilMoist, ::Prognostic, FT) = @vars(ρq_tot::FT)
 vars_state(::EquilMoist, ::Gradient, FT) = @vars(q_tot::FT)
 vars_state(::EquilMoist, ::GradientFlux, FT) = @vars(∇q_tot::SVector{3, FT})
 vars_state(::EquilMoist, ::Auxiliary, FT) =
-    @vars(temperature::FT, θ_v::FT, q_liq::FT)
+    @vars(temperature::FT, θ_v::FT, q_liq::FT, q_ice::FT)
 
 @inline function atmos_nodal_update_auxiliary_state!(
     moist::EquilMoist,
@@ -160,6 +160,7 @@ vars_state(::EquilMoist, ::Auxiliary, FT) =
     aux.moisture.temperature = air_temperature(ts)
     aux.moisture.θ_v = virtual_pottemp(ts)
     aux.moisture.q_liq = PhasePartition(ts).liq
+    aux.moisture.q_ice = PhasePartition(ts).ice
     nothing
 end
 


### PR DESCRIPTION
# Description

@LenkaNovak - This PR adds `q_ice` to the auxiliary state in the `EquilMoist` model. (The `q_liq` was already there). 

I think at least for now for debugging, it would be good to dump and output both. 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
