### PR TITLE
Add LWP

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -916,7 +916,7 @@ steps:
   - label: "gpu_surfacebubble"
     key: "gpu_surfacebubble"
     command:
-      - "mpiexec julia --color=yes --project experiments/AtmosLES/surfacebubble.jl "
+      - "mpiexec julia --color=yes --project experiments/AtmosLES/surfacebubble.jl --diagnostics=default"
     agents:
       config: gpu
       queue: central

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -64,18 +64,7 @@ function vars_atmos_les_default_simple(m::AtmosModel, FT)
     end
 end
 vars_atmos_les_default_simple(::MoistureModel, FT) = @vars()
-function vars_atmos_les_default_simple(m::EquilMoist, FT)
-    @vars begin
-        qt::FT                  # q_tot
-        ql::FT                  # q_liq
-        qi::FT                  # q_ice
-        qv::FT                  # q_vap
-        thv::FT                 # θ_vir
-        thl::FT                 # θ_liq
-        w_qt_sgs::FT
-    end
-end
-function vars_atmos_les_default_simple(m::NonEquilMoist, FT)
+function vars_atmos_les_default_simple(m::Union{EquilMoist, NonEquilMoist}, FT)
     @vars begin
         qt::FT                  # q_tot
         ql::FT                  # q_liq
