### PR TITLE
Low Mach-number Approximate Riemann Solver option (LMARS) 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -209,6 +209,15 @@ steps:
       config: cpu
       queue: central
       slurm_ntasks: 3
+  
+  - label: "cpu_isentropicvortex_lmars"
+    key: "cpu_isentropicvortex_lmars"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/Euler/isentropicvortex_lmars.jl "
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 3
 
   - label: "cpu_isentropicvortex_multirate"
     key: "cpu_isentropicvortex_multirate"
@@ -682,6 +691,16 @@ steps:
     key: "gpu_isentropicvortex_imex"
     command:
       - "mpiexec julia --color=yes --project test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 3
+      slurm_gres: "gpu:1"
+
+  - label: "gpu_isentropicvortex_lmars"
+    key: "gpu_isentropicvortex_lmars"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/Euler/isentropicvortex_lmars.jl "
     agents:
       config: gpu
       queue: central

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -101,6 +101,21 @@
   year = {1990}
 }
 
+@article {Chen2013,
+      author = "Xi Chen and Natalia Andronova and Bram Van Leer and Joyce E. Penner and John P. Boyd and Christiane Jablonowski and Shian-Jiann Lin",
+      title = "A Control-Volume Model of the Compressible Euler Equations with a Vertical Lagrangian Coordinate",
+      journal = "Monthly Weather Review",
+      year = "01 Jul. 2013",
+      publisher = "American Meteorological Society",
+      address = "Boston MA, USA",
+      volume = "141",
+      number = "7",
+      doi = "10.1175/MWR-D-12-00129.1",
+      pages=      "2526 - 2544",
+      url = "https://journals.ametsoc.org/view/journals/mwre/141/7/mwr-d-12-00129.1.xml"
+}
+
+
 @article{Desai2019,
   title = {Aerosol-Mediated Glaciation of Mixed-Phase Clouds: Steady-State Laboratory Measurements},
   author = {Desai, Neel and Chandrakar, KK and Kinney, G and Cantrell, W and Shaw, RA},

--- a/docs/src/APIs/Numerics/DGMethods/NumericalFluxes.md
+++ b/docs/src/APIs/Numerics/DGMethods/NumericalFluxes.md
@@ -17,4 +17,5 @@ NumericalFluxSecondOrder
 CentralNumericalFluxSecondOrder
 CentralNumericalFluxFirstOrder
 CentralNumericalFluxGradient
+LMARSNumericalFlux
 ```

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -5,7 +5,8 @@ export AtmosModel,
     AtmosAcousticGravityLinearModel,
     HLLCNumericalFlux,
     RoeNumericalFlux,
-    RoeNumericalFluxMoist
+    RoeNumericalFluxMoist,
+    LMARSNumericalFlux
 
 using UnPack
 using CLIMAParameters
@@ -91,7 +92,8 @@ using ..DGMethods.NumericalFluxes:
     RoeNumericalFlux,
     HLLCNumericalFlux,
     RusanovNumericalFlux,
-    RoeNumericalFluxMoist
+    RoeNumericalFluxMoist,
+    LMARSNumericalFlux
 
 import ..Courant: advective_courant, nondiffusive_courant, diffusive_courant
 
@@ -1419,6 +1421,100 @@ function numerical_flux_first_order!(
     Δρq_tot = ρq_tot⁺ - ρq_tot⁻
     Δstate = SVector(Δρ, Δρu[1], Δρu[2], Δρu[3], Δρe, Δρq_tot)
     parent(fluxᵀn) .-= M * Λ * (M \ Δstate) / 2
+end
+
+function numerical_flux_first_order!(
+    numerical_flux::LMARSNumericalFlux,
+    balance_law::AtmosModel,
+    fluxᵀn::Vars{S},
+    normal_vector::SVector,
+    state_prognostic⁻::Vars{S},
+    state_auxiliary⁻::Vars{A},
+    state_prognostic⁺::Vars{S},
+    state_auxiliary⁺::Vars{A},
+    t,
+    direction,
+) where {S, A}
+
+
+    @assert balance_law.moisture isa DryModel ||
+            balance_law.moisture isa EquilMoist
+
+    FT = eltype(fluxᵀn)
+    param_set = balance_law.param_set
+
+    ρ⁻ = state_prognostic⁻.ρ
+    ρu⁻ = state_prognostic⁻.ρu
+    ρe⁻ = state_prognostic⁻.ρe
+    ts⁻ = recover_thermo_state(
+        balance_law,
+        balance_law.moisture,
+        state_prognostic⁻,
+        state_auxiliary⁻,
+    )
+
+    u⁻ = ρu⁻ / ρ⁻
+    e⁻ = ρe⁻ / ρ⁻
+    uᵀn⁻ = u⁻' * normal_vector
+    p⁻ = air_pressure(ts⁻)
+    if balance_law.ref_state isa HydrostaticState &&
+       balance_law.ref_state.subtract_off
+        p⁻ -= state_auxiliary⁻.ref_state.p
+    end
+    c⁻ = soundspeed_air(ts⁻)
+    h⁻ = total_specific_enthalpy(ts⁻, e⁻)
+
+    ρ⁺ = state_prognostic⁺.ρ
+    ρu⁺ = state_prognostic⁺.ρu
+    ρe⁺ = state_prognostic⁺.ρe
+    ts⁺ = recover_thermo_state(
+        balance_law,
+        balance_law.moisture,
+        state_prognostic⁺,
+        state_auxiliary⁺,
+    )
+    u⁺ = ρu⁺ / ρ⁺
+    e⁺ = ρe⁺ / ρ⁺
+    uᵀn⁺ = u⁺' * normal_vector
+    p⁺ = air_pressure(ts⁺)
+    if balance_law.ref_state isa HydrostaticState &&
+       balance_law.ref_state.subtract_off
+        p⁺ -= state_auxiliary⁺.ref_state.p
+    end
+    c⁺ = soundspeed_air(ts⁺)
+    h⁺ = total_specific_enthalpy(ts⁺, e⁺)
+
+    # Eqn (49), (50), β the tuning parameter
+    β = FT(1)
+    u_half = 1 / 2 * (uᵀn⁺ + uᵀn⁻) - β * 1 / (ρ⁻ + ρ⁺) / c⁻ * (p⁺ - p⁻)
+    p_half = 1 / 2 * (p⁺ + p⁻) - β * ((ρ⁻ + ρ⁺) * c⁻) / 4 * (uᵀn⁺ - uᵀn⁻)
+
+    # Eqn (46), (47)
+    ρ_b = u_half > FT(0) ? ρ⁻ : ρ⁺
+    ρu_b = u_half > FT(0) ? ρu⁻ : ρu⁺
+    ρh_b = u_half > FT(0) ? ρ⁻ * h⁻ : ρ⁺ * h⁺
+
+    # Update fluxes Eqn (18)
+    fluxᵀn.ρ = ρ_b * u_half
+    fluxᵀn.ρu = ρu_b * u_half .+ p_half * normal_vector
+    fluxᵀn.ρe = ρh_b * u_half
+
+    if balance_law.moisture isa EquilMoist
+        ρq⁻ = state_prognostic⁻.moisture.ρq_tot
+        q⁻ = ρq⁻ / ρ⁻
+        ρq⁺ = state_prognostic⁺.moisture.ρq_tot
+        q⁺ = ρq⁺ / ρ⁺
+        ρq_b = u_half > FT(0) ? ρq⁻ : ρq⁺
+        fluxᵀn.moisture.ρq_tot = ρq_b * u_half
+    end
+    if !(balance_law.tracers isa NoTracers)
+        ρχ⁻ = state_prognostic⁻.tracers.ρχ
+        χ⁻ = ρχ⁻ / ρ⁻
+        ρχ⁺ = state_prognostic⁺.tracers.ρχ
+        χ⁺ = ρχ⁺ / ρ⁺
+        ρχ_b = u_half > FT(0) ? ρχ⁻ : ρχ⁺
+        fluxᵀn.tracers.ρχ = ρχ_b * u_half
+    end
 end
 
 end # module

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -510,3 +510,30 @@ function numerical_flux_first_order!(
 
     parent(fluxᵀn) .-= M * Λ * (M \ Δstate) / 2
 end
+
+function numerical_flux_first_order!(
+    ::LMARSNumericalFlux,
+    balance_law::AtmosLinearModel,
+    fluxᵀn::Vars{S},
+    normal_vector::SVector,
+    state_prognostic⁻::Vars{S},
+    state_auxiliary⁻::Vars{A},
+    state_prognostic⁺::Vars{S},
+    state_auxiliary⁺::Vars{A},
+    t,
+    direction,
+) where {S, A}
+
+    numerical_flux_first_order!(
+        RusanovNumericalFlux(),
+        balance_law,
+        fluxᵀn,
+        normal_vector,
+        state_prognostic⁻,
+        state_auxiliary⁻,
+        state_prognostic⁺,
+        state_auxiliary⁺,
+        t,
+        direction,
+    )
+end

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -11,7 +11,8 @@ export NumericalFluxGradient,
     CentralNumericalFluxFirstOrder,
     CentralNumericalFluxSecondOrder,
     CentralNumericalFluxDivergence,
-    CentralNumericalFluxHigherOrder
+    CentralNumericalFluxHigherOrder,
+    LMARSNumericalFlux
 
 
 using StaticArrays, LinearAlgebra
@@ -342,6 +343,16 @@ Requires a custom implementation for the balance law.
  - [Toro2013](@cite)
 """
 struct HLLCNumericalFlux <: NumericalFluxFirstOrder end
+
+
+"""
+    LMARSNumericalFlux <: NumericalFluxFirstOrder
+Low Mach Number Approximate Riemann Solver. Upwind biased
+first order flux function. 
+
+- [Chen2013](@cite)
+"""
+struct LMARSNumericalFlux <: NumericalFluxFirstOrder end
 
 """
     RoeNumericalFluxMoist <: NumericalFluxFirstOrder

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_lmars.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_lmars.jl
@@ -1,0 +1,281 @@
+using ClimateMachine
+using ClimateMachine.Atmos
+using ClimateMachine.BalanceLaws
+using ClimateMachine.ConfigTypes
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.Mesh.Geometry
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.ODESolvers
+using ClimateMachine.Orientations
+using ClimateMachine.SystemSolvers
+using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.VariableTemplates
+using ClimateMachine.VTK
+
+using CLIMAParameters
+using CLIMAParameters.Planet: kappa_d
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
+
+include("isentropicvortex_setup.jl")
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+
+const output_vtk = false
+
+function main()
+    ClimateMachine.init(parse_clargs = true)
+    ArrayType = ClimateMachine.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 4
+    numlevels = integration_testing ? 4 : 4
+
+    expected_error = Dict()
+
+    # just to make it shorter and aligning
+    LMARS = LMARSNumericalFlux()
+
+    @testset "$(@__FILE__)" begin
+        for FT in (Float64,), dims in (2, 3), polynomialorder in (4,)
+            for NumericalFlux in (LMARS,)
+                @info @sprintf """Configuration
+                                  ArrayType     = %s
+                                  FT        = %s
+                                  NumericalFlux = %s
+                                  dims          = %d
+                                  N_poly        = %d
+                                  """ ArrayType "$FT" "$NumericalFlux" dims polynomialorder
+
+                setup = IsentropicVortexSetup{FT}()
+                errors = Vector{FT}(undef, numlevels)
+
+                for level in 1:numlevels
+                    numelems =
+                        ntuple(dim -> dim == 3 ? 1 : 2^(level - 1) * 5, dims)
+                    errors[level] = test_run(
+                        mpicomm,
+                        ArrayType,
+                        polynomialorder,
+                        numelems,
+                        NumericalFlux,
+                        setup,
+                        FT,
+                        dims,
+                        level,
+                    )
+
+                    @test isapprox(errors[level], FT(1.0); rtol = 1e-5)
+
+                end
+
+            end
+        end
+    end
+end
+
+function test_run(
+    mpicomm,
+    ArrayType,
+    polynomialorder,
+    numelems,
+    NumericalFlux,
+    setup,
+    FT,
+    dims,
+    level,
+)
+    brickrange = ntuple(dims) do dim
+        range(
+            -setup.domain_halflength;
+            length = numelems[dim] + 1,
+            stop = setup.domain_halflength,
+        )
+    end
+
+    topology = BrickTopology(
+        mpicomm,
+        brickrange;
+        periodicity = ntuple(_ -> true, dims),
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = polynomialorder,
+    )
+
+    problem =
+        AtmosProblem(boundaryconditions = (), init_state_prognostic = setup)
+    if NumericalFlux isa RoeNumericalFluxMoist
+        moisture = EquilMoist{FT}()
+    else
+        moisture = DryModel()
+    end
+
+    if NumericalFlux isa LMARSNumericalFlux
+        ref_state = NoReferenceState()
+    end
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        param_set;
+        problem = problem,
+        orientation = NoOrientation(),
+        ref_state = ref_state,
+        turbulence = ConstantDynamicViscosity(FT(0)),
+        moisture = moisture,
+        source = (),
+    )
+
+    dg = DGModel(
+        model,
+        grid,
+        NumericalFlux,
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+
+    timeend = FT(2 * setup.domain_halflength / 10 / setup.translation_speed)
+
+    # determine the time step
+    elementsize = minimum(step.(brickrange))
+    dt =
+        elementsize / soundspeed_air(model.param_set, setup.T∞) /
+        polynomialorder^2
+    nsteps = ceil(Int, timeend / dt)
+    dt = timeend / nsteps
+
+    Q = init_ode_state(dg, FT(0))
+    lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
+
+    eng0 = norm(Q)
+    dims == 2 && (numelems = (numelems..., 0))
+    @info @sprintf """Starting refinement level %d
+                      polyorder = %d
+                      numelems  = (%d, %d, %d)
+                      dt        = %.16e
+                      norm(Q₀)  = %.16e
+                      FT        = %s
+                      """ level polynomialorder numelems... dt eng0 FT
+
+    # Set up the information callback
+    starttime = Ref(now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            runtime = Dates.format(
+                convert(DateTime, now() - starttime[]),
+                dateformat"HH:MM:SS",
+            )
+            @info @sprintf """Update
+                              simtime = %.16e
+                              runtime = %s
+                              norm(Q) = %.16e
+                              """ gettime(lsrk) runtime energy
+        end
+    end
+    callbacks = (cbinfo,)
+
+    if output_vtk
+        # create vtk dir
+        vtkdir =
+            "vtk_isentropicvortex" *
+            "$(typeof(NumericalFlux))" *
+            "_poly$(polynomialorder)_dims$(dims)_$(ArrayType)_$(FT)_level$(level)"
+        mkpath(vtkdir)
+
+        vtkstep = 0
+        # output initial step
+        do_output(mpicomm, vtkdir, vtkstep, dg, Q, Q, model)
+
+        # setup the output callback
+        outputtime = timeend / 10
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dg, gettime(lsrk), setup)
+            do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model)
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    solve!(Q, lsrk; timeend = timeend, callbacks = callbacks)
+
+    # final statistics
+    Qe = init_ode_state(dg, timeend, setup)
+    engf = norm(Q)
+    engfe = norm(Qe)
+    errf = euclidean_distance(Q, Qe)
+    @info @sprintf """Finished refinement level %d
+    norm(Q)                 = %.16e
+    norm(Q) / norm(Q₀)      = %.16e
+    norm(Q) - norm(Q₀)      = %.16e
+    norm(Q - Qe)            = %.16e
+    norm(Q - Qe) / norm(Qe) = %.16e
+    """ level engf engf / eng0 engf - eng0 errf errf / engfe
+    engf / eng0
+end
+
+function do_output(
+    mpicomm,
+    vtkdir,
+    vtkstep,
+    dg,
+    Q,
+    Qe,
+    model,
+    testname = "isentropicvortex_lmars",
+)
+    ## name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+    exactnames = statenames .* "_exact"
+
+    writevtk(filename, Q, dg, statenames, Qe, exactnames)
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+main()


### PR DESCRIPTION
# Description

Adds additional option, LMARS to the available list of interface numerical fluxes. 
1) Tested against Riemann problem [1D]
2) Tested against Rising Thermal Bubble [2D]
3) Tested against Rising Thermal Bubble [3D]

# TODO 
- [x] Consolidate test cases with @slifer50 , based on MoistRoe flux option
- [x] Confirm boundary condition interface changes / requirements
- [x] Add docstrings, rebase 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
