### PR TITLE
Add saturated function to thermo

### DIFF
--- a/docs/src/APIs/Common/Thermodynamics.md
+++ b/docs/src/APIs/Common/Thermodynamics.md
@@ -64,6 +64,7 @@ moist_static_energy
 q_vap_saturation
 q_vap_saturation_generic
 relative_humidity
+saturated
 saturation_adjustment
 saturation_excess
 saturation_vapor_pressure

--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -38,6 +38,7 @@ export air_temperature_from_ideal_gas_law
 export condensate, has_condensate
 export specific_enthalpy, total_specific_enthalpy
 export moist_static_energy
+export saturated
 
 """
     gas_constant_air(param_set, [q::PhasePartition])
@@ -2073,4 +2074,15 @@ function moist_static_energy(
     e_pot::FT,
 ) where {FT <: Real}
     return specific_enthalpy(ts) + e_pot
+end
+
+"""
+    saturated(ts::ThermodynamicState)
+
+Boolean indicating if thermodynamic
+state is saturated.
+"""
+function saturated(ts::ThermodynamicState)
+    RH = relative_humidity(ts)
+    return RH ≈ 1 || RH > 1
 end


### PR DESCRIPTION
# Description

Adds a function `saturated` to Thermodynamics, which returns a bool indicating if a given thermodynamic state is saturated or supersaturated.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