@@ -142,27 +131,7 @@ function atmos_les_default_simple_sums!(
     return nothing
 end
 function atmos_les_default_simple_sums!(
-    moist::EquilMoist,
-    state,
-    gradflux,
-    thermo,
-    MH,
-    D_t,
-    sums,
-)
-    sums.moisture.qt += MH * state.moisture.ρq_tot
-    sums.moisture.ql += MH * thermo.moisture.q_liq * state.ρ
-    sums.moisture.qi += MH * thermo.moisture.q_ice * state.ρ
-    sums.moisture.qv += MH * thermo.moisture.q_vap * state.ρ
-    sums.moisture.thv += MH * thermo.moisture.θ_vir * state.ρ
-    sums.moisture.thl += MH * thermo.moisture.θ_liq_ice * state.ρ
-    d_q_tot = (-D_t) .* gradflux.moisture.∇q_tot
-    sums.moisture.w_qt_sgs += MH * d_q_tot[end] * state.ρ
-
-    return nothing
-end
-function atmos_les_default_simple_sums!(
-    moist::NonEquilMoist,
+    moist::Union{EquilMoist, NonEquilMoist},
     state,
     gradflux,
     thermo,
@@ -182,7 +151,38 @@ function atmos_les_default_simple_sums!(
     return nothing
 end
 
+function atmos_les_default_clouds(
+    ::MoistureModel,
+    thermo,
+    idx,
+    qc_gt_0_z,
+    qc_gt_0_full,
+    z,
+    cld_top,
+    cld_base,
+)
+    return cld_top, cld_base
+end
+function atmos_les_default_clouds(
+    moist::Union{EquilMoist, NonEquilMoist},
+    thermo,
+    idx,
+    qc_gt_0_z,
+    qc_gt_0_full,
+    z,
+    cld_top,
+    cld_base,
+)
+    if thermo.moisture.has_condensate
+        FT = eltype(qc_gt_0_z)
+        qc_gt_0_z[idx] = one(FT)
+        qc_gt_0_full[idx] = one(FT)
 
+        cld_top = max(cld_top, z)
+        cld_base = min(cld_base, z)
+    end
+    return cld_top, cld_base
+end
 
 # Variances and covariances
 function vars_atmos_les_default_ho(m::AtmosModel, FT)
@@ -204,22 +204,7 @@ function vars_atmos_les_default_ho(m::AtmosModel, FT)
     end
 end
 vars_atmos_les_default_ho(::MoistureModel, FT) = @vars()
-function vars_atmos_les_default_ho(m::EquilMoist, FT)
-    @vars begin
-        var_qt::FT              # q_tot′q_tot′
-        var_thl::FT             # θ_liq_ice′θ_liq_ice′
-
-        cov_w_qt::FT            # w′q_tot′
-        cov_w_ql::FT            # w′q_liq′
-        cov_w_qi::FT            # w′q_ice′
-        cov_w_qv::FT            # w′q_vap′
-        cov_w_thv::FT           # w′θ_v′
-        cov_w_thl::FT           # w′θ_liq_ice′
-        cov_qt_thl::FT          # q_tot′θ_liq_ice′
-        cov_qt_ei::FT           # q_tot′e_int′
-    end
-end
-function vars_atmos_les_default_ho(m::NonEquilMoist, FT)
+function vars_atmos_les_default_ho(m::Union{EquilMoist, NonEquilMoist}, FT)
     @vars begin
         var_qt::FT              # q_tot′q_tot′
         var_thl::FT             # θ_liq_ice′θ_liq_ice′
@@ -295,39 +280,7 @@ function atmos_les_default_ho_sums!(
     return nothing
 end
 function atmos_les_default_ho_sums!(
-    moist::EquilMoist,
-    state,
-    thermo,
-    MH,
-    ha,
-    w′,
-    e_int′,
-    sums,
-)
-    q_tot = state.moisture.ρq_tot / state.ρ
-    q_tot′ = q_tot - ha.moisture.qt
-    q_liq′ = thermo.moisture.q_liq - ha.moisture.ql
-    q_ice′ = thermo.moisture.q_ice - ha.moisture.qi
-    q_vap′ = thermo.moisture.q_vap - ha.moisture.qv
-    θ_vir′ = thermo.moisture.θ_vir - ha.moisture.thv
-    θ_liq_ice′ = thermo.moisture.θ_liq_ice - ha.moisture.thl
-
-    sums.moisture.var_qt += MH * q_tot′^2 * state.ρ
-    sums.moisture.var_thl += MH * θ_liq_ice′^2 * state.ρ
-
-    sums.moisture.cov_w_qt += MH * w′ * q_tot′ * state.ρ
-    sums.moisture.cov_w_ql += MH * w′ * q_liq′ * state.ρ
-    sums.moisture.cov_w_qi += MH * w′ * q_ice′ * state.ρ
-    sums.moisture.cov_w_qv += MH * w′ * q_vap′ * state.ρ
-    sums.moisture.cov_w_thv += MH * w′ * θ_vir′ * state.ρ
-    sums.moisture.cov_w_thl += MH * w′ * θ_liq_ice′ * state.ρ
-    sums.moisture.cov_qt_thl += MH * q_tot′ * θ_liq_ice′ * state.ρ
-    sums.moisture.cov_qt_ei += MH * q_tot′ * e_int′ * state.ρ
-
-    return nothing
-end
-function atmos_les_default_ho_sums!(
-    moist::NonEquilMoist,
+    moist::Union{EquilMoist, NonEquilMoist},
     state,
     thermo,
     MH,
@@ -394,6 +347,7 @@ function atmos_les_default_init(dgngrp::DiagnosticsGroup, currtime)
         vars["cld_top"] = ((), FT, Variables["cld_top"].attrib)
         vars["cld_base"] = ((), FT, Variables["cld_base"].attrib)
         vars["cld_cover"] = ((), FT, Variables["cld_cover"].attrib)
+        vars["lwp"] = ((), FT, Variables["lwp"].attrib)
 
         # create the output file
         dprefix = @sprintf(
@@ -436,17 +390,19 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
         state_data = Q.realdata
         aux_data = dg.state_auxiliary.realdata
         vgeo = grid.vgeo
+        ω = grid.ω
         gradflux_data = dg.state_gradient_flux.realdata
     else
         state_data = Array(Q.realdata)
         aux_data = Array(dg.state_auxiliary.realdata)
         vgeo = Array(grid.vgeo)
+        ω = Array(grid.ω)
         gradflux_data = Array(dg.state_gradient_flux.realdata)
     end
     FT = eltype(state_data)
 
     zvals = AtmosCollected.zvals
-    repdvsr = AtmosCollected.repdvsr
+    MH_z = AtmosCollected.MH_z
 
     # Visit each node of the state variables array and:
     # - generate and store the thermo variables,
@@ -459,6 +415,9 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
         zeros(FT, num_atmos_les_default_simple_vars(bl, FT))
         for _ in 1:(Nqk * nvertelem)
     ]
+    # for LWP
+    ρq_liq_z = [zero(FT) for _ in 1:(Nqk * nvertelem)]
+    # for cld*
     qc_gt_0_z = [zeros(FT, (Nq * Nq * nhorzelem)) for _ in 1:(Nqk * nvertelem)]
     qc_gt_0_full = zeros(FT, (Nq * Nq * nhorzelem))
     # In honor of PyCLES!
@@ -487,28 +446,22 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
             simple,
         )
 
+        idx = (Nq * Nq * (eh - 1)) + (Nq * (j - 1)) + i
+        cld_top, cld_base = atmos_les_default_clouds(
+            bl.moisture,
+            thermo,
+            idx,
+            qc_gt_0_z[evk],
+            qc_gt_0_full,
+            zvals[evk],
+            cld_top,
+            cld_base,
+        )
+
         # FIXME properly
-        if isa(bl.moisture, EquilMoist)
-            if thermo.moisture.has_condensate
-                idx = (Nq * Nq * (eh - 1)) + (Nq * (j - 1)) + i
-                qc_gt_0_z[evk][idx] = one(FT)
-                qc_gt_0_full[idx] = one(FT)
-
-                z = zvals[evk]
-                cld_top = max(cld_top, z)
-                cld_base = min(cld_base, z)
-            end
-        end
-        if isa(bl.moisture, NonEquilMoist)
-            if thermo.moisture.has_condensate
-                idx = (Nq * Nq * (eh - 1)) + (Nq * (j - 1)) + i
-                qc_gt_0_z[evk][idx] = one(FT)
-                qc_gt_0_full[idx] = one(FT)
-
-                z = zvals[evk]
-                cld_top = max(cld_top, z)
-                cld_base = min(cld_base, z)
-            end
+        if isa(bl.moisture, EquilMoist) || isa(bl.moisture, NonEquilMoist)
+            # for LWP
+            ρq_liq_z[evk] += MH * thermo.moisture.q_liq * state.ρ * state.ρ
         end
     end
 
@@ -520,42 +473,25 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     cld_frac = zeros(FT, Nqk * nvertelem)
     for evk in 1:(Nqk * nvertelem)
         MPI.Allreduce!(simple_sums[evk], simple_avgs[evk], +, mpicomm)
-        simple_avgs[evk] .= simple_avgs[evk] ./ repdvsr[evk]
+        simple_avgs[evk] .= simple_avgs[evk] ./ MH_z[evk]
 
         # FIXME properly
-        if isa(bl.moisture, EquilMoist)
+        if isa(bl.moisture, EquilMoist) || isa(bl.moisture, NonEquilMoist)
             tot_qc_gt_0_z = MPI.Reduce(sum(qc_gt_0_z[evk]), +, 0, mpicomm)
             tot_horz_z = MPI.Reduce(length(qc_gt_0_z[evk]), +, 0, mpicomm)
             if mpirank == 0
                 cld_frac[evk] = tot_qc_gt_0_z / tot_horz_z
             end
-        end
-        if isa(bl.moisture, NonEquilMoist)
-            tot_qc_gt_0_z = MPI.Reduce(sum(qc_gt_0_z[evk]), +, 0, mpicomm)
-            tot_horz_z = MPI.Reduce(length(qc_gt_0_z[evk]), +, 0, mpicomm)
+
+            # for LWP
+            tot_ρq_liq_z = MPI.Reduce(ρq_liq_z[evk], +, 0, mpicomm)
             if mpirank == 0
-                cld_frac[evk] = tot_qc_gt_0_z / tot_horz_z
+                ρq_liq_z[evk] = tot_ρq_liq_z / MH_z[evk]
             end
         end
     end
     # FIXME properly
-    if isa(bl.moisture, EquilMoist)
-        cld_top = MPI.Reduce(cld_top, max, 0, mpicomm)
-        if cld_top == FT(-100000)
-            cld_top = NaN
-        end
-        cld_base = MPI.Reduce(cld_base, min, 0, mpicomm)
-        if cld_base == FT(100000)
-            cld_base = NaN
-        end
-        tot_qc_gt_0_full = MPI.Reduce(sum(qc_gt_0_full), +, 0, mpicomm)
-        tot_horz_full = MPI.Reduce(length(qc_gt_0_full), +, 0, mpicomm)
-        cld_cover = zero(FT)
-        if mpirank == 0
-            cld_cover = tot_qc_gt_0_full / tot_horz_full
-        end
-    end
-    if isa(bl.moisture, NonEquilMoist)
+    if isa(bl.moisture, EquilMoist) || isa(bl.moisture, NonEquilMoist)
         cld_top = MPI.Reduce(cld_top, max, 0, mpicomm)
         if cld_top == FT(-100000)
             cld_top = NaN
@@ -577,14 +513,34 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
         s -> startswith(s, "moisture.") ? s[10:end] : s,
         flattenednames(vars_atmos_les_default_simple(bl, FT)),
     )
-    for vari in 1:length(simple_varnames)
-        for evk in 1:(Nqk * nvertelem)
-            simple_ha = atmos_les_default_simple_vars(bl, simple_avgs[evk])
-            avg_rho = simple_ha.avg_rho
+    for evk in 1:(Nqk * nvertelem)
+        simple_ha = atmos_les_default_simple_vars(bl, simple_avgs[evk])
+        avg_rho = simple_ha.avg_rho
+        for vari in 1:length(simple_varnames)
             if simple_varnames[vari] != "avg_rho"
                 simple_avgs[evk][vari] /= avg_rho
             end
         end
+
+        # for LWP
+        # FIXME properly
+        if isa(bl.moisture, EquilMoist) || isa(bl.moisture, NonEquilMoist)
+            ρq_liq_z[evk] /= avg_rho
+        end
+    end
+
+    # compute LWP
+    lwp = NaN
+    if mpirank == 0
+        JcV = reshape(
+            view(vgeo, :, grid.JcVid, topology.realelems),
+            Nq^2,
+            Nqk,
+            nvertelem,
+            nhorzelem,
+        )
+        Mvert = (ω .* JcV[1, :, :, 1])[:]
+        lwp = FT(sum(ρq_liq_z .* Mvert))
     end
 
     # compute the variances and covariances
@@ -612,7 +568,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     for evk in 1:(Nqk * nvertelem)
         MPI.Reduce!(ho_sums[evk], ho_avgs[evk], +, 0, mpicomm)
         if mpirank == 0
-            ho_avgs[evk] .= ho_avgs[evk] ./ repdvsr[evk]
+            ho_avgs[evk] .= ho_avgs[evk] ./ MH_z[evk]
         end
     end
 
@@ -641,17 +597,12 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
             varvals[varname] = davg
         end
 
-        if isa(bl.moisture, EquilMoist)
+        if isa(bl.moisture, EquilMoist) || isa(bl.moisture.NonEquilMoist)
             varvals["cld_frac"] = cld_frac
             varvals["cld_top"] = cld_top
             varvals["cld_base"] = cld_base
             varvals["cld_cover"] = cld_cover
-        end
-        if isa(bl.moisture, NonEquilMoist)
-            varvals["cld_frac"] = cld_frac
-            varvals["cld_top"] = cld_top
-            varvals["cld_base"] = cld_base
-            varvals["cld_cover"] = cld_cover
+            varvals["lwp"] = lwp
         end
 
         # write output

--- a/src/Diagnostics/atmos_les_default_perturbations.jl
+++ b/src/Diagnostics/atmos_les_default_perturbations.jl
@@ -218,8 +218,7 @@ function atmos_les_default_perturbations_init(
             flattenednames(vars_atmos_les_default_perturbations(atmos, FT)),
         )
         for varname in varnames
-            var = Variables[varname]
-            vars[varname] = (tuple(collect(keys(dims))...), FT, var.attrib)
+            vars[varname] = (tuple(collect(keys(dims))...), FT, OrderedDict())
         end
 
         # create the output file
@@ -284,8 +283,8 @@ function atmos_les_default_perturbations_collect(
     # Compute thermo variables
     thermo_array = Array{FT}(undef, npoints, num_thermo(atmos, FT), nrealelem)
     @visitQ nhorzelem nvertelem Nqk Nq begin
-        state = extract_state_prognostic(dg, state_data, ijk, e)
-        aux = extract_state_auxiliary(dg, aux_data, ijk, e)
+        state = extract_state(dg, state_data, ijk, e, Prognostic())
+        aux = extract_state(dg, aux_data, ijk, e, Auxiliary())
 
         thermo = thermo_vars(atmos, view(thermo_array, ijk, :, e))
         compute_thermo!(atmos, state, aux, thermo)
@@ -294,7 +293,7 @@ function atmos_les_default_perturbations_collect(
     # Interpolate the state and thermo variables.
     interpol = dgngrp.interpol
     istate =
-        ArrayType{FT}(undef, interpol.Npl, number_state_prognostic(atmos, FT))
+        ArrayType{FT}(undef, interpol.Npl, number_states(atmos, Prognostic()))
     interpolate_local!(interpol, Q.realdata, istate)
 
     ithermo = ArrayType{FT}(undef, interpol.Npl, num_thermo(atmos, FT))

--- a/src/Diagnostics/thermo.jl
+++ b/src/Diagnostics/thermo.jl
@@ -16,17 +16,7 @@ function vars_thermo(atmos::AtmosModel, FT)
     end
 end
 vars_thermo(::MoistureModel, FT) = @vars()
-function vars_thermo(m::EquilMoist, FT)
-    @vars begin
-        q_liq::FT
-        q_ice::FT
-        q_vap::FT
-        θ_vir::FT
-        θ_liq_ice::FT
-        has_condensate::Bool
-    end
-end
-function vars_thermo(m::NonEquilMoist, FT)
+function vars_thermo(m::Union{EquilMoist, NonEquilMoist}, FT)
     @vars begin
         q_liq::FT
         q_ice::FT
@@ -60,20 +50,13 @@ end
 function compute_thermo!(::MoistureModel, state, aux, ts, thermo)
     return nothing
 end
-function compute_thermo!(moist::EquilMoist, state, aux, ts, thermo)
-    Phpart = PhasePartition(ts)
-
-    thermo.moisture.has_condensate = has_condensate(ts)
-    thermo.moisture.q_liq = Phpart.liq
-    thermo.moisture.q_ice = Phpart.ice
-    thermo.moisture.q_vap = vapor_specific_humidity(ts)
-    thermo.moisture.θ_vir = virtual_pottemp(ts)
-    thermo.moisture.θ_liq_ice = liquid_ice_pottemp(ts)
-
-    return nothing
-end
-function compute_thermo!(moist::NonEquilMoist, state, aux, ts, thermo)
-
+function compute_thermo!(
+    moist::Union{EquilMoist, NonEquilMoist},
+    state,
+    aux,
+    ts,
+    thermo,
+)
     thermo.moisture.has_condensate = has_condensate(ts)
     thermo.moisture.q_liq = liquid_specific_humidity(ts)
     thermo.moisture.q_ice = ice_specific_humidity(ts)

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -162,13 +162,6 @@ function main()
         nothing,
         currtime,
     )
-    GenericCallbacks.call!(
-        dgn_config.groups[1],
-        nothing,
-        nothing,
-        nothing,
-        currtime,
-    )
 
     ClimateMachine.invoke!(solver_config)
 


### PR DESCRIPTION
# Description

Add LWP to Atmos LES default diagnostics group. Closes #943.

Also:
- Reduce some repeated code across EquilMoist and NonEquilMoist
- Rename repdvsr to MH_z (in default and core)
- Get Atmos LES default perturbations working again and add to CI

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
