### PR TITLE
Project density to N-1 degree polynomial in the vertical

### DIFF
--- a/src/Atmos/Model/filters.jl
+++ b/src/Atmos/Model/filters.jl
@@ -1,4 +1,5 @@
 export AtmosFilterPerturbations
+export AtmosFilterDensityPerturbation
 
 import ..Mesh.Filters:
     AbstractFilterTarget,
@@ -50,4 +51,28 @@ function compute_filter_result!(
         filter_state.moisture.ρq_liq += aux.ref_state.ρq_liq
         filter_state.moisture.ρq_ice += aux.ref_state.ρq_ice
     end
+end
+
+struct AtmosFilterDensityPerturbation{M} <: AbstractFilterTarget
+    atmos::M
+end
+
+vars_state_filtered(target::AtmosFilterDensityPerturbation, FT) =
+    @vars(projected_ρ::FT)
+
+function compute_filter_argument!(
+    target::AtmosFilterDensityPerturbation,
+    filter_state::Vars,
+    state::Vars,
+    aux::Vars,
+)
+    filter_state.projected_ρ = aux.projected_ρ - aux.ref_state.ρ
+end
+function compute_filter_result!(
+    target::AtmosFilterDensityPerturbation,
+    state::Vars,
+    filter_state::Vars,
+    aux::Vars,
+)
+    state.projected_ρ = filter_state.projected_ρ + aux.ref_state.ρ
 end

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -254,6 +254,41 @@ function flux_first_order!(
     flux.ρe = ((ref.ρe + ref.p) / ref.ρ) * state.ρu
     nothing
 end
+
+function update_auxiliary_state!(
+    dg::DGModel,
+    lm::AtmosAcousticGravityLinearModel,
+    Q::MPIStateArray,
+    t::Real,
+    elems::UnitRange,
+)
+    state_auxiliary = dg.state_auxiliary
+    update_auxiliary_state!(nodal_update_auxiliary_state!, dg, lm, Q, t, elems)
+
+    # Filter the highest order vertical mode from density
+    grid = dg.grid
+    Filters.apply!(
+        state_auxiliary,
+        (:projected_ρ,),
+        grid,
+        Filters.CutoffFilter(grid),
+        state_auxiliary = state_auxiliary,
+        direction = VerticalDirection(),
+    )
+
+    return true
+end
+
+function nodal_update_auxiliary_state!(
+    ::AtmosAcousticGravityLinearModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    aux.projected_ρ = state.ρ
+end
+
+
 function source!(
     lm::AtmosAcousticGravityLinearModel,
     source::Vars,
@@ -265,7 +300,7 @@ function source!(
 ) where {Dir <: Direction}
     if Dir === VerticalDirection || Dir === EveryDirection
         ∇Φ = ∇gravitational_potential(lm.atmos.orientation, aux)
-        source.ρu -= state.ρ * ∇Φ
+        source.ρu -= aux.projected_ρ * ∇Φ
     end
     nothing
 end

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -75,9 +75,9 @@ function atmos_source!(
     direction,
 )
     if atmos.ref_state isa HydrostaticState
-        source.ρu -= (state.ρ - aux.ref_state.ρ) * aux.orientation.∇Φ
+        source.ρu -= (aux.projected_ρ - aux.ref_state.ρ) * aux.orientation.∇Φ
     else
-        source.ρu -= state.ρ * aux.orientation.∇Φ
+        source.ρu -= aux.projected_ρ * aux.orientation.∇Φ
     end
 end
 


### PR DESCRIPTION
Co-authored-by: Thomas Gibson <thomas.gibson@nps.edu>

# Description

Applies the projection technique from the paper https://doi.org/10.1002/fld.4197 that may help with stability.
The highest order mode of density in the vertical is filtered out in the gravity source term.

@bischtob 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
