### PR TITLE
moved contributing tutorial code to the Contributing section

### DIFF
--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -55,7 +55,6 @@ if generate_tutorials
                     "Diagnostics/Debug/StateCheck.jl",
             ],
         ],
-        "Contributing" => ["Notes on Literate" => "literate_markdown.jl"],
     ]
 
     # Prepend tutorials_dir

--- a/docs/src/Contributing.md
+++ b/docs/src/Contributing.md
@@ -133,6 +133,47 @@ The makefile script will generate the appropriate markdown files and
 static html from both the `docs/src` and `tutorials/` directories,
 saving the output in `docs/src/generated`.
 
+### How to generate a literate tutorial file
+
+To create a tutorial using ClimateMachine, please use
+[Literate.jl](https://github.com/fredrikekre/Literate.jl),
+and consult the [Literate documentation](https://fredrikekre.github.io/Literate.jl/stable/)
+for questions. For now, all literate tutorials are held in
+the `tutorials` directory.
+
+With Literate, all comments turn into markdown text and any
+Julia code is read and run *as if it is in the Julia REPL*.
+As a small caveat to this, you might need to suppress the
+output of certain commands. For example, if you define and
+run the following function
+
+```
+function f()
+    return x = [i * i for i in 1:10]
+end
+
+x = f()
+```
+
+The entire list will be output, while
+
+```
+f();
+```
+
+does not (because of the `;`).
+
+To show plots, you may do something like the following:
+
+```
+using Plots
+plot(x)
+```
+
+Please consider writing the comments in your tutorial as if they are meant to be read as an *article explaining the topic the tutorial is meant to explain.*
+If there are any specific nuances to writing Literate documentation for ClimateMachine, please let us know!
+
+
 ### Speeding up the documentation build process
 Building the tutorials can take a long time so there is an environment variable switch to toggle on / off building the tutorials (`true` deafult):
 


### PR DESCRIPTION
# Description

I move the contributing tutorials file to the Contributing.md section - now all contributing info is in one spot.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [X] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
