### PR TITLE
Change construction of bulk surface fluxes

### DIFF
--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -432,8 +432,7 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax, surface_flux)
     elseif surface_flux == "bulk"
         energy = BulkFormulaEnergy(
             (state, aux, t, normPu_int) -> C_drag,
-            (state, aux, t) -> T_sfc,
-            (state, aux, t) -> q_sfc,
+            (state, aux, t) -> (T_sfc, q_sfc),
         )
         moisture = BulkFormulaMoisture(
             (state, aux, t, normPu_int) -> C_drag,

--- a/src/Atmos/Model/bc_energy.jl
+++ b/src/Atmos/Model/bc_energy.jl
@@ -118,17 +118,16 @@ end
 """
     BulkFormulaEnergy(fn) :: EnergyBC
 
-Calculate the net inward energy flux across the boundary.
-The drag coefficient is `C_h = fn_C_h(state, aux, t, normu_int_tan)`.
-temperature at the boundary is `T= fn_T(state, aux, t)`.
-q_tot at the boundary is `q_tot = fn_q_tot(state, aux, t)`.
-`_int` refers to the first interior node.
+Calculate the net inward energy flux across the boundary. The drag
+coefficient is `C_h = fn_C_h(state, aux, t, normu_int_tan)`. Temperature
+and moisture at the boundary are `T, q_tot = fn_T_and_q_tot(state,
+aux, t)`. `_int` refers to the first interior node.
+
 Return the flux (in W m^-2).
 """
-struct BulkFormulaEnergy{FNX, FNT, FNM} <: EnergyBC
+struct BulkFormulaEnergy{FNX, FNTM} <: EnergyBC
     fn_C_h::FNX
-    fn_T::FNT
-    fn_q_tot::FNM
+    fn_T_and_q_tot::FNTM
 end
 function atmos_energy_boundary_state!(
     nf,
@@ -161,8 +160,7 @@ function atmos_energy_normal_boundary_flux_second_order!(
     u_int⁻_tan = projection_tangential(atmos, aux_int⁻, u_int⁻)
     normu_int⁻_tan = norm(u_int⁻_tan)
     C_h = bc_energy.fn_C_h(state⁻, aux⁻, t, normu_int⁻_tan)
-    T = bc_energy.fn_T(state⁻, aux⁻, t)
-    q_tot = bc_energy.fn_q_tot(state⁻, aux⁻, t)
+    T, q_tot = bc_energy.fn_T_and_q_tot(state⁻, aux⁻, t)
 
     # calculate MSE from the states at the boundary and at the interior point
     ts = TemperatureSHumEquil(atmos.param_set, T, state⁻.ρ, q_tot)

--- a/src/Atmos/Model/bc_moisture.jl
+++ b/src/Atmos/Model/bc_moisture.jl
@@ -64,11 +64,11 @@ end
 """
     BulkFormulaMoisture(fn) :: MoistureBC
 
-Calculate the net inward moisture flux across the boundary using
-the bulk formula.
-The drag coefficient is `C_q = fn_C_q(state, aux, t, normu_int_tan)`.
-q_tot at the boundary is `q_tot = fn_q_tot(state, aux, t)`.
-`_int` refers to the first interior node.
+Calculate the net inward moisture flux across the boundary using the
+bulk formula. The drag coefficient is `C_q = fn_C_q(state, aux, t,
+normu_int_tan)`. q_tot at the boundary is `q_tot = fn_q_tot(state,
+aux, t)`. `_int` refers to the first interior node.
+
 Return the flux (in kg m^-2 s^-1).
 """
 struct BulkFormulaMoisture{FNX, FNM} <: MoistureBC
@@ -108,6 +108,7 @@ function atmos_moisture_normal_boundary_flux_second_order!(
     C_q = bc_moisture.fn_C_q(state⁻, aux⁻, t, normu_int⁻_tan)
     q_tot = bc_moisture.fn_q_tot(state⁻, aux⁻, t)
     q_tot_int = state_int⁻.moisture.ρq_tot / state_int⁻.ρ
+
     # TODO: use the correct density at the surface
     ρ_avg = average_density(state⁻.ρ, state_int⁻.ρ)
     # NOTE: difference from design docs since normal points outwards


### PR DESCRIPTION
# Description

Merge temperature and moisture computation functions for energy in bulk surface fluxes. Simplifies #1447.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
