### PR TITLE
Patch experiment: Taylor-Green Vortex

### DIFF
--- a/experiments/AtmosLES/taylor_green.jl
+++ b/experiments/AtmosLES/taylor_green.jl
@@ -130,6 +130,7 @@ function config_greenvortex(
         AtmosLESConfigType,                 # Flow in a box, requires the AtmosLESConfigType
         param_set;                          # Parameter set corresponding to earth parameters
         init_state_prognostic = init_greenvortex!,             # Apply the initial condition
+        ref_state = NoReferenceState(),
         orientation = NoOrientation(),
         turbulence = Vreman(_C_smag),       # Turbulence closure model
         moisture = DryModel(),


### PR DESCRIPTION
# Description

This experiment was breaking after updates to the ref-state design, this PR patches this issue by explicitly specifying the reference state when orientation = `NoOrientation()`. 

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
