### PR TITLE
User facing changes for divergence damping

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -91,6 +91,7 @@ Users may over-ride prescribed default values for each field.
         ref_state,
         turbulence,
         hyperdiffusion,
+        divergencedamping,
         moisture,
         radiation,
         source,
@@ -259,6 +260,7 @@ function vars_state(m::AtmosModel, st::Gradient, FT)
         turbulence::vars_state(m.turbulence, st, FT)
         turbconv::vars_state(m.turbconv, st, FT)
         hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
+        divergencedamping::vars_state(m.divergencedamping, st, FT)
         moisture::vars_state(m.moisture, st, FT)
         tracers::vars_state(m.tracers, st, FT)
     end
@@ -273,6 +275,7 @@ function vars_state(m::AtmosModel, st::GradientFlux, FT)
         turbulence::vars_state(m.turbulence, st, FT)
         turbconv::vars_state(m.turbconv, st, FT)
         hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
+        divergencedamping::vars_state(m.divergencedamping, st, FT)
         moisture::vars_state(m.moisture, st, FT)
         tracers::vars_state(m.tracers, st, FT)
     end
@@ -315,6 +318,7 @@ function vars_state(m::AtmosModel, st::Auxiliary, FT)
         turbulence::vars_state(m.turbulence, st, FT)
         turbconv::vars_state(m.turbconv, st, FT)
         hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
+        divergencedamping::vars_state(m.divergencedamping, st, FT)
         moisture::vars_state(m.moisture, st, FT)
         tracers::vars_state(m.tracers, st, FT)
         radiation::vars_state(m.radiation, st, FT)
@@ -436,6 +440,7 @@ function compute_gradient_argument!(
     )
     compute_gradient_argument!(atmos.tracers, transform, state, aux, t)
     compute_gradient_argument!(atmos.turbconv, atmos, transform, state, aux, t)
+    compute_gradient_argument!(atmos.divergencedamping, atmos, transform, state, aux, t)
 end
 
 function compute_gradient_flux!(
@@ -461,6 +466,7 @@ function compute_gradient_flux!(
     # diffusivity of moisture components
     compute_gradient_flux!(atmos.moisture, diffusive, ∇transform, state, aux, t)
     compute_gradient_flux!(atmos.tracers, diffusive, ∇transform, state, aux, t)
+    compute_gradient_flux!(atmos.divergencedamping, diffusive, ∇transform, state, aux, t)
     compute_gradient_flux!(
         atmos.turbconv,
         atmos,

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -75,7 +75,7 @@ export TurbulenceClosureModel,
     EquilMoistBiharmonic,
     DivergenceDampingModel, 
     NoDivergenceDamping, 
-    HorizontalDivergenceDamping,
+    ConstantCoeffDivergenceDamping,
     turbulence_tensors,
     init_aux_turbulence!,
     init_aux_hyperdiffusion!,
@@ -1017,7 +1017,7 @@ vars_state(::NoDivergenceDamping, ::Gradient, FT) = @vars()
 vars_state(::NoDivergenceDamping, ::GradientFlux, FT) = @vars()
 
 """
-    HorizontalDivergenceDamping{FT} <: DivergenceDampingModel
+    ConstantCoeffDivergenceDamping{FT} <: DivergenceDampingModel
 
 Computes fluxes for horizontal divergence damping term, 
 # Fields
@@ -1025,18 +1025,18 @@ Computes fluxes for horizontal divergence damping term,
 $(DocStringExtensions.FIELDS)
 
 """
-struct HorizontalDivergenceDamping{FT} <: DivergenceDampingModel
+struct ConstantCoeffDivergenceDamping{FT} <: DivergenceDampingModel
     "Horizontal Divergence Damping Coefficient"
     νd_h::FT
     "Vertical Divergence Damping Coefficient"
     νd_v::FT
 end
-vars_state(::HorizontalDivergenceDamping, ::Auxiliary, FT) = @vars()
-vars_state(::HorizontalDivergenceDamping, ::Gradient, FT) = @vars(ρu::SVector{3,FT})
-vars_state(::HorizontalDivergenceDamping, ::GradientFlux, FT) = @vars(∇ρu::SMatrix{3,3,FT,9})
+vars_state(::ConstantCoeffDivergenceDamping, ::Auxiliary, FT) = @vars()
+vars_state(::ConstantCoeffDivergenceDamping, ::Gradient, FT) = @vars(ρu::SVector{3,FT})
+vars_state(::ConstantCoeffDivergenceDamping, ::GradientFlux, FT) = @vars(∇ρu::SMatrix{3,3,FT,9})
 
 function init_aux_divdamping!(
-    ::HorizontalDivergenceDamping,
+    ::ConstantCoeffDivergenceDamping,
     ::BalanceLaw,
     aux::Vars,
     geom::LocalGeometry,
@@ -1044,7 +1044,7 @@ function init_aux_divdamping!(
     nothing
 end
 function compute_gradient_argument!(
-    m::HorizontalDivergenceDamping,
+    m::ConstantCoeffDivergenceDamping,
     bl::BalanceLaw,
     transform::Vars,
     state::Vars,
@@ -1055,7 +1055,7 @@ function compute_gradient_argument!(
 end
 
 function compute_gradient_flux!(
-    m::HorizontalDivergenceDamping,
+    m::ConstantCoeffDivergenceDamping,
     diffusive::Vars,
     ∇transform::Grad,
     state::Vars,
@@ -1066,7 +1066,7 @@ function compute_gradient_flux!(
 end
 
 function flux_second_order!(
-    m::HorizontalDivergenceDamping,
+    m::ConstantCoeffDivergenceDamping,
     bl::BalanceLaw,
     flux::Grad,
     state::Vars,

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -231,7 +231,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
         AtmosLESConfigType,                            # Flow in a box, requires the AtmosLESConfigType
         param_set;                                     # Parameter set corresponding to earth parameters
         turbulence = SmagorinskyLilly(_C_smag),        # Turbulence closure model
-        divergencedamping = HorizontalDivergenceDamping(FT(90),FT(0)),
+        divergencedamping = ConstantCoeffDivergenceDamping(FT(90),FT(0)),
         moisture = DryModel(),                         # Exclude moisture variables
         source = (Gravity(),),                         # Gravity is the only source term here
         tracers = NTracers{ntracers, FT}(δ_χ),         # Tracer model with diffusivity coefficients

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -67,7 +67,7 @@
 # specific to atmospheric and ocean flow modeling.
 
 using ClimateMachine
-ClimateMachine.init()
+ClimateMachine.init(parse_clargs=true)
 using ClimateMachine.Atmos
 using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
@@ -231,6 +231,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
         AtmosLESConfigType,                            # Flow in a box, requires the AtmosLESConfigType
         param_set;                                     # Parameter set corresponding to earth parameters
         turbulence = SmagorinskyLilly(_C_smag),        # Turbulence closure model
+        divergencedamping = HorizontalDivergenceDamping(FT(90),FT(0)),
         moisture = DryModel(),                         # Exclude moisture variables
         source = (Gravity(),),                         # Gravity is the only source term here
         tracers = NTracers{ntracers, FT}(δ_χ),         # Tracer model with diffusivity coefficients


### PR DESCRIPTION
# Description

Adds `AtmosModel` property for divergence damping methods. 
Introduces `NoDivergenceDamping` and `ConstantCoeffDivergenceDamping`
Currently the relevant functions are placed in `TurbulenceClosures.jl`. 

The functions are tested in the single-stack burgers equation tutorial. 
Adds method to risingbubble tutorial.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
