### PR TITLE
Yt/moist roe

### DIFF
--- a/docs/src/APIs/Numerics/DGMethods/NumericalFluxes.md
+++ b/docs/src/APIs/Numerics/DGMethods/NumericalFluxes.md
@@ -11,6 +11,7 @@ NumericalFluxGradient
 RusanovNumericalFlux
 RoeNumericalFlux
 HLLCNumericalFlux
+RoeNumericalFluxMoist
 NumericalFluxFirstOrder
 NumericalFluxSecondOrder
 CentralNumericalFluxSecondOrder

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -1,10 +1,15 @@
 module Atmos
 
-export AtmosModel, AtmosAcousticLinearModel, AtmosAcousticGravityLinearModel
+export AtmosModel,
+    AtmosAcousticLinearModel,
+    AtmosAcousticGravityLinearModel,
+    HLLCNumericalFlux,
+    RoeNumericalFlux,
+    RoeNumericalFluxMoist
 
 using UnPack
 using CLIMAParameters
-using CLIMAParameters.Planet: grav, cp_d
+using CLIMAParameters.Planet: grav, cp_d, R_v, LH_v0, e_int_v0
 using CLIMAParameters.Atmos.SubgridScale: C_smag
 using DocStringExtensions
 using LinearAlgebra, StaticArrays
@@ -80,7 +85,10 @@ import ..DGMethods.NumericalFluxes:
     numerical_flux_first_order!,
     NumericalFluxFirstOrder
 using ..DGMethods.NumericalFluxes:
-    RoeNumericalFlux, HLLCNumericalFlux, RusanovNumericalFlux
+    RoeNumericalFlux,
+    HLLCNumericalFlux,
+    RusanovNumericalFlux,
+    RoeNumericalFluxMoist
 
 import ..Courant: advective_courant, nondiffusive_courant, diffusive_courant
 
