### PR TITLE
Fixes dormant 2d vector not 3d vector typo in barotropic ocean noslip bc

### DIFF
--- a/src/Ocean/ShallowWater/bc_velocity.jl
+++ b/src/Ocean/ShallowWater/bc_velocity.jl
@@ -137,7 +137,7 @@ set numerical flux to zero for U
     args...,
 )
     FT = eltype(q⁺)
-    q⁺.U = @SVector zeros(FT, 3)
+    q⁺.U = @SVector zeros(FT, 2)
 
     return nothing
 end


### PR DESCRIPTION
# Description

Fix small vector size typo in Barotropic (2d) ocean no-slip boundary code. 
Previously code errored at runtime. 

```
ERROR: LoadError: TaskFailedException:
DimensionMismatch("array could not be broadcast to match destination")
Stacktrace:
 [1] materialize! at ./broadcast.jl:0 [inlined]
 [2] macro expansion at /Users/chrishill/projects/clim-z2/src/Utilities/VariableTemplates/VariableTemplates.jl:244 [inlined]
 [3] setproperty! at /Users/chrishill/projects/clim-z2/src/Utilities/VariableTemplates/VariableTemplates.jl:218 [inlined]
 [4] ocean_boundary_state! at /Users/chrishill/projects/clim-z2/src/Ocean/ShallowWater/bc_velocity.jl:140 [inlined]
 [5] ocean_boundary_state! at /Users/chrishill/projects/clim-z2/src/Ocean/ShallowWater/ShallowWaterModel.jl:319 [inlined]
```

Now the code runs and boundary velocities are pulled to zero as expected. 

<img width="711" alt="image" src="https://user-images.githubusercontent.com/3535328/95909363-5b0ade00-0d6c-11eb-9cfa-0d9f6a1e014b.png">
