### PR TITLE
Use "outside metrics" discretization in flux first order

### DIFF
--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -454,26 +454,106 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
     ###################
     # RHS Computation #
     ###################
-    comp_stream = volume_tendency!(device, (Nq, Nq))(
-        balance_law,
-        Val(dim),
-        Val(N),
-        dg.direction,
-        tendency.data,
-        state_prognostic.data,
-        state_gradient_flux.data,
-        Qhypervisc_grad.data,
-        state_auxiliary.data,
-        grid.vgeo,
-        t,
-        grid.ω,
-        grid.D,
-        topology.realelems,
-        α,
-        β;
-        ndrange = (nrealelem * Nq, Nq),
-        dependencies = (comp_stream,),
-    )
+    if dim == 2
+        Nslice = 1
+        Nwork = 1
+        comp_stream = volume_tendency!(device, (Nq, Nq, Nwork))(
+            balance_law,
+            Val(dim),
+            Val(N),
+            Val(Nslice),
+            dg.direction,
+            HorizontalDirection(),
+            tendency.data,
+            state_prognostic.data,
+            state_gradient_flux.data,
+            Qhypervisc_grad.data,
+            state_auxiliary.data,
+            grid.vgeo,
+            t,
+            grid.ω,
+            grid.D,
+            topology.realelems,
+            α,
+            β,
+            true;
+            ndrange = (nrealelem * Nq, Nq, Nwork),
+            dependencies = (comp_stream,),
+        )
+    else
+        Nslice = N <= 5 ? 1 : Nq
+        Nwork = div(Nq, Nslice)
+        if dg.direction isa EveryDirection
+            comp_stream = volume_tendency!(device, (Nq, Nq, Nwork))(
+                balance_law,
+                Val(dim),
+                Val(N),
+                Val(Nslice),
+                dg.direction,
+                HorizontalDirection(),
+                tendency.data,
+                state_prognostic.data,
+                state_gradient_flux.data,
+                Qhypervisc_grad.data,
+                state_auxiliary.data,
+                grid.vgeo,
+                t,
+                grid.ω,
+                grid.D,
+                topology.realelems,
+                α,
+                β,
+                false;
+                ndrange = (nrealelem * Nq, Nq, Nwork),
+                dependencies = (comp_stream,),
+            )
+            comp_stream = volume_tendency!(device, (Nq, Nq, Nwork))(
+                balance_law,
+                Val(dim),
+                Val(N),
+                Val(Nslice),
+                dg.direction,
+                VerticalDirection(),
+                tendency.data,
+                state_prognostic.data,
+                state_gradient_flux.data,
+                Qhypervisc_grad.data,
+                state_auxiliary.data,
+                grid.vgeo,
+                t,
+                grid.ω,
+                grid.D,
+                topology.realelems,
+                α,
+                FT(1);
+                ndrange = (nrealelem * Nq, Nq, Nwork),
+                dependencies = (comp_stream,),
+            )
+        else
+            comp_stream = volume_tendency!(device, (Nq, Nq, Nwork))(
+                balance_law,
+                Val(dim),
+                Val(N),
+                Val(Nslice),
+                dg.direction,
+                dg.direction,
+                tendency.data,
+                state_prognostic.data,
+                state_gradient_flux.data,
+                Qhypervisc_grad.data,
+                state_auxiliary.data,
+                grid.vgeo,
+                t,
+                grid.ω,
+                grid.D,
+                topology.realelems,
+                α,
+                β;
+                ndrange = (nrealelem * Nq, Nq, Nwork),
+                dependencies = (comp_stream,),
+            )
+        end
+    end
 
     comp_stream = interface_tendency!(device, workgroups_surface)(
         balance_law,

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -36,20 +36,23 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
     balance_law::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
-    direction,
+    ::Val{Nslice},
+    model_direction,
+    direction::HorizontalDirection,
     tendency,
-    state_prognostic,
-    state_gradient_flux,
-    Qhypervisc_grad,
-    state_auxiliary,
-    vgeo,
+    @Const(state_prognostic),
+    @Const(state_gradient_flux),
+    @Const(Qhypervisc_grad),
+    @Const(state_auxiliary),
+    @Const(vgeo),
     t,
-    ω,
-    D,
+    @Const(ω),
+    @Const(D),
     elems,
     α,
     β,
-) where {dim, polyorder}
+    add_source = true,
+) where {dim, polyorder, Nslice}
     @uniform begin
         N = polyorder
         FT = eltype(state_prognostic)
