### PR TITLE
Add HLLC numerical flux

### DIFF
--- a/docs/src/APIs/Numerics/DGMethods/NumericalFluxes.md
+++ b/docs/src/APIs/Numerics/DGMethods/NumericalFluxes.md
@@ -10,6 +10,7 @@ CurrentModule = ClimateMachine.DGMethods.NumericalFluxes
 NumericalFluxGradient
 RusanovNumericalFlux
 RoeNumericalFlux
+HLLCNumericalFlux
 NumericalFluxFirstOrder
 NumericalFluxSecondOrder
 CentralNumericalFluxSecondOrder

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -72,8 +72,10 @@ import ..DGMethods.NumericalFluxes:
     CentralNumericalFluxHigherOrder,
     CentralNumericalFluxDivergence,
     CentralNumericalFluxFirstOrder,
-    numerical_flux_first_order!
-using ..DGMethods.NumericalFluxes: RoeNumericalFlux
+    numerical_flux_first_order!,
+    NumericalFluxFirstOrder
+using ..DGMethods.NumericalFluxes:
+    RoeNumericalFlux, HLLCNumericalFlux, RusanovNumericalFlux
 
 import ..Courant: advective_courant, nondiffusive_courant, diffusive_courant
 
@@ -900,4 +902,128 @@ function numerical_flux_first_order!(
         fluxᵀn.tracers.ρχ -= ((w1 + w2) * χ̃ + wt) / 2
     end
 end
+
+function numerical_flux_first_order!(
+    ::HLLCNumericalFlux,
+    balance_law::AtmosModel,
+    fluxᵀn::Vars{S},
+    normal_vector::SVector,
+    state_prognostic⁻::Vars{S},
+    state_auxiliary⁻::Vars{A},
+    state_prognostic⁺::Vars{S},
+    state_auxiliary⁺::Vars{A},
+    t,
+    direction,
+) where {S, A}
+    FT = eltype(fluxᵀn)
+    num_state_prognostic = number_states(balance_law, Prognostic())
+    param_set = balance_law.param_set
+
+    flux⁻ = similar(parent(fluxᵀn), Size(3, num_state_prognostic))
+    fill!(flux⁻, -zero(FT))
+    flux_first_order!(
+        balance_law,
+        Grad{S}(flux⁻),
+        state_prognostic⁻,
+        state_auxiliary⁻,
+        t,
+        direction,
+    )
+    fluxᵀn⁻ = flux⁻' * normal_vector
+
+    flux⁺ = similar(flux⁻)
+    fill!(flux⁺, -zero(FT))
+    flux_first_order!(
+        balance_law,
+        Grad{S}(flux⁺),
+        state_prognostic⁺,
+        state_auxiliary⁺,
+        t,
+        direction,
+    )
+    fluxᵀn⁺ = flux⁺' * normal_vector
+
+    ρ⁻ = state_prognostic⁻.ρ
+    ρu⁻ = state_prognostic⁻.ρu
+    ρe⁻ = state_prognostic⁻.ρe
+    ts⁻ = recover_thermo_state(
+        balance_law,
+        balance_law.moisture,
+        state_prognostic⁻,
+        state_auxiliary⁻,
+    )
+
+    u⁻ = ρu⁻ / ρ⁻
+    c⁻ = soundspeed_air(ts⁻)
+
+    uᵀn⁻ = u⁻' * normal_vector
+    e⁻ = ρe⁻ / ρ⁻
+    p⁻ = air_pressure(ts⁻)
+
+    ρ⁺ = state_prognostic⁺.ρ
+    ρu⁺ = state_prognostic⁺.ρu
+    ρe⁺ = state_prognostic⁺.ρe
+    ts⁺ = recover_thermo_state(
+        balance_law,
+        balance_law.moisture,
+        state_prognostic⁺,
+        state_auxiliary⁺,
+    )
+
+    u⁺ = ρu⁺ / ρ⁺
+    uᵀn⁺ = u⁺' * normal_vector
+    e⁺ = ρe⁺ / ρ⁺
+    p⁺ = air_pressure(ts⁺)
+    c⁺ = soundspeed_air(ts⁺)
+    S⁻ = min(uᵀn⁻ - c⁻, uᵀn⁺ - c⁺)
+    S⁺ = max(uᵀn⁻ + c⁻, uᵀn⁺ + c⁺)
+
+    # Compute the middle wave speed S⁰
+    S⁰ =
+        (p⁺ - p⁻ + ρ⁻ * uᵀn⁻ * (S⁻ - uᵀn⁻) - ρ⁺ * uᵀn⁺ * (S⁺ - uᵀn⁺)) /
+        (ρ⁻ * (S⁻ - uᵀn⁻) - ρ⁺ * (S⁺ - uᵀn⁺))
+
+    p⁰ =
+        (
+            p⁺ +
+            p⁻ +
+            ρ⁻ * (S⁻ - uᵀn⁻) * (S⁰ - uᵀn⁻) +
+            ρ⁺ * (S⁺ - uᵀn⁺) * (S⁰ - uᵀn⁺)
+        ) / 2
+
+    # Compute p * D = p * (0, n₁, n₂, n₃, S⁰)
+    pD = @MVector zeros(FT, num_state_prognostic)
+    if balance_law.ref_state isa HydrostaticState
+        # pressure should be continuous but it doesn't hurt to average
+        ref_p⁻ = state_auxiliary⁻.ref_state.p
+        ref_p⁺ = state_auxiliary⁺.ref_state.p
+        ref_p⁰ = (ref_p⁻ + ref_p⁺) / 2
+
+        momentum_p = p⁰ - ref_p⁰
+    else
+        momentum_p = p⁰
+    end
+
+    pD[2] = momentum_p * normal_vector[1]
+    pD[3] = momentum_p * normal_vector[2]
+    pD[4] = momentum_p * normal_vector[3]
+    pD[5] = p⁰ * S⁰
+
+    # Computes both +/- sides of intermediate flux term F⁰
+    flux⁰⁻ =
+        (S⁰ * (S⁻ * parent(state_prognostic⁻) - fluxᵀn⁻) + S⁻ * pD) / (S⁻ - S⁰)
+    flux⁰⁺ =
+        (S⁰ * (S⁺ * parent(state_prognostic⁺) - fluxᵀn⁺) + S⁺ * pD) / (S⁺ - S⁰)
+
+    if 0 <= S⁻
+        parent(fluxᵀn) .= fluxᵀn⁻
+    elseif S⁻ < 0 <= S⁰
+        parent(fluxᵀn) .= flux⁰⁻
+    elseif S⁰ < 0 <= S⁺
+        parent(fluxᵀn) .= flux⁰⁺
+    else # 0 > S⁺
+        parent(fluxᵀn) .= fluxᵀn⁺
+    end
+end
+
 end # module

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -903,6 +903,32 @@ function numerical_flux_first_order!(
     end
 end
 
+"""
+    NumericalFluxFirstOrder()
+        ::HLLCNumericalFlux,
+        balance_law::AtmosModel,
+        fluxᵀn,
+        normal_vector,
+        state_prognostic⁻,
+        state_auxiliary⁻,
+        state_prognostic⁺,
+        state_auxiliary⁺,
+        t,
+        direction,
+    )
+
+An implementation of the numerical flux based on the HLLC method for
+the AtmosModel. For more information on this particular implementation,
+see Chapter 10.4 in the provided reference below.
+
+## References
+    @book{toro2013riemann,
+        title={Riemann solvers and numerical methods for fluid dynamics: a practical introduction},
+        author={Toro, Eleuterio F},
+        year={2013},
+        publisher={Springer Science & Business Media}
+    }
+"""
 function numerical_flux_first_order!(
     ::HLLCNumericalFlux,
     balance_law::AtmosModel,
@@ -919,6 +945,9 @@ function numerical_flux_first_order!(
     num_state_prognostic = number_states(balance_law, Prognostic())
     param_set = balance_law.param_set
 
+    # Extract the first-order fluxes from the AtmosModel (underlying BalanceLaw)
+    # and compute normals on the positive + and negative - sides of the
+    # interior facets
     flux⁻ = similar(parent(fluxᵀn), Size(3, num_state_prognostic))
     fill!(flux⁻, -zero(FT))
     flux_first_order!(
@@ -943,6 +972,8 @@ function numerical_flux_first_order!(
     )
     fluxᵀn⁺ = flux⁺' * normal_vector
 
+    # Extract relevant fields and thermodynamic variables defined on
+    # the positive + and negative - sides of the interior facets
     ρ⁻ = state_prognostic⁻.ρ
     ρu⁻ = state_prognostic⁻.ρu
     ρe⁻ = state_prognostic⁻.ρe
@@ -975,10 +1006,12 @@ function numerical_flux_first_order!(
     e⁺ = ρe⁺ / ρ⁺
     p⁺ = air_pressure(ts⁺)
     c⁺ = soundspeed_air(ts⁺)
+
+    # Wave speeds estimates S⁻ and S⁺
     S⁻ = min(uᵀn⁻ - c⁻, uᵀn⁺ - c⁺)
     S⁺ = max(uᵀn⁻ + c⁻, uᵀn⁺ + c⁺)
 
-    # Compute the middle wave speed S⁰
+    # Compute the middle wave speed S⁰ in the contact/star region
     S⁰ =
         (p⁺ - p⁻ + ρ⁻ * uᵀn⁻ * (S⁻ - uᵀn⁻) - ρ⁺ * uᵀn⁺ * (S⁺ - uᵀn⁺)) /
         (ρ⁻ * (S⁻ - uᵀn⁻) - ρ⁺ * (S⁺ - uᵀn⁺))
@@ -1009,7 +1042,7 @@ function numerical_flux_first_order!(
     pD[4] = momentum_p * normal_vector[3]
     pD[5] = p⁰ * S⁰
 
-    # Computes both +/- sides of intermediate flux term F⁰
+    # Computes both +/- sides of intermediate flux term flux⁰
     flux⁰⁻ =
         (S⁰ * (S⁻ * parent(state_prognostic⁻) - fluxᵀn⁻) + S⁻ * pD) / (S⁻ - S⁰)
     flux⁰⁺ =

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -345,3 +345,32 @@ function numerical_flux_first_order!(
     fluxᵀn.ρu -= c̃ * Δρuᵀn * normal_vector / 2
     fluxᵀn.ρe -= h̃ * ΔpL / 2c̃
 end
+
+function numerical_flux_first_order!(
+    ::HLLCNumericalFlux,
+    balance_law::AtmosLinearModel,
+    fluxᵀn::Vars{S},
+    normal_vector::SVector,
+    state_prognostic⁻::Vars{S},
+    state_auxiliary⁻::Vars{A},
+    state_prognostic⁺::Vars{S},
+    state_auxiliary⁺::Vars{A},
+    t,
+    direction,
+) where {S, A}
+
+    # There is no intermediate speed for the AtmosLinearModel.
+    # As a result, HLLC simplifies to Rusanov.
+    numerical_flux_first_order!(
+        RusanovNumericalFlux(),
+        balance_law,
+        fluxᵀn,
+        normal_vector,
+        state_prognostic⁻,
+        state_auxiliary⁻,
+        state_prognostic⁺,
+        state_auxiliary⁺,
+        t,
+        direction,
+    )
+end

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -5,6 +5,7 @@ export NumericalFluxGradient,
     NumericalFluxSecondOrder,
     RusanovNumericalFlux,
     RoeNumericalFlux,
+    HLLCNumericalFlux,
     CentralNumericalFluxGradient,
     CentralNumericalFluxFirstOrder,
     CentralNumericalFluxSecondOrder,
@@ -319,6 +320,20 @@ A numerical flux based on the approximate Riemann solver of Roe
 Requires a custom implementation for the balance law.
 """
 struct RoeNumericalFlux <: NumericalFluxFirstOrder end
+
+"""
+    HLLCNumericalFlux() <: NumericalFluxFirstOrder
+
+A numerical flux based on the approximate Riemann solver of the
+HLLC method.
+
+# Usage
+
+    HLLCNumericalFlux()
+
+Requires a custom implementation for the balance law.
+"""
+struct HLLCNumericalFlux <: NumericalFluxFirstOrder end
 
 """
     NumericalFluxSecondOrder

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -325,13 +325,24 @@ struct RoeNumericalFlux <: NumericalFluxFirstOrder end
     HLLCNumericalFlux() <: NumericalFluxFirstOrder
 
 A numerical flux based on the approximate Riemann solver of the
-HLLC method.
+HLLC method. The HLLC flux is a modification of the Harten, Lax, van-Leer
+(HLL) flux, where an additional contact property is introduced in order
+to restore missing rarefraction waves. The HLLC flux requires
+model-specific information, hence it requires a custom implementation
+based on the underlying balance law.
 
 # Usage
 
     HLLCNumericalFlux()
 
 Requires a custom implementation for the balance law.
+
+    @book{toro2013riemann,
+        title={Riemann solvers and numerical methods for fluid dynamics: a practical introduction},
+        author={Toro, Eleuterio F},
+        year={2013},
+        publisher={Springer Science & Business Media}
+    }
 """
 struct HLLCNumericalFlux <: NumericalFluxFirstOrder end
 

--- a/test/Atmos/Model/discrete-hydrostatic-balance.jl
+++ b/test/Atmos/Model/discrete-hydrostatic-balance.jl
@@ -127,8 +127,11 @@ function main()
 
     @testset for config in (LES, GCM)
         @testset for ode_solver_type in (explicit_solver_type, imex_solver_type)
-            @testset for numflux in
-                         (CentralNumericalFluxFirstOrder(), RoeNumericalFlux())
+            @testset for numflux in (
+                CentralNumericalFluxFirstOrder(),
+                RoeNumericalFlux(),
+                HLLCNumericalFlux(),
+            )
                 @testset for temp_profile in (
                     IsothermalProfile(param_set, FT),
                     DecayingTemperatureProfile{FT}(param_set),

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -48,6 +48,7 @@ function main()
     Rusanov = RusanovNumericalFlux
     Central = CentralNumericalFluxFirstOrder
     Roe = RoeNumericalFlux
+    HLLC = HLLCNumericalFlux
 
     expected_error[Float64, 2, Rusanov, 1] = 1.1990999506538110e+01
     expected_error[Float64, 2, Rusanov, 2] = 2.0813000228865612e+00
@@ -64,6 +65,11 @@ function main()
     expected_error[Float64, 2, Roe, 3] = 6.6174934435569849e-02
     expected_error[Float64, 2, Roe, 4] = 2.1917769287815940e-03
 
+    expected_error[Float64, 2, HLLC, 1] = 1.2889756097329746e+01
+    expected_error[Float64, 2, HLLC, 2] = 1.3895808565455936e+00
+    expected_error[Float64, 2, HLLC, 3] = 6.6175116756217900e-02
+    expected_error[Float64, 2, HLLC, 4] = 2.1917772135679118e-03
+
     expected_error[Float64, 3, Rusanov, 1] = 3.7918869862613858e+00
     expected_error[Float64, 3, Rusanov, 2] = 6.5816485664822677e-01
     expected_error[Float64, 3, Rusanov, 3] = 2.0160333422867591e-02
@@ -78,6 +84,11 @@ function main()
     expected_error[Float64, 3, Roe, 2] = 4.3942394181655547e-01
     expected_error[Float64, 3, Roe, 3] = 2.0926351682882375e-02
     expected_error[Float64, 3, Roe, 4] = 6.9310072176312712e-04
+
+    expected_error[Float64, 3, HLLC, 1] = 4.0760987751605402e+00
+    expected_error[Float64, 3, HLLC, 2] = 4.3942404996518236e-01
+    expected_error[Float64, 3, HLLC, 3] = 2.0926409337758904e-02
+    expected_error[Float64, 3, HLLC, 4] = 6.9310081182571569e-04
 
     expected_error[Float32, 2, Rusanov, 1] = 1.1990781784057617e+01
     expected_error[Float32, 2, Rusanov, 2] = 2.0813269615173340e+00
@@ -94,6 +105,11 @@ function main()
     expected_error[Float32, 2, Roe, 3] = 6.8037144839763641e-02
     expected_error[Float32, 2, Roe, 4] = 3.8893952965736389e-02
 
+    expected_error[Float32, 2, HLLC, 1] = 1.2889801025390625e+01
+    expected_error[Float32, 2, HLLC, 2] = 1.3895059823989868e+00
+    expected_error[Float32, 2, HLLC, 3] = 6.8006515502929688e-02
+    expected_error[Float32, 2, HLLC, 4] = 3.8637656718492508e-02
+
     expected_error[Float32, 3, Rusanov, 1] = 3.7918186187744141e+00
     expected_error[Float32, 3, Rusanov, 2] = 6.5816193819046021e-01
     expected_error[Float32, 3, Rusanov, 3] = 2.0893247798085213e-02
@@ -109,9 +125,14 @@ function main()
     expected_error[Float32, 3, Roe, 3] = 2.1365188062191010e-02
     expected_error[Float32, 3, Roe, 4] = 9.3323951587080956e-03
 
+    expected_error[Float32, 3, HLLC, 1] = 4.0760631561279297e+00
+    expected_error[Float32, 3, HLLC, 2] = 4.3940672278404236e-01
+    expected_error[Float32, 3, HLLC, 3] = 2.1352596580982208e-02
+    expected_error[Float32, 3, HLLC, 4] = 9.2315869405865669e-03
+
     @testset "$(@__FILE__)" begin
         for FT in (Float64, Float32), dims in (2, 3)
-            for NumericalFlux in (Roe, Rusanov, Central)
+            for NumericalFlux in (Rusanov, Central, Roe, HLLC)
                 @info @sprintf """Configuration
                                   ArrayType     = %s
                                   FT        = %s


### PR DESCRIPTION
Co-authored-by: Thomas Gibson <thomas.gibson@nps.edu>

# Description

Adds HLLC numerical flux.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
