### PR TITLE
Integrate SplitExplicit01 code with OceanProblems code

### DIFF
--- a/experiments/OceanSplitExplicit/simple_box.jl
+++ b/experiments/OceanSplitExplicit/simple_box.jl
@@ -8,132 +8,29 @@ using ClimateMachine.Mesh.Grids: polynomialorder
 using ClimateMachine.BalanceLaws
 using ClimateMachine.Ocean
 using ClimateMachine.Ocean.SplitExplicit01
-using ClimateMachine.Ocean.SplitExplicit01: AbstractOceanProblem
 using ClimateMachine.Ocean.OceanProblems
-
-
-using StaticArrays
 
 using CLIMAParameters
 using CLIMAParameters.Planet: grav
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-import ClimateMachine.Ocean.SplitExplicit01:
-    ocean_init_aux!, ocean_init_state!, ocean_boundary_state!
-
-struct SimpleBox{T} <: AbstractOceanProblem
-    Lˣ::T
-    Lʸ::T
-    H::T
-    τₒ::T
-    λʳ::T
-    θᴱ::T
-end
-
-function ocean_init_state!(p::SimpleBox, Q, A, coords, t)
-    @inbounds y = coords[2]
-    @inbounds z = coords[3]
-    @inbounds H = p.H
-
-    Q.u = @SVector [-0, -0]
-    Q.η = -0
-    Q.θ = (5 + 4 * cos(y * π / p.Lʸ)) * (1 + z / H)
-
-    return nothing
-end
-
-function ocean_init_aux!(m::OceanModel, p::SimpleBox, A, geom)
-    FT = eltype(A)
-    @inbounds A.y = geom.coord[2]
-
-    # not sure if this is needed but getting weird intialization stuff
-    A.w = -0
-    A.pkin = -0
-    A.wz0 = -0
-    A.u_d = @SVector [-0, -0]
-    A.ΔGu = @SVector [-0, -0]
-
-    return nothing
-end
-
-# A is Filled afer the state
-function ocean_init_aux!(m::BarotropicModel, P::SimpleBox, A, geom)
-    @inbounds A.y = geom.coord[2]
-
-    A.Gᵁ = @SVector [-0, -0]
-    A.U_c = @SVector [-0, -0]
-    A.η_c = -0
-    A.U_s = @SVector [-0, -0]
-    A.η_s = -0
-    A.Δu = @SVector [-0, -0]
-    A.η_diag = -0
-    A.Δη = -0
-
-    return nothing
-end
-
-@inline function ocean_boundary_state!(
-    m::Continuity3dModel,
-    p::SimpleBox,
-    bctype,
-    x...,
-)
-    return ocean_boundary_state!(
-        m,
-        ClimateMachine.Ocean.SplitExplicit01.CoastlineNoSlip(),
-        x...,
-    )
-end
-
-@inline function ocean_boundary_state!(
-    m::OceanModel,
-    p::SimpleBox,
-    bctype,
-    x...,
-)
-    if bctype == 1
-        ocean_boundary_state!(
-            m,
-            ClimateMachine.Ocean.SplitExplicit01.CoastlineNoSlip(),
-            x...,
-        )
-    elseif bctype == 2
-        ocean_boundary_state!(
-            m,
-            ClimateMachine.Ocean.SplitExplicit01.OceanFloorNoSlip(),
-            x...,
-        )
-    elseif bctype == 3
-        ocean_boundary_state!(
-            m,
-            ClimateMachine.Ocean.SplitExplicit01.OceanSurfaceStressForcing(),
-            x...,
-        )
-    end
-end
-
-@inline function ocean_boundary_state!(
-    m::BarotropicModel,
-    p::SimpleBox,
-    bctype,
-    x...,
-)
-    return ocean_boundary_state!(
-        m,
-        ClimateMachine.Ocean.SplitExplicit01.CoastlineNoSlip(),
-        x...,
-    )
-end
-
 function config_simple_box(
     name,
     resolution,
-    dimensions;
+    dimensions,
+    boundary_conditions;
     dt_slow = 90.0 * 60.0,
     dt_fast = 240.0,
 )
