### PR TITLE
Fix horizontal average

### DIFF
--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -324,8 +324,9 @@ function horizontally_average!(
     state_data = array_device(Q) isa CPU ? Q.realdata : Array(Q.realdata)
     Nqk = dimensionality(grid) == 2 ? 1 : Nq
     for ev in 1:size(state_data, 3), k in 1:Nqk, i_v in i_vars
-        Q_sum = sum((1:Nq, 1:Nq)) do ij
-            state_data[ij[1] + Nq * ((ij[2] - 1) + Nq * (k - 1)), i_v, ev]
+        Q_sum = 0
+        for i in 1:Nq, j in 1:Nq
+            Q_sum += state_data[i + Nq * ((j - 1) + Nq * (k - 1)), i_v, ev]
         end
         Q_ave = Q_sum / (Nq * Nq)
         for i in 1:Nq, j in 1:Nq

--- a/test/Utilities/SingleStackUtils/ssu_tests.jl
+++ b/test/Utilities/SingleStackUtils/ssu_tests.jl
@@ -85,7 +85,7 @@ function test_horizontally_ave(
 ) where {T, dim, N}
     Q = deepcopy(Q_in)
     state_vars_var = get_horizontal_variance(grid, Q, vars)
-    i_vars = (varsindex(vars, :ρ),)
+    i_vars = varsindex(vars, :ρ)
     horizontally_average!(grid, Q, i_vars)
     FT = eltype(Q)
     state_vars_var = get_horizontal_variance(grid, Q, vars)


### PR DESCRIPTION
# Description

Fixes a bug in `horizontally_average!`. That syntax didn't do what I thought.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
