### PR TITLE
fix bug in atmos_les_default.jl

### DIFF
--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -597,7 +597,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
             varvals[varname] = davg
         end
 
-        if isa(bl.moisture, EquilMoist) || isa(bl.moisture.NonEquilMoist)
+        if isa(bl.moisture, EquilMoist) || isa(bl.moisture, NonEquilMoist)
             varvals["cld_frac"] = cld_frac
             varvals["cld_top"] = cld_top
             varvals["cld_base"] = cld_base


### PR DESCRIPTION
# Description

Fix a bug in `atmos_les_default.jl` that causes problems when using `DryModel`.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
