### PR TITLE
Rename `thermo_state` to `recover_thermo_state`, add `new_thermo_state`

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -25,6 +25,13 @@ ClimateMachine.Atmos.ReferenceState
 ClimateMachine.Atmos.NoReferenceState
 ```
 
+## Thermodynamics
+
+```@docs
+ClimateMachine.Atmos.recover_thermo_state
+ClimateMachine.Atmos.new_thermo_state
+```
+
 ## Moisture
 
 ```@docs

--- a/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
+++ b/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
@@ -26,7 +26,7 @@ using Test
 
 using ClimateMachine
 using ClimateMachine.Atmos
-using ClimateMachine.Atmos: thermo_state
+using ClimateMachine.Atmos: recover_thermo_state
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks

--- a/experiments/AtmosGCM/GCMDriver/gcm_sources.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_sources.jl
@@ -25,7 +25,7 @@ function held_suarez_forcing!(
     ρu = state.ρu
     ρe = state.ρe
 
-    ts = thermo_state(bl, state, aux)
+    ts = recover_thermo_state(bl, state, aux)
     e_int = internal_energy(ts)
     T = air_temperature(ts)
     _R_d = FT(R_d(bl.param_set))

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -81,7 +81,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
 import ClimateMachine.Atmos: atmos_source!
-using ClimateMachine.Atmos: altitude, thermo_state
+using ClimateMachine.Atmos: altitude, recover_thermo_state
 
 """
   Bomex Geostrophic Forcing (Source)
@@ -210,7 +210,7 @@ function atmos_source!(
     _e_int_v0 = FT(e_int_v0(atmos.param_set))
 
     # Establish thermodynamic state
-    TS = thermo_state(atmos, state, aux)
+    TS = recover_thermo_state(atmos, state, aux)
 
     # Moisture tendencey (sink term)
     # Temperature tendency (Radiative cooling)

--- a/experiments/AtmosLES/stable_bl_kosovic.jl
+++ b/experiments/AtmosLES/stable_bl_kosovic.jl
@@ -56,7 +56,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
 import ClimateMachine.Atmos: atmos_source!, flux_second_order!
-using ClimateMachine.Atmos: altitude, thermo_state
+using ClimateMachine.Atmos: altitude, recover_thermo_state
 
 """
   StableBL Geostrophic Forcing (Source)

--- a/experiments/AtmosLES/unstable_bl_kitamura.jl
+++ b/experiments/AtmosLES/unstable_bl_kitamura.jl
@@ -58,7 +58,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
 import ClimateMachine.Atmos: atmos_source!, flux_second_order!
-using ClimateMachine.Atmos: altitude, thermo_state
+using ClimateMachine.Atmos: altitude, recover_thermo_state
 
 """
   UnstableBL Geostrophic Forcing (Source)

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -370,6 +370,7 @@ turbulence_tensors(atmos::AtmosModel, args...) =
 include("problem.jl")
 include("ref_state.jl")
 include("moisture.jl")
+include("thermodynamics.jl")
 include("precipitation.jl")
 include("radiation.jl")
 include("source.jl")
@@ -807,7 +808,7 @@ function numerical_flux_first_order!(
     ρ⁻ = state_prognostic⁻.ρ
     ρu⁻ = state_prognostic⁻.ρu
     ρe⁻ = state_prognostic⁻.ρe
-    ts⁻ = thermo_state(
+    ts⁻ = recover_thermo_state(
         balance_law,
         balance_law.moisture,
         state_prognostic⁻,
@@ -829,7 +830,10 @@ function numerical_flux_first_order!(
     ρ⁺ = state_prognostic⁺.ρ
     ρu⁺ = state_prognostic⁺.ρu
     ρe⁺ = state_prognostic⁺.ρe
-    ts⁺ = thermo_state(
+
+    # TODO: state_auxiliary⁺ is not up-to-date
+    # with state_prognostic⁺ on the boundaries
+    ts⁺ = recover_thermo_state(
         balance_law,
         balance_law.moisture,
         state_prognostic⁺,

--- a/src/Atmos/Model/bc_energy.jl
+++ b/src/Atmos/Model/bc_energy.jl
@@ -163,7 +163,7 @@ function atmos_energy_normal_boundary_flux_second_order!(
 
     # calculate MSE from the states at the boundary and at the interior point
     ts = TemperatureSHumEquil(atmos.param_set, T, state⁻.ρ, q_tot)
-    ts_int = thermo_state(atmos, atmos.moisture, state_int⁻, aux_int⁻)
+    ts_int = recover_thermo_state(atmos, atmos.moisture, state_int⁻, aux_int⁻)
     e_pot = gravitational_potential(atmos.orientation, aux⁻)
     e_pot_int = gravitational_potential(atmos.orientation, aux_int⁻)
     MSE = moist_static_energy(ts, e_pot)

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -64,11 +64,11 @@ internal_energy(atmos::AtmosModel, state::Vars, aux::Vars) =
 end
 
 temperature(atmos::AtmosModel, ::MoistureModel, state::Vars, aux::Vars) =
-    air_temperature(thermo_state(atmos, state, aux))
+    air_temperature(recover_thermo_state(atmos, state, aux))
 pressure(atmos::AtmosModel, ::MoistureModel, state::Vars, aux::Vars) =
-    air_pressure(thermo_state(atmos, state, aux))
+    air_pressure(recover_thermo_state(atmos, state, aux))
 soundspeed(atmos::AtmosModel, ::MoistureModel, state::Vars, aux::Vars) =
-    soundspeed_air(thermo_state(atmos, state, aux))
+    soundspeed_air(recover_thermo_state(atmos, state, aux))
 
 @inline function total_specific_enthalpy(
     atmos::AtmosModel,
@@ -76,7 +76,7 @@ soundspeed(atmos::AtmosModel, ::MoistureModel, state::Vars, aux::Vars) =
     state::Vars,
     aux::Vars,
 )
-    phase = thermo_state(atmos, state, aux)
+    phase = recover_thermo_state(atmos, state, aux)
     e_tot = state.ρe * (1 / state.ρ)
     return total_specific_enthalpy(phase, e_tot)
 end
@@ -96,27 +96,10 @@ vars_state(::DryModel, ::Auxiliary, FT) = @vars(θ_v::FT, air_T::FT)
     aux::Vars,
     t::Real,
 )
-    e_int = internal_energy(atmos, state, aux)
-    ts = PhaseDry(atmos.param_set, e_int, state.ρ)
+    ts = new_thermo_state(atmos, state, aux)
     aux.moisture.θ_v = virtual_pottemp(ts)
     aux.moisture.air_T = air_temperature(ts)
     nothing
-end
-
-thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
-    thermo_state(atmos, atmos.moisture, state, aux)
-
-function thermo_state(
-    atmos::AtmosModel,
-    moist::DryModel,
-    state::Vars,
-    aux::Vars,
-)
-    return PhaseDry(
-        atmos.param_set,
-        internal_energy(atmos, state, aux),
-        state.ρ,
-    )
 end
 
 """
@@ -147,40 +130,13 @@ vars_state(::EquilMoist, ::Auxiliary, FT) =
     aux::Vars,
     t::Real,
 )
