### PR TITLE
Remove dup tutorial link, add fmt, rm trailing spaces

### DIFF
--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -27,7 +27,6 @@ if generate_tutorials
                 "Atmos/burgers_single_stack.jl",
             "LES Experiment (Density Current)" => "Atmos/densitycurrent.jl",
             "LES Experiment (Rising Thermal Bubble)" => "Atmos/risingbubble.jl",
-            "LES Experiment (Density Current)" => "Atmos/densitycurrent.jl",
             "Linear Hydrostatic Mountain (Topography)" =>
                 "Atmos/agnesi_hs_lin.jl",
             "Linear Non-Hydrostatic Mountain (Topography)" =>

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -21,13 +21,13 @@
 # ```math
 # \theta = \theta_0 = T_0
 # ```
-# 
+#
 # ```math
 # \pi = 1 + \frac{g^2}{c_p \theta_0 N^2}\left(\exp\left(\frac{-N^2 z}{g} \right)\right)
 # ```
 #
 # where $\theta_0 = T_0 K$.
-# ``
+#
 # so that
 #
 # ```math

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -30,7 +30,7 @@
 # ```
 #
 # where $\theta_0 = 280K$.
-# ``
+#
 # so that
 #
 # $ρ = \frac{p_{sfc}}{R_{gas}\theta}pi^{c_v/R_{gas}}$

--- a/tutorials/Land/Soil/Coupled/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Coupled/equilibrium_test.jl
@@ -71,7 +71,7 @@
 
 # If we evolve this system for times long compared to the dynamical timescales
 # of the system, we expect it to reach an equilibrium where
-# the LHS of these equations tends to zero. 
+# the LHS of these equations tends to zero.
 # Assuming zero fluxes at the boundaries, the resulting equilibrium state
 # should satisfy ``∂h/∂z = 0`` and ``∂T/∂z = 0``. Physically, this means that
 # the water settles into a vertical profile in which
@@ -130,7 +130,7 @@ include(joinpath(
     "Soil",
     "interpolation_helper.jl",
 ));
-# Set soil parameters to be consistent with sand. 
+# Set soil parameters to be consistent with sand.
 # Please see e.g. the [soil heat tutorial](../Heat/bonan_heat_tutorial.md)
 # for other soil type parameters, or [2].
 

--- a/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
+++ b/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
@@ -1,9 +1,9 @@
 # # Solving the heat equation in soil
 
 # This tutorial shows how to use CliMA code to solve the heat
-# equation in soil. 
+# equation in soil.
 # For background on the heat equation in general,
-# and how to solve it using CliMA code, please see the 
+# and how to solve it using CliMA code, please see the
 # [`heat_equation.jl`](../../Heat/heat_equation.md)
 # tutorial.
 
@@ -298,7 +298,7 @@ function init_soil!(land, state, aux, coordinates, time)
 end;
 
 
