### PR TITLE
Make `init_state_auxiliary!` direction aware

### DIFF
--- a/docs/src/APIs/Numerics/DGMethods/DGMethods.md
+++ b/docs/src/APIs/Numerics/DGMethods/DGMethods.md
@@ -7,7 +7,7 @@ CurrentModule = ClimateMachine.DGMethods
 ```@docs
 DGModel
 remainder_DGModel
-contiguous_field_gradient!
+continuous_field_gradient!
 courant
 ```
 

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -671,8 +671,9 @@ function init_state_auxiliary!(
     m::AtmosModel,
     state_auxiliary::MPIStateArray,
     grid,
+    direction,
 )
-    init_aux!(m, m.orientation, state_auxiliary, grid)
+    init_aux!(m, m.orientation, state_auxiliary, grid, direction)
 
     init_state_auxiliary!(
         m,
@@ -680,6 +681,7 @@ function init_state_auxiliary!(
             atmos_init_ref_state_pressure!(m.ref_state, m, aux, geom),
         state_auxiliary,
         grid,
+        direction,
     )
 
     ∇p = ∇reference_pressure(m.ref_state, state_auxiliary, grid)
@@ -689,6 +691,7 @@ function init_state_auxiliary!(
         atmos_nodal_init_state_auxiliary!,
         state_auxiliary,
         grid,
+        direction;
         state_temporary = ∇p,
     )
 end

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -152,7 +152,12 @@ function boundary_state!(
 )
     nothing
 end
-init_state_auxiliary!(lm::AtmosLinearModel, aux::MPIStateArray, grid) = nothing
+init_state_auxiliary!(
+    lm::AtmosLinearModel,
+    aux::MPIStateArray,
+    grid,
+    direction,
+) = nothing
 init_state_prognostic!(
     lm::AtmosLinearModel,
     state::Vars,

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -132,6 +132,7 @@ function init_state_auxiliary!(
     m::PressureGradientModel,
     state_auxiliary::MPIStateArray,
     grid,
+    direction,
 ) end
 function init_state_prognostic!(
     ::PressureGradientModel,

--- a/src/Common/Orientations/Orientations.jl
+++ b/src/Common/Orientations/Orientations.jl
@@ -30,7 +30,7 @@ using ..BalanceLaws
 using ..MPIStateArrays: MPIStateArray
 import ..BalanceLaws: vars_state
 using ..DGMethods:
-    init_state_auxiliary!, contiguous_field_gradient!, LocalGeometry
+    init_state_auxiliary!, continuous_field_gradient!, LocalGeometry
 
 export Orientation, NoOrientation, FlatOrientation, SphericalOrientation
 
@@ -98,22 +98,30 @@ function projection_tangential(
     return u⃗ .- projection_normal(orientation, param_set, aux, u⃗)
 end
 
-function init_aux!(m, ::Orientation, state_auxiliary::MPIStateArray, grid)
+function init_aux!(
+    m,
+    ::Orientation,
+    state_auxiliary::MPIStateArray,
+    grid,
+    direction,
+)
     init_state_auxiliary!(
         m,
         (m, aux, tmp, geom) ->
             orientation_nodal_init_aux!(m.orientation, m.param_set, aux, geom),
         state_auxiliary,
         grid,
+        direction,
     )
 
-    contiguous_field_gradient!(
+    continuous_field_gradient!(
         m,
         state_auxiliary,
         ("orientation.∇Φ",),
         state_auxiliary,
         ("orientation.Φ",),
         grid,
+        direction,
     )
 end
 
@@ -128,7 +136,8 @@ No gravitational force or potential.
 """
 struct NoOrientation <: Orientation end
 
-init_aux!(m, ::NoOrientation, state_auxiliary::MPIStateArray, grid) = nothing
+init_aux!(m, ::NoOrientation, state_auxiliary::MPIStateArray, grid, direction) =
+    nothing
 
 vars_state(m::NoOrientation, ::Auxiliary, FT) = @vars()
 

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -53,7 +53,7 @@ export DGModel,
     restart_auxiliary_state,
     basic_grid_info,
     init_state_auxiliary!,
-    contiguous_field_gradient!,
+    continuous_field_gradient!,
     courant
 
 include("NumericalFluxes.jl")

--- a/src/Numerics/DGMethods/create_states.jl
+++ b/src/Numerics/DGMethods/create_states.jl
@@ -39,7 +39,7 @@ function create_state(
     return state
 end
 
-function init_state(state, balance_law, grid, ::Auxiliary)
-    init_state_auxiliary!(balance_law, state, grid)
+function init_state(state, balance_law, grid, direction, ::Auxiliary)
+    init_state_auxiliary!(balance_law, state, grid, direction)
     return state
 end

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -180,12 +180,18 @@ function ocean_init_aux! end
 sets the initial value for auxiliary variables (those that aren't related to vertical integrals)
 dispatches to ocean_init_aux! which is defined in a problem file such as SimpleBoxProblem.jl
 """
-function init_state_auxiliary!(m::HBModel, state_auxiliary::MPIStateArray, grid)
+function init_state_auxiliary!(
+    m::HBModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+    direction,
+)
     init_state_auxiliary!(
         m,
         (m, A, tmp, geom) -> ocean_init_aux!(m, m.problem, A, geom),
         state_auxiliary,
         grid,
+        direction,
     )
 end
 

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -42,8 +42,12 @@ vars_state(lm::LinearHBModel, ::UpwardIntegrals, FT) = @vars()
 """
     No need to init, initialize by full model
 """
-init_state_auxiliary!(lm::LinearHBModel, state_auxiliary::MPIStateArray, grid) =
-    nothing
+init_state_auxiliary!(
+    lm::LinearHBModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+    direction,
+) = nothing
 init_state_prognostic!(lm::LinearHBModel, Q::Vars, A::Vars, coords, t) = nothing
 
 """

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -110,12 +110,18 @@ function vars_state(m::SWModel, ::Auxiliary, T)
     end
 end
 
-function init_state_auxiliary!(m::SWModel, state_auxiliary::MPIStateArray, grid)
+function init_state_auxiliary!(
+    m::SWModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+    direction,
+)
     init_state_auxiliary!(
         m,
         (m, A, tmp, geom) -> ocean_init_aux!(m, m.problem, A, geom),
         state_auxiliary,
         grid,
+        direction,
     )
 end
 

--- a/src/Ocean/SplitExplicit/VerticalIntegralModel.jl
+++ b/src/Ocean/SplitExplicit/VerticalIntegralModel.jl
@@ -22,8 +22,12 @@ function vars_state(m::VerticalIntegralModel, ::Auxiliary, T)
     end
 end
 
-init_state_auxiliary!(tm::VerticalIntegralModel, A::MPIStateArray, grid) =
-    nothing
+init_state_auxiliary!(
+    tm::VerticalIntegralModel,
+    A::MPIStateArray,
+    grid,
+    direction,
+) = nothing
 
 function vars_state(m::VerticalIntegralModel, ::UpwardIntegrals, T)
     @vars begin

--- a/test/Numerics/DGMethods/grad_test.jl
+++ b/test/Numerics/DGMethods/grad_test.jl
@@ -13,7 +13,7 @@ import ClimateMachine.BalanceLaws: vars_state, nodal_init_state_auxiliary!
 
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 
-struct GradTestModel{dim} <: BalanceLaw end
+struct GradTestModel{dim, dir} <: BalanceLaw end
 
 vars_state(m::GradTestModel, ::Auxiliary, T) = @vars begin
     a::T
@@ -23,27 +23,40 @@ end
 vars_state(::GradTestModel, ::Prognostic, T) = @vars()
 
 function nodal_init_state_auxiliary!(
-    ::GradTestModel{dim},
+    ::GradTestModel{dim, dir},
     aux::Vars,
     tmp::Vars,
     g::LocalGeometry,
-) where {dim}
+) where {dim, dir}
     x, y, z = g.coord
     if dim == 2
         aux.a = x^2 + y^3 - x * y
-        aux.∇a_exact = SVector(2 * x - y, 3 * y^2 - x, 0)
+        if dir isa EveryDirection
+            aux.∇a_exact = SVector(2 * x - y, 3 * y^2 - x, 0)
+        elseif dir isa HorizontalDirection
+            aux.∇a_exact = SVector(2 * x - y, 0, 0)
+        elseif dir isa VerticalDirection
+            aux.∇a_exact = SVector(0, 3 * y^2 - x, 0)
+        end
     else
         aux.a = x^2 + y^3 + z^2 * y^2 - x * y * z
-        aux.∇a_exact = SVector(
-            2 * x - y * z,
-            3 * y^2 + 2 * z^2 * y - x * z,
-            2 * z * y^2 - x * y,
-        )
+        if dir isa EveryDirection
+            aux.∇a_exact = SVector(
+                2 * x - y * z,
+                3 * y^2 + 2 * z^2 * y - x * z,
+                2 * z * y^2 - x * y,
+            )
+        elseif dir isa HorizontalDirection
+            aux.∇a_exact =
+                SVector(2 * x - y * z, 3 * y^2 + 2 * z^2 * y - x * z, 0)
+        elseif dir isa VerticalDirection
+            aux.∇a_exact = SVector(0, 0, 2 * z * y^2 - x * y)
+        end
     end
 end
 
 using Test
-function run(mpicomm, dim, Ne, N, FT, ArrayType)
+function run(mpicomm, dim, direction, Ne, N, FT, ArrayType)
 
     brickrange = ntuple(j -> range(FT(0); length = Ne[j] + 1, stop = 3), dim)
     topl = StackedBrickTopology(
@@ -59,7 +72,7 @@ function run(mpicomm, dim, Ne, N, FT, ArrayType)
         polynomialorder = N,
     )
 
-    model = GradTestModel{dim}()
+    model = GradTestModel{dim, direction}()
     dg = DGModel(
         model,
         grid,
@@ -69,13 +82,14 @@ function run(mpicomm, dim, Ne, N, FT, ArrayType)
         state_gradient_flux = nothing,
     )
 
-    contiguous_field_gradient!(
+    continuous_field_gradient!(
         model,
         dg.state_auxiliary,
         (:∇a,),
         dg.state_auxiliary,
         (:a,),
         grid,
+        direction,
     )
 
     # Wrapping in Array ensure both GPU and CPU code use same approx
@@ -94,15 +108,22 @@ let
 
     @testset for FT in (Float64, Float32)
         @testset for dim in 2:3
-            for l in 1:lvls
-                run(
-                    mpicomm,
-                    dim,
-                    ntuple(j -> 2^(l - 1) * numelem[j], dim),
-                    polynomialorder,
-                    FT,
-                    ArrayType,
-                )
+            @testset for direction in (
+                EveryDirection(),
+                HorizontalDirection(),
+                VerticalDirection(),
+            )
+                for l in 1:lvls
+                    run(
+                        mpicomm,
+                        dim,
+                        direction,
+                        ntuple(j -> 2^(l - 1) * numelem[j], dim),
+                        polynomialorder,
+                        FT,
+                        ArrayType,
+                    )
+                end
             end
         end
     end

--- a/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
+++ b/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
@@ -126,13 +126,14 @@ function run_hydrostatic_spindown(
     )
 
     if restart > 0
+        direction = EveryDirection()
         Q_3D, A_3D, t0 =
             read_checkpoint(vtkpath, "baroclinic", ArrayType, mpicomm, restart)
         Q_2D, A_2D, _ =
             read_checkpoint(vtkpath, "barotropic", ArrayType, mpicomm, restart)
 
-        A_3D = restart_auxiliary_state(model_3D, grid_3D, A_3D)
-        A_2D = restart_auxiliary_state(model_2D, grid_2D, A_2D)
+        A_3D = restart_auxiliary_state(model_3D, grid_3D, A_3D, direction)
+        A_2D = restart_auxiliary_state(model_2D, grid_2D, A_2D, direction)
 
         dg_3D = DGModel(
             model_3D,

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -225,10 +225,17 @@ function init_state_auxiliary!(
     m::BurgersEquation,
     state_auxiliary::MPIStateArray,
     grid,
+    direction,
 )
-    init_aux!(m, m.orientation, state_auxiliary, grid)
+    init_aux!(m, m.orientation, state_auxiliary, grid, direction)
 
-    init_state_auxiliary!(m, nodal_init_state_auxiliary!, state_auxiliary, grid)
+    init_state_auxiliary!(
+        m,
+        nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+        direction,
+    )
 end;
 
 # Specify the initial values in `state::Vars`. Note that


### PR DESCRIPTION
# Description

One problem I ran into (and @jkozdon helped in tracking down), when working on the BOMEX single stack, was that `direction` currently does not propagate to `contiguous_field_gradient!`. As a result, the horizontal components of `orientation.∇Φ`, which should be zero for single stack configurations (and maybe LES configurations? @akshaysridhar), had precision errors which significantly impacted results at `Float32` precision. This PR makes `init_state_auxiliary!` and `contiguous_field_gradient!` direction-aware so that the horizontal components of `orientation.∇Φ` are exactly zero for single stack configurations.

In addition, this PR renames `contiguous_field_gradient!` to `continuous_field_gradient!` and fixes the implementation for when `direction = VerticalDirection()`.

## Before
![prog_ρu 1](https://user-images.githubusercontent.com/1880641/91064232-db6e5780-e5e3-11ea-9925-0db25f3bf4ec.png)

## After*
![prog_ρu 1](https://user-images.githubusercontent.com/1880641/91064255-e1643880-e5e3-11ea-872a-bbd837fa8e62.png)

 - *Note that differences near the surface are the result from a separate issue, which we'll resolve in a subsequent PR.

Co-authored with: @mwarusz 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
