### PR TITLE
Fix 2D vtk bug

### DIFF
--- a/src/InputOutput/VTK/writemesh.jl
+++ b/src/InputOutput/VTK/writemesh.jl
@@ -171,7 +171,7 @@ function writemesh(
         )
     end
     for (name, v) in fields
-        vtk_cell_data(vtkfile, v, name)
+        vtk_point_data(vtkfile, v, name)
     end
     outfiles = vtk_save(vtkfile)
 end


### PR DESCRIPTION
Fixing a bug in the 2D VTK files introduced in PR #1352.

The previous PR inadvertently changed an instance of `vtk_point_data` to `vtk_cell_data`, e.g., format for nodal data to format for cell data.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
