### PR TITLE
Fix Munk setup type typo, so code now compiles

### DIFF
--- a/src/Ocean/OceanProblems/ShallowWaterInitialStates.jl
+++ b/src/Ocean/OceanProblems/ShallowWaterInitialStates.jl
@@ -156,7 +156,7 @@ function gyre_init_state!(
     C = τₒ / (_grav * H) * (fₒ / β)
 
     state.η = η_munk(coords[1], coords[2], Lˣ, Lʸ, δᵐ, C)
-    state.U = @SVector zeros(T, 2)
+    state.U = @SVector zeros(FT, 2)
 
     return nothing
 end


### PR DESCRIPTION
# Description

Fixes small type typo that stopped current Ocean barotropic gyre code compiling when Munk
style problem was selected.

