### PR TITLE
Add BOMEX single stack experiment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -914,10 +914,30 @@ steps:
       slurm_ntasks: 3
       slurm_gres: "gpu:1"
 
-  - label: "gpu_bomex"
-    key: "gpu_bomex"
+  - label: "gpu_bomex_les"
+    key: "gpu_bomex_les"
     command:
-      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex.jl --diagnostics=default --fix-rng-seed"
+      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex_les.jl --diagnostics=default --fix-rng-seed"
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
+  - label: "gpu_bomex_single_stack"
+    key: "gpu_bomex_single_stack"
+    command:
+      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex_single_stack.jl --diagnostics=default --fix-rng-seed"
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
+  - label: "gpu_bomex_bulk_sfc_flux"
+    key: "gpu_bomex_bulk_sfc_flux"
+    command:
+      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex_les.jl --surface-flux=bulk --fix-rng-seed"
     agents:
       config: gpu
       queue: central
@@ -928,16 +948,6 @@ steps:
     key: "gpu_taylor_green"
     command:
       - "mpiexec julia --color=yes --project experiments/AtmosLES/taylor_green.jl --diagnostics=default --fix-rng-seed"
-    agents:
-      config: gpu
-      queue: central
-      slurm_ntasks: 1  
-      slurm_gres: "gpu:1"
-
-  - label: "gpu_bomex_bulk_sfc_flux"
-    key: "gpu_bomex_bulk_sfc_flux"
-    command:
-      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex.jl --surface-flux=bulk --fix-rng-seed"
     agents:
       config: gpu
       queue: central

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 ClimateMachine = "777c4786-024f-11e9-21a3-85d5d4106250"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/experiments/AtmosLES/bomex_les.jl
+++ b/experiments/AtmosLES/bomex_les.jl
@@ -1,0 +1,113 @@
+include("bomex_model.jl")
+
+function main()
+    # add a command line argument to specify the kind of surface flux
+    # TODO: this will move to the future namelist functionality
+    bomex_args = ArgParseSettings(autofix_names = true)
+    add_arg_group!(bomex_args, "BOMEX")
+    @add_arg_table! bomex_args begin
+        "--surface-flux"
+        help = "specify surface flux for energy and moisture"
+        metavar = "prescribed|bulk"
+        arg_type = String
+        default = "prescribed"
+    end
+
+    cl_args =
+        ClimateMachine.init(parse_clargs = true, custom_clargs = bomex_args)
+
+    surface_flux = cl_args["surface_flux"]
+
+    FT = Float32
+    config_type = AtmosLESConfigType
+
+    # DG polynomial order
+    N = 4
+    # Domain resolution and size
+    Δh = FT(100)
+    Δv = FT(40)
+
+    resolution = (Δh, Δh, Δv)
+
+    # Prescribe domain parameters
+    xmax = FT(6400)
+    ymax = FT(6400)
+    zmax = FT(3000)
+
+    t0 = FT(0)
+
+    # For a full-run, please set the timeend to 3600*6 seconds
+    # For the test we set this to == 30 minutes
+    timeend = FT(1800)
+    #timeend = FT(3600 * 6)
+    CFLmax = FT(0.90)
+
+    # Choose default IMEX solver
+    ode_solver_type = ClimateMachine.IMEXSolverType()
+
+    model = bomex_model(FT, config_type, zmax, surface_flux)
+    ics = model.problem.init_state_prognostic
+    # Assemble configuration
+    driver_config = ClimateMachine.AtmosLESConfiguration(
+        "BOMEX",
+        N,
+        resolution,
+        xmax,
+        ymax,
+        zmax,
+        param_set,
+        ics;
+        solver_type = ode_solver_type,
+        model = model,
+    )
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+    )
+    dgn_config = config_diagnostics(driver_config)
+
+    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            ("moisture.ρq_tot",),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
+        nothing
+    end
+
+    # State variable
+    Q = solver_config.Q
+    # Volume geometry information
+    vgeo = driver_config.grid.vgeo
+    M = vgeo[:, Grids._M, :]
+    # Unpack prognostic vars
+    ρ₀ = Q.ρ
+    ρe₀ = Q.ρe
+    # DG variable sums
+    Σρ₀ = sum(ρ₀ .* M)
+    Σρe₀ = sum(ρe₀ .* M)
+    cb_check_cons = GenericCallbacks.EveryXSimulationSteps(3000) do
+        Q = solver_config.Q
+        δρ = (sum(Q.ρ .* M) - Σρ₀) / Σρ₀
+        δρe = (sum(Q.ρe .* M) .- Σρe₀) ./ Σρe₀
+        @show (abs(δρ))
+        @show (abs(δρe))
+        @test (abs(δρ) <= 0.0001)
+        @test (abs(δρe) <= 0.0025)
+        nothing
+    end
+
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (cbtmarfilter, cb_check_cons),
+        check_euclidean_distance = true,
+    )
+end
+
+main()

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -70,16 +70,18 @@ using ClimateMachine.Mesh.Grids
 using ClimateMachine.ODESolvers
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TurbulenceClosures
+using ClimateMachine.TurbulenceConvection
 using ClimateMachine.VariableTemplates
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Auxiliary, Gradient, GradientFlux, Prognostic
 
 using CLIMAParameters
 using CLIMAParameters.Planet: e_int_v0, grav, day
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-import ClimateMachine.BalanceLaws: vars_state
-import ClimateMachine.Atmos: source!, atmos_source!, altitude
-import ClimateMachine.Atmos: flux_second_order!, thermo_state
+import ClimateMachine.Atmos: atmos_source!
+using ClimateMachine.Atmos: altitude, thermo_state
 
 """
   Bomex Geostrophic Forcing (Source)
@@ -361,9 +363,10 @@ function init_bomex!(problem, bl, state, aux, (x, y, z), t)
         state.ρe += rand() * ρe_tot / 100
         state.moisture.ρq_tot += rand() * ρ * q_tot / 100
     end
+    init_state_prognostic!(bl.turbconv, bl, state, aux, (x, y, z), t)
 end
 
-function config_bomex(FT, N, resolution, xmax, ymax, zmax, surface_flux)
+function bomex_model(::Type{FT}, config_type, zmax, surface_flux) where {FT}
 
     ics = init_bomex!     # Initial conditions
 
@@ -397,6 +400,7 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax, surface_flux)
 
     f_coriolis = FT(0.376e-4) # Coriolis parameter
 
+    turbconv = NoTurbConv()
     # Assemble source components
     source = (
         Gravity(),
@@ -420,10 +424,8 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax, surface_flux)
             v_geostrophic,
         ),
         BomexGeostrophic{FT}(f_coriolis, u_geostrophic, u_slope, v_geostrophic),
+        turbconv_sources(turbconv)...,
     )
-
-    # Choose default IMEX solver
-    ode_solver_type = ClimateMachine.IMEXSolverType()
 
     # Set up problem initial and boundary conditions
     if surface_flux == "prescribed"
@@ -455,6 +457,7 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax, surface_flux)
                 )),
                 energy = energy,
                 moisture = moisture,
+                turbconv = turbconv_bcs(turbconv),
             ),
             AtmosBC(),
         ),
@@ -463,28 +466,15 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax, surface_flux)
 
     # Assemble model components
     model = AtmosModel{FT}(
-        AtmosLESConfigType,
+        config_type,
         param_set;
         problem = problem,
         turbulence = SmagorinskyLilly{FT}(C_smag),
         moisture = EquilMoist{FT}(; maxiter = 5, tolerance = FT(0.1)),
         source = source,
+        turbconv = turbconv,
     )
-
-    # Assemble configuration
-    config = ClimateMachine.AtmosLESConfiguration(
-        "BOMEX",
-        N,
-        resolution,
-        xmax,
-        ymax,
-        zmax,
-        param_set,
-        init_bomex!,
-        solver_type = ode_solver_type,
-        model = model,
-    )
-    return config
+    return model
 end
 
 function config_diagnostics(driver_config)
@@ -503,97 +493,3 @@ function config_diagnostics(driver_config)
         core_dgngrp,
     ])
 end
-
-function main()
-    # add a command line argument to specify the kind of surface flux
-    # TODO: this will move to the future namelist functionality
-    bomex_args = ArgParseSettings(autofix_names = true)
-    add_arg_group!(bomex_args, "BOMEX")
-    @add_arg_table! bomex_args begin
-        "--surface-flux"
-        help = "specify surface flux for energy and moisture"
-        metavar = "prescribed|bulk"
-        arg_type = String
-        default = "prescribed"
-    end
-
-    cl_args =
-        ClimateMachine.init(parse_clargs = true, custom_clargs = bomex_args)
-
-    surface_flux = cl_args["surface_flux"]
-
-    FT = Float32
-
-    # DG polynomial order
-    N = 4
-    # Domain resolution and size
-    Δh = FT(100)
-    Δv = FT(40)
-
-    resolution = (Δh, Δh, Δv)
-
-    # Prescribe domain parameters
-    xmax = FT(6400)
-    ymax = FT(6400)
-    zmax = FT(3000)
-
-    t0 = FT(0)
-
-    # For a full-run, please set the timeend to 3600*6 seconds
-    # For the test we set this to == 30 minutes
-    timeend = FT(1800)
-    #timeend = FT(3600 * 6)
-    CFLmax = FT(0.90)
-
-    driver_config =
-        config_bomex(FT, N, resolution, xmax, ymax, zmax, surface_flux)
-    solver_config = ClimateMachine.SolverConfiguration(
-        t0,
-        timeend,
-        driver_config,
-        init_on_cpu = true,
-        Courant_number = CFLmax,
-    )
-    dgn_config = config_diagnostics(driver_config)
-
-    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
-        Filters.apply!(
-            solver_config.Q,
-            ("moisture.ρq_tot",),
-            solver_config.dg.grid,
-            TMARFilter(),
-        )
-        nothing
-    end
-
-    # State variable
-    Q = solver_config.Q
-    # Volume geometry information
-    vgeo = driver_config.grid.vgeo
-    M = vgeo[:, Grids._M, :]
-    # Unpack prognostic vars
-    ρ₀ = Q.ρ
-    ρe₀ = Q.ρe
-    # DG variable sums
-    Σρ₀ = sum(ρ₀ .* M)
-    Σρe₀ = sum(ρe₀ .* M)
-    cb_check_cons = GenericCallbacks.EveryXSimulationSteps(3000) do
-        Q = solver_config.Q
-        δρ = (sum(Q.ρ .* M) - Σρ₀) / Σρ₀
-        δρe = (sum(Q.ρe .* M) .- Σρe₀) ./ Σρe₀
-        @show (abs(δρ))
-        @show (abs(δρe))
-        @test (abs(δρ) <= 0.0001)
-        @test (abs(δρe) <= 0.0025)
-        nothing
-    end
-
-    result = ClimateMachine.invoke!(
-        solver_config;
-        diagnostics_config = dgn_config,
-        user_callbacks = (cbtmarfilter, cb_check_cons),
-        check_euclidean_distance = true,
-    )
-end
-
-main()

--- a/experiments/AtmosLES/bomex_single_stack.jl
+++ b/experiments/AtmosLES/bomex_single_stack.jl
@@ -1,0 +1,104 @@
+include("bomex_model.jl")
+
+function main()
+    # add a command line argument to specify the kind of surface flux
+    # TODO: this will move to the future namelist functionality
+    bomex_args = ArgParseSettings(autofix_names = true)
+    add_arg_group!(bomex_args, "BOMEX")
+    @add_arg_table! bomex_args begin
+        "--surface-flux"
+        help = "specify surface flux for energy and moisture"
+        metavar = "prescribed|bulk"
+        arg_type = String
+        default = "prescribed"
+    end
+
+    cl_args =
+        ClimateMachine.init(parse_clargs = true, custom_clargs = bomex_args)
+
+    surface_flux = cl_args["surface_flux"]
+
+    FT = Float64
+    config_type = SingleStackConfigType
+
+    # DG polynomial order
+    N = 1
+
+    # Prescribe domain parameters
+    nelem_vert = 50
+    zmax = FT(3000)
+
+    t0 = FT(0)
+
+    # For a full-run, please set the timeend to 3600*6 seconds
+    # For the test we set this to == 30 minutes
+    timeend = FT(1800)
+    #timeend = FT(3600 * 6)
+    CFLmax = FT(0.90)
+
+    # Choose default IMEX solver
+    ode_solver_type = ClimateMachine.IMEXSolverType()
+
+    model = bomex_model(FT, config_type, zmax, surface_flux)
+    ics = model.problem.init_state_prognostic
+    # Assemble configuration
+    driver_config = ClimateMachine.SingleStackConfiguration(
+        "BOMEX_SINGLE_STACK",
+        N,
+        nelem_vert,
+        zmax,
+        param_set,
+        model;
+        solver_type = ode_solver_type,
+    )
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+    )
+    dgn_config = config_diagnostics(driver_config)
+
+    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            ("moisture.ρq_tot",),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
+        nothing
+    end
+
+    # State variable
+    Q = solver_config.Q
+    # Volume geometry information
+    vgeo = driver_config.grid.vgeo
+    M = vgeo[:, Grids._M, :]
+    # Unpack prognostic vars
+    ρ₀ = Q.ρ
+    ρe₀ = Q.ρe
+    # DG variable sums
+    Σρ₀ = sum(ρ₀ .* M)
+    Σρe₀ = sum(ρe₀ .* M)
+    cb_check_cons = GenericCallbacks.EveryXSimulationSteps(3000) do
+        Q = solver_config.Q
+        δρ = (sum(Q.ρ .* M) - Σρ₀) / Σρ₀
+        δρe = (sum(Q.ρe .* M) .- Σρe₀) ./ Σρe₀
+        @show (abs(δρ))
+        @show (abs(δρe))
+        @test (abs(δρ) <= 0.0001)
+        @test (abs(δρe) <= 0.0025)
+        nothing
+    end
+
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (cbtmarfilter, cb_check_cons),
+        check_euclidean_distance = true,
+    )
+end
+
+main()

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -11,10 +11,12 @@ using ..VariableTemplates: @vars, Vars, Grad
 
 export TurbulenceConvectionModel, NoTurbConv
 
-export init_aux_turbconv!, turbconv_nodal_update_auxiliary_state!
+export init_state_prognostic!,
+    init_aux_turbconv!, turbconv_nodal_update_auxiliary_state!
 
 import ..BalanceLaws:
     vars_state,
+    init_state_prognostic!,
     init_state_auxiliary!,
     update_auxiliary_state!,
     flux_first_order!,
@@ -134,6 +136,15 @@ function integral_set_auxiliary_state!(
 )
     return nothing
 end
+
+function init_state_prognostic!(
+    m::NoTurbConv,
+    bl::BalanceLaw,
+    state,
+    aux,
+    (x, y, z),
+    t,
+) end
 
 include("boundary_conditions.jl")
 include("source.jl")

--- a/src/Common/TurbulenceConvection/boundary_conditions.jl
+++ b/src/Common/TurbulenceConvection/boundary_conditions.jl
@@ -2,6 +2,7 @@
 
 export TurbConvBC,
     NoTurbConvBC,
+    turbconv_bcs,
     turbconv_boundary_state!,
     turbconv_normal_boundary_flux_second_order!
 
@@ -13,6 +14,8 @@ abstract type TurbConvBC end
 Boundary conditions are not applied
 """
 struct NoTurbConvBC <: TurbConvBC end
+
+turbconv_bcs(::NoTurbConv) = NoTurbConvBC()
 
 function turbconv_boundary_state!(nf, bc_turbulence::NoTurbConvBC, bl, args...)
     nothing


### PR DESCRIPTION
# Description

This PR adds a BOMEX single stack experiment and splits up the existing BOMEX LES experiment into a shared model file and an LES and single stack experiment files. This PR needs changes coming from #1462 to pass CI. This new experiment should provide a baseline to compare the single stack BOMEX with/without EDMF.

This also modifies the default horizontal domain extent to 50km.

Closes #1356

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