@@ -61,55 +64,39 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
         nhyperviscstate = number_states(balance_law, Hyperdiffusive())
 
         Nq = N + 1
-
-        Nqk = dim == 2 ? 1 : Nq
+        Nwork = div(Nq, Nslice)
 
         local_source = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_prognostic = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_gradient_flux =
-            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-        local_state_hyperdiffusion = MArray{Tuple{nhyperviscstate}, FT}(undef)
-        local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
         local_flux = MArray{Tuple{3, num_state_prognostic}, FT}(undef)
         local_flux_3 = MArray{Tuple{num_state_prognostic}, FT}(undef)
     end
 
-    shared_flux = @localmem FT (2, Nq, Nq, num_state_prognostic)
+    shared_flux = @localmem FT (3, Nq, Nq, Nwork, num_state_prognostic)
     s_D = @localmem FT (Nq, Nq)
+    s_ω = @localmem FT (Nq,)
 
-    local_tendency = @private FT (Nqk, num_state_prognostic)
-    local_MI = @private FT (Nqk,)
+    local_tendency = @private FT (num_state_prognostic,)
+    local_state_prognostic = @private FT (num_state_prognostic,)
+    local_state_gradient_flux = @private FT (num_state_gradient_flux,)
+    local_state_hyperdiffusion = @private FT (nhyperviscstate,)
+    local_state_auxiliary = @private FT (num_state_auxiliary,)
 
     e = @index(Group, Linear)
-    i, j = @index(Local, NTuple)
+    i, j, k_ix = @index(Local, NTuple)
 
-    @inbounds begin
+    @inbounds @views begin
         s_D[i, j] = D[i, j]
-        @unroll for k in 1:Nqk
-            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
-            @unroll for s in 1:num_state_prognostic
-                local_tendency[k, s] = zero(FT)
-            end
-            local_MI[k] = vgeo[ijk, _MI, e]
+
+        if (j == 1)
+            s_ω[i] = ω[i]
         end
 
-        @unroll for k in 1:Nqk
+        @unroll for k_slice in 1:Nslice
             @synchronize
+            k = k_ix + k_slice - 1
             ijk = i + Nq * ((j - 1) + Nq * (k - 1))
-
-            M = vgeo[ijk, _M, e]
-            ξ1x1 = vgeo[ijk, _ξ1x1, e]
-            ξ1x2 = vgeo[ijk, _ξ1x2, e]
-            ξ1x3 = vgeo[ijk, _ξ1x3, e]
-            if dim == 3 || (dim == 2 && direction isa EveryDirection)
-                ξ2x1 = vgeo[ijk, _ξ2x1, e]
-                ξ2x2 = vgeo[ijk, _ξ2x2, e]
-                ξ2x3 = vgeo[ijk, _ξ2x3, e]
-            end
-            if dim == 3 && direction isa EveryDirection
-                ξ3x1 = vgeo[ijk, _ξ3x1, e]
-                ξ3x2 = vgeo[ijk, _ξ3x2, e]
-                ξ3x3 = vgeo[ijk, _ξ3x3, e]
+            @unroll for s in 1:num_state_prognostic
+                local_tendency[s] = zero(FT)
             end
 
             @unroll for s in 1:num_state_prognostic
@@ -132,179 +119,242 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
             flux_first_order!(
                 balance_law,
                 Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[:],),
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:],),
                 t,
-                (direction,),
+                (model_direction,),
             )
 
             @unroll for s in 1:num_state_prognostic
