### PR TITLE
Update moisture auxiliary state in boundary_state!

### DIFF
--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -35,8 +35,34 @@ Base.@kwdef struct AtmosBC{M, E, Q, TR, TC}
     turbconv::TC = NoTurbConvBC()
 end
 
-function boundary_state!(nf, atmos::AtmosModel, args...)
-    atmos_boundary_state!(nf, atmos.problem.boundarycondition, atmos, args...)
+function boundary_state!(
+    nf,
+    atmos::AtmosModel,
+    state⁺,
+    aux⁺,
+    n,
+    state⁻,
+    aux⁻,
+    bctype,
+    t,
+    args...,
+)
+    atmos_boundary_state!(
+        nf,
+        atmos.problem.boundarycondition,
+        atmos,
+        state⁺,
+        aux⁺,
+        n,
+        state⁻,
+        aux⁻,
+        bctype,
+        t,
+        args...,
+    )
+    # update moisture auxiliary variables (perform saturation adjustment, if necessary)
+    # to make thermodynamic quantities consistent with the boundary state
+    atmos_nodal_update_auxiliary_state!(atmos.moisture, atmos, state⁺, aux⁺, t)
 end
 
 function boundary_state!(


### PR DESCRIPTION
# Description

A proposed fix to the boundary state issue discussed in #1528. Moisture auxiliary variables are updated
in `boundary_state!` to make them consistent with the boundary conditions.

I didn't see any significant performance issues.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
