### PR TITLE
Use dry ref state for dry moisture model

### DIFF
--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -100,7 +100,11 @@ function atmos_init_aux!(
     q_tot = q_pt.tot
     q_liq = q_pt.liq
     q_ice = q_pt.ice
-    ts = TemperatureSHumEquil(atmos.param_set, T, ρ, q_tot)
+    if atmos.moisture isa DryModel
+        ts = PhaseDry_given_ρT(atmos.param_set, ρ, T)
+    else
+        ts = TemperatureSHumEquil(atmos.param_set, T, ρ, q_tot)
+    end
 
     aux.ref_state.ρq_tot = ρ * q_tot
     aux.ref_state.ρq_liq = ρ * q_liq


### PR DESCRIPTION
# Description

This PR makes the local thermo state in `src/Atmos/Model/ref_state.jl` a dry thermo state if we have a dry model, so that we don't run into sat adjust issues when we shouldn't need to.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