-                shared_flux[1, i, j, s] = local_flux[1, s]
-                shared_flux[2, i, j, s] = local_flux[2, s]
-                local_flux_3[s] = local_flux[3, s]
+                shared_flux[1, i, j, k_ix, s] = local_flux[1, s]
+                shared_flux[2, i, j, k_ix, s] = local_flux[2, s]
+                shared_flux[3, i, j, k_ix, s] = local_flux[3, s]
+            end
+
+            # In the case of the remainder model we may need to loop through the
+            # models to add in restricted direction componennts
+            if model_direction isa EveryDirection &&
+               balance_law isa RemBL &&
+               rembl_has_subs_direction(HorizontalDirection(), balance_law)
+                fill!(local_flux, -zero(eltype(local_flux)))
+                flux_first_order!(
+                    balance_law,
+                    Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[:],),
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:],),
+                    t,
+                    (HorizontalDirection(),),
+                )
+                @unroll for s in 1:num_state_prognostic
+                    shared_flux[1, i, j, k_ix, s] += local_flux[1, s]
+                    shared_flux[2, i, j, k_ix, s] += local_flux[2, s]
+                    shared_flux[3, i, j, k_ix, s] += local_flux[3, s]
+                end
+            end
+
+            @synchronize
+
+            k = k_ix + k_slice - 1
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            if dim == 3 ||
+               (dim == 2 && !(model_direction isa VerticalDirection))
+                ξ1x1 = vgeo[ijk, _ξ1x1, e]
+                ξ1x2 = vgeo[ijk, _ξ1x2, e]
+                ξ1x3 = vgeo[ijk, _ξ1x3, e]
+            end
+            if dim == 3 ||
+               (dim == 2 && !(model_direction isa HorizontalDirection))
+                ξ2x1 = vgeo[ijk, _ξ2x1, e]
+                ξ2x2 = vgeo[ijk, _ξ2x2, e]
+                ξ2x3 = vgeo[ijk, _ξ2x3, e]
+            end
+
+            if model_direction isa HorizontalDirection || balance_law isa RemBL
+                GCLH1 = GCLH2 = GCLH3 = -zero(FT)
+                @unroll for n in 1:Nq
+                    njk = n + Nq * ((j - 1) + Nq * (k - 1))
+                    GCLH1 +=
+                        s_D[i, n] * s_ω[i] / s_ω[n] *
+                        vgeo[njk, _M, e] *
+                        vgeo[njk, _ξ1x1, e]
+                    GCLH2 +=
+                        s_D[i, n] * s_ω[i] / s_ω[n] *
+                        vgeo[njk, _M, e] *
+                        vgeo[njk, _ξ1x2, e]
+                    GCLH3 +=
+                        s_D[i, n] * s_ω[i] / s_ω[n] *
+                        vgeo[njk, _M, e] *
+                        vgeo[njk, _ξ1x3, e]
+
+                    if dim == 3
+                        ink = i + Nq * ((n - 1) + Nq * (k - 1))
+                        GCLH1 +=
+                            s_D[j, n] * s_ω[j] / s_ω[n] *
+                            vgeo[ink, _M, e] *
+                            vgeo[ink, _ξ2x1, e]
+                        GCLH2 +=
+                            s_D[j, n] * s_ω[j] / s_ω[n] *
+                            vgeo[ink, _M, e] *
+                            vgeo[ink, _ξ2x2, e]
+                        GCLH3 +=
+                            s_D[j, n] * s_ω[j] / s_ω[n] *
+                            vgeo[ink, _M, e] *
+                            vgeo[ink, _ξ2x3, e]
+                    end
+                end
+            end
+
+            # weak outside metrics derivative
+            @unroll for s in 1:num_state_prognostic
+                if dim == 3 ||
+                   (dim == 2 && !(model_direction isa VerticalDirection))
+                    F1ξ1 = F2ξ1 = F3ξ1 = -zero(FT)
+                end
+                if dim == 3 ||
+                   (dim == 2 && !(model_direction isa HorizontalDirection))
+                    F1ξ2 = F2ξ2 = F3ξ2 = -zero(FT)
+                end
+
+                @unroll for n in 1:Nq
+                    if dim == 3 ||
+                       (dim == 2 && !(model_direction isa VerticalDirection))
+                        Dni = s_D[n, i] * s_ω[n] / s_ω[i]
+                        F1ξ1 += Dni * shared_flux[1, n, j, k_ix, s]
+                        F2ξ1 += Dni * shared_flux[2, n, j, k_ix, s]
+                        F3ξ1 += Dni * shared_flux[3, n, j, k_ix, s]
+                    end
+
+                    if dim == 3 ||
+                       (dim == 2 && !(model_direction isa HorizontalDirection))
+                        Dnj = s_D[n, j] * s_ω[n] / s_ω[j]
+                        F1ξ2 += Dnj * shared_flux[1, i, n, k_ix, s]
+                        F2ξ2 += Dnj * shared_flux[2, i, n, k_ix, s]
+                        F3ξ2 += Dnj * shared_flux[3, i, n, k_ix, s]
+                    end
+                end
+
+                if dim == 3 ||
+                   (dim == 2 && !(model_direction isa VerticalDirection))
+                    local_tendency[s] += ξ1x1 * F1ξ1 + ξ1x2 * F2ξ1 + ξ1x3 * F3ξ1
+                end
+                if dim == 3 ||
+                   (dim == 2 && !(model_direction isa HorizontalDirection))
+                    local_tendency[s] += ξ2x1 * F1ξ2 + ξ2x2 * F2ξ2 + ξ2x3 * F3ξ2
+                end
+
+                F1 = shared_flux[1, i, j, k_ix, s]
+                F2 = shared_flux[2, i, j, k_ix, s]
+                F3 = shared_flux[3, i, j, k_ix, s]
+
+                if model_direction isa HorizontalDirection ||
+                   balance_law isa RemBL
+                    local_tendency[s] -=
+                        (GCLH1 * F1 + GCLH2 * F2 + GCLH3 * F3) *
+                        vgeo[ijk, _MI, e]
+                end
+            end
+
+            @synchronize
+            k = k_ix + k_slice - 1
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+
+            M = vgeo[ijk, _M, e]
+            if dim == 3 ||
+               (dim == 2 && !(model_direction isa VerticalDirection))
+                ξ1x1 = vgeo[ijk, _ξ1x1, e]
+                ξ1x2 = vgeo[ijk, _ξ1x2, e]
+                ξ1x3 = vgeo[ijk, _ξ1x3, e]
+            end
+            if dim == 3 ||
+               (dim == 2 && !(model_direction isa HorizontalDirection))
+                ξ2x1 = vgeo[ijk, _ξ2x1, e]
+                ξ2x2 = vgeo[ijk, _ξ2x2, e]
+                ξ2x3 = vgeo[ijk, _ξ2x3, e]
             end
 
             fill!(local_flux, -zero(eltype(local_flux)))
             flux_second_order!(
                 balance_law,
                 Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux,
-                ),
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[:],),
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(local_state_gradient_flux[:],),
+                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(local_state_hyperdiffusion[:],),
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:],),
                 t,
             )
 
             @unroll for s in 1:num_state_prognostic
