### PR TITLE
Make plot helpers GPU-friendly

### DIFF
--- a/docs/plothelpers.jl
+++ b/docs/plothelpers.jl
@@ -1,4 +1,6 @@
 using Plots
+using KernelAbstractions: CPU
+using ClimateMachine.MPIStateArrays: array_device
 using ClimateMachine.BalanceLaws: Prognostic, Auxiliary, GradientFlux
 
 """
@@ -124,6 +126,7 @@ function export_state_plots(
 )
     FT = eltype(solver_config.Q)
     z = get_z(solver_config.dg.grid)
+    z = array_device(solver_config.Q) isa CPU ? z : Array(z)
     mkpath(output_dir)
     for st in state_types
         vs = vars_state(solver_config.dg.balance_law, st, FT)


### PR DESCRIPTION
# Description

This PR makes `export_state_plots` work when the grids exist on the GPU (by converting the CuArray to an ordinary array).

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