@@ -1139,6 +1147,245 @@ function numerical_flux_first_order!(
     else # 0 > S⁺
         parent(fluxᵀn) .= fluxᵀn⁺
     end
+end
+
+function numerical_flux_first_order!(
+    numerical_flux::RoeNumericalFluxMoist,
+    balance_law::AtmosModel,
+    fluxᵀn::Vars{S},
+    normal_vector::SVector,
+    state_prognostic⁻::Vars{S},
+    state_auxiliary⁻::Vars{A},
+    state_prognostic⁺::Vars{S},
+    state_auxiliary⁺::Vars{A},
+    t,
+    direction,
+) where {S, A}
+    balance_law.moisture isa EquilMoist ||
+        error("Must use a EquilMoist model for RoeNumericalFluxMoist")
+    numerical_flux_first_order!(
+        CentralNumericalFluxFirstOrder(),
+        balance_law,
+        fluxᵀn,
+        normal_vector,
+        state_prognostic⁻,
+        state_auxiliary⁻,
+        state_prognostic⁺,
+        state_auxiliary⁺,
+        t,
+        direction,
+    )
+
+    FT = eltype(fluxᵀn)
+    param_set = balance_law.param_set
+    _cv_d::FT = cv_d(param_set)
+    _T_0::FT = T_0(param_set)
+    γ::FT = cp_d(param_set) / cv_d(param_set)
+    _e_int_v0::FT = e_int_v0(param_set)
+    Φ = gravitational_potential(balance_law, state_auxiliary⁻)
+
+    ρ⁻ = state_prognostic⁻.ρ
+    ρu⁻ = state_prognostic⁻.ρu
+    ρe⁻ = state_prognostic⁻.ρe
+    ρq_tot⁻ = state_prognostic⁻.moisture.ρq_tot
+
+    u⁻ = ρu⁻ / ρ⁻
+    e⁻ = ρe⁻ / ρ⁻
+    ts⁻ = recover_thermo_state(balance_law, state_prognostic⁻, state_auxiliary⁻)
+    h⁻ = total_specific_enthalpy(ts⁻, e⁻)
+    qt⁻ = ρq_tot⁻ / ρ⁻
+    c⁻ = soundspeed_air(ts⁻)
+
+    ρ⁺ = state_prognostic⁺.ρ
+    ρu⁺ = state_prognostic⁺.ρu
+    ρe⁺ = state_prognostic⁺.ρe
+    ρq_tot⁺ = state_prognostic⁺.moisture.ρq_tot
+
+    u⁺ = ρu⁺ / ρ⁺
+    e⁺ = ρe⁺ / ρ⁺
+    ts⁺ = recover_thermo_state(balance_law, state_prognostic⁺, state_auxiliary⁺)
+    h⁺ = total_specific_enthalpy(ts⁺, e⁺)
+    qt⁺ = ρq_tot⁺ / ρ⁺
+    c⁺ = soundspeed_air(ts⁺)
+    ũ = roe_average(ρ⁻, ρ⁺, u⁻, u⁺)
+    e_tot = roe_average(ρ⁻, ρ⁺, e⁻, e⁺)
+    h̃ = roe_average(ρ⁻, ρ⁺, h⁻, h⁺)
+    qt = roe_average(ρ⁻, ρ⁺, qt⁻, qt⁺)
+    ρ = sqrt(ρ⁻ * ρ⁺)
+    e_int⁻ = internal_energy(ts⁻)
+    e_int⁺ = internal_energy(ts⁺)
+    e_int = roe_average(ρ⁻, ρ⁺, e_int⁻, e_int⁺)
+    ts = PhaseEquil(
+        param_set,
+        e_int,
+        ρ,
+        qt,
+        balance_law.moisture.maxiter,
+        balance_law.moisture.tolerance,
+    )
+    c̃ = sqrt((γ - 1) * (h̃ - (ũ[1]^2 + ũ[2]^2 + ũ[3]^2) / 2))
+    (R_m, _cp_m, _cv_m, gamma) = gas_constants(ts)
+    # chosen by fair dice roll
+    # guaranteed to be random
+    ω = FT(π) / 3
+    δ = FT(π) / 5
+    random_unit_vector = SVector(sin(ω) * cos(δ), cos(ω) * cos(δ), sin(δ))
+    # tangent space basis
+    τ1 = random_unit_vector × normal_vector
+    τ2 = τ1 × normal_vector
+    ũᵀn⁻ = u⁻' * normal_vector
+    ũᵀn⁺ = u⁺' * normal_vector
+    ũᵀn = ũ' * normal_vector
+    ũc̃⁻ = ũ + c̃ * normal_vector
+    ũc̃⁺ = ũ - c̃ * normal_vector
+    e_kin_pot = h̃ - _e_int_v0 * qt - _cp_m * c̃^2 / R_m
+    if (numerical_flux.LM == true)
+        Mach⁺ = sqrt(u⁺' * u⁺) / c⁺
+        Mach⁻ = sqrt(u⁻' * u⁻) / c⁻
+        Mach = (Mach⁺ + Mach⁻) / 2
+        c̃_LM = c̃ * min(Mach * sqrt(4 + (1 - Mach^2)^2) / (1 + Mach^2), 1)
+    else
+        c̃_LM = c̃
+    end
+    #Standard Roe
+    Λ = SDiagonal(
+        abs(ũᵀn - c̃_LM),
+        abs(ũᵀn),
+        abs(ũᵀn),
+        abs(ũᵀn),
+        abs(ũᵀn + c̃_LM),
+        abs(ũᵀn),
+    )
+    #Harten Hyman
+    if (numerical_flux.HH == true)
+        Λ = SDiagonal(
+            max(
+                abs(ũᵀn - c̃_LM),
+                max(
+                    0,
+                    ũᵀn - c̃_LM - (u⁻' * normal_vector - c⁻),
+                    u⁺' * normal_vector - c⁺ - (ũᵀn - c̃_LM),
+                ),
+            ),
+            max(
+                abs(ũᵀn),
+                max(
+                    0,
+                    ũᵀn - (u⁻' * normal_vector),
+                    u⁺' * normal_vector - (ũᵀn),
+                ),
+            ),
+            max(
+                abs(ũᵀn),
+                max(
+                    0,
+                    ũᵀn - (u⁻' * normal_vector),
+                    u⁺' * normal_vector - (ũᵀn),
+                ),
+            ),
+            max(
+                abs(ũᵀn),
+                max(
+                    0,
+                    ũᵀn - (u⁻' * normal_vector),
+                    u⁺' * normal_vector - (ũᵀn),
+                ),
+            ),
+            max(
+                abs(ũᵀn + c̃_LM),
+                max(
+                    0,
+                    ũᵀn + c̃_LM - (u⁻' * normal_vector + c⁻),
+                    u⁺' * normal_vector + c⁺ - (ũᵀn + c̃_LM),
+                ),
+            ),
+            max(
+                abs(ũᵀn),
+                max(
+                    0,
+                    ũᵀn - (u⁻' * normal_vector),
+                    u⁺' * normal_vector - (ũᵀn),
+                ),
+            ),
+        )
+    end
+    if (numerical_flux.LV == true)
+        #Pseudo LeVeque Fix
+        δ_L_1 = max(0, ũᵀn - ũᵀn⁻)
+        δ_L_2 = max(0, ũᵀn - c̃_LM - (ũᵀn⁻ - c⁻))
+        δ_L_3 = max(0, ũᵀn + c̃_LM - (ũᵀn⁻ + c⁻))
+        δ_R_1 = max(0, ũᵀn⁺ - ũᵀn)
+        δ_R_2 = max(0, ũᵀn⁺ - c⁺ - (ũᵀn - c̃_LM))
+        δ_R_3 = max(0, ũᵀn⁺ + c⁺ - (ũᵀn + c̃_LM))
+        if (ũᵀn < δ_L_1 && ũᵀn > -δ_R_1)
+            qa1 = ((δ_L_1 - δ_R_1) * ũᵀn + 2 * δ_L_1 * δ_R_1) / (δ_L_1 + δ_R_1)
+        else
+            qa1 = abs(ũᵀn)
+        end
+        if (ũᵀn - c̃ < δ_L_2 && ũᵀn - c̃_LM > -δ_R_2)
+            qa2 =
+                ((δ_L_2 - δ_R_2) * (ũᵀn - c̃_LM) + 2 * δ_L_2 * δ_R_2) /
+                (δ_L_2 + δ_R_2)
+        else
+            qa2 = abs(ũᵀn - c̃_LM)
+        end
+        if (ũᵀn + c̃_LM < δ_L_3 && ũᵀn + c̃ > -δ_R_3)
+            qa3 =
+                ((δ_L_3 - δ_R_3) * (ũᵀn + c̃_LM) + 2 * δ_R_3 * δ_R_3) /
+                (δ_L_3 + δ_R_3)
+        else
+            qa3 = abs(ũᵀn + c̃_LM)
+        end
+        Λ = SDiagonal(qa2, qa1, qa1, qa1, qa3, qa1)
+    end
+    if (numerical_flux.LVPP == true)
+        #PosPreserving with LeVeque
+        b_L = min(ũᵀn - c̃_LM, ũᵀn⁻ - c⁻)
+        b_R = max(ũᵀn + c̃_LM, ũᵀn⁺ + c⁺)
+        b⁻ = min(0, b_L)
+        b⁺ = max(0, b_R)
+        δ_L_1 = max(0, ũᵀn - b⁻)
+        δ_L_2 = max(0, ũᵀn - c̃_LM - b⁻)
+        δ_L_3 = max(0, ũᵀn + c̃_LM - b⁻)
+        δ_R_1 = max(0, b⁺ - ũᵀn)
+        δ_R_2 = max(0, b⁺ - (ũᵀn - c̃_LM))
+        δ_R_3 = max(0, b⁺ - (ũᵀn + c̃_LM))
+        if (ũᵀn < δ_L_1 && ũᵀn > -δ_R_1)
+            qa1 = ((δ_L_1 - δ_R_1) * ũᵀn + 2 * δ_L_1 * δ_R_1) / (δ_L_1 + δ_R_1)
+        else
+            qa1 = abs(ũᵀn)
+        end
+        if (ũᵀn - c̃_LM < δ_L_2 && ũᵀn - c̃_LM > -δ_R_2)
+            qa2 =
+                ((δ_L_2 - δ_R_2) * (ũᵀn - c̃) + 2 * δ_L_2 * δ_R_2) /
+                (δ_L_2 + δ_R_2)
+        else
+            qa2 = abs(ũᵀn - c̃_LM)
+        end
+        if (ũᵀn + c̃_LM < δ_L_3 && ũᵀn + c̃_LM > -δ_R_3)
+            qa3 =
+                ((δ_L_3 - δ_R_3) * (ũᵀn + c̃_LM) + 2 * δ_R_3 * δ_R_3) /
+                (δ_L_3 + δ_R_3)
+        else
+            qa3 = abs(ũᵀn + c̃_LM)
+        end
+        Λ = SDiagonal(qa2, qa1, qa1, qa1, qa3, qa1)
+    end
+
+    M = hcat(
+        SVector(1, ũc̃⁺[1], ũc̃⁺[2], ũc̃⁺[3], h̃ - c̃ * ũᵀn, qt),
+        SVector(0, τ1[1], τ1[2], τ1[3], τ1' * ũ, 0),
+        SVector(0, τ2[1], τ2[2], τ2[3], τ2' * ũ, 0),
+        SVector(1, ũ[1], ũ[2], ũ[3], ũ' * ũ / 2 + Φ - _T_0 * _cv_m, 0),
+        SVector(1, ũc̃⁻[1], ũc̃⁻[2], ũc̃⁻[3], h̃ + c̃ * ũᵀn, qt),
+        SVector(0, 0, 0, 0, _e_int_v0, 1),
+    )
+    Δρ = ρ⁺ - ρ⁻
+    Δρu = ρu⁺ - ρu⁻
+    Δρe = ρe⁺ - ρe⁻
+    Δρq_tot = ρq_tot⁺ - ρq_tot⁻
+    Δstate = SVector(Δρ, Δρu[1], Δρu[2], Δρu[3], Δρe, Δρq_tot)
+    parent(fluxᵀn) .-= M * Λ * (M \ Δstate) / 2
 end
 
 end # module

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -6,6 +6,7 @@ export NumericalFluxGradient,
     RusanovNumericalFlux,
     RoeNumericalFlux,
     HLLCNumericalFlux,
+    RoeNumericalFluxMoist,
     CentralNumericalFluxGradient,
     CentralNumericalFluxFirstOrder,
     CentralNumericalFluxSecondOrder,
@@ -340,6 +341,31 @@ Requires a custom implementation for the balance law.
  - [Toro2013](@cite)
 """
 struct HLLCNumericalFlux <: NumericalFluxFirstOrder end
+
+"""
+    RoeNumericalFluxMoist <: NumericalFluxFirstOrder
+
+A moist implementation of the numerical flux based on the approximate Riemann solver of Roe
+
+Requires a custom implementation for the balance law.
+"""
+struct RoeNumericalFluxMoist <: NumericalFluxFirstOrder
+    " set to true for low Mach number correction"
+    LM::Bool
+    " set to true for Hartman Hyman correction"
+    HH::Bool
+    " set to true for LeVeque correction"
+    LV::Bool
+    " set to true for Positivity preserving LeVeque Correction"
+    LVPP::Bool
+end
+
+RoeNumericalFluxMoist(;
+    LM::Bool = false,
+    HH::Bool = false,
+    LV::Bool = false,
+    LVPP::Bool = false,
+) = RoeNumericalFluxMoist(LM, HH, LV, LVPP)
 
 """
     NumericalFluxSecondOrder

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -34,7 +34,7 @@ end
 const output_vtk = false
 
 function main()
-    ClimateMachine.init()
+    ClimateMachine.init(parse_clargs = true)
     ArrayType = ClimateMachine.array_type()
 
     mpicomm = MPI.COMM_WORLD
@@ -45,10 +45,15 @@ function main()
     expected_error = Dict()
 
     # just to make it shorter and aligning
-    Rusanov = RusanovNumericalFlux
-    Central = CentralNumericalFluxFirstOrder
-    Roe = RoeNumericalFlux
-    HLLC = HLLCNumericalFlux
+    Rusanov = RusanovNumericalFlux()
+    Central = CentralNumericalFluxFirstOrder()
+    Roe = RoeNumericalFlux()
+    HLLC = HLLCNumericalFlux()
+    RoeMoist = RoeNumericalFluxMoist()
+    RoeMoistLM = RoeNumericalFluxMoist(; LM = true)
+    RoeMoistHH = RoeNumericalFluxMoist(; HH = true)
+    RoeMoistLV = RoeNumericalFluxMoist(; LV = true)
+    RoeMoistLVPP = RoeNumericalFluxMoist(; LVPP = true)
 
     expected_error[Float64, 2, Rusanov, 1] = 1.1990999506538110e+01
     expected_error[Float64, 2, Rusanov, 2] = 2.0813000228865612e+00
@@ -64,6 +69,31 @@ function main()
     expected_error[Float64, 2, Roe, 2] = 1.3895805145495934e+00
     expected_error[Float64, 2, Roe, 3] = 6.6174934435569849e-02
     expected_error[Float64, 2, Roe, 4] = 2.1917769287815940e-03
+
+    expected_error[Float64, 2, RoeMoist, 1] = 1.2415957884123003e+01
+    expected_error[Float64, 2, RoeMoist, 2] = 1.4188653323424882e+00
+    expected_error[Float64, 2, RoeMoist, 3] = 6.7913325894248130e-02
+    expected_error[Float64, 2, RoeMoist, 4] = 2.0377963111049128e-03
+
+    expected_error[Float64, 2, RoeMoistLM, 1] = 1.2316906651180444e+01
+    expected_error[Float64, 2, RoeMoistLM, 2] = 1.4359406523244560e+00
+    expected_error[Float64, 2, RoeMoistLM, 3] = 6.8650238542101505e-02
+    expected_error[Float64, 2, RoeMoistLM, 4] = 2.0000156591586842e-03
+
+    expected_error[Float64, 2, RoeMoistHH, 1] = 1.2425625606467793e+01
+    expected_error[Float64, 2, RoeMoistHH, 2] = 1.4029458093339020e+00
+    expected_error[Float64, 2, RoeMoistHH, 3] = 6.8648208937091268e-02
+    expected_error[Float64, 2, RoeMoistHH, 4] = 2.0711985861781648e-03
+
+    expected_error[Float64, 2, RoeMoistLV, 1] = 1.2415957884123003e+01
+    expected_error[Float64, 2, RoeMoistLV, 2] = 1.4188653323424882e+00
+    expected_error[Float64, 2, RoeMoistLV, 3] = 6.7913325894248130e-02
+    expected_error[Float64, 2, RoeMoistLV, 4] = 2.0377963111049128e-03
+
+    expected_error[Float64, 2, RoeMoistLVPP, 1] = 1.2441813136310969e+01
+    expected_error[Float64, 2, RoeMoistLVPP, 2] = 2.0219325767566727e+00
+    expected_error[Float64, 2, RoeMoistLVPP, 3] = 6.7716921628626484e-02
+    expected_error[Float64, 2, RoeMoistLVPP, 4] = 2.1051129944994005e-03
 
     expected_error[Float64, 2, HLLC, 1] = 1.2889756097329746e+01
     expected_error[Float64, 2, HLLC, 2] = 1.3895808565455936e+00
@@ -85,6 +115,31 @@ function main()
     expected_error[Float64, 3, Roe, 3] = 2.0926351682882375e-02
     expected_error[Float64, 3, Roe, 4] = 6.9310072176312712e-04
 
+    expected_error[Float64, 3, RoeMoist, 1] = 3.9262706246552574e+00
+    expected_error[Float64, 3, RoeMoist, 2] = 4.4868461432545598e-01
+    expected_error[Float64, 3, RoeMoist, 3] = 2.1476079330305119e-02
+    expected_error[Float64, 3, RoeMoist, 4] = 6.4440777504566171e-04
+
+    expected_error[Float64, 3, RoeMoistLM, 1] = 3.8949478745407458e+00
+    expected_error[Float64, 3, RoeMoistLM, 2] = 4.5408430461734528e-01
+    expected_error[Float64, 3, RoeMoistLM, 3] = 2.1709111570716800e-02
+    expected_error[Float64, 3, RoeMoistLM, 4] = 6.3246048386171073e-04
+
+    expected_error[Float64, 3, RoeMoistHH, 1] = 3.9293278268948622e+00
+    expected_error[Float64, 3, RoeMoistHH, 2] = 4.4365041912830866e-01
+    expected_error[Float64, 3, RoeMoistHH, 3] = 2.1708469753267460e-02
+    expected_error[Float64, 3, RoeMoistHH, 4] = 6.5497050185153694e-04
+
+    expected_error[Float64, 3, RoeMoistLV, 1] = 3.9262706246552574e+00
+    expected_error[Float64, 3, RoeMoistLV, 2] = 4.4868461432545598e-01
+    expected_error[Float64, 3, RoeMoistLV, 3] = 2.1476079330305119e-02
+    expected_error[Float64, 3, RoeMoistLV, 4] = 6.4440777504566171e-04
+
+    expected_error[Float64, 3, RoeMoistLVPP, 1] = 3.9344467732944071e+00
+    expected_error[Float64, 3, RoeMoistLVPP, 2] = 6.3939122178436703e-01
+    expected_error[Float64, 3, RoeMoistLVPP, 3] = 2.1413970848172485e-02
+    expected_error[Float64, 3, RoeMoistLVPP, 4] = 6.6569517942933988e-04
+
     expected_error[Float64, 3, HLLC, 1] = 4.0760987751605402e+00
     expected_error[Float64, 3, HLLC, 2] = 4.3942404996518236e-01
     expected_error[Float64, 3, HLLC, 3] = 2.0926409337758904e-02
@@ -104,6 +159,31 @@ function main()
     expected_error[Float32, 2, Roe, 2] = 1.3895936012268066e+00
     expected_error[Float32, 2, Roe, 3] = 6.8037144839763641e-02
     expected_error[Float32, 2, Roe, 4] = 3.8893952965736389e-02
+
+    expected_error[Float32, 2, RoeMoist, 1] = 1.2415886878967285e+01
+    expected_error[Float32, 2, RoeMoist, 2] = 1.4188879728317261e+00
+    expected_error[Float32, 2, RoeMoist, 3] = 6.9743692874908447e-02
+    expected_error[Float32, 2, RoeMoist, 4] = 3.7607192993164063e-02
+
+    expected_error[Float32, 2, RoeMoistLM, 1] = 1.2316809654235840e+01
+    expected_error[Float32, 2, RoeMoistLM, 2] = 4.5408430461734528e+00
+    expected_error[Float32, 2, RoeMoistLM, 3] = 7.0370830595493317e-02
+    expected_error[Float32, 2, RoeMoistLM, 4] = 3.7792034447193146e-02
+
+    expected_error[Float32, 2, RoeMoistHH, 1] = 1.2425449371337891e+01
+    expected_error[Float32, 2, RoeMoistHH, 2] = 1.4030106067657471e+00
+    expected_error[Float32, 2, RoeMoistHH, 3] = 7.0363849401473999e-02
+    expected_error[Float32, 2, RoeMoistHH, 4] = 3.7904966622591019e-02
+
+    expected_error[Float32, 2, RoeMoistLV, 1] = 1.2415886878967285e+01
+    expected_error[Float32, 2, RoeMoistLV, 2] = 1.4188879728317261e+00
+    expected_error[Float32, 2, RoeMoistLV, 3] = 6.9743692874908447e-02
+    expected_error[Float32, 2, RoeMoistLV, 4] = 3.7607192993164063e-02
+
+    expected_error[Float32, 2, RoeMoistLVPP, 1] = 1.2441481590270996e+01
+    expected_error[Float32, 2, RoeMoistLVPP, 2] = 2.0217459201812744e+00
+    expected_error[Float32, 2, RoeMoistLVPP, 3] = 7.0483185350894928e-02
+    expected_error[Float32, 2, RoeMoistLVPP, 4] = 5.1601748913526535e-02
 
     expected_error[Float32, 2, HLLC, 1] = 1.2889801025390625e+01
     expected_error[Float32, 2, HLLC, 2] = 1.3895059823989868e+00
@@ -125,6 +205,31 @@ function main()
     expected_error[Float32, 3, Roe, 3] = 2.1365188062191010e-02
     expected_error[Float32, 3, Roe, 4] = 9.3323951587080956e-03
 
+    expected_error[Float32, 3, RoeMoist, 1] = 3.9262301921844482e+00
+    expected_error[Float32, 3, RoeMoist, 2] = 4.4864514470100403e-01
+    expected_error[Float32, 3, RoeMoist, 3] = 2.1889146417379379e-02
+    expected_error[Float32, 3, RoeMoist, 4] = 8.8266804814338684e-03
+
+    expected_error[Float32, 3, RoeMoistLM, 1] = 3.8948786258697510e+00
+    expected_error[Float32, 3, RoeMoistLM, 2] = 4.5405751466751099e-01
+    expected_error[Float32, 3, RoeMoistLM, 3] = 2.2112159058451653e-02
+    expected_error[Float32, 3, RoeMoistLM, 4] = 8.7371272966265678e-03
+
+    expected_error[Float32, 3, RoeMoistHH, 1] = 3.9292929172515869e+00
+    expected_error[Float32, 3, RoeMoistHH, 2] = 4.4363334774971008e-01
+    expected_error[Float32, 3, RoeMoistHH, 3] = 2.2118536755442619e-02
+    expected_error[Float32, 3, RoeMoistHH, 4] = 8.9262928813695908e-03
+
+    expected_error[Float32, 3, RoeMoistLV, 1] = 3.9262151718139648e+00
+    expected_error[Float32, 3, RoeMoistLV, 2] = 4.4865489006042480e-01
+    expected_error[Float32, 3, RoeMoistLV, 3] = 2.1889505907893181e-02
+    expected_error[Float32, 3, RoeMoistLV, 4] = 8.8385939598083496e-03
+
+    expected_error[Float32, 3, RoeMoistLVPP, 1] = 3.9343423843383789e+00
+    expected_error[Float32, 3, RoeMoistLVPP, 2] = 6.3935810327529907e-01
+    expected_error[Float32, 3, RoeMoistLVPP, 3] = 2.1930629387497902e-02
+    expected_error[Float32, 3, RoeMoistLVPP, 4] = 1.0632344521582127e-02
+
     expected_error[Float32, 3, HLLC, 1] = 4.0760631561279297e+00
     expected_error[Float32, 3, HLLC, 2] = 4.3940672278404236e-01
     expected_error[Float32, 3, HLLC, 3] = 2.1352596580982208e-02
@@ -132,7 +237,17 @@ function main()
 
     @testset "$(@__FILE__)" begin
         for FT in (Float64, Float32), dims in (2, 3)
-            for NumericalFlux in (Rusanov, Central, Roe, HLLC)
+            for NumericalFlux in (
+                Rusanov,
+                Central,
+                Roe,
+                HLLC,
+                RoeMoist,
+                RoeMoistLM,
+                RoeMoistHH,
+                RoeMoistLV,
+                RoeMoistLVPP,
+            )
                 @info @sprintf """Configuration
                                   ArrayType     = %s
                                   FT        = %s
@@ -222,7 +337,11 @@ function test_run(
         boundaryconditions = (),
         init_state_prognostic = isentropicvortex_initialcondition!,
     )
-
+    if NumericalFlux isa RoeNumericalFluxMoist
+        moisture = EquilMoist{FT}()
+    else
+        moisture = DryModel()
+    end
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         param_set;
@@ -230,14 +349,14 @@ function test_run(
         orientation = NoOrientation(),
         ref_state = NoReferenceState(),
         turbulence = ConstantDynamicViscosity(FT(0)),
-        moisture = DryModel(),
+        moisture = moisture,
         source = (),
     )
 
     dg = DGModel(
         model,
         grid,
-        NumericalFlux(),
+        NumericalFlux,
         CentralNumericalFluxSecondOrder(),
         CentralNumericalFluxGradient(),
     )
@@ -379,6 +498,9 @@ function isentropicvortex_initialcondition!(
     state.ρu = ρ * u
     e_kin = u' * u / 2
     state.ρe = ρ * total_energy(e_kin, e_pot, ts)
+    if !(bl.moisture isa DryModel)
+        state.moisture.ρq_tot = FT(0)
+    end
 end
 
 function do_output(


### PR DESCRIPTION
# Description

An Moist Roe flux implementation

<!--- Please fill out the following section --->

I have added a Moist Roe flux, a moist rising bubble test and Riemann shock tube type test. Also I have added additional boundary conditions necessary for running these test.

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
