### PR TITLE
Bugfix for sponge modifier

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -524,7 +524,7 @@ function. Contributions from subcomponents are then assembled (pointwise).
     t::Real,
 )
     ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
-    sponge_viscosity_modifier!(atmos, atmos.viscoussponge, ν, D_t, aux)
+    sponge_viscosity_modifier!(atmos, atmos.viscoussponge, ν, D_t, τ, aux)
     d_h_tot = -D_t .* diffusive.∇h_tot
     flux_second_order!(atmos, flux, state, τ, d_h_tot)
     flux_second_order!(atmos.moisture, flux, state, diffusive, aux, t, D_t)

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -959,7 +959,8 @@ end
 # `ViscousSponge` requires a user to specify a constant viscosity (kinematic), 
 # a sponge start height, the domain height, a sponge strength, and a sponge
 # exponent.
-# It works like `ConstantViscosityWithDivergence` but without divergence and is
+# Given viscosity, diffusivity and stresses from arbitrary turbulence models, 
+# the viscous sponge enhances diffusive terms within a user-specified layer,
 # typically used at the top of the domain to absorb waves. A smooth onset is
 # ensured through a weight function that increases weight height from the sponge
 # onset height.
@@ -977,6 +978,7 @@ function sponge_viscosity_modifier!(
     m::NoViscousSponge,
     ν,
     D_t,
+    τ,
     aux,
 )
     nothing
@@ -1006,6 +1008,7 @@ function sponge_viscosity_modifier!(
     m::UpperAtmosSponge,
     ν,
     D_t,
+    τ,
     aux::Vars,
 )
     z = altitude(bl.orientation, bl.param_set, aux)
@@ -1014,6 +1017,7 @@ function sponge_viscosity_modifier!(
         β_sponge = m.α_max * sinpi(r / 2)^m.γ
         ν += β_sponge * ν
         D_t += β_sponge * D_t
+        τ += β_sponge * τ
     end
 end
 


### PR DESCRIPTION
# Description
`\tau` is an output of `turbulence_tensors` ; for optional  
upper atmosphere sponges this fixes the viscous stress modifier. 

No effect on existing master branch experiments/ tutorials. 
Independent of the rayleigh linear sponge in `source.jl`

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
