### PR TITLE
Remove implicit broadcast for `Grad`

### DIFF
--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -281,7 +281,7 @@ end
 @generated function Base.setproperty!(
     v::Grad{S, A, offset},
     sym::Symbol,
-    val,
+    val::AbstractArray,
 ) where {S, A, offset}
     if A <: SubArray
         M = size(fieldtype(A, 1), 1)
@@ -295,11 +295,11 @@ end
     for k in fieldnames(S)
         T = fieldtype(S, k)
         if T <: Real
-            retexpr = :(array[:, $(offset + 1)] .= val)
+            retexpr = :(array[:, $(offset + 1)] = val)
             offset += 1
         elseif T <: StaticArray
             N = length(T)
-            retexpr = :(array[:, ($(offset + 1)):($(offset + N))] .= val)
+            retexpr = :(array[:, ($(offset + 1)):($(offset + N))] = val)
             offset += N
         else
             offset += varsize(T)


### PR DESCRIPTION
We want to disallow the following:
```julia
using StaticArrays
using ClimateMachine.VariableTemplates

function vs(FT)
  @vars begin
    a::FT
  end
end

FT = Float64
arr = fill!(MArray{Tuple{3, 1}, FT}(undef), 0)
g = Grad{vs(FT)}(arr)

g.a = 4           # changes arr to [4 4 4]
g.a = [5]         # changes arr to [5 5 5]
```

This is not a perfect solution though, because it will result in the sort of unclear error:
```julia
julia> g.a = 4
ERROR: type Grad has no field a
Stacktrace:
 [1] setproperty!(::Grad{NamedTuple{(:a,),Tuple{Float64}},MArray{Tuple{3,1},Float64,2,3},0}, ::Symbol, ::Int64) at ./Base.jl:34
 [2] top-level scope at REPL[7]:1
```

close #1457 