### PR TITLE
Add `liquid_specific_humidity` and `ice_specific_humidity` to Thermodynamics

### DIFF
--- a/docs/src/APIs/Common/Thermodynamics.md
+++ b/docs/src/APIs/Common/Thermodynamics.md
@@ -49,6 +49,7 @@ gas_constant_air
 gas_constants
 has_condensate
 Ice
+ice_specific_humidity
 internal_energy
 internal_energy_sat
 latent_heat_fusion
@@ -60,6 +61,7 @@ liquid_fraction
 liquid_ice_pottemp
 liquid_ice_pottemp_given_pressure
 liquid_ice_pottemp_sat
+liquid_specific_humidity
 moist_static_energy
 q_vap_saturation
 q_vap_saturation_generic

--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -1,7 +1,8 @@
 # Atmospheric equation of state
 export air_pressure,
     air_temperature, air_density, specific_volume, soundspeed_air
-export total_specific_humidity
+export total_specific_humidity,
+    liquid_specific_humidity, ice_specific_humidity, vapor_specific_humidity
 
 # Energies
 export total_energy, internal_energy, internal_energy_sat
@@ -31,7 +32,6 @@ export liquid_ice_pottemp,
 export air_temperature_from_liquid_ice_pottemp,
     air_temperature_from_liquid_ice_pottemp_given_pressure
 export air_temperature_from_liquid_ice_pottemp_non_linear
-export vapor_specific_humidity
 export virtual_temperature
 export temperature_and_humidity_from_virtual_temperature
 export air_temperature_from_ideal_gas_law
@@ -67,14 +67,6 @@ gas_constant_air(ts::ThermodynamicState) =
     gas_constant_air(ts.param_set, PhasePartition(ts))
 gas_constant_air(ts::PhaseDry{FT}) where {FT <: Real} = FT(R_d(ts.param_set))
 
-"""
-    vapor_specific_humidity(q::PhasePartition{FT})
-
-The vapor specific humidity, given a `PhasePartition` `q`.
-"""
-vapor_specific_humidity(q::PhasePartition) = q.tot - q.liq - q.ice
-vapor_specific_humidity(ts::ThermodynamicState) =
-    vapor_specific_humidity(PhasePartition(ts))
 
 """
     air_pressure(param_set, T, ρ[, q::PhasePartition])
@@ -161,6 +153,43 @@ or
 total_specific_humidity(ts::ThermodynamicState) = ts.q_tot
 total_specific_humidity(ts::PhaseDry{FT}) where {FT} = FT(0)
 total_specific_humidity(ts::PhaseNonEquil) = ts.q.tot
+
+"""
+    liquid_specific_humidity(ts::ThermodynamicState)
+    liquid_specific_humidity(q::PhasePartition)
+
+Liquid specific humidity given
+ - `ts` a thermodynamic state
+or
+ - `q` a `PhasePartition`
+"""
+liquid_specific_humidity(q::PhasePartition) = q.liq
+liquid_specific_humidity(ts::ThermodynamicState) = PhasePartition(ts).liq
+liquid_specific_humidity(ts::PhaseDry{FT}) where {FT} = FT(0)
+liquid_specific_humidity(ts::PhaseNonEquil) = ts.q.liq
+
+"""
+    ice_specific_humidity(ts::ThermodynamicState)
+    ice_specific_humidity(q::PhasePartition)
+
+Ice specific humidity given
+ - `ts` a thermodynamic state
+or
+ - `q` a `PhasePartition`
+"""
+ice_specific_humidity(q::PhasePartition) = q.ice
+ice_specific_humidity(ts::ThermodynamicState) = PhasePartition(ts).ice
+ice_specific_humidity(ts::PhaseDry{FT}) where {FT} = FT(0)
+ice_specific_humidity(ts::PhaseNonEquil) = ts.q.ice
+
+"""
+    vapor_specific_humidity(q::PhasePartition{FT})
+
+The vapor specific humidity, given a `PhasePartition` `q`.
+"""
+vapor_specific_humidity(q::PhasePartition) = q.tot - q.liq - q.ice
+vapor_specific_humidity(ts::ThermodynamicState) =
+    vapor_specific_humidity(PhasePartition(ts))
 
 """
     cp_m(param_set, [q::PhasePartition])

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -1102,6 +1102,8 @@ end
         @test typeof.(air_pressure.(ts)) == typeof.(e_int)
         @test typeof.(air_density.(ts)) == typeof.(e_int)
         @test typeof.(total_specific_humidity.(ts)) == typeof.(e_int)
+        @test typeof.(liquid_specific_humidity.(ts)) == typeof.(e_int)
+        @test typeof.(ice_specific_humidity.(ts)) == typeof.(e_int)
         @test typeof.(cp_m.(ts)) == typeof.(e_int)
         @test typeof.(cv_m.(ts)) == typeof.(e_int)
         @test typeof.(air_temperature.(ts)) == typeof.(e_int)
@@ -1153,6 +1155,10 @@ end
     @test all(
         total_specific_humidity.(ts_eq) .≈ total_specific_humidity.(ts_dry),
     )
+    @test all(
+        liquid_specific_humidity.(ts_eq) .≈ liquid_specific_humidity.(ts_dry),
+    )
+    @test all(ice_specific_humidity.(ts_eq) .≈ ice_specific_humidity.(ts_dry))
     @test all(cp_m.(ts_eq) .≈ cp_m.(ts_dry))
     @test all(cv_m.(ts_eq) .≈ cv_m.(ts_dry))
     @test all(air_temperature.(ts_eq) .≈ air_temperature.(ts_dry))


### PR DESCRIPTION
# Description

This PR adds
 - `liquid_specific_humidity`
 - `ice_specific_humidity`

to Thermodynamics. This may allow us to nicely extend some pieces in the EDMF model (subdomain statistics).

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