-                shared_flux[1, i, j, s] += local_flux[1, s]
-                shared_flux[2, i, j, s] += local_flux[2, s]
-                local_flux_3[s] += local_flux[3, s]
+                shared_flux[1, i, j, k_ix, s] = local_flux[1, s]
+                shared_flux[2, i, j, k_ix, s] = local_flux[2, s]
+                local_flux_3[s] = local_flux[3, s]
             end
 
             # Build "inside metrics" flux
             @unroll for s in 1:num_state_prognostic
-                F1, F2, F3 = shared_flux[1, i, j, s],
-                shared_flux[2, i, j, s],
+                F1, F2, F3 = shared_flux[1, i, j, k_ix, s],
+                shared_flux[2, i, j, k_ix, s],
                 local_flux_3[s]
 
-                shared_flux[1, i, j, s] =
-                    M * (ξ1x1 * F1 + ξ1x2 * F2 + ξ1x3 * F3)
-                if dim == 3 || (dim == 2 && direction isa EveryDirection)
-                    shared_flux[2, i, j, s] =
+                if dim == 3 ||
+                   (dim == 2 && !(model_direction isa VerticalDirection))
+                    shared_flux[1, i, j, k_ix, s] =
+                        M * (ξ1x1 * F1 + ξ1x2 * F2 + ξ1x3 * F3)
+                end
+                if dim == 3 ||
+                   (dim == 2 && !(model_direction isa HorizontalDirection))
+                    shared_flux[2, i, j, k_ix, s] =
                         M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
                 end
-                if dim == 3 && direction isa EveryDirection
-                    local_flux_3[s] = M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
-                end
             end
 