-# # Create the model structure                                        
+# # Create the model structure
 soil_water_model = PrescribedWaterModel(
     (aux, t) -> prescribed_augmented_liquid_fraction,
     (aux, t) -> prescribed_volumetric_ice_fraction,
@@ -438,7 +438,7 @@ ClimateMachine.invoke!(solver_config);
 aux = solver_config.dg.state_auxiliary;
 
 
-# Specify interpolation grid: 
+# Specify interpolation grid:
 zres = FT(0.02)
 boundaries = [
     FT(0) FT(0) zmin

--- a/tutorials/Land/Soil/Water/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Water/equilibrium_test.jl
@@ -239,7 +239,7 @@ all_data[n_outputs] = all_vars
 t = [all_data[k]["t"] for k in 0:n_outputs]
 
 
-# # Create some plots. 
+# # Create some plots.
 slope = -1e-3
 
 # The initial state.

--- a/tutorials/Land/Soil/Water/hydraulic_functions.jl
+++ b/tutorials/Land/Soil/Water/hydraulic_functions.jl
@@ -70,42 +70,53 @@ hydraulics_bc = BrooksCorey{FT}(ψb = ψ_sat, m = Mval);
 # Float division takes two numbers as input, and returns a floating point number, including the decimal.
 # In Julia, we might write these as:
 
-#     function division(a::Int, b::Int)
-#          return floor(Int, a/b)
-#     end
-#
-#     function division(a::Float64, b::Float64)
-#          return a/b
-#     end
+# ```julia
+# function division(a::Int, b::Int)
+#      return floor(Int, a/b)
+# end
+# ```
+# ```julia
+# function division(a::Float64, b::Float64)
+#      return a/b
+# end
+# ```
 
 
 # We can see that `division` is now a function with two methods.
 
-#     julia> division
-#     division (generic function with 2 methods)
+# ```julia
+# julia> division
+# division (generic function with 2 methods)
+# ```
 
 # Now, using the same function signature, we can carry out integer
 # division or floating point division, depending on the types of the
 # arguments:
 
-#     julia> division(1,2)
-#     0
+# ```julia
+# julia> division(1,2)
+# 0
 #
-#     julia> division(1.0,2.0)
-#     0.5
+# julia> division(1.0,2.0)
+# 0.5
+# ```
 
 
 # Here is a more pertinent example:
 # `hydraulics` is of type `vanGenuchten{Float32}` based on our choice of `FT`:
 
-#     julia> typeof(hydraulics)
-#     vanGenuchten{Float32}
+# ```julia
+# julia> typeof(hydraulics)
+# vanGenuchten{Float32}
+# ```
 
 
 # but meanwhile,
 
-#     julia> typeof(hydraulics_bc)
-#     BrooksCorey{Float32}
+# ```julia
+# julia> typeof(hydraulics_bc)
+# BrooksCorey{Float32}
+# ```
 
 
 # The function `matric_potential` will execute different methods
@@ -114,7 +125,7 @@ hydraulics_bc = BrooksCorey{FT}(ψb = ψ_sat, m = Mval);
 # for `ψ`.
 
 # Let's plot the matric potential as a function of the effective saturation `S_l = θ_l/ν`,
-# which can range from zero to one. 
+# which can range from zero to one.
 S_l = FT.(0.01:0.01:0.99)
 ψ = matric_potential.(Ref(hydraulics), S_l)
 ψ_bc = matric_potential.(Ref(hydraulics_bc), S_l)
@@ -163,7 +174,7 @@ impedance_choice = NoImpedance{FT}();
 
 # Like we defined new type
 # classes for `vanGenuchten{FT}` and `BrooksCorey{FT}`, we also created new type classes
-# for the impedance choice, the viscosity choice, and the moisture choice. 
+# for the impedance choice, the viscosity choice, and the moisture choice.
 #  For example, the function
 # called `viscosity_factor`, when passed an object of type `ConstantViscosity{FT}`, executes a method that always
 # returns 1. The same is true for the function `impedance_factor`, using the type
@@ -251,7 +262,7 @@ ice_impedance_I = IceImpedance{FT}()
 S_i = θ_i / ν;
 # The total volumetric water fraction cannot
 # exceed unity, so the effective liquid water saturation
-# should have a max of 1-S_i. 
+# should have a max of 1-S_i.
 S_l_accounting_for_ice = FT.(0.01:0.01:(0.99 - S_i))
 K_i =
     Ksat .*
@@ -338,10 +349,10 @@ K_constant =
         Ref(T),
         S_l,
     );
-# ```
-#     julia> unique(K_constant)
-#     1-element Array{Float32,1}:
-#      1.2277777f-5
+# ```julia
+# julia> unique(K_constant)
+# 1-element Array{Float32,1}:
+#  1.2277777f-5
 # ```
 
 # Note that choosing this option does not mean the matric potential


### PR DESCRIPTION
# Description

There's a duplicate density current link in the tutorials. This PR
 - Removes the duplicate.
 - Removes some trailing whitespace in some tutorials
 - Adds formatting to some tutorial code

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
