### PR TITLE
Set defaults properly for GCMDriver experiments

### DIFF
--- a/experiments/AtmosGCM/GCMDriver/baroclinicwave_problem.jl
+++ b/experiments/AtmosGCM/GCMDriver/baroclinicwave_problem.jl
@@ -18,10 +18,21 @@ struct BaroclinicWaveProblem{BC, ISP, ISA, WP, BS, MP} <: AbstractAtmosProblem
 end
 function BaroclinicWaveProblem(;
     boundarycondition = (AtmosBC(), AtmosBC()),
-    perturbation = DeterministicPerturbation(),
-    base_state = BCWaveBaseState(),
-    moisture_profile = MoistLowTropicsMoistureProfile(),
+    perturbation = nothing,
+    base_state = nothing,
+    moisture_profile = nothing,
 )
+    # Set up defaults
+    if isnothing(perturbation)
+        perturbation = DeterministicPerturbation()
+    end
+    if isnothing(base_state)
+        base_state = BCWaveBaseState()
+    end
+    if isnothing(moisture_profile)
+        moisture_profile = MoistLowTropicsMoistureProfile()
+    end
+
     problem = (
         boundarycondition,
         init_gcm_experiment!,

--- a/experiments/AtmosGCM/GCMDriver/gcm_base_states.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_base_states.jl
@@ -8,7 +8,9 @@ struct HeldSuarezBaseState <: AbstractBaseState end
 
 # Helper for parsing `--init-base-state`` command line argument
 function parse_base_state_arg(arg)
-    if arg === nothing || arg == "bc_wave"
+    if arg === nothing
+        base_state = nothing
+    elseif arg == "bc_wave"
         base_state = BCWaveBaseState()
     elseif arg == "heldsuarez"
         base_state = HeldSuarezBaseState()

--- a/experiments/AtmosGCM/GCMDriver/gcm_moisture_profiles.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_moisture_profiles.jl
@@ -8,7 +8,9 @@ struct MoistLowTropicsMoistureProfile <: AbstractMoistureProfile end
 
 # Helper for parsing `--init-moisture-profile` command line argument
 function parse_moisture_profile_arg(arg)
-    if arg === nothing || arg == "moist_low_tropics"
+    if arg === nothing
+        moisture_profile = nothing
+    elseif arg == "moist_low_tropics"
         moisture_profile = MoistLowTropicsMoistureProfile()
     elseif arg == "zero"
         moisture_profile = ZeroMoistureProfile()

--- a/experiments/AtmosGCM/GCMDriver/gcm_perturbations.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_perturbations.jl
@@ -13,7 +13,9 @@ struct RandomPerturbation <: AbstractPerturbation end
 
 # Helper for parsing `--init-perturbation` command line argument
 function parse_perturbation_arg(arg)
-    if arg === nothing || arg == "deterministic"
+    if arg === nothing
+        perturbation = nothing
+    elseif arg == "deterministic"
         perturbation = DeterministicPerturbation()
     elseif arg == "zero"
         perturbation = NoPerturbation()

--- a/experiments/AtmosGCM/GCMDriver/heldsuarez_problem.jl
+++ b/experiments/AtmosGCM/GCMDriver/heldsuarez_problem.jl
@@ -24,10 +24,21 @@ struct HeldSuarezProblem{BC, ISP, ISA, WP, BS, MP} <: AbstractAtmosProblem
 end
 function HeldSuarezProblem(;
     boundarycondition = (AtmosBC(), AtmosBC()),
-    perturbation = DeterministicPerturbation(),
-    base_state = HeldSuarezBaseState(),
-    moisture_profile = MoistLowTropicsMoistureProfile(),
+    perturbation = nothing,
+    base_state = nothing,
+    moisture_profile = nothing,
 )
+    # Set up defaults
+    if isnothing(perturbation)
+        perturbation = DeterministicPerturbation()
+    end
+    if isnothing(base_state)
+        base_state = HeldSuarezBaseState()
+    end
+    if isnothing(moisture_profile)
+        moisture_profile = MoistLowTropicsMoistureProfile()
+    end
+
     problem = (
         boundarycondition,
         init_gcm_experiment!,


### PR DESCRIPTION
# Description

Properly set defaults for each GCMDriver experiment when the user does not specify perturbation, base state or moisture profile.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