-    problem = SimpleBox{FT}(dimensions..., 0.1, 10 // 86400, 10)
+
+    problem = OceanGyre{FT}(
+        dimensions...;
+        τₒ = 0.1,
+        λʳ = 10 // 86400,
+        θᴱ = 10,
+        BC = boundary_conditions,
+    )
 
     add_fast_substeps = 2
     numImplSteps = 5

--- a/src/Numerics/ODESolvers/SplitExplicitMethod.jl
+++ b/src/Numerics/ODESolvers/SplitExplicitMethod.jl
@@ -68,7 +68,7 @@ mutable struct SplitExplicitSolver{SS, FS, RT, MSA} <: AbstractODESolver
 end
 
 function dostep!(
-    Qvec,
+    Qslow,
     split::SplitExplicitSolver{SS},
     param,
     time::Real,
@@ -76,8 +76,7 @@ function dostep!(
     slow = split.slow_solver
     fast = split.fast_solver
 
-    Qslow = Qvec.slow
-    Qfast = Qvec.fast
+    Qfast = slow.rhs!.modeldata.Q_2D
 
     dQslow = slow.dQ
     dQ2fast = split.dQ2fast

--- a/src/Ocean/Ocean.jl
+++ b/src/Ocean/Ocean.jl
@@ -1,7 +1,18 @@
 module Ocean
 
-export AbstractOceanCoupling,
-    Uncoupled, Coupled, AdvectionTerm, NonLinearAdvectionTerm
+using ..BalanceLaws
+using ..Problems
+
+export AbstractOceanModel,
+    AbstractOceanProblem,
+    AbstractOceanCoupling,
+    Uncoupled,
+    Coupled,
+    AdvectionTerm,
+    NonLinearAdvectionTerm
+
+abstract type AbstractOceanModel <: BalanceLaw end
+abstract type AbstractOceanProblem <: AbstractProblem end
 
 abstract type AbstractOceanCoupling end
 struct Uncoupled <: AbstractOceanCoupling end
@@ -12,6 +23,7 @@ struct NonLinearAdvectionTerm <: AdvectionTerm end
 
 function ocean_init_state! end
 function ocean_init_aux! end
+function ocean_boundary_state! end
 
 function coriolis_parameter end
 function kinematic_stress end
@@ -22,7 +34,8 @@ include("OceanBC.jl")
 include("HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl")
 include("ShallowWater/ShallowWaterModel.jl")
 include("SplitExplicit/SplitExplicitModel.jl")
-include("OceanProblems/SimpleBoxProblem.jl")
 include("SplitExplicit01/SplitExplicitModel.jl")
+include("OceanProblems/SimpleBoxProblem.jl")
+
 
 end

--- a/src/Ocean/OceanBC.jl
+++ b/src/Ocean/OceanBC.jl
@@ -11,6 +11,7 @@ export OceanBC,
     TemperatureFlux
 
 using ..BalanceLaws
+using ..DGMethods.NumericalFluxes
 
 """
     OceanBC(velocity    = Impenetrable(NoSlip())
@@ -86,3 +87,89 @@ Prescribe the net inward temperature flux across the boundary by `flux`,
 a function with signature `flux(problem, state, aux, t)`, returning the flux (in m⋅K/s).
 """
 struct TemperatureFlux <: TemperatureBC end
+
+"""
+    ocean_boundary_state!(nf, boundaries::Tuple, ::HBModel,
+                          Q⁺, A⁺, n, Q⁻, A⁻, bctype)
+applies boundary conditions for the first-order and gradient fluxes
+dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
+"""
+@generated function ocean_boundary_state!(
+    nf::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
+    boundaries::Tuple,
+    ocean,
+    Q⁺,
+    A⁺,
+    n,
+    Q⁻,
+    A⁻,
+    bctype,
+    t,
+    args...,
+)
+    N = fieldcount(boundaries)
+    return quote
+        Base.Cartesian.@nif(
+            $(N + 1),
+            i -> bctype == i, # conditionexpr
+            i -> ocean_boundary_state!(
+                nf,
+                boundaries[i],
+                ocean,
+                Q⁺,
+                A⁺,
+                n,
+                Q⁻,
+                A⁻,
+                t,
+            ), # expr
+            i -> error("Invalid boundary tag")
+        ) # elseexpr
+        return nothing
+    end
+end
+
+"""
+    ocean_boundary_state!(nf, boundaries::Tuple, ::HBModel,
+                          Q⁺, A⁺, D⁺, n, Q⁻, A⁻, D⁻, bctype)
+applies boundary conditions for the second-order fluxes
+dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
+"""
+@generated function ocean_boundary_state!(
+    nf::NumericalFluxSecondOrder,
+    boundaries::Tuple,
+    ocean,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n,
+    Q⁻,
+    D⁻,
+    A⁻,
+    bctype,
+    t,
+    args...,
+)
+    N = fieldcount(boundaries)
+    return quote
+        Base.Cartesian.@nif(
+            $(N + 1),
+            i -> bctype == i, # conditionexpr
+            i -> ocean_boundary_state!(
+                nf,
+                boundaries[i],
+                ocean,
+                Q⁺,
+                D⁺,
+                A⁺,
+                n,
+                Q⁻,
+                D⁻,
+                A⁻,
+                t,
+            ), # expr
+            i -> error("Invalid boundary tag")
+        ) # elseexpr
+        return nothing
+    end
+end

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -27,7 +27,7 @@ import ...BalanceLaws:
     source!,
     wavespeed,
     boundary_state!
-import ..Ocean: ocean_init_state!, ocean_init_aux!
+import ..Ocean: ocean_init_state!, ocean_init_aux!, ocean_boundary_state!
 
 using ...Mesh.Geometry: LocalGeometry
 
@@ -307,102 +307,16 @@ dispatches to a function in OceanBoundaryConditions.jl based on bytype defined b
 """
 @inline function boundary_state!(nf, shallow::SWModel, args...)
     boundary_conditions = shallow.problem.boundary_conditions
-    return shallow_boundary_state!(nf, boundary_conditions, shallow, args...)
+    return ocean_boundary_state!(nf, boundary_conditions, shallow, args...)
 end
 
 """
-    shallow_boundary_state!(nf, bc::OceanBC, ::SWModel)
+    ocean_boundary_state!(nf, bc::OceanBC, ::SWModel)
 
 splits boundary condition application into velocity
 """
-@inline function shallow_boundary_state!(nf, bc::OceanBC, m::SWModel, args...)
-    return shallow_boundary_state!(nf, bc.velocity, m, m.turbulence, args...)
-end
-
-"""
-    shallow_boundary_state!(nf, boundaries::Tuple, ::HBModel,
-                          Q⁺, A⁺, n, Q⁻, A⁻, bctype)
-applies boundary conditions for the first-order and gradient fluxes
-dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
-"""
-@generated function shallow_boundary_state!(
-    nf::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
-    boundaries::Tuple,
-    shallow,
-    Q⁺,
-    A⁺,
-    n,
-    Q⁻,
-    A⁻,
-    bctype,
-    t,
-    args...,
-)
-    N = fieldcount(boundaries)
-    return quote
-        Base.Cartesian.@nif(
-            $(N + 1),
-            i -> bctype == i, # conditionexpr
-            i -> shallow_boundary_state!(
-                nf,
-                boundaries[i],
-                shallow,
-                Q⁺,
-                A⁺,
-                n,
-                Q⁻,
-                A⁻,
-                t,
-            ), # expr
-            i -> error("Invalid boundary tag")
-        ) # elseexpr
-        return nothing
-    end
-end
-
-"""
-    shallow_boundary_state!(nf, boundaries::Tuple, ::HBModel,
-                          Q⁺, A⁺, D⁺, n, Q⁻, A⁻, D⁻, bctype)
-applies boundary conditions for the second-order fluxes
-dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
-"""
-@generated function shallow_boundary_state!(
-    nf::NumericalFluxSecondOrder,
-    boundaries::Tuple,
-    shallow,
-    Q⁺,
-    D⁺,
-    A⁺,
-    n,
-    Q⁻,
-    D⁻,
-    A⁻,
-    bctype,
-    t,
-    args...,
-)
-    N = fieldcount(boundaries)
-    return quote
-        Base.Cartesian.@nif(
-            $(N + 1),
-            i -> bctype == i, # conditionexpr
-            i -> shallow_boundary_state!(
-                nf,
-                boundaries[i],
-                shallow,
-                Q⁺,
-                D⁺,
-                A⁺,
-                n,
-                Q⁻,
-                D⁻,
-                A⁻,
-                t,
-            ), # expr
-            i -> error("Invalid boundary tag")
-        ) # elseexpr
-        return nothing
-    end
+@inline function ocean_boundary_state!(nf, bc::OceanBC, m::SWModel, args...)
+    return ocean_boundary_state!(nf, bc.velocity, m, m.turbulence, args...)
 end
 
 include("bc_velocity.jl")

--- a/src/Ocean/ShallowWater/bc_velocity.jl
+++ b/src/Ocean/ShallowWater/bc_velocity.jl
@@ -1,10 +1,10 @@
 """
-    shallow_boundary_state!(::NumericalFluxFirstOrder, ::Impenetrable{FreeSlip}, ::SWModel)
+    ocean_boundary_state!(::NumericalFluxFirstOrder, ::Impenetrable{FreeSlip}, ::SWModel)
 
 apply free slip boundary condition for velocity
 sets reflective ghost point
 """
-@inline function shallow_boundary_state!(
+@inline function ocean_boundary_state!(
     ::NumericalFluxFirstOrder,
     ::Impenetrable{FreeSlip},
     ::SWModel,
@@ -27,11 +27,11 @@ sets reflective ghost point
 end
 
 """
-    shallow_boundary_state!(::Union{NumericalFluxGradient, NumericalFluxSecondOrder}, ::Impenetrable{FreeSlip}, ::SWModel)
+    ocean_boundary_state!(::Union{NumericalFluxGradient, NumericalFluxSecondOrder}, ::Impenetrable{FreeSlip}, ::SWModel)
 
 no second order flux computed for linear drag
 """
-shallow_boundary_state!(
+ocean_boundary_state!(
     ::Union{NumericalFluxGradient, NumericalFluxSecondOrder},
     ::VelocityBC,
     ::SWModel,
@@ -40,12 +40,12 @@ shallow_boundary_state!(
 ) = nothing
 
 """
-    shallow_boundary_state!(::NumericalFluxGradient, ::Impenetrable{FreeSlip}, ::SWModel)
+    ocean_boundary_state!(::NumericalFluxGradient, ::Impenetrable{FreeSlip}, ::SWModel)
 
 apply free slip boundary condition for velocity
 sets non-reflective ghost point
 """
-function shallow_boundary_state!(
+function ocean_boundary_state!(
     ::NumericalFluxGradient,
     ::Impenetrable{FreeSlip},
     ::SWModel,
@@ -71,7 +71,7 @@ end
 apply free slip boundary condition for velocity
 apply zero numerical flux in the normal direction
 """
-function shallow_boundary_state!(
+function ocean_boundary_state!(
     ::NumericalFluxSecondOrder,
     ::Impenetrable{FreeSlip},
     ::SWModel,
@@ -93,12 +93,12 @@ function shallow_boundary_state!(
 end
 
 """
-    shallow_boundary_state!(::NumericalFluxFirstOrder, ::Impenetrable{NoSlip}, ::SWModel)
+    ocean_boundary_state!(::NumericalFluxFirstOrder, ::Impenetrable{NoSlip}, ::SWModel)
 
 apply no slip boundary condition for velocity
 sets reflective ghost point
 """
-@inline function shallow_boundary_state!(
+@inline function ocean_boundary_state!(
     ::NumericalFluxFirstOrder,
     ::Impenetrable{NoSlip},
     ::SWModel,
@@ -118,12 +118,12 @@ sets reflective ghost point
 end
 
 """
-    shallow_boundary_state!(::NumericalFluxGradient, ::Impenetrable{NoSlip}, ::SWModel)
+    ocean_boundary_state!(::NumericalFluxGradient, ::Impenetrable{NoSlip}, ::SWModel)
 
 apply no slip boundary condition for velocity
 set numerical flux to zero for U
 """
-@inline function shallow_boundary_state!(
+@inline function ocean_boundary_state!(
     ::NumericalFluxGradient,
     ::Impenetrable{NoSlip},
     ::SWModel,
@@ -143,12 +143,12 @@ set numerical flux to zero for U
 end
 
 """
-    shallow_boundary_state!(::NumericalFluxSecondOrder, ::Impenetrable{NoSlip}, ::SWModel)
+    ocean_boundary_state!(::NumericalFluxSecondOrder, ::Impenetrable{NoSlip}, ::SWModel)
 
 apply no slip boundary condition for velocity
 sets ghost point to have no numerical flux on the boundary for U
 """
-@inline function shallow_boundary_state!(
+@inline function ocean_boundary_state!(
     ::NumericalFluxSecondOrder,
     ::Impenetrable{NoSlip},
     ::SWModel,
@@ -170,11 +170,11 @@ sets ghost point to have no numerical flux on the boundary for U
 end
 
 """
-    shallow_boundary_state!(::Union{NumericalFluxFirstOrder, NumericalFluxGradient}, ::Penetrable{FreeSlip}, ::SWModel)
+    ocean_boundary_state!(::Union{NumericalFluxFirstOrder, NumericalFluxGradient}, ::Penetrable{FreeSlip}, ::SWModel)
 
 no mass boundary condition for penetrable
 """
-shallow_boundary_state!(
+ocean_boundary_state!(
     ::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
     ::Penetrable{FreeSlip},
     ::SWModel,
@@ -183,12 +183,12 @@ shallow_boundary_state!(
 ) = nothing
 
 """
-    shallow_boundary_state!(::NumericalFluxSecondOrder, ::Penetrable{FreeSlip}, ::SWModel)
+    ocean_boundary_state!(::NumericalFluxSecondOrder, ::Penetrable{FreeSlip}, ::SWModel)
 
 apply free slip boundary condition for velocity
 apply zero numerical flux in the normal direction
 """
-function shallow_boundary_state!(
+function ocean_boundary_state!(
     ::NumericalFluxSecondOrder,
     ::Penetrable{FreeSlip},
     ::SWModel,
@@ -210,19 +210,19 @@ function shallow_boundary_state!(
 end
 
 """
-    shallow_boundary_state!(::Union{NumericalFluxFirstOrder, NumericalFluxGradient}, ::Impenetrable{KinematicStress}, ::HBModel)
+    ocean_boundary_state!(::Union{NumericalFluxFirstOrder, NumericalFluxGradient}, ::Impenetrable{KinematicStress}, ::HBModel)
 
 apply kinematic stress boundary condition for velocity
 applies free slip conditions for first-order and gradient fluxes
 """
-function shallow_boundary_state!(
+function ocean_boundary_state!(
     nf::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
     ::Impenetrable{KinematicStress},
     shallow::SWModel,
     turb::TurbulenceClosure,
     args...,
 )
-    return shallow_boundary_state!(
+    return ocean_boundary_state!(
         nf,
         Impenetrable(FreeSlip()),
         shallow,
@@ -232,12 +232,12 @@ function shallow_boundary_state!(
 end
 
 """
-    shallow_boundary_state!(::NumericalFluxSecondOrder, ::Impenetrable{KinematicStress}, ::HBModel)
+    ocean_boundary_state!(::NumericalFluxSecondOrder, ::Impenetrable{KinematicStress}, ::HBModel)
 
 apply kinematic stress boundary condition for velocity
 sets ghost point to have specified flux on the boundary for ν∇u
 """
-@inline function shallow_boundary_state!(
+@inline function ocean_boundary_state!(
     ::NumericalFluxSecondOrder,
     ::Impenetrable{KinematicStress},
     shallow::SWModel,
@@ -258,19 +258,19 @@ sets ghost point to have specified flux on the boundary for ν∇u
 end
 
 """
-    shallow_boundary_state!(::Union{NumericalFluxFirstOrder, NumericalFluxGradient}, ::Penetrable{KinematicStress}, ::HBModel)
+    ocean_boundary_state!(::Union{NumericalFluxFirstOrder, NumericalFluxGradient}, ::Penetrable{KinematicStress}, ::HBModel)
 
 apply kinematic stress boundary condition for velocity
 applies free slip conditions for first-order and gradient fluxes
 """
-function shallow_boundary_state!(
+function ocean_boundary_state!(
     nf::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
     ::Penetrable{KinematicStress},
     shallow::SWModel,
     turb::TurbulenceClosure,
     args...,
 )
-    return shallow_boundary_state!(
+    return ocean_boundary_state!(
         nf,
         Penetrable(FreeSlip()),
         shallow,
@@ -280,12 +280,12 @@ function shallow_boundary_state!(
 end
 
 """
-    shallow_boundary_state!(::NumericalFluxSecondOrder, ::Penetrable{KinematicStress}, ::HBModel)
+    ocean_boundary_state!(::NumericalFluxSecondOrder, ::Penetrable{KinematicStress}, ::HBModel)
 
 apply kinematic stress boundary condition for velocity
 sets ghost point to have specified flux on the boundary for ν∇u
 """
-@inline function shallow_boundary_state!(
+@inline function ocean_boundary_state!(
     ::NumericalFluxSecondOrder,
     ::Penetrable{KinematicStress},
     shallow::SWModel,

--- a/src/Ocean/SplitExplicit01/BarotropicModel.jl
+++ b/src/Ocean/SplitExplicit01/BarotropicModel.jl
@@ -13,9 +13,7 @@ function vars_state(m::BarotropicModel, ::Prognostic, T)
 end
 
 function init_state_prognostic!(m::BarotropicModel, Q::Vars, A::Vars, coords, t)
-    Q.U = @SVector [-0, -0]
-    Q.η = -0
-    return nothing
+    return ocean_init_state!(m, m.baroclinic.problem, Q, A, coords, t)
 end
 
 function vars_state(m::BarotropicModel, ::Auxiliary, T)
@@ -174,70 +172,13 @@ function update_penalty!(
     return nothing
 end
 
-"""
-    boundary_state!(nf, ::BarotropicModel, Q⁺, A⁺, Q⁻, A⁻, bctype)
-
-applies boundary conditions for the hyperbolic fluxes
-dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
-"""
-@inline function boundary_state!(
-    nf,
-    m::BarotropicModel,
-    Q⁺::Vars,
-    A⁺::Vars,
-    n⁻,
-    Q⁻::Vars,
-    A⁻::Vars,
-    bctype,
-    t,
-    _...,
-)
-    return ocean_boundary_state!(
-        m,
-        m.baroclinic.problem,
-        bctype,
-        nf,
-        Q⁺,
-        A⁺,
-        n⁻,
-        Q⁻,
-        A⁻,
-        t,
+@inline function boundary_state!(nf, bm::BarotropicModel, args...)
+    # hack for handling multiple boundaries for now
+    # will fix with a future update
+    boundary_conditions = (
+        bm.baroclinic.problem.boundary_conditions[1],
+        bm.baroclinic.problem.boundary_conditions[1],
+        bm.baroclinic.problem.boundary_conditions[1],
     )
-end
-
-"""
-    boundary_state!(nf, ::BarotropicModel, Q⁺, D⁺, A⁺, Q⁻, D⁻, A⁻, bctype)
-
-applies boundary conditions for the parabolic fluxes
-dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
-"""
-@inline function boundary_state!(
-    nf,
-    m::BarotropicModel,
-    Q⁺::Vars,
-    D⁺::Vars,
-    A⁺::Vars,
-    n⁻,
-    Q⁻::Vars,
-    D⁻::Vars,
-    A⁻::Vars,
-    bctype,
-    t,
-    _...,
-)
-    return ocean_boundary_state!(
-        m,
-        m.baroclinic.problem,
-        bctype,
-        nf,
-        Q⁺,
-        D⁺,
-        A⁺,
-        n⁻,
-        Q⁻,
-        D⁻,
-        A⁻,
-        t,
-    )
+    return ocean_boundary_state!(nf, boundary_conditions, bm, args...)
 end

--- a/src/Ocean/SplitExplicit01/Continuity3dModel.jl
+++ b/src/Ocean/SplitExplicit01/Continuity3dModel.jl
@@ -58,28 +58,13 @@ boundary_state!(
 applies boundary conditions for the hyperbolic fluxes
 dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
 """
-@inline function boundary_state!(
-    nf,
-    cm::Continuity3dModel,
-    Q⁺::Vars,
-    A⁺::Vars,
-    n⁻,
-    Q⁻::Vars,
-    A⁻::Vars,
-    bctype,
-    t,
-    _...,
-)
-    return ocean_boundary_state!(
-        cm,
-        cm.ocean.problem,
-        bctype,
-        nf,
-        Q⁺,
-        A⁺,
-        n⁻,
-        Q⁻,
-        A⁻,
-        t,
+@inline function boundary_state!(nf, cm::Continuity3dModel, args...)
+    # hack for handling multiple boundaries for now
+    # will fix with a future update
+    boundary_conditions = (
+        cm.ocean.problem.boundary_conditions[1],
+        cm.ocean.problem.boundary_conditions[1],
+        cm.ocean.problem.boundary_conditions[1],
     )
+    return ocean_boundary_state!(nf, boundary_conditions, cm, args...)
 end

--- a/src/Ocean/SplitExplicit01/OceanBoundaryConditions.jl
+++ b/src/Ocean/SplitExplicit01/OceanBoundaryConditions.jl
@@ -19,15 +19,15 @@ applies boundary condition ∇u = 0 and ∇θ = 0
 """
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder})
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::NumericalFluxFirstOrder)
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxFirstOrder,
     ::CoastlineFreeSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::AbstractOceanModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -38,16 +38,15 @@ apply no penetration boundary for temperature
     u⁻ = Q⁻.u
     n = @SVector [n⁻[1], n⁻[2]]
 
-    # Q⁺.u = u⁻ - 2 * (n⋅u⁻) * n
     Q⁺.u = u⁻ - 2 * (n ∘ u⁻) * n
 
     return nothing
 end
 
 @inline function ocean_boundary_state!(
-    ::BarotropicModel,
+    ::NumericalFluxFirstOrder,
     ::CoastlineFreeSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::BarotropicModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -58,22 +57,21 @@ end
     U⁻ = Q⁻.U
     n = @SVector [n⁻[1], n⁻[2]]
 
-    # Q⁺.U = U⁻ - 2 * (n⋅U⁻) * n
     Q⁺.U = U⁻ - 2 * (n ∘ U⁻) * n
 
     return nothing
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::CentralNumericalFluxGradient)
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::NumericalFluxGradient)
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxGradient,
     ::CoastlineFreeSlip,
-    ::CentralNumericalFluxGradient,
+    ::AbstractOceanModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -93,9 +91,9 @@ apply no penetration boundary for temperature
 end
 
 @inline function ocean_boundary_state!(
-    ::BarotropicModel,
+    ::NumericalFluxGradient,
     ::CoastlineFreeSlip,
-    ::CentralNumericalFluxGradient,
+    ::BarotropicModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -113,15 +111,15 @@ end
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::NumericalFluxSecondOrder)
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxSecondOrder,
     ::CoastlineFreeSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::AbstractOceanModel,
     Q⁺,
     D⁺,
     A⁺,
@@ -138,9 +136,9 @@ apply no penetration boundary for temperature
 end
 
 @inline function ocean_boundary_state!(
-    ::BarotropicModel,
+    ::NumericalFluxSecondOrder,
     ::CoastlineFreeSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::BarotropicModel,
     Q⁺,
     D⁺,
     A⁺,
@@ -168,9 +166,9 @@ apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxFirstOrder,
     ::CoastlineNoSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::AbstractOceanModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -184,9 +182,9 @@ apply no penetration boundary for temperature
 end
 
 @inline function ocean_boundary_state!(
-    ::BarotropicModel,
+    ::NumericalFluxFirstOrder,
     ::CoastlineNoSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::BarotropicModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -200,15 +198,15 @@ end
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineNoSlip, ::CentralNumericalFluxGradient)
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineNoSlip, ::NumericalFluxGradient)
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxGradient,
     ::CoastlineNoSlip,
-    ::CentralNumericalFluxGradient,
+    ::AbstractOceanModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -224,9 +222,9 @@ apply no penetration boundary for temperature
 end
 
 @inline function ocean_boundary_state!(
-    ::BarotropicModel,
+    ::NumericalFluxGradient,
     ::CoastlineNoSlip,
-    ::CentralNumericalFluxGradient,
+    ::BarotropicModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -241,15 +239,15 @@ end
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineNoSlip, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineNoSlip, ::NumericalFluxSecondOrder)
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxSecondOrder,
     ::CoastlineNoSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::AbstractOceanModel,
     Q⁺,
     D⁺,
     A⁺,
@@ -268,9 +266,9 @@ apply no penetration boundary for temperature
 end
 
 @inline function ocean_boundary_state!(
-    ::BarotropicModel,
+    ::NumericalFluxSecondOrder,
     ::CoastlineNoSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::BarotropicModel,
     Q⁺,
     D⁺,
     A⁺,
@@ -298,9 +296,9 @@ apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxFirstOrder,
     ::OceanFloorFreeSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::AbstractOceanModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -314,15 +312,15 @@ apply no penetration boundary for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorFreeSlip, ::CentralNumericalFluxGradient)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorFreeSlip, ::NumericalFluxGradient)
 
 apply free slip boundary condition for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxGradient,
     ::OceanFloorFreeSlip,
-    ::CentralNumericalFluxGradient,
+    ::AbstractOceanModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -337,15 +335,15 @@ apply no penetration boundary for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorFreeSlip, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorFreeSlip, ::NumericalFluxSecondOrder)
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxSecondOrder,
     ::OceanFloorFreeSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::AbstractOceanModel,
     Q⁺,
     D⁺,
     A⁺,
@@ -376,9 +374,9 @@ apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxFirstOrder,
     ::OceanFloorNoSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::AbstractOceanModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -393,15 +391,15 @@ apply no penetration boundary for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorNoSlip, ::CentralNumericalFluxGradient)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorNoSlip, ::NumericalFluxGradient)
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxGradient,
     ::OceanFloorNoSlip,
-    ::CentralNumericalFluxGradient,
+    ::AbstractOceanModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -417,15 +415,15 @@ apply no penetration boundary for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorNoSlip, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorNoSlip, ::NumericalFluxSecondOrder)
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxSecondOrder,
     ::OceanFloorNoSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::AbstractOceanModel,
     Q⁺,
     D⁺,
     A⁺,
@@ -445,23 +443,19 @@ apply no penetration boundary for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::Union{OceanSurface*}, ::Union{RusanovNumericalFlux, CentralNumericalFluxGradient})
+    ocean_boundary_state!(::AbstractOceanModel, ::Union{OceanSurface*}, ::Union{RusanovNumericalFlux, NumericalFluxGradient})
 
 applying neumann boundary conditions, so don't need to do anything for these numerical fluxes
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
     ::Union{
         OceanSurfaceNoStressNoForcing,
         OceanSurfaceStressNoForcing,
         OceanSurfaceNoStressForcing,
         OceanSurfaceStressForcing,
     },
-    ::Union{
-        RusanovNumericalFlux,
-        CentralNumericalFluxFirstOrder,
-        CentralNumericalFluxGradient,
-    },
+    ::AbstractOceanModel,
     Q⁺,
     A⁺,
     n⁻,
@@ -473,15 +467,15 @@ applying neumann boundary conditions, so don't need to do anything for these num
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceNoStressNoForcing, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceNoStressNoForcing, ::NumericalFluxSecondOrder)
 
 apply no flux boundary condition for velocity
 apply no flux boundary condition for temperature
 """
 @inline function ocean_boundary_state!(
-    ::AbstractOceanModel,
+    ::NumericalFluxSecondOrder,
     ::OceanSurfaceNoStressNoForcing,
-    ::CentralNumericalFluxSecondOrder,
+    ::AbstractOceanModel,
     Q⁺,
     D⁺,
     A⁺,
@@ -499,15 +493,15 @@ apply no flux boundary condition for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceStressNoForcing, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceStressNoForcing, ::NumericalFluxSecondOrder)
 
 apply wind-stress boundary condition for velocity
 apply no flux boundary condition for temperature
 """
 @inline function ocean_boundary_state!(
-    m::AbstractOceanModel,
+    ::NumericalFluxSecondOrder,
     ::OceanSurfaceStressNoForcing,
-    ::CentralNumericalFluxSecondOrder,
+    m::AbstractOceanModel,
     Q⁺,
     D⁺,
     A⁺,
@@ -527,15 +521,15 @@ apply no flux boundary condition for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceNoStressForcing, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceNoStressForcing, ::NumericalFluxSecondOrder)
 
 apply no flux boundary condition for velocity
 apply forcing boundary condition for temperature
 """
 @inline function ocean_boundary_state!(
-    m::AbstractOceanModel,
+    ::NumericalFluxSecondOrder,
     ::OceanSurfaceNoStressForcing,
-    ::CentralNumericalFluxSecondOrder,
+    m::AbstractOceanModel,
     Q⁺,
     D⁺,
     A⁺,
@@ -555,15 +549,15 @@ apply forcing boundary condition for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceStressForcing, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceStressForcing, ::NumericalFluxSecondOrder)
 
 apply wind-stress boundary condition for velocity
 apply forcing boundary condition for temperature
 """
 @inline function ocean_boundary_state!(
-    m::AbstractOceanModel,
+    ::NumericalFluxSecondOrder,
     ::OceanSurfaceStressForcing,
-    ::CentralNumericalFluxSecondOrder,
+    m::AbstractOceanModel,
     Q⁺,
     D⁺,
     A⁺,

--- a/src/Ocean/SplitExplicit01/OceanModel.jl
+++ b/src/Ocean/SplitExplicit01/OceanModel.jl
@@ -169,7 +169,7 @@ function vars_state(m::OceanModel, ::Prognostic, T)
 end
 
 function init_state_prognostic!(m::OceanModel, Q::Vars, A::Vars, coords, t)
-    return ocean_init_state!(m.problem, Q, A, coords, t)
+    return ocean_init_state!(m, m.problem, Q, A, coords, t)
 end
 
 function vars_state(m::OceanModel, ::Auxiliary, T)
@@ -590,70 +590,7 @@ function update_penalty!(
     return nothing
 end
 
-"""
-    boundary_state!(nf, ::OceanModel, Q⁺, A⁺, Q⁻, A⁻, bctype)
-
-applies boundary conditions for the hyperbolic fluxes
-dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
-"""
-@inline function boundary_state!(
-    nf,
-    m::OceanModel,
-    Q⁺::Vars,
-    A⁺::Vars,
-    n⁻,
-    Q⁻::Vars,
-    A⁻::Vars,
-    bctype,
-    t,
-    _...,
-)
-    return ocean_boundary_state!(
-        m,
-        m.problem,
-        bctype,
-        nf,
-        Q⁺,
-        A⁺,
-        n⁻,
-        Q⁻,
-        A⁻,
-        t,
-    )
-end
-
-"""
-    boundary_state!(nf, ::OceanModel, Q⁺, D⁺, A⁺, Q⁻, D⁻, A⁻, bctype)
-
-applies boundary conditions for the parabolic fluxes
-dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
-"""
-@inline function boundary_state!(
-    nf,
-    m::OceanModel,
-    Q⁺::Vars,
-    D⁺::Vars,
-    A⁺::Vars,
-    n⁻,
-    Q⁻::Vars,
-    D⁻::Vars,
-    A⁻::Vars,
-    bctype,
-    t,
-    _...,
-)
-    return ocean_boundary_state!(
-        m,
-        m.problem,
-        bctype,
-        nf,
-        Q⁺,
-        D⁺,
-        A⁺,
-        n⁻,
-        Q⁻,
-        D⁻,
-        A⁻,
-        t,
-    )
+@inline function boundary_state!(nf, ocean::OceanModel, args...)
+    boundary_conditions = ocean.problem.boundary_conditions
+    return ocean_boundary_state!(nf, boundary_conditions, ocean, args...)
 end

--- a/src/Ocean/SplitExplicit01/SplitExplicitLSRK2nMethod.jl
+++ b/src/Ocean/SplitExplicit01/SplitExplicitLSRK2nMethod.jl
@@ -79,7 +79,7 @@ mutable struct SplitExplicitLSRK2nSolver{SS, FS, RT, MSA} <: AbstractODESolver
 end
 
 function dostep!(
-    Q,
+    Qslow,
     split::SplitExplicitLSRK2nSolver{SS},
     param,
     time::Real,
@@ -87,7 +87,6 @@ function dostep!(
     slow = split.slow_solver
     fast = split.fast_solver
 
-    Qslow = Q
     Qfast = slow.rhs!.modeldata.Q_2D
 
     dQslow = slow.dQ

--- a/src/Ocean/SplitExplicit01/SplitExplicitModel.jl
+++ b/src/Ocean/SplitExplicit01/SplitExplicitModel.jl
@@ -33,6 +33,10 @@ using ...DGMethods.NumericalFluxes:
     CentralNumericalFluxSecondOrder,
     CentralNumericalFluxFirstOrder
 
+using ..Ocean
+
+import ..Ocean: ocean_init_aux!, ocean_init_state!, ocean_boundary_state!
+
 import ...DGMethods.NumericalFluxes:
     update_penalty!, numerical_flux_second_order!, NumericalFluxFirstOrder
 
@@ -64,11 +68,6 @@ import ...SystemSolvers: BatchedGeneralizedMinimalResidual, linearsolve!
 ×(a::SVector, b::SVector) = StaticArrays.cross(a, b)
 ∘(a::SVector, b::SVector) = StaticArrays.dot(a, b)
 
-abstract type AbstractOceanModel <: BalanceLaw end
-abstract type AbstractOceanProblem end
-
-function ocean_init_aux! end
-function ocean_init_state! end
 function initialize_fast_state! end
 function initialize_adjustment! end
 

--- a/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
+++ b/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
@@ -1,6 +1,18 @@
 include("split_explicit.jl")
 
-function SplitConfig(name, resolution, dimensions, coupling, rotation = Fixed())
+function SplitConfig(
+    name,
+    resolution,
+    dimensions,
+    coupling,
+    rotation = Fixed();
+    boundary_conditions = (
+        OceanBC(Impenetrable(FreeSlip()), Insulating()),
+        OceanBC(Penetrable(FreeSlip()), Insulating()),
+    ),
+    solver = SplitExplicitSolver,
+    dt_slow = 90 * 60,
+)
     mpicomm = MPI.COMM_WORLD
     ArrayType = ClimateMachine.array_type()
 
@@ -39,7 +51,34 @@ function SplitConfig(name, resolution, dimensions, coupling, rotation = Fixed())
         polynomialorder = N,
     )
 
-    problem = SimpleBox{FT}(Lˣ, Lʸ, H; rotation = rotation)
+    problem = SimpleBox{FT}(
+        dimensions...;
+        BC = boundary_conditions,
+        rotation = rotation,
+    )
+
+    dg_3D, dg_2D = setup_models(
+        solver,
+        problem,
+        grid_3D,
+        grid_2D,
+        param_set,
+        coupling,
+        dt_slow,
+    )
+
+    return SplitConfig(name, dg_3D, dg_2D, solver, mpicomm, ArrayType)
+end
+
+function setup_models(
+    ::Type{SplitExplicitSolver},
+    problem,
+    grid_3D,
+    grid_2D,
+    param_set,
+    coupling,
+    _,
+)
 
     model_3D = HydrostaticBoussinesqModel{FT}(
         param_set,
@@ -60,13 +99,44 @@ function SplitConfig(name, resolution, dimensions, coupling, rotation = Fixed())
         c = FT(1),
     )
 
-    return SplitConfig(
-        name,
-        model_3D,
-        model_2D,
+    vert_filter = CutoffFilter(grid_3D, polynomialorder(grid_3D) - 1)
+    exp_filter = ExponentialFilter(grid_3D, 1, 8)
+
+    integral_model = DGModel(
+        VerticalIntegralModel(model_3D),
         grid_3D,
-        grid_2D,
-        mpicomm,
-        ArrayType,
+        CentralNumericalFluxFirstOrder(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
     )
+
+    dg_2D = DGModel(
+        model_2D,
+        grid_2D,
+        CentralNumericalFluxFirstOrder(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+
+    Q_2D = init_ode_state(dg_2D, FT(0); init_on_cpu = true)
+
+    modeldata = (
+        dg_2D = dg_2D,
+        Q_2D = Q_2D,
+        vert_filter = vert_filter,
+        exp_filter = exp_filter,
+        integral_model = integral_model,
+    )
+
+    dg_3D = DGModel(
+        model_3D,
+        grid_3D,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient();
+        modeldata = modeldata,
+    )
+
+    return dg_3D, dg_2D
+
 end

--- a/test/Ocean/SplitExplicit/simple_box_ivd.jl
+++ b/test/Ocean/SplitExplicit/simple_box_ivd.jl
@@ -12,6 +12,7 @@ using ClimateMachine.MPIStateArrays
 using ClimateMachine.ODESolvers
 using ClimateMachine.VariableTemplates: flattenednames
 using ClimateMachine.Ocean.SplitExplicit01
+using ClimateMachine.Ocean.OceanProblems
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.VTK
 
@@ -26,119 +27,10 @@ using CLIMAParameters.Planet: grav
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-import ClimateMachine.Ocean.SplitExplicit01:
-    ocean_init_aux!,
-    ocean_init_state!,
-    ocean_boundary_state!,
-    CoastlineFreeSlip,
-    CoastlineNoSlip,
-    OceanFloorFreeSlip,
-    OceanFloorNoSlip,
-    OceanSurfaceNoStressNoForcing,
-    OceanSurfaceStressNoForcing,
-    OceanSurfaceNoStressForcing,
-    OceanSurfaceStressForcing
-import ClimateMachine.DGMethods:
-    update_auxiliary_state!, update_auxiliary_state_gradient!, VerticalDirection
-# using GPUifyLoops
-
 const ArrayType = ClimateMachine.array_type()
 
-struct SimpleBox{T} <: AbstractOceanProblem
-    Lˣ::T
-    Lʸ::T
-    H::T
-    τₒ::T
-    λʳ::T
-    θᴱ::T
-end
-
-@inline function ocean_boundary_state!(
-    m::OceanModel,
-    p::SimpleBox,
-    bctype,
-    x...,
-)
-    if bctype == 1
-        ocean_boundary_state!(m, CoastlineNoSlip(), x...)
-    elseif bctype == 2
-        ocean_boundary_state!(m, OceanFloorNoSlip(), x...)
-    elseif bctype == 3
-        ocean_boundary_state!(m, OceanSurfaceStressForcing(), x...)
-    end
-end
-
-@inline function ocean_boundary_state!(
-    m::Continuity3dModel,
-    p::SimpleBox,
-    bctype,
-    x...,
-)
-    #if bctype == 1
-    ocean_boundary_state!(m, CoastlineNoSlip(), x...)
-    #end
-end
-
-@inline function ocean_boundary_state!(
-    m::BarotropicModel,
-    p::SimpleBox,
-    bctype,
-    x...,
-)
-    return ocean_boundary_state!(m, CoastlineNoSlip(), x...)
-end
-
-function ocean_init_state!(p::SimpleBox, Q, A, coords, t)
-    @inbounds y = coords[2]
-    @inbounds z = coords[3]
-    @inbounds H = p.H
-
-    Q.u = @SVector [-0, -0]
-    Q.η = -0
-    Q.θ = (5 + 4 * cos(y * π / p.Lʸ)) * (1 + z / H)
-
-    return nothing
-end
-
-function ocean_init_aux!(m::OceanModel, p::SimpleBox, A, geom)
-    FT = eltype(A)
-    @inbounds A.y = geom.coord[2]
-
-    # not sure if this is needed but getting weird intialization stuff
-    A.w = -0
-    A.pkin = -0
-    A.wz0 = -0
-    A.u_d = @SVector [-0, -0]
-    A.ΔGu = @SVector [-0, -0]
-
-    return nothing
-end
-
-# A is Filled afer the state
-function ocean_init_aux!(m::BarotropicModel, P::SimpleBox, A, geom)
-    @inbounds A.y = geom.coord[2]
-
-    A.Gᵁ = @SVector [-0, -0]
-    A.U_c = @SVector [-0, -0]
-    A.η_c = -0
-    A.U_s = @SVector [-0, -0]
-    A.η_s = -0
-    A.Δu = @SVector [-0, -0]
-    A.η_diag = -0
-    A.Δη = -0
-
-    return nothing
-end
-
-function main()
+function main(BC)
     mpicomm = MPI.COMM_WORLD
-
-    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
-    loglevel = ll == "DEBUG" ? Logging.Debug :
-        ll == "WARN" ? Logging.Warn :
-        ll == "ERROR" ? Logging.Error : Logging.Info
-    logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
-    global_logger(ConsoleLogger(logger_stream, loglevel))
 
     brickrange_2D = (xrange, yrange)
     topl_2D =
@@ -164,14 +56,13 @@ function main()
         polynomialorder = N,
     )
 
-    prob = SimpleBox{FT}(Lˣ, Lʸ, H, τₒ, λʳ, θᴱ)
+    prob = OceanGyre{FT}(Lˣ, Lʸ, H; τₒ = τₒ, λʳ = λʳ, θᴱ = θᴱ, BC = BC)
     gravity::FT = grav(param_set)
 
     #- set model time-step:
     dt_fast = 240
     dt_slow = 5400
-    # dt_fast = 300
-    # dt_slow = 300
+
     nout = ceil(Int64, tout / dt_slow)
     dt_slow = tout / nout
     numImplSteps > 0 ? ivdc_dt = dt_slow / FT(numImplSteps) : ivdc_dt = dt_slow
@@ -185,8 +76,8 @@ function main()
         ivdc_dt = ivdc_dt,
         κᶜ = FT(0.1),
     )
-    # model = OceanModel{FT}(prob, cʰ = cʰ, fₒ = FT(0), β = FT(0) )
-    # model = OceanModel{FT}(prob, cʰ = cʰ, νʰ = FT(1e3), νᶻ = FT(1e-3) )
+    # model = OceanModel{FT}(prob, cʰ = cʰ, fₒ = FT(0), β = FT(0) )	
+    # model = OceanModel{FT}(prob, cʰ = cʰ, νʰ = FT(1e3), νᶻ = FT(1e-3) )	
     # model = OceanModel{FT}(prob, cʰ = cʰ, νʰ = FT(0), fₒ = FT(0), β = FT(0) )
 
     barotropicmodel = BarotropicModel(model)
@@ -220,7 +111,6 @@ function main()
         dt_slow
     )
 
-
     barotropic_dg = DGModel(
         barotropicmodel,
         grid_2D,
@@ -235,7 +125,6 @@ function main()
     dg = OceanDGModel(
         model,
         grid_3D,
-        # CentralNumericalFluxFirstOrder(),
         RusanovNumericalFlux(),
         CentralNumericalFluxSecondOrder(),
         CentralNumericalFluxGradient();
@@ -243,8 +132,6 @@ function main()
     )
 
     Q_3D = init_ode_state(dg, FT(0); init_on_cpu = true)
-    # update_auxiliary_state!(dg, model, Q_3D, FT(0))
-    # update_auxiliary_state_gradient!(dg, model, Q_3D, FT(0))
 
     lsrk_ocean = LSRK54CarpenterKennedy(dg, Q_3D, dt = dt_slow, t0 = 0)
     lsrk_barotropic =
@@ -258,19 +145,18 @@ function main()
         [
             (Q_3D, "oce Q_3D"),
             (dg.state_auxiliary, "oce aux"),
-            # (dg.diffstate,"oce diff",),
-            # (lsrk_ocean.dQ,"oce_dQ",),
-            # (dg.modeldata.tendency_dg.state_auxiliary,"tend Int aux",),
-            # (dg.modeldata.conti3d_Q,"conti3d_Q",),
             (Q_2D, "baro Q_2D"),
             (barotropic_dg.state_auxiliary, "baro aux"),
+            # (dg.diffstate,"oce diff",),	
+            # (lsrk_ocean.dQ,"oce_dQ",),	
+            # (dg.modeldata.tendency_dg.state_auxiliary,"tend Int aux",),	
+            # (dg.modeldata.conti3d_Q,"conti3d_Q",),
+            # (barotropic_dg.diffstate,"baro diff",),	
+            # (lsrk_barotropic.dQ,"baro_dQ",)
         ],
         ntFreq;
         prec = 12,
     )
-    # (barotropic_dg.diffstate,"baro diff",),
-    # (lsrk_barotropic.dQ,"baro_dQ",)
-    #--
 
     step = [0, 0]
     cbvector = make_callbacks(
@@ -292,9 +178,6 @@ function main()
     norm(Q₀) = %.16e
     ArrayType = %s""" eng0 ArrayType
 
-    # slow fast state tuple
-    Qvec = (slow = Q_3D, fast = Q_2D)
-    # solve!(Qvec, odesolver; timeend = timeend, callbacks = cbvector)
     cbv = (cbvector..., cbcs_dg)
     solve!(Q_3D, odesolver; timeend = timeend, callbacks = cbv)
 
@@ -430,8 +313,6 @@ vtkpath = abspath(joinpath(ClimateMachine.Settings.output_dir, "vtk_split"))
 
 const timeend = 5 * 24 * 3600 # s
 const tout = 24 * 3600 # s
-#const timeend = 6 * 3600 # s
-#const tout = 6 * 3600 # s
 
 const N = 4
 const Nˣ = 20
@@ -464,6 +345,12 @@ const τₒ = 1e-1
 const λʳ = 10 // 86400 # m/s
 const θᴱ = 10    # deg.C
 
+BC = (
+    ClimateMachine.Ocean.SplitExplicit01.CoastlineNoSlip(),
+    ClimateMachine.Ocean.SplitExplicit01.OceanFloorNoSlip(),
+    ClimateMachine.Ocean.SplitExplicit01.OceanSurfaceStressForcing(),
+)
+
 @testset "$(@__FILE__)" begin
-    main()
+    main(BC)
 end

--- a/test/Ocean/SplitExplicit/test_restart.jl
+++ b/test/Ocean/SplitExplicit/test_restart.jl
@@ -35,29 +35,17 @@ const FT = Float64
 
     config = SplitConfig("test_restart", resolution, dimensions, Coupled())
 
-    @testset "single run" begin
-        run_split_explicit(
-            config,
-            timespan;
-            dt_slow = 90 * 60,
-            refDat = refVals.ninety_minutes,
-            analytic_solution = true,
-        )
-    end
+    midpoint = timeend / 2
+    timespan = (tout, midpoint)
 
-    @testset "restart run" begin
-        midpoint = timeend / 2
-        timespan = (tout, midpoint)
+    run_split_explicit(config, timespan; dt_slow = 90 * 60)
 
-        run_split_explicit(config, timespan; dt_slow = 90 * 60)
-
-        run_split_explicit(
-            config,
-            timespan;
-            dt_slow = 90 * 60,
-            refDat = refVals.ninety_minutes,
-            analytic_solution = true,
-            restart = Int(midpoint / tout) - 1,
-        )
-    end
+    run_split_explicit(
+        config,
+        timespan;
+        dt_slow = 90 * 60,
+        refDat = refVals.ninety_minutes,
+        analytic_solution = true,
+        restart = Int(midpoint / tout),
+    )
 end

--- a/test/Ocean/SplitExplicit/test_simple_box.jl
+++ b/test/Ocean/SplitExplicit/test_simple_box.jl
@@ -5,7 +5,6 @@ ClimateMachine.init()
 # Float type
 const FT = Float64
 
-
 #################
 # RUN THE TESTS #
 #################
@@ -34,10 +33,17 @@ const FT = Float64
     H = 1000   # m
     dimensions = (Lˣ, Lʸ, H)
 
+    BC = (
+        ClimateMachine.Ocean.SplitExplicit01.CoastlineNoSlip(),
+        ClimateMachine.Ocean.SplitExplicit01.OceanFloorNoSlip(),
+        ClimateMachine.Ocean.SplitExplicit01.OceanSurfaceStressForcing(),
+    )
+
     config = config_simple_box(
         "test_simple_box",
         resolution,
-        dimensions;
+        dimensions,
+        BC;
         dt_slow = FT(90 * 60),
         dt_fast = FT(240),
     )

--- a/test/Ocean/SplitExplicit/test_spindown_long.jl
+++ b/test/Ocean/SplitExplicit/test_spindown_long.jl
@@ -58,10 +58,10 @@ const FT = Float64
         end
     end
 
-    config = SplitConfig("multirate", resolution, dimensions, Coupled())
-
     @testset "Multi-rate" begin
         @testset "Δt = 30 mins" begin
+            config = SplitConfig("multirate", resolution, dimensions, Coupled())
+
             run_split_explicit(
                 config,
                 timespan,
@@ -72,6 +72,8 @@ const FT = Float64
         end
 
         @testset "Δt = 60 mins" begin
+            config = SplitConfig("multirate", resolution, dimensions, Coupled())
+
             run_split_explicit(
                 config,
                 timespan,
@@ -82,6 +84,8 @@ const FT = Float64
         end
 
         @testset "Δt = 90 mins" begin
+            config = SplitConfig("multirate", resolution, dimensions, Coupled())
+
             run_split_explicit(
                 config,
                 timespan,

--- a/test/Ocean/SplitExplicit/test_spindown_short.jl
+++ b/test/Ocean/SplitExplicit/test_spindown_short.jl
@@ -32,7 +32,18 @@ const FT = Float64
     H = 400  # m
     dimensions = (Lˣ, Lʸ, H)
 
-    config = SplitConfig("spindown_short", resolution, dimensions, Coupled())
+    BC = (
+        OceanBC(Impenetrable(FreeSlip()), Insulating()),
+        OceanBC(Penetrable(FreeSlip()), Insulating()),
+    )
+
+    config = SplitConfig(
+        "spindown_short",
+        resolution,
+        dimensions,
+        Coupled();
+        boundary_conditions = BC,
+    )
 
     run_split_explicit(
         config,


### PR DESCRIPTION
# Description

Makes it so the SplitExplicit01 code has shares the same problems as the rest of the Ocean code and provides defaults for each case. Also does some integration of the boundary condition handling across the different ocean models.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
