### PR TITLE
Add SplitExplicitLSRK2nSolver to mini-driver setup

### DIFF
--- a/experiments/OceanBoxGCM/simple_box.jl
+++ b/experiments/OceanBoxGCM/simple_box.jl
@@ -17,7 +17,7 @@ const param_set = EarthParameterSet()
 
 function config_simple_box(name, resolution, dimensions, problem; BC = nothing)
     if BC == nothing
-        problem = problem{FT}(dimensions...)
+        problem = problem{FT}(dimensions..., τₒ = 0.2)
     else
         problem = problem{FT}(dimensions...; BC = BC)
     end

--- a/src/Ocean/SplitExplicit01/Continuity3dModel.jl
+++ b/src/Ocean/SplitExplicit01/Continuity3dModel.jl
@@ -58,6 +58,7 @@ boundary_state!(
 applies boundary conditions for the hyperbolic fluxes
 dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
 """
+
 @inline function boundary_state!(nf, cm::Continuity3dModel, args...)
     # hack for handling multiple boundaries for now
     # will fix with a future update
@@ -68,3 +69,22 @@ dispatches to a function in OceanBoundaryConditions.jl based on bytype defined b
     )
     return ocean_boundary_state!(nf, boundary_conditions, cm, args...)
 end
+#=
+@inline function boundary_state!(
+    ::NumericalFluxFirstOrder,
+    ::Continuity3dModel,
+    Q⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    A⁻,
+    bctype,
+    t,
+    args...,
+)
+    Q⁺.u = Q⁻.u
+
+    return nothing
+end
+=#
+

--- a/test/Ocean/SplitExplicit/split_explicit.jl
+++ b/test/Ocean/SplitExplicit/split_explicit.jl
@@ -21,6 +21,7 @@ using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.MPIStateArrays
 using ClimateMachine.VTK
 using ClimateMachine.Checkpoint
+using ClimateMachine.SystemSolvers
 
 using MPI
 using LinearAlgebra
@@ -53,6 +54,9 @@ function run_split_explicit(
     Q_3D, Q_2D, t0 = init_states(config, Val(restart))
 
     tout, timeend = timespan
+
+    # @show dt_fast = floor(Int, 1 / (2 * sqrt(gravity * H) / minΔx)) # / 4
+    # @show dt_slow = floor(Int, minΔx / 15) # / 4
 
     nout = ceil(Int64, tout / dt_slow)
     dt_slow = tout / nout

--- a/test/Ocean/SplitExplicit/test_coriolis.jl
+++ b/test/Ocean/SplitExplicit/test_coriolis.jl
@@ -33,14 +33,42 @@ const FT = Float64
     H = 400  # m
     dimensions = (Lˣ, Lʸ, H)
 
-    config =
-        SplitConfig("rotating", resolution, dimensions, Coupled(), Rotating())
+    BC = (
+        OceanBC(Impenetrable(FreeSlip()), Insulating()),
+        OceanBC(Penetrable(FreeSlip()), Insulating()),
+    )
+    config = SplitConfig(
+        "rotating_bla",
+        resolution,
+        dimensions,
+        Coupled(),
+        Rotating();
+        solver = SplitExplicitSolver,
+        boundary_conditions = BC,
+    )
+
+    #=
+    BC = (
+        ClimateMachine.Ocean.SplitExplicit01.OceanFloorFreeSlip(),
+        ClimateMachine.Ocean.SplitExplicit01.OceanSurfaceNoStressNoForcing(),
+    )
+
+    config = SplitConfig(
+        "rotating_jmc",
+        resolution,
+        dimensions,
+        Coupled(),
+        Rotating();
+        solver = SplitExplicitLSRK2nSolver,
+        boundary_conditions = BC,
+    )
+    =#
 
     run_split_explicit(
         config,
         timespan,
         dt_fast = 300,
-        dt_slow = 300,
+        dt_slow = 300, # 90 * 60,
         # refDat = refVals.ninety_minutes,
         analytic_solution = true,
     )

--- a/test/Ocean/SplitExplicit/test_spindown_short.jl
+++ b/test/Ocean/SplitExplicit/test_spindown_short.jl
@@ -36,21 +36,37 @@ const FT = Float64
         OceanBC(Impenetrable(FreeSlip()), Insulating()),
         OceanBC(Penetrable(FreeSlip()), Insulating()),
     )
-
     config = SplitConfig(
-        "spindown_short",
+        "spindown_bla",
         resolution,
         dimensions,
         Coupled();
+        solver = SplitExplicitSolver,
         boundary_conditions = BC,
     )
+
+    #=
+    BC = (
+        ClimateMachine.Ocean.SplitExplicit01.OceanFloorFreeSlip(),
+        ClimateMachine.Ocean.SplitExplicit01.OceanSurfaceNoStressNoForcing(),
+    )
+
+    config = SplitConfig(
+        "spindown_jmc",
+        resolution,
+        dimensions,
+        Coupled();
+        solver = SplitExplicitLSRK2nSolver,
+        boundary_conditions = BC,
+    )
+    =#
 
     run_split_explicit(
         config,
         timespan;
         dt_fast = 300, # seconds
         dt_slow = 90 * 60, # seconds
-        refDat = refVals.ninety_minutes,
+        # refDat = refVals.ninety_minutes,
         analytic_solution = true,
     )
 end


### PR DESCRIPTION
# Description

See title. Allows comparing spindown and coriolis tests across multiple solvers.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