-            # In the case of the remainder model we may need to loop through the
-            # models to add in restricted direction componennts
-            if direction isa EveryDirection && balance_law isa RemBL
-                if rembl_has_subs_direction(HorizontalDirection(), balance_law)
-                    fill!(local_flux, -zero(eltype(local_flux)))
-                    flux_first_order!(
-                        balance_law,
-                        Grad{vars_state(balance_law, Prognostic(), FT)}(
-                            local_flux,
-                        ),
-                        Vars{vars_state(balance_law, Prognostic(), FT)}(
-                            local_state_prognostic,
-                        ),
-                        Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                            local_state_auxiliary,
-                        ),
-                        t,
-                        (HorizontalDirection(),),
-                    )
-                    @unroll for s in 1:num_state_prognostic
-                        F1, F2, F3 =
-                            local_flux[1, s], local_flux[2, s], local_flux[3, s]
-                        shared_flux[1, i, j, s] +=
-                            M * (ξ1x1 * F1 + ξ1x2 * F2 + ξ1x3 * F3)
-                        if dim == 3
-                            shared_flux[2, i, j, s] +=
-                                M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
-                        end
-                    end
-                end
-                if rembl_has_subs_direction(VerticalDirection(), balance_law)
-                    fill!(local_flux, -zero(eltype(local_flux)))
-                    flux_first_order!(
-                        balance_law,
-                        Grad{vars_state(balance_law, Prognostic(), FT)}(
-                            local_flux,
-                        ),
-                        Vars{vars_state(balance_law, Prognostic(), FT)}(
-                            local_state_prognostic,
-                        ),
-                        Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                            local_state_auxiliary,
-                        ),
-                        t,
-                        (VerticalDirection(),),
-                    )
-                    @unroll for s in 1:num_state_prognostic
-                        F1, F2, F3 =
-                            local_flux[1, s], local_flux[2, s], local_flux[3, s]
-                        if dim == 2
-                            shared_flux[2, i, j, s] +=
-                                M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
-                        elseif dim == 3
-                            local_flux_3[s] +=
-                                M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
-                        end
-                    end
-                end
-            end
+            if add_source
+                fill!(local_source, -zero(eltype(local_source)))
+                source!(
+                    balance_law,
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(
+                        local_source,
+                    ),
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[:],),
+                    Vars{vars_state(balance_law, GradientFlux(), FT)}(local_state_gradient_flux[:],),
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:],),
+                    t,
+                    (model_direction,),
+                )
 
-            if dim == 3 && direction isa EveryDirection
-                @unroll for n in 1:Nqk
-                    MI = local_MI[n]
-                    @unroll for s in 1:num_state_prognostic
-                        local_tendency[n, s] += MI * s_D[k, n] * local_flux_3[s]
-                    end
+                @unroll for s in 1:num_state_prognostic
+                    local_tendency[s] += local_source[s]
                 end
-            end
-
-            fill!(local_source, -zero(eltype(local_source)))
-            source!(
-                balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_source),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
-                t,
-                (direction,),
-            )
-
-            @unroll for s in 1:num_state_prognostic
-                local_tendency[k, s] += local_source[s]
             end
             @synchronize
+            k = k_ix + k_slice - 1
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            MI = vgeo[ijk, _MI, e]
 
             # Weak "inside metrics" derivative
-            MI = local_MI[k]
             @unroll for s in 1:num_state_prognostic
                 @unroll for n in 1:Nq
                     # ξ1-grid lines
-                    local_tendency[k, s] +=
-                        MI * s_D[n, i] * shared_flux[1, n, j, s]
+                    if dim == 3 ||
+                       (dim == 2 && !(model_direction isa VerticalDirection))
+                        local_tendency[s] +=
+                            MI * s_D[n, i] * shared_flux[1, n, j, k_ix, s]
+                    end
 
                     # ξ2-grid lines
-                    if dim == 3 || (dim == 2 && direction isa EveryDirection)
-                        local_tendency[k, s] +=
-                            MI * s_D[n, j] * shared_flux[2, i, n, s]
+                    if dim == 3 ||
+                       (dim == 2 && !(model_direction isa HorizontalDirection))
+                        local_tendency[s] +=
+                            MI * s_D[n, j] * shared_flux[2, i, n, k_ix, s]
                     end
                 end
             end
-        end
 
