### PR TITLE
Fix constant preservation metrics tests

### DIFF
--- a/test/Numerics/Mesh/Metrics.jl
+++ b/test/Numerics/Mesh/Metrics.jl
@@ -333,8 +333,8 @@ end
             Cx1[:, n] += D * (J[:, n, e] .* ξ1x1[:, n, e])
             Cx1[n, :] += D * (J[n, :, e] .* ξ2x1[n, :, e])
 
-            Cx2[:, n] += D * (J[:, n, e] .* ξ1x1[:, n, e])
-            Cx2[n, :] += D * (J[n, :, e] .* ξ2x1[n, :, e])
+            Cx2[:, n] += D * (J[:, n, e] .* ξ1x2[:, n, e])
+            Cx2[n, :] += D * (J[n, :, e] .* ξ2x2[n, :, e])
         end
         @test maximum(abs.(Cx1)) ≤ 1000 * eps(T)
         @test maximum(abs.(Cx2)) ≤ 1000 * eps(T)
@@ -989,13 +989,13 @@ end
                     Cx1[n, :, m] += D * (J[n, :, m, e] .* ξ2x1[n, :, m, e])
                     Cx1[n, m, :] += D * (J[n, m, :, e] .* ξ3x1[n, m, :, e])
 
-                    Cx2[:, n, m] += D * (J[:, n, m, e] .* ξ1x1[:, n, m, e])
-                    Cx2[n, :, m] += D * (J[n, :, m, e] .* ξ2x1[n, :, m, e])
-                    Cx2[n, m, :] += D * (J[n, m, :, e] .* ξ3x1[n, m, :, e])
+                    Cx2[:, n, m] += D * (J[:, n, m, e] .* ξ1x2[:, n, m, e])
+                    Cx2[n, :, m] += D * (J[n, :, m, e] .* ξ2x2[n, :, m, e])
+                    Cx2[n, m, :] += D * (J[n, m, :, e] .* ξ3x2[n, m, :, e])
 
-                    Cx3[:, n, m] += D * (J[:, n, m, e] .* ξ1x1[:, n, m, e])
-                    Cx3[n, :, m] += D * (J[n, :, m, e] .* ξ2x1[n, :, m, e])
-                    Cx3[n, m, :] += D * (J[n, m, :, e] .* ξ3x1[n, m, :, e])
+                    Cx3[:, n, m] += D * (J[:, n, m, e] .* ξ1x3[:, n, m, e])
+                    Cx3[n, :, m] += D * (J[n, :, m, e] .* ξ2x3[n, :, m, e])
+                    Cx3[n, m, :] += D * (J[n, m, :, e] .* ξ3x3[n, m, :, e])
                 end
             end
             @test maximum(abs.(Cx1)) ≤ 1000 * eps(T)


### PR DESCRIPTION
# Description

The first component of the geometric conservation law was tested multiple times by mistake (instead of testing all components).
  
<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
