### PR TITLE
GCM ref_state refinement

### DIFF
--- a/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
+++ b/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
@@ -140,7 +140,7 @@ function config_gcm_experiment(
 ) where {FT}
     # Set up a reference state for linearization of equations
     temp_profile_ref =
-        DecayingTemperatureProfile{FT}(param_set, FT(275), FT(75), FT(45e3))
+        DecayingTemperatureProfile{FT}(param_set, FT(290), FT(220), FT(8e3))
     ref_state = HydrostaticState(temp_profile_ref)
 
     # Distance between surface and top of atmosphere (m)

--- a/experiments/AtmosGCM/baroclinic-wave.jl
+++ b/experiments/AtmosGCM/baroclinic-wave.jl
@@ -159,7 +159,7 @@ end
 function config_baroclinic_wave(FT, poly_order, resolution, with_moisture)
     # Set up a reference state for linearization of equations
     temp_profile_ref =
-        DecayingTemperatureProfile{FT}(param_set, FT(275), FT(75), FT(45e3))
+        DecayingTemperatureProfile{FT}(param_set, FT(290), FT(220), FT(8e3))
     ref_state = HydrostaticState(temp_profile_ref)
 
     # Set up the atmosphere model

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -160,7 +160,7 @@ end
 function config_heldsuarez(FT, poly_order, resolution)
     # Set up a reference state for linearization of equations
     temp_profile_ref =
-        DecayingTemperatureProfile{FT}(param_set, FT(275), FT(75), FT(45e3))
+        DecayingTemperatureProfile{FT}(param_set, FT(290), FT(220), FT(8e3))
     ref_state = HydrostaticState(temp_profile_ref)
 
     # Set up the atmosphere model

--- a/experiments/AtmosGCM/moist-baroclinic-wave-bulksfcflux.jl
+++ b/experiments/AtmosGCM/moist-baroclinic-wave-bulksfcflux.jl
@@ -222,7 +222,7 @@ function config_baroclinic_wave(
 )
     # Set up a reference state for linearization of equations
     temp_profile_ref =
-        DecayingTemperatureProfile{FT}(param_set, FT(275), FT(75), FT(45e3))
+        DecayingTemperatureProfile{FT}(param_set, FT(290), FT(220), FT(8e3))
     ref_state = HydrostaticState(temp_profile_ref)
 
     # Set up the atmosphere model


### PR DESCRIPTION
Small fix that refines the GCM ref_state to be more physical, allowing for more stable runs.

# Description

A clear and concise description of the code with usage.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
