### PR TITLE
add q_vap_saturation wrapper for NonEquilMoist model

### DIFF
--- a/docs/src/APIs/Common/Thermodynamics.md
+++ b/docs/src/APIs/Common/Thermodynamics.md
@@ -64,6 +64,8 @@ liquid_ice_pottemp_sat
 liquid_specific_humidity
 moist_static_energy
 q_vap_saturation
+q_vap_saturation_liquid
+q_vap_saturation_ice
 q_vap_saturation_generic
 relative_humidity
 saturated

--- a/test/Atmos/Parameterizations/Microphysics/runtests.jl
+++ b/test/Atmos/Parameterizations/Microphysics/runtests.jl
@@ -174,14 +174,14 @@ end
 
     # no supersaturation -> no snow
     T = 273.15 - 5
-    q_sat_ice = q_vap_saturation_generic(prs, T, ρ; phase = Ice())
+    q_sat_ice = q_vap_saturation_generic(prs, T, ρ, Ice())
     q = PhasePartition(q_sat_ice, 2e-3, 3e-3)
     @test conv_q_ice_to_q_sno(prs, ice_prs, q, ρ, T) == 0.0
 
     # TODO - coudnt find a plot of what it should be from the original paper
     # just chacking if the number stays the same
     T = 273.15 - 10
-    q_vap = 1.02 * q_vap_saturation_generic(prs, T, ρ; phase = Ice())
+    q_vap = 1.02 * q_vap_saturation_generic(prs, T, ρ, Ice())
     q_liq = 0.0
     q_ice = 0.03 * q_vap
     q = PhasePartition(q_vap + q_liq + q_ice, q_liq, q_ice)
@@ -253,7 +253,7 @@ end
         ρ::FT,
     ) where {FT <: Real}
 
-        q_sat = q_vap_saturation_generic(prs, T, ρ; phase = Liquid())
+        q_sat = q_vap_saturation_generic(prs, T, ρ, Liquid())
         q_vap = q.tot - q.liq
         rr = q_rai / (1 - q.tot)
         rv_sat = q_sat / (1 - q.tot)


### PR DESCRIPTION
# Description

This is a wrapper for q_vap_saturation_generic that will be needed in the NonEquilMoist model.

@charleskawczynski

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
