### PR TITLE
Add documentation for system image

### DIFF
--- a/docs/list_of_dev_docs.jl
+++ b/docs/list_of_dev_docs.jl
@@ -7,4 +7,5 @@ dev_docs = Any[
     "Acceptable Unicode" => "DevDocs/AcceptableUnicode.md",
     "Variable list" => "DevDocs/VariableList.md",
     "Diagnostic variable list" => "DevDocs/DiagnosticVariables.md",
+    "Custom System Image" => "DevDocs/SystemImage.md",
 ]

--- a/docs/src/DevDocs/SystemImage.md
+++ b/docs/src/DevDocs/SystemImage.md
@@ -1,0 +1,37 @@
+# System Image
+
+To speed up the start time of `ClimateMachine` a custom system image can be
+built with the
+[`PackageCompiler`](https://github.com/JuliaLang/PackageCompiler.jl).
+
+A helper script for doing this is provided at
+[`.dev/systemimage/climate_machine_image.jl`](https://github.com/CliMA/ClimateMachine.jl/blob/master/.dev/systemimage/climate_machine_image.jl)
+
+If called with
+
+ - **no arguments**: will create the system image `ClimateMachine.so` in the
+   `@__DIR__` directory (i.e., the directory in which the script is located)
+
+ - **a single argument**: the system image will be placed in the path specified
+   by the argument (relative to the callers path)
+
+ - **a specified systemimg path and `true`**: the system image will compile the
+   climate machine package module (useful for CI). This option should not be
+   used when actually developing the climate machine package; see the
+   [drawback](https://julialang.github.io/PackageCompiler.jl/dev/sysimages/#Drawbacks-to-custom-sysimages-1)
+   from the `PackageCompiler` repository.
+
+To run julia using the newly created system image use:
+```
+julia -J/PATH/TO/SYSTEM/IMAGE/ClimateMachine.so --project
+```
+
+!!! tip
+
+    If you put the system image in your `.git` directory, your system image will
+    not be remove by calls to `git clean`.
+
+!!! warning
+
+    If the climate machine `Manifest.toml` is updated you must build a new
+    system image for these changes to be seen.


### PR DESCRIPTION
I have been asked about this a few times in the past couple days, so thought it should be in the docs.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
