### PR TITLE
Make `varsindex` work for ntuple models

### DIFF
--- a/test/Utilities/VariableTemplates/complex_models.jl
+++ b/test/Utilities/VariableTemplates/complex_models.jl
@@ -48,13 +48,23 @@ function state(m::CompositModel, T)
     end
 end
 
-Base.@kwdef struct NTupleModel{S} <: OneLayerModel
+Base.@kwdef struct NTupleModel{S, V, Nv} <: OneLayerModel
     scalar_model::S = ScalarModel()
+    vector_model::V = VectorModel{Nv}()
+end
+
+function NTupleModel(
+    Nv;
+    scalar_model::S = ScalarModel(),
+    vector_model::V = VectorModel{Nv}(),
+) where {S, V}
+    return NTupleModel{S, V, Nv}(scalar_model, vector_model)
 end
 
 function state(m::NTupleModel, T)
     @vars begin
         scalar_model::state(m.scalar_model, T)
+        vector_model::state(m.vector_model, T)
     end
 end
 
@@ -69,7 +79,7 @@ end
 function NTupleContainingModel(
     N,
     Nv;
-    ntuple_model = ntuple(i -> NTupleModel(), N),
+    ntuple_model = ntuple(i -> NTupleModel(Nv), N),
     vector_model = VectorModel{Nv}(),
     scalar_model = ScalarModel(),
 )

--- a/test/Utilities/VariableTemplates/test_complex_models.jl
+++ b/test/Utilities/VariableTemplates/test_complex_models.jl
@@ -1,3 +1,6 @@
+using Test
+using StaticArrays
+using ClimateMachine.VariableTemplates
 
 @testset "Test complex models" begin
 
@@ -5,7 +8,7 @@
 
     FT = Float32
 
-    # ------------------------------- Test getproperty
+    # test getproperty
     m = ScalarModel()
     st = state(m, FT)
     vs = varsize(st)
@@ -13,13 +16,13 @@
     v = Vars{st}(a_global)
     @test v.x == FT(1)
 
-    Nv = 3
+    Nv = 4
     m = VectorModel{Nv}()
     st = state(m, FT)
     vs = varsize(st)
     a_global = collect(1:vs)
     v = Vars{st}(a_global)
-    @test v.x == SVector{Nv, FT}(FT[1, 2, 3])
+    @test v.x == SVector{Nv, FT}(1:Nv)
 
     N = 3
     M = 6
@@ -50,42 +53,83 @@
           SHermitianCompact{N, FT, M}(collect(5:(5 + M - 1)))
 
     Nv = 3
-    N = 3
+    N = 5
     m = NTupleContainingModel(N, Nv)
     st = state(m, FT)
     vs = varsize(st)
     a_global = collect(1:vs)
     v = Vars{st}(a_global)
 
-    @test v.vector_model.x == SVector{Nv, FT}([4, 5, 6])
-    @test v.scalar_model.x == FT(7)
+    offset = (Nv + 1) * N
+    @test v.vector_model.x == SVector{Nv, FT}(collect(1:Nv) .+ offset)
+    @test v.scalar_model.x == FT(1 + Nv) + offset
 
     unval(::Val{i}) where {i} = i
     @unroll_map(N) do i
         @test m.ntuple_model[i] isa NTupleModel
         @test m.ntuple_model[i].scalar_model isa ScalarModel
-        @test v.ntuple_model[i].scalar_model.x == FT(unval(i))
-        @test v.vector_model.x == SVector{Nv, FT}((N + 1):(N + Nv))
-        @test v.scalar_model.x == FT(N + Nv + 1)
+        @test v.ntuple_model[i].scalar_model.x ==
+              FT(unval(i)) + (Nv) * (unval(i) - 1)
+        @test v.vector_model.x == SVector{Nv, FT}(1:Nv) .+ offset
+        @test v.scalar_model.x == FT(Nv + 1) + offset
     end
 
+    # test flattenednames
     fn = flattenednames(st)
