### PR TITLE
add NonEquilMoist model to Atmos

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -35,9 +35,10 @@ ClimateMachine.Atmos.new_thermo_state
 ## Moisture
 
 ```@docs
-ClimateMachine.Atmos.NoPrecipitation
 ClimateMachine.Atmos.DryModel
 ClimateMachine.Atmos.EquilMoist
+ClimateMachine.Atmos.NonEquilMoist
+ClimateMachine.Atmos.NoPrecipitation
 ClimateMachine.Atmos.Rain
 ```
 
@@ -70,4 +71,5 @@ ClimateMachine.Atmos.average_density
 
 ```@docs
 ClimateMachine.Atmos.RemovePrecipitation
+ClimateMachine.Atmos.CreateClouds
 ```

--- a/src/Atmos/Model/filters.jl
+++ b/src/Atmos/Model/filters.jl
@@ -27,6 +27,10 @@ function compute_filter_argument!(
     if !(target.atmos.moisture isa DryModel)
         filter_state.moisture.ρq_tot -= aux.ref_state.ρq_tot
     end
+    if (target.atmos.moisture isa NonEquilMoist)
+        filter_state.moisture.ρq_liq -= aux.ref_state.ρq_liq
+        filter_state.moisture.ρq_ice -= aux.ref_state.ρq_ice
+    end
 end
 function compute_filter_result!(
     target::AtmosFilterPerturbations,
@@ -41,5 +45,9 @@ function compute_filter_result!(
     state.ρe += aux.ref_state.ρe
     if !(target.atmos.moisture isa DryModel)
         state.moisture.ρq_tot += aux.ref_state.ρq_tot
+    end
+    if (target.atmos.moisture isa NonEquilMoist)
+        filter_state.moisture.ρq_liq += aux.ref_state.ρq_liq
+        filter_state.moisture.ρq_ice += aux.ref_state.ρq_ice
     end
 end

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -61,6 +61,24 @@ end
         state.moisture.ρq_tot,
     )
 end
+@inline function linearized_pressure(
+    ::NonEquilMoist,
+    param_set::AbstractParameterSet,
+    orientation::Orientation,
+    state::Vars,
+    aux::Vars,
+)
+    ρe_pot = state.ρ * gravitational_potential(orientation, aux)
+    linearized_air_pressure(
+        param_set,
+        state.ρ,
+        state.ρe,
+        ρe_pot,
+        state.moisture.ρq_tot,
+        state.moisture.ρq_liq,
+        state.moisture.ρq_ice,
+    )
+end
 
 abstract type AtmosLinearModel <: BalanceLaw end
 

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -53,7 +53,7 @@ function HydrostaticState(
 end
 
 vars_state(m::HydrostaticState, ::Auxiliary, FT) =
-    @vars(ρ::FT, p::FT, T::FT, ρe::FT, ρq_tot::FT)
+    @vars(ρ::FT, p::FT, T::FT, ρe::FT, ρq_tot::FT, ρq_liq::FT, ρq_ice::FT)
 
 atmos_init_ref_state_pressure!(m, _...) = nothing
 function atmos_init_ref_state_pressure!(
@@ -98,9 +98,13 @@ function atmos_init_aux!(
     # p, ρ, and q_pt
     T = air_temperature_from_ideal_gas_law(atmos.param_set, p, ρ, q_pt)
     q_tot = q_pt.tot
+    q_liq = q_pt.liq
+    q_ice = q_pt.ice
     ts = TemperatureSHumEquil(atmos.param_set, T, ρ, q_tot)
 
     aux.ref_state.ρq_tot = ρ * q_tot
+    aux.ref_state.ρq_liq = ρ * q_liq
+    aux.ref_state.ρq_ice = ρ * q_ice
     aux.ref_state.T = T
     e_kin = F(0)
     e_pot = gravitational_potential(atmos.orientation, aux)

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -1,5 +1,5 @@
 using ..Microphysics_0M
-using CLIMAParameters.Planet: Omega, e_int_i0, cv_d, cv_l, cv_i, T_0
+using CLIMAParameters.Planet: Omega, e_int_i0, cv_l, cv_i, T_0
 
 export Source,
     Gravity,
@@ -7,7 +7,8 @@ export Source,
     Subsidence,
     GeostrophicForcing,
     Coriolis,
-    RemovePrecipitation
+    RemovePrecipitation,
+    CreateClouds
 
 # kept for compatibility
 # can be removed if no functions are using this
@@ -180,6 +181,43 @@ function atmos_source!(
         β_sponge = s.α_max * sinpi(r / 2)^s.γ
         source.ρu -= β_sponge * (state.ρu .- state.ρ * s.u_relaxation)
     end
+end
+
+"""
+    CreateClouds{FT} <: Source
+
+A source/sink to `q_liq` and `q_ice` implemented as a relaxation towards
+equilibrium in the Microphysics module.
+The default relaxation timescales are defined in CLIMAParameters.jl.
+"""
+struct CreateClouds <: Source end
+function atmos_source!(
+    ::CreateClouds,
+    atmos::AtmosModel,
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
+    # get current temperature and phase partition
+    FT = eltype(state)
+    ts = recover_thermo_state(atmos, state, aux)
+    q = PhasePartition(ts)
+    T = air_temperature(ts)
+
+    # phase partition corresponding to the current T and q.tot
+    # (this is not the same as phase partition from saturation adjustment)
+    ts_eq = TemperatureSHumEquil(atmos.param_set, T, state.ρ, q.tot)
+    q_eq = PhasePartition(ts_eq)
+
+    # cloud condensate as relaxation source terms
+    S_q_liq = conv_q_vap_to_q_liq_ice(atmos.param_set.microphys.liq, q_eq, q)
+    S_q_ice = conv_q_vap_to_q_liq_ice(atmos.param_set.microphys.ice, q_eq, q)
+
+    source.moisture.ρq_liq += state.ρ * S_q_liq
+    source.moisture.ρq_ice += state.ρ * S_q_ice
 end
 
 """

--- a/src/Atmos/Model/thermodynamics.jl
+++ b/src/Atmos/Model/thermodynamics.jl
@@ -42,6 +42,27 @@ function new_thermo_state(
     )
 end
 
+function new_thermo_state(
+    atmos::AtmosModel,
+    moist::NonEquilMoist,
+    state::Vars,
+    aux::Vars,
+)
+    e_int = internal_energy(atmos, state, aux)
+    q = PhasePartition(
+        state.moisture.ρq_tot / state.ρ,
+        state.moisture.ρq_liq / state.ρ,
+        state.moisture.ρq_ice / state.ρ,
+    )
+
+    return PhaseNonEquil{eltype(state), typeof(atmos.param_set)}(
+        atmos.param_set,
+        e_int,
+        state.ρ,
+        q,
+    )
+end
+
 """
     recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars)
 
@@ -78,5 +99,26 @@ function recover_thermo_state(
         state.ρ,
         state.moisture.ρq_tot / state.ρ,
         aux.moisture.temperature,
+    )
+end
+
+function recover_thermo_state(
+    atmos::AtmosModel,
+    moist::NonEquilMoist,
+    state::Vars,
+    aux::Vars,
+)
+    e_int = internal_energy(atmos, state, aux)
+    q = PhasePartition(
+        state.moisture.ρq_tot / state.ρ,
+        state.moisture.ρq_liq / state.ρ,
+        state.moisture.ρq_ice / state.ρ,
+    )
+
+    return PhaseNonEquil{eltype(state), typeof(atmos.param_set)}(
+        atmos.param_set,
+        e_int,
+        state.ρ,
+        q,
     )
 end

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -68,6 +68,18 @@ function vars_atmos_les_default_simple(m::EquilMoist, FT)
     @vars begin
         qt::FT                  # q_tot
         ql::FT                  # q_liq
+        qi::FT                  # q_ice
+        qv::FT                  # q_vap
+        thv::FT                 # θ_vir
+        thl::FT                 # θ_liq
+        w_qt_sgs::FT
+    end
+end
+function vars_atmos_les_default_simple(m::NonEquilMoist, FT)
+    @vars begin
+        qt::FT                  # q_tot
+        ql::FT                  # q_liq
+        qi::FT                  # q_ice
         qv::FT                  # q_vap
         thv::FT                 # θ_vir
         thl::FT                 # θ_liq
@@ -140,6 +152,7 @@ function atmos_les_default_simple_sums!(
 )
     sums.moisture.qt += MH * state.moisture.ρq_tot
     sums.moisture.ql += MH * thermo.moisture.q_liq * state.ρ
+    sums.moisture.qi += MH * thermo.moisture.q_ice * state.ρ
     sums.moisture.qv += MH * thermo.moisture.q_vap * state.ρ
     sums.moisture.thv += MH * thermo.moisture.θ_vir * state.ρ
     sums.moisture.thl += MH * thermo.moisture.θ_liq_ice * state.ρ
@@ -148,6 +161,28 @@ function atmos_les_default_simple_sums!(
 
     return nothing
 end
+function atmos_les_default_simple_sums!(
+    moist::NonEquilMoist,
+    state,
+    gradflux,
+    thermo,
+    MH,
+    D_t,
+    sums,
+)
+    sums.moisture.qt += MH * state.moisture.ρq_tot
+    sums.moisture.ql += MH * thermo.moisture.q_liq * state.ρ
+    sums.moisture.qi += MH * thermo.moisture.q_ice * state.ρ
+    sums.moisture.qv += MH * thermo.moisture.q_vap * state.ρ
+    sums.moisture.thv += MH * thermo.moisture.θ_vir * state.ρ
+    sums.moisture.thl += MH * thermo.moisture.θ_liq_ice * state.ρ
+    d_q_tot = (-D_t) .* gradflux.moisture.∇q_tot
+    sums.moisture.w_qt_sgs += MH * d_q_tot[end] * state.ρ
+
+    return nothing
+end
+
+
 
 # Variances and covariances
 function vars_atmos_les_default_ho(m::AtmosModel, FT)
@@ -176,6 +211,22 @@ function vars_atmos_les_default_ho(m::EquilMoist, FT)
 
         cov_w_qt::FT            # w′q_tot′
         cov_w_ql::FT            # w′q_liq′
+        cov_w_qi::FT            # w′q_ice′
+        cov_w_qv::FT            # w′q_vap′
+        cov_w_thv::FT           # w′θ_v′
+        cov_w_thl::FT           # w′θ_liq_ice′
+        cov_qt_thl::FT          # q_tot′θ_liq_ice′
+        cov_qt_ei::FT           # q_tot′e_int′
+    end
+end
+function vars_atmos_les_default_ho(m::NonEquilMoist, FT)
+    @vars begin
+        var_qt::FT              # q_tot′q_tot′
+        var_thl::FT             # θ_liq_ice′θ_liq_ice′
+
+        cov_w_qt::FT            # w′q_tot′
+        cov_w_ql::FT            # w′q_liq′
+        cov_w_qi::FT            # w′q_ice′
         cov_w_qv::FT            # w′q_vap′
         cov_w_thv::FT           # w′θ_v′
         cov_w_thl::FT           # w′θ_liq_ice′
@@ -256,6 +307,7 @@ function atmos_les_default_ho_sums!(
     q_tot = state.moisture.ρq_tot / state.ρ
     q_tot′ = q_tot - ha.moisture.qt
     q_liq′ = thermo.moisture.q_liq - ha.moisture.ql
+    q_ice′ = thermo.moisture.q_ice - ha.moisture.qi
     q_vap′ = thermo.moisture.q_vap - ha.moisture.qv
     θ_vir′ = thermo.moisture.θ_vir - ha.moisture.thv
     θ_liq_ice′ = thermo.moisture.θ_liq_ice - ha.moisture.thl
@@ -265,6 +317,39 @@ function atmos_les_default_ho_sums!(
 
     sums.moisture.cov_w_qt += MH * w′ * q_tot′ * state.ρ
     sums.moisture.cov_w_ql += MH * w′ * q_liq′ * state.ρ
+    sums.moisture.cov_w_qi += MH * w′ * q_ice′ * state.ρ
+    sums.moisture.cov_w_qv += MH * w′ * q_vap′ * state.ρ
+    sums.moisture.cov_w_thv += MH * w′ * θ_vir′ * state.ρ
+    sums.moisture.cov_w_thl += MH * w′ * θ_liq_ice′ * state.ρ
+    sums.moisture.cov_qt_thl += MH * q_tot′ * θ_liq_ice′ * state.ρ
+    sums.moisture.cov_qt_ei += MH * q_tot′ * e_int′ * state.ρ
+
+    return nothing
+end
+function atmos_les_default_ho_sums!(
+    moist::NonEquilMoist,
+    state,
+    thermo,
+    MH,
+    ha,
+    w′,
+    e_int′,
+    sums,
+)
+    q_tot = state.moisture.ρq_tot / state.ρ
+    q_tot′ = q_tot - ha.moisture.qt
+    q_liq′ = thermo.moisture.q_liq - ha.moisture.ql
+    q_ice′ = thermo.moisture.q_ice - ha.moisture.qi
+    q_vap′ = thermo.moisture.q_vap - ha.moisture.qv
+    θ_vir′ = thermo.moisture.θ_vir - ha.moisture.thv
+    θ_liq_ice′ = thermo.moisture.θ_liq_ice - ha.moisture.thl
+
+    sums.moisture.var_qt += MH * q_tot′^2 * state.ρ
+    sums.moisture.var_thl += MH * θ_liq_ice′^2 * state.ρ
+
+    sums.moisture.cov_w_qt += MH * w′ * q_tot′ * state.ρ
+    sums.moisture.cov_w_ql += MH * w′ * q_liq′ * state.ρ
+    sums.moisture.cov_w_qi += MH * w′ * q_ice′ * state.ρ
     sums.moisture.cov_w_qv += MH * w′ * q_vap′ * state.ρ
     sums.moisture.cov_w_thv += MH * w′ * θ_vir′ * state.ρ
     sums.moisture.cov_w_thl += MH * w′ * θ_liq_ice′ * state.ρ
@@ -374,8 +459,8 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
         zeros(FT, num_atmos_les_default_simple_vars(bl, FT))
         for _ in 1:(Nqk * nvertelem)
     ]
-    ql_gt_0_z = [zeros(FT, (Nq * Nq * nhorzelem)) for _ in 1:(Nqk * nvertelem)]
-    ql_gt_0_full = zeros(FT, (Nq * Nq * nhorzelem))
+    qc_gt_0_z = [zeros(FT, (Nq * Nq * nhorzelem)) for _ in 1:(Nqk * nvertelem)]
+    qc_gt_0_full = zeros(FT, (Nq * Nq * nhorzelem))
     # In honor of PyCLES!
     cld_top = FT(-100000)
     cld_base = FT(100000)
@@ -404,10 +489,21 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
 
         # FIXME properly
         if isa(bl.moisture, EquilMoist)
-            if !iszero(thermo.moisture.q_liq)
+            if thermo.moisture.has_condensate
                 idx = (Nq * Nq * (eh - 1)) + (Nq * (j - 1)) + i
-                ql_gt_0_z[evk][idx] = one(FT)
-                ql_gt_0_full[idx] = one(FT)
+                qc_gt_0_z[evk][idx] = one(FT)
+                qc_gt_0_full[idx] = one(FT)
+
+                z = zvals[evk]
+                cld_top = max(cld_top, z)
+                cld_base = min(cld_base, z)
+            end
+        end
+        if isa(bl.moisture, NonEquilMoist)
+            if thermo.moisture.has_condensate
+                idx = (Nq * Nq * (eh - 1)) + (Nq * (j - 1)) + i
+                qc_gt_0_z[evk][idx] = one(FT)
+                qc_gt_0_full[idx] = one(FT)
 
                 z = zvals[evk]
                 cld_top = max(cld_top, z)
@@ -428,10 +524,17 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
 
         # FIXME properly
         if isa(bl.moisture, EquilMoist)
-            tot_ql_gt_0_z = MPI.Reduce(sum(ql_gt_0_z[evk]), +, 0, mpicomm)
-            tot_horz_z = MPI.Reduce(length(ql_gt_0_z[evk]), +, 0, mpicomm)
+            tot_qc_gt_0_z = MPI.Reduce(sum(qc_gt_0_z[evk]), +, 0, mpicomm)
+            tot_horz_z = MPI.Reduce(length(qc_gt_0_z[evk]), +, 0, mpicomm)
             if mpirank == 0
-                cld_frac[evk] = tot_ql_gt_0_z / tot_horz_z
+                cld_frac[evk] = tot_qc_gt_0_z / tot_horz_z
+            end
+        end
+        if isa(bl.moisture, NonEquilMoist)
+            tot_qc_gt_0_z = MPI.Reduce(sum(qc_gt_0_z[evk]), +, 0, mpicomm)
+            tot_horz_z = MPI.Reduce(length(qc_gt_0_z[evk]), +, 0, mpicomm)
+            if mpirank == 0
+                cld_frac[evk] = tot_qc_gt_0_z / tot_horz_z
             end
         end
     end
@@ -445,11 +548,27 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
         if cld_base == FT(100000)
             cld_base = NaN
         end
-        tot_ql_gt_0_full = MPI.Reduce(sum(ql_gt_0_full), +, 0, mpicomm)
-        tot_horz_full = MPI.Reduce(length(ql_gt_0_full), +, 0, mpicomm)
+        tot_qc_gt_0_full = MPI.Reduce(sum(qc_gt_0_full), +, 0, mpicomm)
+        tot_horz_full = MPI.Reduce(length(qc_gt_0_full), +, 0, mpicomm)
         cld_cover = zero(FT)
         if mpirank == 0
-            cld_cover = tot_ql_gt_0_full / tot_horz_full
+            cld_cover = tot_qc_gt_0_full / tot_horz_full
+        end
+    end
+    if isa(bl.moisture, NonEquilMoist)
+        cld_top = MPI.Reduce(cld_top, max, 0, mpicomm)
+        if cld_top == FT(-100000)
+            cld_top = NaN
+        end
+        cld_base = MPI.Reduce(cld_base, min, 0, mpicomm)
+        if cld_base == FT(100000)
+            cld_base = NaN
+        end
+        tot_qc_gt_0_full = MPI.Reduce(sum(qc_gt_0_full), +, 0, mpicomm)
+        tot_horz_full = MPI.Reduce(length(qc_gt_0_full), +, 0, mpicomm)
+        cld_cover = zero(FT)
+        if mpirank == 0
+            cld_cover = tot_qc_gt_0_full / tot_horz_full
         end
     end
 
@@ -523,6 +642,12 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
         end
 
         if isa(bl.moisture, EquilMoist)
+            varvals["cld_frac"] = cld_frac
+            varvals["cld_top"] = cld_top
+            varvals["cld_base"] = cld_base
+            varvals["cld_cover"] = cld_cover
+        end
+        if isa(bl.moisture, NonEquilMoist)
             varvals["cld_frac"] = cld_frac
             varvals["cld_top"] = cld_top
             varvals["cld_base"] = cld_base

--- a/src/Diagnostics/variables.jl
+++ b/src/Diagnostics/variables.jl
@@ -224,6 +224,14 @@ function setup_variables()
             "",
         ),
     )
+    Variables["cov_w_qi"] = DiagnosticVariable(
+        "cov_w_qi",
+        var_attrib(
+            "kg kg^-1 m s^-1",
+            "vertical eddy flux of cloud ice specific humidity",
+            "",
+        ),
+    )
     Variables["cov_w_qv"] = DiagnosticVariable(
         "cov_w_qv",
         var_attrib(


### PR DESCRIPTION
# Description

This adds a non-equilibrium model of moisture in Atmos by:
  - adding two more variables to state (rho_q_liq, rho_q_ice)
  - replacing saturation adjustment with relaxation to equilibrium source terms.

@akshaysridhar , @charleskawczynski - could you take a look and check if I'm missing something?

@kpamnany - I included here a draft of possible changes in the diagnostics. It's not the most elegant. Could you also take a look there?

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
