### PR TITLE
add solid body rotation test

### DIFF
--- a/experiments/AtmosGCM/solid-body-rotation.jl
+++ b/experiments/AtmosGCM/solid-body-rotation.jl
@@ -1,0 +1,173 @@
+#!/usr/bin/env julia --project
+using ClimateMachine
+ClimateMachine.init(parse_clargs = true)
+
+using ClimateMachine.Atmos
+using ClimateMachine.Orientations
+using ClimateMachine.ConfigTypes
+using ClimateMachine.Diagnostics
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.ODESolvers
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.SystemSolvers: ManyColumnLU
+using ClimateMachine.Mesh.Filters
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Thermodynamics: air_density, total_energy
+
+using LinearAlgebra
+using StaticArrays
+using Test
+
+using CLIMAParameters
+using CLIMAParameters.Planet: day, planet_radius
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+function init_solid_body_rotation!(problem, bl, state, aux, coords, t)
+    FT = eltype(state)
+
+    # The initial state is in hydrostatic balance
+    # It is chosen to be the same as reference state
+    # But we should expect the flow to stay at rest
+    # with any hydrostatic initial state
+    temp_profile_init =
+        DecayingTemperatureProfile{FT}(param_set, FT(290), FT(220), FT(8e3))
+    z = altitude(bl.orientation, bl.param_set, aux)
+    T₀, p = temp_profile_init(bl.param_set, z)
+    ρ = air_density(bl.param_set, T₀, p)
+    e_pot = gravitational_potential(bl.orientation, aux)
+    e_kin = FT(0)
+
+    # Assign state variables
+    state.ρ = ρ
+    state.ρu = SVector{3, FT}(0, 0, 0)
+    state.ρe = ρ * total_energy(bl.param_set, e_kin, e_pot, T₀)
+
+    nothing
+end
+
+function config_solid_body_rotation(FT, poly_order, resolution)
+    # Set up a reference state for linearization of equations
+    temp_profile_ref =
+        DecayingTemperatureProfile{FT}(param_set, FT(290), FT(220), FT(8e3))
+    ref_state = HydrostaticState(temp_profile_ref)
+
+    # Set up the atmosphere model
+    exp_name = "SolidBodyRotation"
+    domain_height::FT = 30e3 # distance between surface and top of atmosphere (m)
+
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        param_set;
+        init_state_prognostic = init_solid_body_rotation!,
+        ref_state = ref_state,
+        turbulence = ConstantKinematicViscosity(FT(0)),
+        #hyperdiffusion = DryBiharmonic(FT(8 * 3600)),
+        moisture = DryModel(),
+        source = (Gravity(), Coriolis()),
+    )
+
+    config = ClimateMachine.AtmosGCMConfiguration(
+        exp_name,
+        poly_order,
+        resolution,
+        domain_height,
+        param_set,
+        init_solid_body_rotation!;
+        model = model,
+    )
+
+    return config
+end
+
+function main()
+    # Driver configuration parameters
+    FT = Float64                             # floating type precision
+    poly_order = 3                           # discontinuous Galerkin polynomial order
+    n_horz = 12                              # horizontal element number
+    n_vert = 6                               # vertical element number
+    n_days::FT = 1
+    timestart::FT = 0                        # start time (s)
+    timeend::FT = n_days * day(param_set)    # end time (s)
+
+    # Set up driver configuration
+    driver_config = config_solid_body_rotation(FT, poly_order, (n_horz, n_vert))
+
+    # Set up experiment
+    ode_solver_type = ClimateMachine.IMEXSolverType(
+        implicit_model = AtmosAcousticGravityLinearModel,
+        implicit_solver = ManyColumnLU,
+        solver_method = ARK2GiraldoKellyConstantinescu,
+        split_explicit_implicit = true,
+        discrete_splitting = false,
+    )
+
+    CFL = FT(0.1) # target acoustic CFL number
+
+    # time step is computed such that the horizontal acoustic Courant number is CFL
+    solver_config = ClimateMachine.SolverConfiguration(
+        timestart,
+        timeend,
+        driver_config,
+        Courant_number = CFL,
+        ode_solver_type = ode_solver_type,
+        CFL_direction = HorizontalDirection(),
+        diffdir = HorizontalDirection(),
+    )
+
+    # Set up diagnostics
+    dgn_config = config_diagnostics(FT, driver_config)
+
+    # Set up user-defined callbacks
+    filterorder = 20
+    filter = ExponentialFilter(solver_config.dg.grid, 0, filterorder)
+    cbfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            AtmosFilterPerturbations(driver_config.bl),
+            solver_config.dg.grid,
+            filter,
+            state_auxiliary = solver_config.dg.state_auxiliary,
+        )
+        nothing
+    end
+
+    # Run the model
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (cbfilter,),
+        check_euclidean_distance = true,
+    )
+end
+
+function config_diagnostics(FT, driver_config)
+    interval = "40000steps" # chosen to allow a single diagnostics collection
+
+    _planet_radius = FT(planet_radius(param_set))
+
+    info = driver_config.config_info
+    boundaries = [
+        FT(-90.0) FT(-180.0) _planet_radius
+        FT(90.0) FT(180.0) FT(_planet_radius + info.domain_height)
+    ]
+    resolution = (FT(2), FT(2), FT(1000)) # in (deg, deg, m)
+    interpol = ClimateMachine.InterpolationConfiguration(
+        driver_config,
+        boundaries,
+        resolution,
+    )
+
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosGCMConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+
+    return ClimateMachine.DiagnosticsConfiguration([dgngrp])
+end
+
+main()


### PR DESCRIPTION
# Description

Co-authored by: @bischtob 
Add a solid body rotation test. This driver needs to become part of our nightly evaluation set. It tests whether hydrostatic balance is respected in the GCM.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