-    @test fn[1] === "ntuple_model[1].scalar_model.x"
-    @test fn[2] === "ntuple_model[2].scalar_model.x"
-    @test fn[3] === "ntuple_model[3].scalar_model.x"
-    @test fn[4] === "vector_model.x[1]"
-    @test fn[5] === "vector_model.x[2]"
-    @test fn[6] === "vector_model.x[3]"
-    @test fn[7] === "scalar_model.x"
+    j = 1
+    for i in 1:N
+        @test fn[j] === "ntuple_model[$i].scalar_model.x"
+        j += 1
+        for k in 1:Nv
+            @test fn[j] === "ntuple_model[$i].vector_model.x[$k]"
+            j += 1
+        end
+    end
+    for k in 1:Nv
+        @test fn[j] === "vector_model.x[$k]"
+        j += 1
+    end
+    @test fn[j] === "scalar_model.x"
 
+    # test flattened_tup_chain
     ftc = flattened_tup_chain(st)
-    @test ftc[1] === (:ntuple_model, 1, :scalar_model, :x)
-    @test ftc[2] === (:ntuple_model, 2, :scalar_model, :x)
-    @test ftc[3] === (:ntuple_model, 3, :scalar_model, :x)
-    @test ftc[4] === (:vector_model, :x)
-    @test ftc[5] === (:scalar_model, :x)
+    j = 1
+    for i in 1:N
+        @test ftc[j] === (:ntuple_model, i, :scalar_model, :x)
+        j += 1
+        @test ftc[j] === (:ntuple_model, i, :vector_model, :x)
+        j += 1
+    end
+    @test ftc[j] === (:vector_model, :x)
+    j += 1
+    @test ftc[j] === (:scalar_model, :x)
 
-    # getproperty with tup-chain
+    # test varsindex
+    ntuple(N) do i
+        i_val = Val(i)
+        i_sm = varsindex(st, :ntuple_model, i_val, :scalar_model, :x)
+        i_vm = varsindex(st, :ntuple_model, i_val, :vector_model, :x)
+        nt_offset = (Nv + 1) - 1
+
+        i_sm_correct = (i + nt_offset * (i - 1)):(i + nt_offset * (i - 1))
+        @test i_sm == i_sm_correct
+
+        offset = 1
+        i_start = i + nt_offset * (i - 1) + offset
+        i_vm_correct = (i_start):(i_start + Nv - 1)
+        @test i_vm == i_vm_correct
+    end
+
+    convert_to_val(sym) = sym
+    convert_to_val(i::Int) = Val(i)
+    # test that getproperty matches varsindex
+    ntuple(N) do i
+        i_ϕ = varsindex(st, convert_to_val.(ftc[i])...)
+        ϕ = getproperty(v, ftc[i])
+        @test all(parent(v)[i_ϕ] .≈ ϕ)
+    end
+
+    # test getproperty with tup-chain
     @unroll_map(N) do i
         @test v.scalar_model.x == getproperty(v, (:scalar_model, :x))
         @test v.vector_model.x == getproperty(v, (:vector_model, :x))

--- a/test/Utilities/VariableTemplates/test_complex_models_gpu.jl
+++ b/test/Utilities/VariableTemplates/test_complex_models_gpu.jl
@@ -53,11 +53,13 @@ function mem_copy!(m::NTupleContainingModel{N}, dst::Vars, src::Vars) where {N}
     dst.scalar_model.x = src.scalar_model.x
 
     up = vuntuple(i -> src.ntuple_model[i].scalar_model.x, N)
+    up_v = vuntuple(i -> src.ntuple_model[i].vector_model.x, N)
     up_sv = SVector(up...)
 
     @unroll_map(N) do i
         dst.ntuple_model[i].scalar_model.x = up[i]    # index into tuple
         dst.ntuple_model[i].scalar_model.x = up_sv[i] # index into SArray
+        dst.ntuple_model[i].vector_model.x = up_v[i]
     end
 end
 


### PR DESCRIPTION
# Description

This PR modifies `varsindex` so that it works with `ntuple` models. For example, with this PR, we can now do

```julia
    m = NTupleContainingModel(N, Nv)
    st = state(m, FT)
    for i in 1:N
      i_x = varsindex(st, :ntuple_model, Val(i), :scalar_model, :x)
    end
```

I added a `vector_model` to the `NTupleModel` to test for slightly more complicated offsets.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