-        @unroll for k in 1:Nqk
             ijk = i + Nq * ((j - 1) + Nq * (k - 1))
             @unroll for s in 1:num_state_prognostic
                 if β != 0
-                    T = α * local_tendency[k, s] + β * tendency[ijk, s, e]
+                    T = α * local_tendency[s] + β * tendency[ijk, s, e]
                 else
-                    T = α * local_tendency[k, s]
+                    T = α * local_tendency[s]
                 end
                 tendency[ijk, s, e] = T
             end
@@ -316,20 +366,23 @@ end
     balance_law::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
+    ::Val{Nslice},
+    model_direction,
     direction::VerticalDirection,
     tendency,
-    state_prognostic,
-    state_gradient_flux,
-    Qhypervisc_grad,
-    state_auxiliary,
-    vgeo,
+    @Const(state_prognostic),
+    @Const(state_gradient_flux),
+    @Const(Qhypervisc_grad),
+    @Const(state_auxiliary),
+    @Const(vgeo),
     t,
-    ω,
-    D,
+    @Const(ω),
+    @Const(D),
     elems,
     α,
     β,
-) where {dim, polyorder}
+    add_source = true,
+) where {dim, polyorder, Nslice}
     @uniform begin
         N = polyorder
         FT = eltype(state_prognostic)
@@ -341,55 +394,40 @@ end
         nhyperviscstate = number_states(balance_law, Hyperdiffusive())
 
         Nq = N + 1
-
-        Nqk = dim == 2 ? 1 : Nq
+        Nwork = div(Nq, Nslice)
 
         local_source = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_prognostic = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_gradient_flux =
-            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-        local_state_hyperdiffusion = MArray{Tuple{nhyperviscstate}, FT}(undef)
-        local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
         local_flux = MArray{Tuple{3, num_state_prognostic}, FT}(undef)
-        local_flux_total = MArray{Tuple{3, num_state_prognostic}, FT}(undef)
-
-        _ζx1 = dim == 2 ? _ξ2x1 : _ξ3x1
-        _ζx2 = dim == 2 ? _ξ2x2 : _ξ3x2
-        _ζx3 = dim == 2 ? _ξ2x3 : _ξ3x3
-
-        shared_flux_size = dim == 2 ? (Nq, Nq, num_state_prognostic) : (0, 0, 0)
+        local_flux_3 = MArray{Tuple{num_state_prognostic}, FT}(undef)
     end
 
-    local_tendency = @private FT (Nqk, num_state_prognostic)
-    local_MI = @private FT (Nqk,)
-
-    shared_flux = @localmem FT shared_flux_size
+    shared_flux = @localmem FT (3, Nq, Nq, Nwork, num_state_prognostic)
     s_D = @localmem FT (Nq, Nq)
+    s_ω = @localmem FT (Nq,)
+
+    local_tendency = @private FT (num_state_prognostic,)
+    local_state_prognostic = @private FT (num_state_prognostic,)
+    local_state_gradient_flux = @private FT (num_state_gradient_flux,)
+    local_state_hyperdiffusion = @private FT (nhyperviscstate,)
+    local_state_auxiliary = @private FT (num_state_auxiliary,)
 
     e = @index(Group, Linear)
-    i, j = @index(Local, NTuple)
+    k, i, j_ix = @index(Local, NTuple)
 
-    @inbounds begin
-        s_D[i, j] = D[i, j]
+    @inbounds @views begin
+        s_D[k, i] = D[k, i]
 
-        @unroll for k in 1:Nqk
-            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
-            @unroll for s in 1:num_state_prognostic
-                local_tendency[k, s] = zero(FT)
-            end
-            local_MI[k] = vgeo[ijk, _MI, e]
+        if (i == 1)
+            s_ω[k] = ω[k]
         end
 
-        # ensure D is loaded
-        @synchronize(dim == 3)
-
-        @unroll for k in 1:Nqk
+        @unroll for j_slice in 1:Nslice
+            @synchronize
+            j = j_ix + j_slice - 1
             ijk = i + Nq * ((j - 1) + Nq * (k - 1))
