### PR TITLE
Improve names in Roe fluxes

### DIFF
--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -257,9 +257,9 @@ function numerical_flux_first_order!(
     balance_law::AtmosLinearModel,
     fluxᵀn::Vars{S},
     normal_vector::SVector,
-    state_conservative⁻::Vars{S},
+    state_prognostic⁻::Vars{S},
     state_auxiliary⁻::Vars{A},
-    state_conservative⁺::Vars{S},
+    state_prognostic⁺::Vars{S},
     state_auxiliary⁺::Vars{A},
     t,
     direction,
@@ -271,9 +271,9 @@ function numerical_flux_first_order!(
         balance_law,
         fluxᵀn,
         normal_vector,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
         t,
         direction,
@@ -282,7 +282,7 @@ function numerical_flux_first_order!(
     atmos = balance_law.atmos
     param_set = atmos.param_set
 
-    ρu⁻ = state_conservative⁻.ρu
+    ρu⁻ = state_prognostic⁻.ρu
 
     ref_ρ⁻ = state_auxiliary⁻.ref_state.ρ
     ref_ρe⁻ = state_auxiliary⁻.ref_state.ρe
@@ -295,11 +295,11 @@ function numerical_flux_first_order!(
         atmos.moisture,
         param_set,
         atmos.orientation,
-        state_conservative⁻,
+        state_prognostic⁻,
         state_auxiliary⁻,
     )
 
-    ρu⁺ = state_conservative⁺.ρu
+    ρu⁺ = state_prognostic⁺.ρu
 
     ref_ρ⁺ = state_auxiliary⁺.ref_state.ρ
     ref_ρe⁺ = state_auxiliary⁺.ref_state.ρe
@@ -312,7 +312,7 @@ function numerical_flux_first_order!(
         atmos.moisture,
         param_set,
         atmos.orientation,
-        state_conservative⁺,
+        state_prognostic⁺,
         state_auxiliary⁺,
     )
 


### PR DESCRIPTION
# Description

State conservative is no more, `ũc̃⁺` and `ũc̃⁻` were misleading since the superscripts didn't refer to the + and - face.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
