### PR TITLE
Remove deprecated call to `Pkg.installed()`

### DIFF
--- a/.dev/systemimage/climate_machine_image.jl
+++ b/.dev/systemimage/climate_machine_image.jl
@@ -30,12 +30,10 @@ pkgs = Symbol[]
 if climatemachine_pkg
     push!(pkgs, :ClimateMachine)
 else
-    # TODO: reorg project structure (Project.toml) to use
-    # Pkg.dependencies() with PackageCompiler
-    #if VERSION >= v"1.4"
-    #    append!(pkgs, [Symbol(v.name) for v in values(Pkg.dependencies())])
-    #end
-    append!(pkgs, [Symbol(name) for name in keys(Pkg.installed())])
+    append!(
+        pkgs,
+        [Symbol(v.name) for v in values(Pkg.dependencies()) if v.is_direct_dep],
+    )
 end
 
 # use package compiler


### PR DESCRIPTION
Switches to using `Pkg.dependencies` instead of 'Pkg.installed` for creating the system image.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
