### PR TITLE
safeguards against negative microphysics values

### DIFF
--- a/src/Atmos/Parameterizations/CloudPhysics/Microphysics.jl
+++ b/src/Atmos/Parameterizations/CloudPhysics/Microphysics.jl
@@ -367,7 +367,7 @@ function conv_q_liq_to_q_rai(rain_param_set::ARPS, q_liq::FT) where {FT <: Real}
     _τ_acnv::FT = τ_acnv(rain_param_set)
     _q_liq_threshold::FT = q_liq_threshold(rain_param_set)
 
-    return max(FT(0), q_liq - _q_liq_threshold) / _τ_acnv
+    return max(0, q_liq - _q_liq_threshold) / _τ_acnv
 end
 
 """

--- a/src/Common/Thermodynamics/Thermodynamics.jl
+++ b/src/Common/Thermodynamics/Thermodynamics.jl
@@ -48,7 +48,7 @@ error_on_non_convergence() = true
 # Allow users to skip printing warnings on non-convergence
 print_warning() = true
 
-@inline q_pt_0(::Type{FT}) where {FT} = PhasePartition{FT}(FT(0), FT(0), FT(0))
+@inline q_pt_0(::Type{FT}) where {FT} = PhasePartition(FT(0), FT(0), FT(0))
 
 include("states.jl")
 include("relations.jl")

--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -188,7 +188,7 @@ ice_specific_humidity(ts::PhaseNonEquil) = ts.q.ice
 
 The vapor specific humidity, given a `PhasePartition` `q`.
 """
-vapor_specific_humidity(q::PhasePartition) = q.tot - q.liq - q.ice
+vapor_specific_humidity(q::PhasePartition) = max(0, q.tot - q.liq - q.ice)
 vapor_specific_humidity(ts::ThermodynamicState) =
     vapor_specific_humidity(PhasePartition(ts))
 
@@ -904,7 +904,7 @@ function supersaturation(
 ) where {FT <: Real}
 
     q_sat::FT = q_vap_saturation_generic(param_set, T, ρ, Liquid())
-    q_vap::FT = q.tot - q.liq - q.ice
+    q_vap::FT = vapor_specific_humidity(q)
 
     return q_vap / q_sat - FT(1)
 end
@@ -917,7 +917,7 @@ function supersaturation(
 ) where {FT <: Real}
 
     q_sat::FT = q_vap_saturation_generic(param_set, T, ρ, Ice())
-    q_vap::FT = q.tot - q.liq - q.ice
+    q_vap::FT = vapor_specific_humidity(q)
 
     return q_vap / q_sat - FT(1)
 end

--- a/src/Common/Thermodynamics/states.jl
+++ b/src/Common/Thermodynamics/states.jl
@@ -37,13 +37,18 @@ struct PhasePartition{FT <: Real}
     liq::FT
     "ice specific humidity (default: `0`)"
     ice::FT
+    function PhasePartition(tot::FT, liq::FT, ice::FT) where {FT}
+        q_tot_safe = max(tot, 0)
+        q_liq_safe = max(liq, 0)
+        q_ice_safe = max(ice, 0)
+        return new{FT}(q_tot_safe, q_liq_safe, q_ice_safe)
+    end
 end
 
 PhasePartition(q_tot::FT, q_liq::FT) where {FT <: Real} =
     PhasePartition(q_tot, q_liq, zero(FT))
 PhasePartition(q_tot::FT) where {FT <: Real} =
     PhasePartition(q_tot, zero(FT), zero(FT))
-
 
 """
     ThermodynamicState{FT}


### PR DESCRIPTION
# Description

I'm splitting the old ice microphysics integration test [PR](https://github.com/CliMA/ClimateMachine.jl/pull/1330) into two separate PRs. This is the first of them and it brings in the additional safeguards against negative microphysics variables `q_vap`, `q_liq` and `q_ice`. 

For `q_liq` and `q_ice` it would happen in `PhasePartition` constructor. For `q_vap` it would happen in its function in `Thermodynamics/relations.jl`.

None of those overwrite the actual state variables. Instead they make sure that the later used thermodynamics and microphysics functions behave as if they get zero as input argument. 

@tapios , @charleskawczynski - Would that be an ok middle step?

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
