### PR TITLE
Remove BrickMesh.mappings function

### DIFF
--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -53,8 +53,6 @@ Geometry.resolutionmetric
 BrickMesh.partition
 BrickMesh.brickmesh
 BrickMesh.connectmesh
-BrickMesh.mappings
-BrickMesh.commmapping
 BrickMesh.centroidtocode
 ```
 

--- a/src/Numerics/Mesh/BrickMesh.jl
+++ b/src/Numerics/Mesh/BrickMesh.jl
@@ -1,6 +1,6 @@
 module BrickMesh
 
-export brickmesh, centroidtocode, connectmesh, partition, mappings, commmapping
+export brickmesh, centroidtocode, connectmesh, partition
 
 using MPI
 
@@ -1118,116 +1118,5 @@ function connectmesh(
     )        # neighbor send ranges into `sendelems`
 end
 
-"""
-    mappings(N, elemtoelem, elemtoface, elemtoordr)
-
-This function takes in a polynomial order `N` and parts of a mesh (as returned
-from `connectmesh`) and returns index mappings for the element surface flux
-computation.  The returned `Tuple` contains:
-
- - `vmap⁻` an array of linear indices into the volume degrees of freedom where
-   `vmap⁻[:,f,e]` are the degrees of freedom indices for face `f` of element
-    `e`.
-
- - `vmap⁺` an array of linear indices into the volume degrees of freedom where
-   `vmap⁺[:,f,e]` are the degrees of freedom indices for the face neighboring
-   face `f` of element `e`.
-"""
-function mappings(N, elemtoelem, elemtoface, elemtoordr)
-    nface, nelem = size(elemtoelem)
-
-    d = div(nface, 2)
-    Np, Nfp = (N + 1)^d, (N + 1)^(d - 1)
-
-    p = reshape(1:Np, ntuple(j -> N + 1, d))
-    fd(f) = div(f - 1, 2) + 1
-    fe(f) = N * mod(f - 1, 2) + 1
-    fmask = hcat((
-        p[ntuple(j -> (j == fd(f)) ? (fe(f):fe(f)) : (:), d)...][:] for
-        f in 1:nface
-    )...)
-
-    vmap⁻ = similar(elemtoelem, Nfp, nface, nelem)
-    vmap⁺ = similar(elemtoelem, Nfp, nface, nelem)
-
-    for e1 in 1:nelem, f1 in 1:nface
-        e2 = elemtoelem[f1, e1]
-        f2 = elemtoface[f1, e1]
-        o2 = elemtoordr[f1, e1]
-
-        # TODO support different orientations
-        @assert o2 == 1
-
-        vmap⁻[:, f1, e1] .= Np * (e1 - 1) .+ fmask[:, f1]
-        vmap⁺[:, f1, e1] .= Np * (e2 - 1) .+ fmask[:, f2]
-    end
-
-    (vmap⁻, vmap⁺)
-end
-
-"""
-   commmapping(N, commelems, commfaces, nabrtocomm)
-
-This function takes in a polynomial order `N` and parts of a mesh (as returned
-from `connectmesh` such as `sendelems`, `sendfaces`, and `nabrtosend`) and
-returns index mappings for the element surface flux parallel communcation.
-The returned `Tuple` contains:
-
- - `vmapC` an array of linear indices into the volume degrees of freedom to be
-   communicated.
-
- - `nabrtovmapC` a range in `vmapC` to communicate with each neighbor.
-"""
-function commmapping(N, commelems, commfaces, nabrtocomm)
-    nface, nelem = size(commfaces)
-
-    @assert nelem == length(commelems)
-
-    d = div(nface, 2)
-    Nq = N + 1
-    Np = (N + 1)^d
-
-    vmapC = similar(commelems, nelem * Np)
-    nabrtovmapC = similar(nabrtocomm)
-
-    i = 1
-    e = 1
-    for neighbor in 1:length(nabrtocomm)
-        rbegin = i
-        for ne in nabrtocomm[neighbor]
-            ce = commelems[ne]
-
-            # Whole element sending
-            # for n = 1:Np
-            #   vmapC[i] = (ce-1)*Np + n
-            #   i += 1
-            # end
-
-            CI = CartesianIndices(ntuple(_ -> 1:Nq, d))
-            for (ci, li) in zip(CI, LinearIndices(CI))
-                addpoint = false
-                for j in 1:d
-                    addpoint |=
-                        (commfaces[2 * (j - 1) + 1, e] && ci[j] == 1) ||
-                        (commfaces[2 * (j - 1) + 2, e] && ci[j] == Nq)
-                end
-
-                if addpoint
-                    vmapC[i] = (ce - 1) * Np + li
-                    i += 1
-                end
-            end
-
-            e += 1
-        end
-        rend = i - 1
-
-        nabrtovmapC[neighbor] = rbegin:rend
-    end
-
-    resize!(vmapC, i - 1)
-
-    (vmapC, nabrtovmapC)
-end
 
 end # module

--- a/test/Numerics/Mesh/BrickMesh.jl
+++ b/test/Numerics/Mesh/BrickMesh.jl
@@ -1,4 +1,5 @@
 using ClimateMachine.Mesh.BrickMesh
+using ClimateMachine.Mesh.Grids: mappings, commmapping
 using Test
 using MPI
 


### PR DESCRIPTION
# Description

Before this PR there were two very similar `mappings` functions with identical arguments, one in `Mesh.Grids`, the other in `Mesh.Grids.BrickMesh`. From what I could tell `BrickMesh.mappings` had unit tests but it was `Grids.mappings` that was used to construct the DG grid. This PR removes `BrickMesh.mappings` and changes the tests to use `Grids.mappings`. Additionally, `BrickMesh.commmapping` is moved to `Grids` for consistency, and to have `BrickMesh` only contain functions that don't depend on the polynomial order.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
