### PR TITLE
Fix/improve single stack utils and plothelpers

### DIFF
--- a/docs/plothelpers.jl
+++ b/docs/plothelpers.jl
@@ -1,3 +1,5 @@
+using Plots
+using ClimateMachine.BalanceLaws: Prognostic, Auxiliary, GradientFlux
 
 """
     plot_friendly_name(ϕ)
@@ -100,6 +102,9 @@ function save_binned_surface_plots(
     savefig(filename)
 end;
 
+state_prefix(::Prognostic) = "prog_"
+state_prefix(::Auxiliary) = "aux_"
+state_prefix(::GradientFlux) = "grad_flux_"
 
 """
     plot_results(solver_config, all_data, time_data, output_dir)
@@ -110,36 +115,30 @@ Exports plots of states given
  - `time_data` an array of time values
  - `output_dir` output directory
 """
-function export_state_plots(solver_config, all_data, time_data, output_dir)
+function export_state_plots(
+    solver_config,
+    all_data,
+    time_data,
+    output_dir;
+    state_types = (Prognostic(), Auxiliary()),
+)
     FT = eltype(solver_config.Q)
     z = get_z(solver_config.dg.grid)
     mkpath(output_dir)
-    vs = vars_state(solver_config.dg.balance_law, Prognostic(), FT)
-    for fn in flattenednames(vs)
-        file_name = "prog_" * replace(fn, "." => "_")
-        export_plot(
-            z,
-            all_data,
-            (fn,),
-            joinpath(output_dir, "$(file_name).png");
-            xlabel = fn,
-            ylabel = "z [m]",
-            time_data = time_data,
-            round_digits = 5,
-        )
-    end
-    vs = vars_state(solver_config.dg.balance_law, Auxiliary(), FT)
-    for fn in flattenednames(vs)
-        file_name = "aux_" * replace(fn, "." => "_")
-        export_plot(
-            z,
-            all_data,
-            (fn,),
-            joinpath(output_dir, "$(file_name).png");
-            xlabel = fn,
-            ylabel = "z [m]",
-            time_data = time_data,
-            round_digits = 5,
-        )
+    for st in state_types
+        vs = vars_state(solver_config.dg.balance_law, st, FT)
+        for fn in flattenednames(vs)
+            file_name = state_prefix(st) * replace(fn, "." => "_")
+            export_plot(
+                z,
+                all_data,
+                (fn,),
+                joinpath(output_dir, "$(file_name).png");
+                xlabel = fn,
+                ylabel = "z [m]",
+                time_data = time_data,
+                round_digits = 5,
+            )
+        end
     end
 end


### PR DESCRIPTION
# Description

Fixes bug in `dict_of_nodal_states` (`aux_excludes = [],` -> `aux_excludes = String[],`), and generalizes to plotting prognostic, auxiliary, and gradient flux states. This PR is peeling off pieces from #1434 and #1308.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
