### PR TITLE
Add traits to turn on and off advection for tests

### DIFF
--- a/src/Ocean/Ocean.jl
+++ b/src/Ocean/Ocean.jl
@@ -1,10 +1,14 @@
 module Ocean
 
-export AbstractOceanCoupling, Uncoupled, Coupled
+export AbstractOceanCoupling,
+    Uncoupled, Coupled, AdvectionTerm, NonLinearAdvectionTerm
 
 abstract type AbstractOceanCoupling end
 struct Uncoupled <: AbstractOceanCoupling end
 struct Coupled <: AbstractOceanCoupling end
+
+abstract type AdvectionTerm end
+struct NonLinearAdvectionTerm <: AdvectionTerm end
 
 function ocean_init_state! end
 function ocean_init_aux! end

--- a/src/Ocean/OceanProblems/SimpleBoxProblem.jl
+++ b/src/Ocean/OceanProblems/SimpleBoxProblem.jl
@@ -301,7 +301,7 @@ function ocean_init_state!(m::SWModel, p::OceanGyre, Q, A, coords, t)
     @inbounds z = coords[3]
     @inbounds H = p.H
 
-    Q.u = @SVector [0, 0]
+    Q.U = @SVector [0, 0]
     Q.η = 0
 
     return nothing

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -43,9 +43,6 @@ struct ConstantViscosity{L} <: TurbulenceClosure
     ν::L
 end
 
-abstract type AdvectionTerm end
-struct NonLinearAdvection <: AdvectionTerm end
-
 """
     ShallowWaterModel <: BalanceLaw
 
@@ -220,7 +217,7 @@ advective_flux!(::SWModel, ::Nothing, _...) = nothing
 
 @inline function advective_flux!(
     m::SWModel,
-    A::NonLinearAdvection,
+    ::NonLinearAdvectionTerm,
     F::Grad,
     q::Vars,
     α::Vars,

--- a/test/Ocean/ShallowWater/GyreDriver.jl
+++ b/test/Ocean/ShallowWater/GyreDriver.jl
@@ -12,11 +12,7 @@ using ClimateMachine.VariableTemplates: flattenednames
 using ClimateMachine.BalanceLaws
 using ClimateMachine.Ocean.ShallowWater
 using ClimateMachine.Ocean.ShallowWater:
-    TurbulenceClosure,
-    LinearDrag,
-    ConstantViscosity,
-    AdvectionTerm,
-    NonLinearAdvection
+    TurbulenceClosure, LinearDrag, ConstantViscosity
 using ClimateMachine.Ocean
 using ClimateMachine.Ocean.OceanProblems
 
@@ -90,7 +86,7 @@ function setup_model(FT, stommel, linear, τₒ, fₒ, β, γ, ν, Lˣ, Lʸ, H)
     if linear
         advection = nothing
     else
-        advection = NonLinearAdvection()
+        advection = NonLinearAdvectionTerm()
     end
 
     model = ShallowWaterModel{FT}(


### PR DESCRIPTION
# Description

Testing #1482 requires running tests with and without temperature advection to test the stability of the averaging scheme (and determine that is specifically temperature advection that is failing and not something else related to temperature). I also went ahead and implemented the same thing for momentum advection because why not. 

There's probably a better version of this where we have a struct for the advection-diffusion equation that is used to turn manipulate both parts (and contains the viscosities/diffusivities). Not sure if it's worth it to go ahead and add that complexity now though.

Also, there is no test for the `::Nothing` case of tracer advection and for the `::NonLinear` case of momentum advection. The former will come in #1482 and the latter will come once we experiment with non-linear momentum advection.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
