### PR TITLE
Update EveryDirection continuous field gradient

### DIFF
--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -185,7 +185,7 @@ struct DiscontinuousSpectralElementGrid{
     ) where {dim}
 
         N = polynomialorder
-        (ξ, ω) = Elements.lglpoints(FloatType, N)
+        (ξ, ω) = Elements.lglpoints(promote_type(Float64, FloatType), N)
         Imat = indefinite_integral_interpolation_matrix(ξ, ω)
         D = Elements.spectralderivative(ξ)
 
@@ -218,17 +218,17 @@ struct DiscontinuousSpectralElementGrid{
         activedofs[vmaprecv] .= true
 
         # Create arrays on the device
-        vgeo = DeviceArray(vgeo)
-        sgeo = DeviceArray(sgeo)
+        vgeo = DeviceArray(FloatType.(vgeo))
+        sgeo = DeviceArray(FloatType.(sgeo))
         elemtobndy = DeviceArray(topology.elemtobndy)
         vmap⁻ = DeviceArray(vmap⁻)
         vmap⁺ = DeviceArray(vmap⁺)
         vmapsend = DeviceArray(vmapsend)
         vmaprecv = DeviceArray(vmaprecv)
         activedofs = DeviceArray(activedofs)
-        ω = DeviceArray(ω)
-        D = DeviceArray(D)
-        Imat = DeviceArray(Imat)
+        ω = DeviceArray(FloatType.(ω))
+        D = DeviceArray(FloatType.(D))
+        Imat = DeviceArray(FloatType.(Imat))
 
         # FIXME: There has got to be a better way!
         DAT1 = typeof(ω)

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -56,7 +56,7 @@ function min_node_distance(
 end
 
 # {{{
-const _nvgeo = 16
+const _nvgeo = 17
 const _ξ1x1,
 _ξ2x1,
 _ξ3x1,
@@ -66,6 +66,7 @@ _ξ3x2,
 _ξ1x3,
 _ξ2x3,
 _ξ3x3,
+_J,
 _M,
 _MI,
 _MH,
@@ -83,6 +84,7 @@ const vgeoid = (
     ξ1x3id = _ξ1x3,
     ξ2x3id = _ξ2x3,
     ξ3x3id = _ξ3x3,
+    Jid = _J,
     Mid = _M,
     MIid = _MI,
     MHid = _MH,
@@ -448,6 +450,7 @@ function computegeometry(
         ξ1x3,
         ξ2x3,
         ξ3x3,
+        J,
         MJ,
         MJI,
         MHJH,
@@ -456,7 +459,6 @@ function computegeometry(
         x3,
         JcV,
     ) = ntuple(j -> (@view vgeo[:, j, :]), _nvgeo)
-    J = similar(x1)
     (n1, n2, n3, sMJ, vMJI) = ntuple(j -> (@view sgeo[j, :, :, :]), _nsgeo)
     sJ = similar(sMJ)
 

--- a/test/Numerics/DGMethods/grad_test.jl
+++ b/test/Numerics/DGMethods/grad_test.jl
@@ -58,7 +58,7 @@ end
 using Test
 function run(mpicomm, dim, direction, Ne, N, FT, ArrayType)
 
-    brickrange = ntuple(j -> range(FT(0); length = Ne[j] + 1, stop = 3), dim)
+    brickrange = ntuple(j -> range(FT(-1); length = Ne[j] + 1, stop = 1), dim)
     topl = StackedBrickTopology(
         mpicomm,
         brickrange,
@@ -93,7 +93,11 @@ function run(mpicomm, dim, direction, Ne, N, FT, ArrayType)
     )
 
     # Wrapping in Array ensure both GPU and CPU code use same approx
-    @test Array(dg.state_auxiliary.∇a) ≈ Array(dg.state_auxiliary.∇a_exact)
+    @test all(isapprox.(
+        Array(dg.state_auxiliary.∇a),
+        Array(dg.state_auxiliary.∇a_exact);
+        rtol = sqrt(eps(FT)), atol = sqrt(eps(FT)),
+    ))
 end
 
 let

--- a/test/Numerics/DGMethods/grad_test_sphere.jl
+++ b/test/Numerics/DGMethods/grad_test_sphere.jl
@@ -132,13 +132,15 @@ let
                     @test abs(err[l]) < FT(1e-13)
                 end
             end
-            @info begin
-                msg = ""
-                for l in 1:(lvls - 1)
-                    rate = log2(err[l]) - log2(err[l + 1])
-                    msg *= @sprintf("\n  rate for level %d = %e\n", l, rate)
+            if lvls > 1
+                @info begin
+                    msg = ""
+                    for l in 1:(lvls - 1)
+                        rate = log2(err[l]) - log2(err[l + 1])
+                        msg *= @sprintf("\n  rate for level %d = %e\n", l, rate)
+                    end
+                    msg
                 end
-                msg
             end
         end
     end


### PR DESCRIPTION
The main change for this PR is to change the `kernel_continuous_field_gradient!` function to use "inside" metrics terms when the gradient is being taken with `EveryDirection`. This is to match the behavior of what is done in the `volume_tendency!` function.

The metric identities we use for this do not carry over to the `HorizontalDirection` and `VerticalDirection` cases.

Other changes in this PR:

 - Update the `grad_test.jl` to use pointwise comparison (instead of norms)
 - Mask out some output in `grad_test_sphere.jl`

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
