### PR TITLE
Doc skipping tutorials during doc build

### DIFF
--- a/docs/src/Contributing.md
+++ b/docs/src/Contributing.md
@@ -132,3 +132,10 @@ julia --project=docs docs/make.jl
 The makefile script will generate the appropriate markdown files and
 static html from both the `docs/src` and `tutorials/` directories,
 saving the output in `docs/src/generated`.
+
+### Speeding up the documentation build process
+Building the tutorials can take a long time so there is an environment variable switch to toggle on / off building the tutorials (`true` deafult):
+
+```
+CLIMATEMACHINE_DOCS_GENERATE_TUTORIALS=false julia --project=docs/ docs/make.jl
+```


### PR DESCRIPTION
<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
