### PR TITLE
Update Array type when switching from GPU to CPU

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -434,6 +434,8 @@ function init(;
     # set up the array type appropriately depending on whether we're using GPUs
     if !Settings.disable_gpu && CUDA.has_cuda_gpu()
         Settings.array_type = CUDA.CuArray
+    else
+        Settings.array_type = Array
     end
 
     # initialize the runtime


### PR DESCRIPTION
# Description

`ClimateMachine.init()` would update the `disable_gpu` setting, but not the `array_type` setting when reinitializing with `disable_gpu = true` after having previously initialized with `disable_gpu = false`. This PR fixes it so you can switch between GPU and CPU backend within a single session of the Julia REPL.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