-
-            M = vgeo[ijk, _M, e]
-            ζx1 = vgeo[ijk, _ζx1, e]
-            ζx2 = vgeo[ijk, _ζx2, e]
-            ζx3 = vgeo[ijk, _ζx3, e]
+            @unroll for s in 1:num_state_prognostic
+                local_tendency[s] = zero(FT)
+            end
 
             @unroll for s in 1:num_state_prognostic
                 local_state_prognostic[s] = state_prognostic[ijk, s, e]
@@ -411,110 +449,153 @@ end
             flux_first_order!(
                 balance_law,
                 Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[:],),
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:],),
                 t,
-                (direction,),
+                (model_direction,),
             )
 
             @unroll for s in 1:num_state_prognostic
-                local_flux_total[1, s] = local_flux[1, s]
-                local_flux_total[2, s] = local_flux[2, s]
-                local_flux_total[3, s] = local_flux[3, s]
+                shared_flux[1, k, i, j_ix, s] = local_flux[1, s]
+                shared_flux[2, k, i, j_ix, s] = local_flux[2, s]
+                shared_flux[3, k, i, j_ix, s] = local_flux[3, s]
             end
+
+            # In the case of the remainder model we may need to loop through the
+            # models to add in restricted direction componennts
+            if model_direction isa EveryDirection &&
+               balance_law isa RemBL &&
+               rembl_has_subs_direction(VerticalDirection(), balance_law)
+                fill!(local_flux, -zero(eltype(local_flux)))
+                flux_first_order!(
+                    balance_law,
+                    Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[:],),
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:],),
+                    t,
+                    (VerticalDirection(),),
+                )
+                @unroll for s in 1:num_state_prognostic
+                    shared_flux[1, k, i, j_ix, s] += local_flux[1, s]
+                    shared_flux[2, k, i, j_ix, s] += local_flux[2, s]
+                    shared_flux[3, k, i, j_ix, s] += local_flux[3, s]
+                end
+            end
+            @synchronize
+
+            j = j_ix + j_slice - 1
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            ξ3x1 = vgeo[ijk, _ξ3x1, e]
+            ξ3x2 = vgeo[ijk, _ξ3x2, e]
+            ξ3x3 = vgeo[ijk, _ξ3x3, e]
+
+            if model_direction isa VerticalDirection || balance_law isa RemBL
+                GCLV1 = GCLV2 = GCLV3 = -zero(FT)
+                @unroll for n in 1:Nq
+                    ijn = i + Nq * ((j - 1) + Nq * (n - 1))
+                    GCLV1 +=
+                        s_D[k, n] * s_ω[k] / s_ω[n] *
+                        vgeo[ijn, _M, e] *
+                        vgeo[ijn, _ξ3x1, e]
+                    GCLV2 +=
+                        s_D[k, n] * s_ω[k] / s_ω[n] *
+                        vgeo[ijn, _M, e] *
+                        vgeo[ijn, _ξ3x2, e]
+                    GCLV3 +=
+                        s_D[k, n] * s_ω[k] / s_ω[n] *
+                        vgeo[ijn, _M, e] *
+                        vgeo[ijn, _ξ3x3, e]
+                end
+            end
+
+            # weak outside metrics derivative
+            @unroll for s in 1:num_state_prognostic
+                F1ξ3 = F2ξ3 = F3ξ3 = -zero(FT)
+                @unroll for n in 1:Nq
+                    Dnk = s_D[n, k] * s_ω[n] / s_ω[k]
+                    F1ξ3 += Dnk * shared_flux[1, n, i, j_ix, s]
+                    F2ξ3 += Dnk * shared_flux[2, n, i, j_ix, s]
+                    F3ξ3 += Dnk * shared_flux[3, n, i, j_ix, s]
+                end
+
+                local_tendency[s] += ξ3x1 * F1ξ3 + ξ3x2 * F2ξ3 + ξ3x3 * F3ξ3
+
+                F1 = shared_flux[1, k, i, j_ix, s]
+                F2 = shared_flux[2, k, i, j_ix, s]
+                F3 = shared_flux[3, k, i, j_ix, s]
+
+                if model_direction isa VerticalDirection ||
+                   balance_law isa RemBL
+                    local_tendency[s] -=
+                        (GCLV1 * F1 + GCLV2 * F2 + GCLV3 * F3) *
+                        vgeo[ijk, _MI, e]
+                end
+            end
+
+            @synchronize
+            j = j_ix + j_slice - 1
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            M = vgeo[ijk, _M, e]
+            ξ3x1 = vgeo[ijk, _ξ3x1, e]
+            ξ3x2 = vgeo[ijk, _ξ3x2, e]
+            ξ3x3 = vgeo[ijk, _ξ3x3, e]
 
             fill!(local_flux, -zero(eltype(local_flux)))
             flux_second_order!(
                 balance_law,
                 Grad{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux,
-                ),
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
+                Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[:],),
+                Vars{vars_state(balance_law, GradientFlux(), FT)}(local_state_gradient_flux[:],),
+                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(local_state_hyperdiffusion[:],),
+                Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:],),
                 t,
             )
