### PR TITLE
Add kinematic stress BC for SWModel

### DIFF
--- a/src/Ocean/ShallowWater/bc_velocity.jl
+++ b/src/Ocean/ShallowWater/bc_velocity.jl
@@ -208,3 +208,100 @@ function shallow_boundary_state!(
 
     return nothing
 end
+
+"""
+    shallow_boundary_state!(::Union{NumericalFluxFirstOrder, NumericalFluxGradient}, ::Impenetrable{KinematicStress}, ::HBModel)
+
+apply kinematic stress boundary condition for velocity
+applies free slip conditions for first-order and gradient fluxes
+"""
+function shallow_boundary_state!(
+    nf::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
+    ::Impenetrable{KinematicStress},
+    shallow::SWModel,
+    turb::TurbulenceClosure,
+    args...,
+)
+    return shallow_boundary_state!(
+        nf,
+        Impenetrable(FreeSlip()),
+        shallow,
+        turb,
+        args...,
+    )
+end
+
+"""
+    shallow_boundary_state!(::NumericalFluxSecondOrder, ::Impenetrable{KinematicStress}, ::HBModel)
+
+apply kinematic stress boundary condition for velocity
+sets ghost point to have specified flux on the boundary for ν∇u
+"""
+@inline function shallow_boundary_state!(
+    ::NumericalFluxSecondOrder,
+    ::Impenetrable{KinematicStress},
+    shallow::SWModel,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
+    Q⁺.U = Q⁻.U
+    D⁺.ν∇U = n⁻ * kinematic_stress(shallow.problem, A⁻.y, 1000)'
+    # applies windstress for now, will be fixed in a later PR
+
+    return nothing
+end
+
+"""
+    shallow_boundary_state!(::Union{NumericalFluxFirstOrder, NumericalFluxGradient}, ::Penetrable{KinematicStress}, ::HBModel)
+
+apply kinematic stress boundary condition for velocity
+applies free slip conditions for first-order and gradient fluxes
+"""
+function shallow_boundary_state!(
+    nf::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
+    ::Penetrable{KinematicStress},
+    shallow::SWModel,
+    turb::TurbulenceClosure,
+    args...,
+)
+    return shallow_boundary_state!(
+        nf,
+        Penetrable(FreeSlip()),
+        shallow,
+        turb,
+        args...,
+    )
+end
+
+"""
+    shallow_boundary_state!(::NumericalFluxSecondOrder, ::Penetrable{KinematicStress}, ::HBModel)
+
+apply kinematic stress boundary condition for velocity
+sets ghost point to have specified flux on the boundary for ν∇u
+"""
+@inline function shallow_boundary_state!(
+    ::NumericalFluxSecondOrder,
+    ::Penetrable{KinematicStress},
+    shallow::SWModel,
+    ::TurbulenceClosure,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
+    Q⁺.u = Q⁻.u
+    D⁺.ν∇u = n⁻ * kinematic_stress(shallow.problem, A⁻.y, 1000)'
+    # applies windstress for now, will be fixed in a later PR
+
+    return nothing
+end


### PR DESCRIPTION
# Description

This really should have been in #1456, since it is the last type of velocity boundary condition. Required for running the ocean gyre set up in #1482. Currently just implemented for GPU compilation, a later PR will actually make these useful for applying wall drag in a shallow water simulation.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
