### PR TITLE
Add mass conservation check to filter showcase

### DIFF
--- a/tutorials/Numerics/DGMethods/Box1D.jl
+++ b/tutorials/Numerics/DGMethods/Box1D.jl
@@ -35,7 +35,8 @@ import ClimateMachine.BalanceLaws:
     update_auxiliary_state!,
     nodal_init_state_auxiliary!,
     init_state_prognostic!,
-    boundary_state!
+    boundary_state!,
+    wavespeed
 
 ClimateMachine.init(; disable_gpu = true, log_level = "warn");
 const clima_dir = dirname(dirname(pathof(ClimateMachine)));
@@ -52,6 +53,13 @@ vars_state(::Box1D, ::Auxiliary, FT) = @vars(z_dim::FT);
 vars_state(::Box1D, ::Prognostic, FT) = @vars(q::FT);
 vars_state(::Box1D, ::Gradient, FT) = @vars();
 vars_state(::Box1D, ::GradientFlux, FT) = @vars();
+
+function wavespeed(
+    ::Box1D{FT, _init_q, _amplitude, _velo},
+    _...,
+) where {FT, _init_q, _amplitude, _velo}
+    return _velo
+end
 
 function nodal_init_state_auxiliary!(
     m::Box1D,
@@ -150,6 +158,7 @@ function run_box1D(
     exp_param_2::Int = 32,
     boyd_param_1::Int = 0,
     boyd_param_2::Int = 32,
+    numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
 )
     N_poly = N_poly
     nelem = 128
@@ -164,7 +173,7 @@ function run_box1D(
         zmax,
         param_set,
         m,
-        numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
+        numerical_flux_first_order = numerical_flux_first_order,
         boundary = ((0, 0), (0, 0), (0, 0)),
         periodicity = (true, true, true),
     )

--- a/tutorials/Numerics/DGMethods/Box1D.jl
+++ b/tutorials/Numerics/DGMethods/Box1D.jl
@@ -4,6 +4,7 @@ using MPI
 using OrderedCollections
 using Plots
 using StaticArrays
+using Printf
 
 using CLIMAParameters
 struct EarthParameterSet <: AbstractEarthParameterSet end
@@ -274,7 +275,21 @@ function run_box1D(
     end
     user_cb = (user_cb_arr...,)
 
+    initial_mass = weightedsum(solver_config.Q)
     ClimateMachine.invoke!(solver_config; user_callbacks = (user_cb))
+    final_mass = weightedsum(solver_config.Q)
+    @info @sprintf(
+        """
+Mass Conservation:
+    initial mass          = %.16e
+    final mass            = %.16e
+    difference            = %.16e
+    normalized difference = %.16e""",
+        initial_mass,
+        final_mass,
+        final_mass - initial_mass,
+        (final_mass - initial_mass) / initial_mass
+    )
 
     push!(all_data, dict_of_nodal_states(solver_config, [z_key]))
     push!(time_data, gettime(solver_config.solver))

--- a/tutorials/Numerics/DGMethods/showcase_filters.jl
+++ b/tutorials/Numerics/DGMethods/showcase_filters.jl
@@ -10,9 +10,23 @@ include(joinpath(clima_dir, "tutorials", "Numerics", "DGMethods", "Box1D.jl"))
 output_dir = @__DIR__;
 mkpath(output_dir);
 
-# The unfiltered result of the box advection test for order 4 polynomial is:
+# The unfiltered result of the box advection test for order 4 polynomial with
+# central flux is
 run_box1D(4, 0.0, 1.0, 1.0, joinpath(output_dir, "box_1D_4_no_filter.svg"))
 # ![](box_1D_4_no_filter.svg)
+
+# The unfiltered result of the box advection test for order 4 polynomial with
+# Rusanov flux (aka upwinding for advection) is
+run_box1D(
+    4,
+    0.0,
+    1.0,
+    1.0,
+    joinpath(output_dir, "box_1D_4_no_filter_upwind.svg"),
+    numerical_flux_first_order = RusanovNumericalFlux(),
+)
+# ![](box_1D_4_no_filter_upwind.svg)
+
 
 # Below we show results for the same box advection test
 # but using different filters.
@@ -20,7 +34,7 @@ run_box1D(4, 0.0, 1.0, 1.0, joinpath(output_dir, "box_1D_4_no_filter.svg"))
 # As seen in the results, when the TMAR filter is used mass is not necessarily
 # conserved (mass increases are possible).
 
-# `TMARFilter()`:
+# `TMARFilter()` with central numerical flux:
 run_box1D(
     4,
     0.0,
@@ -31,7 +45,21 @@ run_box1D(
 )
 # ![](box_1D_4_tmar.svg)
 
-# `CutoffFilter(grid, Nc=1)`:
+# Running the TMAR filter with Rusanov the mass conservation since some of the
+# are reduced, but mass is still not conserved.
+# `TMARFilter()` with Rusanov numerical flux:
+run_box1D(
+    4,
+    0.0,
+    1.0,
+    1.0,
+    joinpath(output_dir, "box_1D_4_tmar_upwind.svg");
+    tmar_filter = true,
+    numerical_flux_first_order = RusanovNumericalFlux(),
+)
+# ![](box_1D_4_tmar_upwind.svg)
+
+# `CutoffFilter(grid, Nc=1)` with central numerical flux:
 run_box1D(
     4,
     0.0,
@@ -43,7 +71,7 @@ run_box1D(
 )
 # ![](box_1D_4_cutoff_1.svg)
 
-# `CutoffFilter(grid, Nc=3)`:
+# `CutoffFilter(grid, Nc=3)` with central numerical flux:
 run_box1D(
     4,
     0.0,
@@ -55,7 +83,7 @@ run_box1D(
 )
 # ![](box_1D_4_cutoff_3.svg)
 
-# `ExponentialFilter(grid, Nc=1, s=4)`:
+# `ExponentialFilter(grid, Nc=1, s=4)` with central numerical flux:
 run_box1D(
     4,
     0.0,
@@ -68,7 +96,7 @@ run_box1D(
 )
 # ![](box_1D_4_exp_1_4.svg)
 
-# `ExponentialFilter(grid, Nc=1, s=8)`:
+# `ExponentialFilter(grid, Nc=1, s=8)` with central numerical flux:
 run_box1D(
     4,
     0.0,
@@ -81,7 +109,7 @@ run_box1D(
 )
 # ![](box_1D_4_exp_1_8.svg)
 
-# `ExponentialFilter(grid, Nc=1, s=32)`:
+# `ExponentialFilter(grid, Nc=1, s=32)` with central numerical flux:
 run_box1D(
     4,
     0.0,
@@ -94,7 +122,7 @@ run_box1D(
 )
 # ![](box_1D_4_exp_1_32.svg)
 
-# `BoydVandevenFilter(grid, Nc=1, s=4)`:
+# `BoydVandevenFilter(grid, Nc=1, s=4)` with central numerical flux:
 run_box1D(
     4,
     0.0,
@@ -107,7 +135,7 @@ run_box1D(
 )
 # ![](box_1D_4_boyd_1_4.svg)
 
-# `BoydVandevenFilter(grid, Nc=1, s=8)`:
+# `BoydVandevenFilter(grid, Nc=1, s=8)` with central numerical flux:
 run_box1D(
     4,
     0.0,
@@ -120,7 +148,7 @@ run_box1D(
 )
 # ![](box_1D_4_boyd_1_8.svg)
 
-# `BoydVandevenFilter(grid, Nc=1, s=32)`:
+# `BoydVandevenFilter(grid, Nc=1, s=32)` with central numerical flux:
 run_box1D(
     4,
     0.0,
@@ -133,7 +161,8 @@ run_box1D(
 )
 # ![](box_1D_4_boyd_1_32.svg)
 
-# `ExponentialFilter(grid, Nc=1, s=8)` and `TMARFilter()`:
+# `ExponentialFilter(grid, Nc=1, s=8)` and `TMARFilter()` with central numerical
+# flux:
 run_box1D(
     4,
     0.0,
@@ -147,7 +176,8 @@ run_box1D(
 )
 # ![](box_1D_4_tmar_exp_1_8.svg)
 
-# `BoydVandevenFilter(grid, Nc=1, s=8)` and `TMARFilter()`:
+# `BoydVandevenFilter(grid, Nc=1, s=8)` and `TMARFilter()` with central
+# numerical flux:
 run_box1D(
     4,
     0.0,

--- a/tutorials/Numerics/DGMethods/showcase_filters.jl
+++ b/tutorials/Numerics/DGMethods/showcase_filters.jl
@@ -16,6 +16,9 @@ run_box1D(4, 0.0, 1.0, 1.0, joinpath(output_dir, "box_1D_4_no_filter.svg"))
 
 # Below we show results for the same box advection test
 # but using different filters.
+#
+# As seen in the results, when the TMAR filter is used mass is not necessarily
+# conserved (mass increases are possible).
 
 # `TMARFilter()`:
 run_box1D(


### PR DESCRIPTION
Add mass conservation check filter showcase to show that TMAR is not mass conservative.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
