### PR TITLE
Add dry thermo constructor

### DIFF
--- a/docs/src/APIs/Common/Thermodynamics.md
+++ b/docs/src/APIs/Common/Thermodynamics.md
@@ -15,6 +15,7 @@ PhasePartition_equil
 ThermodynamicState
 PhaseDry
 PhaseDry_given_pT
+PhaseDry_given_pθ
 PhaseDry_given_ρT
 PhaseEquil
 PhaseNonEquil

--- a/src/Common/Thermodynamics/states.jl
+++ b/src/Common/Thermodynamics/states.jl
@@ -4,6 +4,7 @@ export ThermodynamicState,
     PhaseDry,
     PhaseDry_given_ρT,
     PhaseDry_given_pT,
+    PhaseDry_given_pθ,
     PhaseEquil,
     PhaseNonEquil,
     TemperatureSHumEquil,
@@ -158,6 +159,22 @@ Constructs a [`PhaseDry`](@ref) thermodynamic state from:
  - `T` temperature
 """
 function PhaseDry_given_pT(param_set::APS, p::FT, T::FT) where {FT <: Real}
+    e_int = internal_energy(param_set, T)
+    ρ = air_density(param_set, T, p)
+    return PhaseDry{FT, typeof(param_set)}(param_set, e_int, ρ)
+end
+
+"""
+    PhaseDry_given_pθ(param_set, p, θ_dry)
+
+Constructs a [`PhaseDry`](@ref) thermodynamic state from:
+
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `p` pressure
+ - `θ_dry` dry potential temperature
+"""
+function PhaseDry_given_pθ(param_set::APS, p::FT, θ_dry::FT) where {FT <: Real}
+    T = exner_given_pressure(param_set, p) * θ_dry
     e_int = internal_energy(param_set, T)
     ρ = air_density(param_set, T, p)
     return PhaseDry{FT, typeof(param_set)}(param_set, e_int, ρ)

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -762,6 +762,11 @@ end
         @test all(internal_energy.(ts_p) .≈ internal_energy.(Ref(param_set), T))
         @test all(air_density.(ts_p) .≈ ρ)
 
+        θ_dry = dry_pottemp.(Ref(param_set), T, ρ)
+        ts_p = PhaseDry_given_pθ.(Ref(param_set), p, θ_dry)
+        @test all(internal_energy.(ts_p) .≈ internal_energy.(Ref(param_set), T))
+        @test all(air_density.(ts_p) .≈ ρ)
+
         ts = PhaseDry_given_ρT.(Ref(param_set), ρ, T)
 
         @test all(air_density.(ts_p) .≈ air_density.(ts))
@@ -1043,8 +1048,10 @@ end
     @test typeof.(internal_energy.(ρ, ρ .* e_int, Ref(ρu), e_pot)) ==
           typeof.(e_int)
 
+    θ_dry = dry_pottemp.(Ref(param_set), T, ρ)
     ts_dry = PhaseDry.(Ref(param_set), e_int, ρ)
     ts_dry_pT = PhaseDry_given_pT.(Ref(param_set), p, T)
+    ts_dry_pθ = PhaseDry_given_pθ.(Ref(param_set), p, θ_dry)
     ts_eq = PhaseEquil.(Ref(param_set), e_int, ρ, q_tot, 15, FT(1e-1))
     e_tot = total_energy.(e_kin, e_pot, ts_eq)
 
@@ -1101,6 +1108,7 @@ end
     for ts in (
         ts_dry,
         ts_dry_pT,
+        ts_dry_pθ,
         ts_eq,
         ts_T,
         ts_Tp,


### PR DESCRIPTION
# Description

Adds a dry thermo state constructor (`PhaseDry_given_pθ`), which accepts pressure and `θ_dry`.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
