### PR TITLE
Fix environment variable parsing for String types

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -107,7 +107,7 @@ function get_setting(setting_name::Symbol, settings, defaults)
         return convert(setting_type, settings[setting_name])
     elseif haskey(ENV, setting_env)
         env_val = ENV[setting_env]
-        v = tryparse(setting_type, env_val)
+        v = setting_type == String ? env_val : tryparse(setting_type, env_val)
         if isnothing(v)
             error("cannot parse ENV $setting_env value $env_val, to setting type $setting_type")
         end


### PR DESCRIPTION
Previously would result in error if for instance one did for instance

CLIMATEMACHINE_SETTINGS_VTK="100steps" julia -J.git/ClimateMachine.sys --project test/Atmos/Model/discrete-hydrostatic-balance.jl

since `tryparse(String, "100steps")` gives the error

```
ERROR: MethodError: no method matching tryparse(::Type{String}, ::String)
Closest candidates are:
  tryparse(::Type{T}, ::AbstractString; base) where T<:Integer at parse.jl:234
  tryparse(::Type{Float64}, ::String) at parse.jl:245
  tryparse(::Type{Float32}, ::String) at parse.jl:265
  ...
Stacktrace:
 [1] top-level scope at REPL[2]:1
```

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