-    ps = atmos.param_set
     e_int = internal_energy(atmos, state, aux)
-    ts = PhaseEquil(
-        ps,
-        e_int,
-        state.ρ,
-        state.moisture.ρq_tot / state.ρ,
-        moist.maxiter,
-        moist.tolerance,
-    )
+    ts = new_thermo_state(atmos, state, aux)
     aux.moisture.temperature = air_temperature(ts)
     aux.moisture.θ_v = virtual_pottemp(ts)
     aux.moisture.q_liq = PhasePartition(ts).liq
     aux.moisture.q_ice = PhasePartition(ts).ice
     nothing
-end
-
-function thermo_state(
-    atmos::AtmosModel,
-    moist::EquilMoist,
-    state::Vars,
-    aux::Vars,
-)
-    e_int = internal_energy(atmos, state, aux)
-    ps = atmos.param_set
-    PS = typeof(ps)
-    FT = eltype(state)
-    return PhaseEquil{FT, PS}(
-        ps,
-        e_int,
-        state.ρ,
-        state.moisture.ρq_tot / state.ρ,
-        aux.moisture.temperature,
-    )
 end
 
 function compute_gradient_argument!(

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -92,7 +92,7 @@ function atmos_nodal_update_auxiliary_state!(
     q_rai = max(FT(0), state.ρq_rain * ρinv)
 
     # current state
-    ts = thermo_state(rain, state, aux)
+    ts = recover_thermo_state(rain, state, aux)
     # q     = PhasePartition(q_tot, q_liq, q_ice)
     q = PhasePartition(ts)
     # T     = air_temperature(e_int, q)

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -206,7 +206,7 @@ function atmos_source!(
     direction,
 )
     FT = eltype(state)
-    ts = thermo_state(atmos, state, aux)
+    ts = recover_thermo_state(atmos, state, aux)
     if has_condensate(ts)
 
         q = PhasePartition(ts)

--- a/src/Atmos/Model/thermodynamics.jl
+++ b/src/Atmos/Model/thermodynamics.jl
@@ -1,0 +1,82 @@
+#### thermodynamics
+
+export new_thermo_state, recover_thermo_state
+
+"""
+    new_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars)
+
+Create a new thermodynamic state, based on the `state`, and _not_
+the `aux` state.
+
+!!! note
+    This method calls the iterative saturation adjustment
+    procedure for EquilMoist models.
+"""
+new_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
+    new_thermo_state(atmos, atmos.moisture, state, aux)
+
+function new_thermo_state(
+    atmos::AtmosModel,
+    moist::DryModel,
+    state::Vars,
+    aux::Vars,
+)
+    e_int = internal_energy(atmos, state, aux)
+    return PhaseDry(atmos.param_set, e_int, state.ρ)
+end
+
+function new_thermo_state(
+    atmos::AtmosModel,
+    moist::EquilMoist,
+    state::Vars,
+    aux::Vars,
+)
+    e_int = internal_energy(atmos, state, aux)
+    return PhaseEquil(
+        atmos.param_set,
+        e_int,
+        state.ρ,
+        state.moisture.ρq_tot / state.ρ,
+        moist.maxiter,
+        moist.tolerance,
+    )
+end
+
+"""
+    recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars)
+
+Recover the thermodynamic state, based on the `state` _and_
+the `aux` state, based on the existing temperature.
+
+!!! note
+    This method does _not_ call the iterative saturation adjustment
+    procedure.
+"""
+recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
+    recover_thermo_state(atmos, atmos.moisture, state, aux)
+
+function recover_thermo_state(
+    atmos::AtmosModel,
+    moist::DryModel,
+    state::Vars,
+    aux::Vars,
+)
+    e_int = internal_energy(atmos, state, aux)
+    return PhaseDry(atmos.param_set, e_int, state.ρ)
+end
+
+function recover_thermo_state(
+    atmos::AtmosModel,
+    moist::EquilMoist,
+    state::Vars,
+    aux::Vars,
+)
+    e_int = internal_energy(atmos, state, aux)
+    return PhaseEquil{eltype(state), typeof(atmos.param_set)}(
+        atmos.param_set,
+        e_int,
+        state.ρ,
+        state.moisture.ρq_tot / state.ρ,
+        aux.moisture.temperature,
+    )
+end

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -23,7 +23,7 @@ using Printf
 using Statistics
 
 using ..Atmos
-using ..Atmos: thermo_state
+using ..Atmos: recover_thermo_state
 using ..TurbulenceClosures: turbulence_tensors
 
 """

--- a/src/Diagnostics/atmos_les_core.jl
+++ b/src/Diagnostics/atmos_les_core.jl
@@ -1,5 +1,5 @@
 using ..Atmos
-using ..Atmos: thermo_state
+using ..Atmos: recover_thermo_state
 using ..Mesh.Topologies
 using ..Mesh.Grids
 using ..Thermodynamics

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -1,5 +1,5 @@
 using ..Atmos
-using ..Atmos: MoistureModel, thermo_state
+using ..Atmos: MoistureModel, recover_thermo_state
 using ..Mesh.Topologies
 using ..Mesh.Grids
 using ..Thermodynamics

--- a/src/Diagnostics/thermo.jl
+++ b/src/Diagnostics/thermo.jl
@@ -32,7 +32,7 @@ thermo_vars(bl, array) = Vars{vars_thermo(bl, eltype(array))}(array)
 # compute thermodynamic variables visitor function, to use with `@visitQ`
 function compute_thermo!(atmos::AtmosModel, state, aux, thermo)
     e_tot = state.ρe / state.ρ
-    ts = thermo_state(atmos, state, aux)
+    ts = recover_thermo_state(atmos, state, aux)
     e_int = internal_energy(ts)
 
     thermo.temp = air_temperature(ts)

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -18,7 +18,7 @@ import ClimateMachine.Atmos:
     pressure,
     soundspeed,
     total_specific_enthalpy,
-    thermo_state
+    recover_thermo_state
 
 using CLIMAParameters
 struct EarthParameterSet <: AbstractEarthParameterSet end
@@ -46,7 +46,7 @@ function total_specific_enthalpy(
 )
     zero(eltype(state))
 end
-function thermo_state(
+function recover_thermo_state(
     bl::AtmosModel,
     moist::MMSDryModel,
     state::Vars,

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -41,7 +41,7 @@ import ClimateMachine.Atmos:
     pressure,
     soundspeed,
     total_specific_enthalpy,
-    thermo_state
+    recover_thermo_state
 
 """
     MMSDryModel
@@ -58,7 +58,7 @@ function total_specific_enthalpy(
 )
     zero(eltype(state))
 end
-function thermo_state(
+function recover_thermo_state(
     bl::AtmosModel,
     moist::MMSDryModel,
     state::Vars,


### PR DESCRIPTION
# Description

Closes #1534

Credit to @kmdeck for finding a more general need for what is now `new_thermo_state`.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
