### PR TITLE
Fix depreciated constructor call to `BigFloat`

### DIFF
--- a/src/Numerics/Mesh/BrickMesh.jl
+++ b/src/Numerics/Mesh/BrickMesh.jl
@@ -144,7 +144,10 @@ function centroidtocode(
     code = Array{CT}(undef, d, nelem)
     for e in 1:nelem
         c = (centroids[:, 1, e] .- centroidmin) ./ centroidsize
-        X = CT.(floor.(typemax(CT) .* BigFloat.(c, 16 * sizeof(CT))))
+        X =
+            CT.(floor.(
+                typemax(CT) .* BigFloat.(c; precision = 16 * sizeof(CT)),
+            ))
         code[:, e] = coortocode(X)
     end
 


### PR DESCRIPTION
# Description

Does what the title says

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
