### PR TITLE
Fix `fill!` return on an MPIStateArrays

### DIFF
--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -154,7 +154,10 @@ mutable struct MPIStateArray{
     end
 end
 
-Base.fill!(Q::MPIStateArray, x) = fill!(Q.data, x)
+function Base.fill!(Q::MPIStateArray, x)
+    fill!(Q.data, x)
+    return Q
+end
 
 vars(Q::MPIStateArray{FT, V}) where {FT, V} = V
 function Base.getproperty(Q::MPIStateArray{FT, V}, sym::Symbol) where {FT, V}


### PR DESCRIPTION
Previously the underlying data array was returned for `fill!` with an
`MPIStateArray`, so that calls like
```julia
   B = fill!(A, 0)
```
would return result in `B === A.data` not `B === A` as is standard for
other array types in Julia.