### PR TITLE
Add comment to discrete hydrostatic balance test, wrt numerical flux

### DIFF
--- a/test/Atmos/Model/discrete_hydrostatic_balance.jl
+++ b/test/Atmos/Model/discrete_hydrostatic_balance.jl
@@ -128,6 +128,7 @@ function main()
     @testset for config in (LES, GCM)
         @testset for ode_solver_type in (explicit_solver_type, imex_solver_type)
             @testset for numflux in (
+                # Only applies for numerical fluxes satisfying the contact property
                 CentralNumericalFluxFirstOrder(),
                 RoeNumericalFlux(),
                 HLLCNumericalFlux(),


### PR DESCRIPTION
# Description

Perhaps this is a useful comment to add to the discrete hydrostatic balance test. IIUC, any choice of numerical flux should not result in horizontal divergence of a field for fields that are only a function of altitude, and this does not seem to be the case for `RusanovNumericalFlux`.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
