### PR TITLE
fix tests to ensure they respect ClimateMachine.Setting output_dir path prefix

### DIFF
--- a/test/Atmos/EDMF/bomex_edmf.jl
+++ b/test/Atmos/EDMF/bomex_edmf.jl
@@ -1,7 +1,7 @@
 using ClimateMachine
 ClimateMachine.init(;
     parse_clargs = true,
-    output_dir = "output",
+    output_dir = get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", "output"),
     fix_rng_seed = true,
 )
 using ClimateMachine.SingleStackUtils

--- a/test/Ocean/ShallowWater/test_2D_spindown.jl
+++ b/test/Ocean/ShallowWater/test_2D_spindown.jl
@@ -192,7 +192,10 @@ end
 # RUN THE TESTS #
 #################
 FT = Float64
-vtkpath = "vtk_shallow_spindown"
+vtkpath = abspath(joinpath(
+    ClimateMachine.Settings.output_dir,
+    "vtk_shallow_spindown",
+))
 
 const timeend = FT(24 * 3600) # s
 const tout = FT(2 * 3600) # s

--- a/test/Ocean/SplitExplicit/simple_box_ivd.jl
+++ b/test/Ocean/SplitExplicit/simple_box_ivd.jl
@@ -342,7 +342,6 @@ function make_callbacks(
     Q_fast,
 )
 
-    #=
     if isdir(vtkpath)
         rm(vtkpath, recursive = true)
     end
@@ -396,7 +395,6 @@ function make_callbacks(
         step[2] += 1
         nothing
     end
-    =#
 
     starttime = Ref(now())
     cbinfo = GenericCallbacks.EveryXWallTimeSeconds(60, mpicomm) do (s = false)
@@ -428,7 +426,7 @@ end
 # RUN THE TESTS #
 #################
 FT = Float64
-vtkpath = "vtk_split"
+vtkpath = abspath(joinpath(ClimateMachine.Settings.output_dir, "vtk_split"))
 
 const timeend = 5 * 24 * 3600 # s
 const tout = 24 * 3600 # s

--- a/test/Ocean/SplitExplicit/split_explicit.jl
+++ b/test/Ocean/SplitExplicit/split_explicit.jl
@@ -74,15 +74,17 @@ function run_split_explicit(
     )
 
     if restart > 0
+        checkpoint_path =
+            abspath(joinpath(ClimateMachine.Settings.output_dir, config.name))
         Q_3D, A_3D, t0 = read_checkpoint(
-            config.name,
+            checkpoint_path,
             "baroclinic",
             config.ArrayType,
             config.mpicomm,
             restart,
         )
         Q_2D, A_2D, _ = read_checkpoint(
-            config.name,
+            checkpoint_path,
             "barotropic",
             config.ArrayType,
             config.mpicomm,
@@ -159,7 +161,7 @@ function run_split_explicit(
 
     vtkstep = [restart, restart, restart, restart]
     cbvector = make_callbacks(
-        config.name,
+        abspath(joinpath(ClimateMachine.Settings.output_dir, config.name)),
         vtkstep,
         nout,
         config.mpicomm,


### PR DESCRIPTION
# Description

Prevents race conditions on the cluster when multiple test files are being executed at the same time using different `output_dir` settings.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
