### PR TITLE
Fix density current tutorial

### DIFF
--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -25,7 +25,9 @@ if generate_tutorials
             "Dry Idealized GCM (Held-Suarez)" => "Atmos/heldsuarez.jl",
             "Single Element Stack Experiment (Burgers Equation)" =>
                 "Atmos/burgers_single_stack.jl",
+            "LES Experiment (Density Current)" => "Atmos/densitycurrent.jl",
             "LES Experiment (Rising Thermal Bubble)" => "Atmos/risingbubble.jl",
+            "LES Experiment (Density Current)" => "Atmos/densitycurrent.jl",
             "Linear Hydrostatic Mountain (Topography)" =>
                 "Atmos/agnesi_hs_lin.jl",
             "Linear Non-Hydrostatic Mountain (Topography)" =>

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -1,4 +1,4 @@
-# # [Density Current](@id EX-DC-docs)
+# # Density Current
 #
 # In this example, we demonstrate the usage of the `ClimateMachine`
 #  to solve the density current test by Straka 1993.
@@ -52,7 +52,7 @@
 #
 # ## Boilerplate (Using Modules)
 #
-# #### [Skip Section](@ref init)
+# #### [Skip Section](@ref init-dc)
 #
 # Before setting up our experiment, we recognize that we need to import some
 # pre-defined functions from other packages. Julia allows us to use existing
@@ -68,6 +68,7 @@ using ClimateMachine
 ClimateMachine.init(parse_clargs = true)
 
 using ClimateMachine.Atmos
+using ClimateMachine.Orientations
 # - Required so that we inherit the appropriate model types for the large-eddy
 #   simulation (LES) and global-circulation-model (GCM) configurations.
 using ClimateMachine.ConfigTypes
@@ -116,7 +117,7 @@ using CLIMAParameters.Planet: R_d, cp_d, cv_d, MSLP, grav
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-# ## [Initial Conditions](@id init)
+# ## [Initial Conditions](@id init-dc)
 #md # !!! note
 #md #     The following variables are assigned in the initial condition
 #md #     - `state.ρ` = Scalar quantity for initial density profile
@@ -202,7 +203,7 @@ function config_densitycurrent(FT, N, resolution, xmax, ymax, zmax)
     ##md #     - [`param_set`](https://CliMA.github.io/CLIMAParameters.jl/dev/)
     ##md #     - [`turbulence`](@ref Turbulence-Closures-docs)
     ##md #     - [`source`](@ref atmos-sources)
-    ##md #     - [`init_state`](@ref init)
+    ##md #     - [`init_state`](@ref init-dc)
 
     _C_smag = FT(0.21)
     model = AtmosModel{FT}(

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -94,7 +94,7 @@ using CLIMAParameters.Planet: R_d, cp_d, cv_d, MSLP, grav
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet();
 
-# ## [Initial Conditions](@id init)
+# ## [Initial Conditions](@id init-rtb)
 # This example demonstrates the use of functions defined
 # in the [`Thermodynamics`](@ref ClimateMachine.Thermodynamics) package to
 # generate the appropriate initial state for our problem.


### PR DESCRIPTION
# Description

This PR fixes the density current tutorial in the docs, and adds it to the list of docs.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
