### PR TITLE
Add `horizontally_average!`, `hmax` for single stack, and prep for edmf

### DIFF
--- a/docs/src/APIs/Utilities/SingleStackUtils.md
+++ b/docs/src/APIs/Utilities/SingleStackUtils.md
@@ -13,5 +13,6 @@ get_horizontal_mean
 get_horizontal_variance
 reduce_nodal_stack
 reduce_element_stack
+horizontally_average!
 dict_of_nodal_states
 ```

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -366,7 +366,13 @@ function init_bomex!(problem, bl, state, aux, (x, y, z), t)
     init_state_prognostic!(bl.turbconv, bl, state, aux, (x, y, z), t)
 end
 
-function bomex_model(::Type{FT}, config_type, zmax, surface_flux) where {FT}
+function bomex_model(
+    ::Type{FT},
+    config_type,
+    zmax,
+    surface_flux;
+    turbconv = NoTurbConv(),
+) where {FT}
 
     ics = init_bomex!     # Initial conditions
 
@@ -400,7 +406,6 @@ function bomex_model(::Type{FT}, config_type, zmax, surface_flux) where {FT}
 
     f_coriolis = FT(0.376e-4) # Coriolis parameter
 
-    turbconv = NoTurbConv()
     # Assemble source components
     source = (
         Gravity(),

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -347,6 +347,7 @@ function SingleStackConfiguration(
     param_set::AbstractParameterSet,
     model::BalanceLaw;
     zmin = zero(FT),
+    hmax = one(FT),
     array_type = ClimateMachine.array_type(),
     solver_type = ExplicitSolverType(),
     mpicomm = MPI.COMM_WORLD,
@@ -360,8 +361,8 @@ function SingleStackConfiguration(
 
     print_model_info(model)
 
-    xmin, xmax = zero(FT), one(FT)
-    ymin, ymax = zero(FT), one(FT)
+    xmin, xmax = zero(FT), hmax
+    ymin, ymax = zero(FT), hmax
     brickrange = (
         grid1d(xmin, xmax, nelem = 1),
         grid1d(ymin, ymax, nelem = 1),

--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -6,6 +6,7 @@ export get_vars_from_nodal_stack,
     get_horizontal_mean,
     reduce_nodal_stack,
     reduce_element_stack,
+    horizontally_average!,
     dict_of_nodal_states
 
 using OrderedCollections
@@ -296,6 +297,43 @@ function reduce_element_stack(
             j = j,
         ) for i in 1:Nq, j in 1:Nq
     ]
+end
+
+"""
+    horizontally_average!(
+        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        Q::MPIStateArray,
+        i_vars,
+    ) where {T, dim, N}
+
+Horizontally average variables, from variable
+indexes `i_vars`, in `MPIStateArray` `Q`.
+
+!!! note
+    These are not proper horizontal averages-- the main
+    purpose of this method is to ensure that there are
+    no horizontal fluxes for a single stack configuration.
+"""
+function horizontally_average!(
+    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    Q::MPIStateArray,
+    i_vars,
+) where {T, dim, N}
+    Nq = N + 1
+    ArrType = typeof(Q.data)
+    state_data = array_device(Q) isa CPU ? Q.realdata : Array(Q.realdata)
+    Nqk = dimensionality(grid) == 2 ? 1 : Nq
+    for ev in 1:size(state_data, 3), k in 1:Nqk, i_v in i_vars
+        Q_sum = sum((1:Nq, 1:Nq)) do ij
+            state_data[ij[1] + Nq * ((ij[2] - 1) + Nq * (k - 1)), i_v, ev]
+        end
+        Q_ave = Q_sum / (Nq * Nq)
+        for i in 1:Nq, j in 1:Nq
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            state_data[ijk, i_v, ev] = Q_ave
+        end
+    end
+    Q.realdata .= ArrType(state_data)
 end
 
 get_data(solver_config, ::Prognostic) = solver_config.Q

--- a/test/Utilities/SingleStackUtils/ssu_tests.jl
+++ b/test/Utilities/SingleStackUtils/ssu_tests.jl
@@ -78,6 +78,20 @@ function test_hvar(
     @test state_vars_var["ρ"] ≈ target
 end
 
+function test_horizontally_ave(
+    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    Q_in::MPIStateArray,
+    vars,
+) where {T, dim, N}
+    Q = deepcopy(Q_in)
+    state_vars_var = get_horizontal_variance(grid, Q, vars)
+    i_vars = (varsindex(vars, :ρ),)
+    horizontally_average!(grid, Q, i_vars)
+    FT = eltype(Q)
+    state_vars_var = get_horizontal_variance(grid, Q, vars)
+    @test all(isapprox.(state_vars_var["ρ"], 0, atol = 10 * eps(FT)))
+end
+
 function target_meanprof(
     grid::DiscontinuousSpectralElementGrid{T, dim, N},
 ) where {T, dim, N}
@@ -187,5 +201,12 @@ function main()
         reduce(f, ns)
     end
     @test r3 ≈ FT(2877.6) && z3 == 20
+
+    test_horizontally_ave(
+        driver_config.grid,
+        solver_config.Q,
+        vars_state(m, Prognostic(), FT),
+    )
+
 end
 main()


### PR DESCRIPTION
# Description

This PR
 - Adds `horizontally_average!` for single stack utils. This is needed to avoid issues with horizontally-non uniform initial profiles, resulting from `rand()`.
 - Adds `hmax` to `SingleStackConfiguration` becuase the Smagorinsky model is scale-aware and causes problems at small (`hmax ~ 1m`) and large (`hmax ~ 50km`) horizontal domains. To avoid holding up the EDMF development, we'll make `hmax` adjustable per driver for now.
 - Adds `turbconv` as a kwarg to `bomex_model`.


<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
