### PR TITLE
fix edmf e massflux

### DIFF
--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -620,6 +620,8 @@ function flux_second_order!(
 
     massflux_e = sum(
         vuntuple(N_up) do i
+            up[i].ρa *
+            ρ_inv *
             (gm.ρe * ρ_inv - e_tot_up[i]) *
             (gm.ρu[3] * ρ_inv - up[i].ρaw / ρa_up[i])
         end,


### PR DESCRIPTION
# Description

In line 623 in edmf_kernels.jl the massflux contribution of total energy in the grid mean is computed. It is missing the area fraction 'a'. This PR fixes that bag.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
