### PR TITLE
Require approval from a reviewer besides the PR author

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -10,3 +10,4 @@ delete_merged_branches = true
 timeout_sec = 10800
 block_labels = [ "do-not-merge-yet" ]
 cut_body_after = "<!--"
+required_approvals = 1


### PR DESCRIPTION
# Description

Changes the bors settings to require at least one GitHub approval before merging a PR. This should help make sure all PRs are properly documented and that the PR checklist has *actually* been completed. This is following up on the discussion from the `#software` slack channel.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