-
-            @unroll for s in 1:num_state_prognostic
-                local_flux_total[1, s] += local_flux[1, s]
-                local_flux_total[2, s] += local_flux[2, s]
-                local_flux_total[3, s] += local_flux[3, s]
-            end
 
             # Build "inside metrics" flux
             @unroll for s in 1:num_state_prognostic
-                F1, F2, F3 = local_flux_total[1, s],
-                local_flux_total[2, s],
-                local_flux_total[3, s]
-                Fv = M * (ζx1 * F1 + ζx2 * F2 + ζx3 * F3)
-                if dim == 2
-                    shared_flux[i, j, s] = Fv
-                else
-                    local_flux_total[1, s] = Fv
+                F1, F2, F3 =
+                    local_flux[1, s], local_flux[2, s], local_flux[3, s]
+                shared_flux[1, k, i, j_ix, s] =
+                    M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
+            end
+
+            if add_source
+                fill!(local_source, -zero(eltype(local_source)))
+                source!(
+                    balance_law,
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(
+                        local_source,
+                    ),
+                    Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[:],),
+                    Vars{vars_state(balance_law, GradientFlux(), FT)}(local_state_gradient_flux[:],),
+                    Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[:],),
+                    t,
+                    (model_direction,),
+                )
+
+                @unroll for s in 1:num_state_prognostic
+                    local_tendency[s] += local_source[s]
                 end
             end
-
-            if dim == 3
-                @unroll for n in 1:Nqk
-                    MI = local_MI[n]
-                    @unroll for s in 1:num_state_prognostic
-                        local_tendency[n, s] +=
-                            MI * s_D[k, n] * local_flux_total[1, s]
-                    end
-                end
-            end
-
-            fill!(local_source, -zero(eltype(local_source)))
-            source!(
-                balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_source),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary,
-                ),
-                t,
-                (direction,),
-            )
-
-            @unroll for s in 1:num_state_prognostic
-                local_tendency[k, s] += local_source[s]
-            end
-
-            @synchronize(dim == 2)
-            if dim == 2
-                MI = local_MI[k]
-                @unroll for n in 1:Nq
-                    @unroll for s in 1:num_state_prognostic
-                        local_tendency[k, s] +=
-                            MI * s_D[n, j] * shared_flux[i, n, s]
-                    end
-                end
-            end
-        end
-
-        @unroll for k in 1:Nqk
+            @synchronize
+            j = j_ix + j_slice - 1
             ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            MI = vgeo[ijk, _MI, e]
+
+            # Weak "inside metrics" derivative
+            @unroll for s in 1:num_state_prognostic
+                @unroll for n in 1:Nq
+                    # ξ3-grid lines
+                    local_tendency[s] +=
+                        MI * s_D[n, k] * shared_flux[1, n, i, j_ix, s]
+                end
+            end
+
             @unroll for s in 1:num_state_prognostic
                 if β != 0
-                    T = α * local_tendency[k, s] + β * tendency[ijk, s, e]
+                    T = α * local_tendency[s] + β * tendency[ijk, s, e]
                 else
-                    T = α * local_tendency[k, s]
+                    T = α * local_tendency[s]
                 end
                 tendency[ijk, s, e] = T
             end


### PR DESCRIPTION
# Description

This changes the DG dicretization of first order terms to use the "outside metrics" variant. Together with #1530 this helps
with achieving stable simulations that maintain hydrostatic balance on the sphere.

In order to make this change, the `EveryDirection` volume kernel had to be split into two kernels, doing 
the horizontal and the vertical separately.  

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
