### PR TITLE
bugfix for #1554

### DIFF
--- a/src/Driver/SolverTypes/SplitExplicitSolverType.jl
+++ b/src/Driver/SolverTypes/SplitExplicitSolverType.jl
@@ -71,7 +71,7 @@ function solversetup(ode_solver::SplitExplicitSolverType, dg_3D, Q_3D, _, t0, _)
     fast_solver =
         ode_solver.fast_method(dg_2D, Q_2D, dt = ode_solver.dt_fast, t0 = t0)
     slow_solver =
-        ode_solver.fast_method(dg_3D, Q_3D, dt = ode_solver.dt_slow, t0 = t0)
+        ode_solver.slow_method(dg_3D, Q_3D, dt = ode_solver.dt_slow, t0 = t0)
 
     solver = SplitExplicitLSRK2nSolver(slow_solver, fast_solver)
 


### PR DESCRIPTION
# Description

Addressing this comment: https://github.com/CliMA/ClimateMachine.jl/pull/1554#discussion_r493193331
Pretty straightforward typo fix.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
