### PR TITLE
Use static range in Grad setproperty!

### DIFF
--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -309,7 +309,14 @@ end
             offset += 1
         elseif T <: StaticArray
             N = length(T)
-            retexpr = :(array[:, ($(offset + 1)):($(offset + N))] = val)
+            retexpr = :(
+                array[
+                    :,
+                    # static range is used here to force dispatch to
+                    # StaticArrays setindex! because generic setindex! is slow
+                    StaticArrays.SUnitRange($(offset + 1), $(offset + N)),
+                ] = val
+            )
             offset += N
         else
             offset += varsize(T)


### PR DESCRIPTION
# Description

After #1458 I noticed a slowdown. This PR proposes a fix.
Running ```julia --project=. experiments/AtmosLES/bomex_les.jl --monitor-timestep-duration 100steps``` I get
Before:
```
┌ Info: Wall-clock time per time-step (statistics across MPI ranks)
│    maximum (s) =    1.5273617989999998e-02
│    minimum (s) =    1.5273617989999998e-02
│    median  (s) =    1.5273617989999998e-02
└    std     (s) =                       NaN
```
After:
```
 Info: Wall-clock time per time-step (statistics across MPI ranks)
│    maximum (s) =    1.1554147779999999e-02
│    minimum (s) =    1.1554147779999999e-02
│    median  (s) =    1.1554147779999999e-02
└    std     (s) =                       NaN
```

The fix relies on unexported `StaticArrays` API but https://github.com/JuliaArrays/StaticArrays.jl/pull/474 makes me think that this is ok.


<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
