### PR TITLE
add center coords to init_state_prognostic

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -23,7 +23,7 @@ ClimateMachine.BalanceLaws.flux_first_order!(m::AtmosModel, flux::Grad, state::V
 ClimateMachine.BalanceLaws.flux_second_order!(atmos::AtmosModel, flux::Grad, state::Vars, diffusive::Vars, hyperdiffusive::Vars, aux::Vars, t::Real)
 ClimateMachine.BalanceLaws.init_state_auxiliary!(m::AtmosModel, state_auxiliary::MPIStateArray, grid, direction)
 ClimateMachine.BalanceLaws.source!(m::AtmosModel, source::Vars, state::Vars, diffusive::Vars, aux::Vars, t::Real, direction)
-ClimateMachine.BalanceLaws.init_state_prognostic!(m::AtmosModel, state::Vars, aux::Vars, coords, t, args...)
+ClimateMachine.BalanceLaws.init_state_prognostic!(m::AtmosModel, state::Vars, aux::Vars, coords, center_coords, t, args...)
 ```
 
 ## Reference states

--- a/experiments/AtmosGCM/baroclinic_wave.jl
+++ b/experiments/AtmosGCM/baroclinic_wave.jl
@@ -27,7 +27,7 @@ using CLIMAParameters.Planet: MSLP, R_d, day, grav, Omega, planet_radius
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function init_baroclinic_wave!(problem, bl, state, aux, coords, t)
+function init_baroclinic_wave!(problem, bl, state, aux, coords, center_coords, t)
     FT = eltype(state)
 
     # parameters

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -39,10 +39,10 @@ using CLIMAParameters.Planet:
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function init_heldsuarez!(problem, bl, state, aux, coords, t)
+function init_heldsuarez!(problem, bl, state, aux, coords, center_coords, t)
     FT = eltype(state)
 
-    # parameters 
+    # parameters
     _a::FT = planet_radius(bl.param_set)
 
     z_t::FT = 15e3

--- a/experiments/AtmosGCM/isothermal_zonal_flow.jl
+++ b/experiments/AtmosGCM/isothermal_zonal_flow.jl
@@ -32,7 +32,7 @@ CLIMAParameters.Planet.Omega(::EarthParameterSet) = 0.0
 CLIMAParameters.Planet.planet_radius(::EarthParameterSet) = 6.371e6 / 125.0
 CLIMAParameters.Planet.MSLP(::EarthParameterSet) = 1e5
 
-function init_isothermal_zonal_flow!(problem, bl, state, aux, coords, t)
+function init_isothermal_zonal_flow!(problem, bl, state, aux, coords, center_coords, t)
     FT = eltype(state)
 
     φ = latitude(bl.orientation, aux)

--- a/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
+++ b/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
@@ -40,7 +40,7 @@ CLIMAParameters.Planet.press_triple(::EarthParameterSet) = 610.78
 # driver-specific parameters added here
 T_sfc_pole(::EarthParameterSet) = 271.0
 
-function init_baroclinic_wave!(problem, bl, state, aux, coords, t)
+function init_baroclinic_wave!(problem, bl, state, aux, coords, center_coords, t)
     FT = eltype(state)
 
     # parameters

--- a/experiments/AtmosGCM/nonhydrostatic_gravity_wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic_gravity_wave.jl
@@ -33,7 +33,7 @@ CLIMAParameters.Planet.planet_radius(::EarthParameterSet) = 6.371e6 / 125.0
 CLIMAParameters.Planet.MSLP(::EarthParameterSet) = 1e5
 
 
-function init_nonhydrostatic_gravity_wave!(problem, bl, state, aux, coords, t)
+function init_nonhydrostatic_gravity_wave!(problem, bl, state, aux, coords, center_coords, t)
     FT = eltype(state)
 
     # grid

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -288,7 +288,7 @@ end
 """
   Initial Condition for BOMEX LES
 """
-function init_bomex!(problem, bl, state, aux, (x, y, z), t)
+function init_bomex!(problem, bl, state, aux, (x, y, z), center_coords, t)
     # This experiment runs the BOMEX LES Configuration
     # (Shallow cumulus cloud regime)
     # x,y,z imply eastward, northward and altitude coordinates in `[m]`
@@ -382,7 +382,7 @@ function init_bomex!(problem, bl, state, aux, (x, y, z), t)
         state.ρe += rand() * ρe_tot / 100
         state.moisture.ρq_tot += rand() * ρ * q_tot / 100
     end
-    init_state_prognostic!(bl.turbconv, bl, state, aux, (x, y, z), t)
+    init_state_prognostic!(bl.turbconv, bl, state, aux, (x, y, z), center_coords, t)
 end
 
 function bomex_model(

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -193,7 +193,7 @@ URL = {https://doi.org/10.1175/MWR2930.1},
 eprint = {https://doi.org/10.1175/MWR2930.1}
 }
 """
-function init_dycoms!(problem, bl, state, aux, (x, y, z), t)
+function init_dycoms!(problem, bl, state, aux, (x, y, z), (xc, yc, zc), t)
     FT = eltype(state)
 
     z = altitude(bl, aux)

--- a/experiments/AtmosLES/schar_scalar_advection.jl
+++ b/experiments/AtmosLES/schar_scalar_advection.jl
@@ -25,12 +25,12 @@ const param_set = EarthParameterSet()
 
 ### Citation
 #@article{
-#    author = {Schär, Christoph and 
-#              Leuenberger, Daniel and 
-#              Fuhrer, Oliver and 
-#              Lüthi, Daniel and 
+#    author = {Schär, Christoph and
+#              Leuenberger, Daniel and
+#              Fuhrer, Oliver and
+#              Lüthi, Daniel and
 #              Girard, Claude},
-#    title = "{A New Terrain-Following Vertical Coordinate Formulation 
+#    title = "{A New Terrain-Following Vertical Coordinate Formulation
 #              for Atmospheric Prediction Models}",
 #    journal = {Monthly Weather Review},
 #    volume = {130},
@@ -44,7 +44,7 @@ const param_set = EarthParameterSet()
 #}
 
 # ## [Initial Conditions]
-function init_schar!(problem, bl, state, aux, (x, y, z), t)
+function init_schar!(problem, bl, state, aux, (x, y, z), (xc, yc, zc), t)
     ## Problem float-type
     FT = eltype(state)
 

--- a/experiments/AtmosLES/stable_bl_kosovic.jl
+++ b/experiments/AtmosLES/stable_bl_kosovic.jl
@@ -2,7 +2,7 @@
 
 ## @article{10.1175/1520-0469(2000)057<1052:ALESSO>2.0.CO;2,
 ##     author = {Kosović, Branko and Curry, Judith A.},
-##     title = "{A Large Eddy Simulation Study of a Quasi-Steady, 
+##     title = "{A Large Eddy Simulation Study of a Quasi-Steady,
 ##               Stably Stratified Atmospheric Boundary Layer}",
 ##     journal = {Journal of the Atmospheric Sciences},
 ##     volume = {57},
@@ -150,7 +150,7 @@ end
 """
   Initial Condition for StableBoundaryLayer LES
 """
-function init_problem!(problem, bl, state, aux, (x, y, z), t)
+function init_problem!(problem, bl, state, aux, (x, y, z), (xc, yc, zc), t)
     # Problem floating point precision
     FT = eltype(state)
     R_gas::FT = R_d(bl.param_set)

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -39,7 +39,7 @@ const param_set = EarthParameterSet()
 """
   Surface Driven Thermal Bubble
 """
-function init_surfacebubble!(problem, bl, state, aux, (x, y, z), t)
+function init_surfacebubble!(problem, bl, state, aux, (x, y, z), center_coords, t)
     FT = eltype(state)
     R_gas::FT = R_d(bl.param_set)
     c_p::FT = cp_d(bl.param_set)

--- a/experiments/AtmosLES/taylor_green.jl
+++ b/experiments/AtmosLES/taylor_green.jl
@@ -65,7 +65,7 @@ journal = {AIAA Aviation 7th AIAA theoretical fluid mechanics conference},
 year = {2014},
 }
 """
-function init_greenvortex!(problem, bl, state, aux, (x, y, z), t)
+function init_greenvortex!(problem, bl, state, aux, (x, y, z), (xc, yc, zc), t)
     # Problem float-type
     FT = eltype(state)
 

--- a/experiments/AtmosLES/unstable_bl_kitamura.jl
+++ b/experiments/AtmosLES/unstable_bl_kitamura.jl
@@ -152,7 +152,7 @@ end
 """
   Initial Condition for UnstableBoundaryLayer LES
 """
-function init_problem!(problem, bl, state, aux, (x, y, z), t)
+function init_problem!(problem, bl, state, aux, (x, y, z), (xc, yc, zc), t)
     # Problem floating point precision
     FT = eltype(state)
     R_gas::FT = R_d(bl.param_set)
@@ -334,7 +334,7 @@ function main()
 
     t0 = FT(0)
 
-    # Full simulation requires 16+ hours of simulated time 
+    # Full simulation requires 16+ hours of simulated time
     timeend = FT(3600 * 0.1)
     CFLmax = FT(0.4)
 

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -748,6 +748,7 @@ end
         state::Vars,
         aux::Vars,
         coords,
+        center_coords,
         t,
         args...,
     )
@@ -761,6 +762,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t,
     args...,
 )
@@ -770,6 +772,7 @@ function init_state_prognostic!(
         state,
         aux,
         coords,
+        center_coords,
         t,
         args...,
     )

--- a/src/Atmos/Model/bc_initstate.jl
+++ b/src/Atmos/Model/bc_initstate.jl
@@ -21,7 +21,7 @@ function atmos_boundary_state!(
     t,
     _...,
 )
-    init_state_prognostic!(m, state⁺, aux⁺, aux⁺.coord, t)
+    init_state_prognostic!(m, state⁺, aux⁺, aux⁺.coord, nothing, t)
 end
 
 function atmos_normal_boundary_flux_second_order!(
@@ -78,5 +78,5 @@ function boundary_state!(
     t,
     args...,
 )
-    init_state_prognostic!(m, state⁺, aux⁺, aux⁺.coord, t)
+    init_state_prognostic!(m, state⁺, aux⁺, aux⁺.coord, nothing, t)
 end

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -181,6 +181,7 @@ init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t,
 ) = nothing
 

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -147,6 +147,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coord,
+    center_coord,
     t,
 ) end
 function flux_first_order!(

--- a/src/BalanceLaws/Problems.jl
+++ b/src/BalanceLaws/Problems.jl
@@ -20,6 +20,7 @@ abstract type AbstractProblem end
         state_prognostic::Vars,
         state_auxiliary::Vars,
         coords,
+        center_coords,
         t,
         args...,
     )

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -69,6 +69,7 @@ vars_state(::BalanceLaw, ::AbstractStateType, FT) = @vars()
         state_prognostic::Vars,
         state_auxiliary::Vars,
         coords,
+        center_coords,
         args...,
     )
 

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -143,6 +143,7 @@ function init_state_prognostic!(
     state,
     aux,
     (x, y, z),
+    center_coord,
     t,
 ) end
 

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -1501,6 +1501,18 @@ end
 
     @inbounds begin
         coords = SVector(vgeo[n, _x1, e], vgeo[n, _x2, e], vgeo[n, _x3, e])
+        V = FT(0)
+        xc = FT(0)
+        yc = FT(0)
+        zc = FT(0)
+        @unroll for i in 1:Np
+            M = vgeo[i, _M, e]
+            V += M
+            xc += M * vgeo[i, _x1, e]
+            yc += M * vgeo[i, _x2, e]
+            zc += M * vgeo[i, _x3, e]
+        end
+        center_coords = SVector(xc / V, yc / V, zc / V)
         @unroll for s in 1:num_state_auxiliary
             local_state_auxiliary[s] = state_auxiliary[n, s, e]
         end
@@ -1514,6 +1526,7 @@ end
                 local_state_auxiliary,
             ),
             coords,
+            center_coords,
             args...,
         )
         @unroll for s in 1:num_state_prognostic

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -147,8 +147,8 @@ end
 sets the initial value for state variables
 dispatches to ocean_init_state! which is defined in a problem file such as SimpleBoxProblem.jl
 """
-function init_state_prognostic!(m::HBModel, Q::Vars, A::Vars, coords, t)
-    return ocean_init_state!(m, m.problem, Q, A, coords, t)
+function init_state_prognostic!(m::HBModel, Q::Vars, A::Vars, coords, center_coords, t)
+    return ocean_init_state!(m, m.problem, Q, A, coords, center_coords, t)
 end
 
 """

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -48,7 +48,7 @@ init_state_auxiliary!(
     grid,
     direction,
 ) = nothing
-init_state_prognostic!(lm::LinearHBModel, Q::Vars, A::Vars, coords, t) = nothing
+init_state_prognostic!(lm::LinearHBModel, Q::Vars, A::Vars, coords, center_coords, t) = nothing
 
 """
     compute_gradient_argument!(::LinearHBModel)

--- a/src/Ocean/OceanProblems/ShallowWaterInitialStates.jl
+++ b/src/Ocean/OceanProblems/ShallowWaterInitialStates.jl
@@ -6,6 +6,7 @@ function null_init_state!(
     state,
     aux,
     coord,
+    center_coord,
     t,
 )
     T = eltype(state.U)
@@ -24,6 +25,7 @@ function lsw_init_state!(
     state,
     aux,
     coords,
+    center_coords,
     t,
 )
     state.U = @SVector [
@@ -46,6 +48,7 @@ function lkw_init_state!(
     state,
     aux,
     coords,
+    center_coords,
     t,
 )
     state.U = @SVector [
@@ -93,6 +96,7 @@ function gyre_init_state!(
     state,
     aux,
     coords,
+    center_coords,
     t,
 )
     FT = eltype(state)
@@ -138,6 +142,7 @@ function gyre_init_state!(
     state,
     aux,
     coords,
+    center_coords,
     t,
 )
     FT = eltype(state.U)

--- a/src/Ocean/OceanProblems/SimpleBoxProblem.jl
+++ b/src/Ocean/OceanProblems/SimpleBoxProblem.jl
@@ -174,6 +174,7 @@ function ocean_init_state!(
     Q,
     A,
     coords,
+    center_coords,
     t,
 )
     k = (2π / p.Lˣ, 2π / p.Lʸ, 2π / p.H)
@@ -203,6 +204,7 @@ function ocean_init_state!(
     Q,
     A,
     coords,
+    center_coords,
     t,
 )
     k = (2π / p.Lˣ, 2π / p.Lʸ, 2π / p.H)
@@ -342,9 +344,18 @@ initialize u,v with random values, η with 0, and θ with a constant (20)
 - `Q`: state vector
 - `A`: auxiliary state vector, not used
 - `coords`: the coordidinates, not used
+- `center_coords`: coordinates of element centers, not used
 - `t`: time to evaluate at, not used
 """
-function ocean_init_state!(m::HBModel, p::HomogeneousBox, Q, A, coords, t)
+function ocean_init_state!(
+    m::HBModel,
+    p::HomogeneousBox,
+    Q,
+    A,
+    coords,
+    center_coords,
+    t,
+)
     Q.u = @SVector [0, 0]
     Q.η = 0
     Q.θ = 20
@@ -354,11 +365,19 @@ end
 
 include("ShallowWaterInitialStates.jl")
 
-function ocean_init_state!(m::SWModel, p::HomogeneousBox, Q, A, coords, t)
+function ocean_init_state!(
+    m::SWModel,
+    p::HomogeneousBox,
+    Q,
+    A,
+    coords,
+    center_coords,
+    t,
+)
     if t == 0
-        null_init_state!(p, m.turbulence, Q, A, coords, 0)
+        null_init_state!(p, m.turbulence, Q, A, coords, center_coords, 0)
     else
-        gyre_init_state!(m, p, m.turbulence, Q, A, coords, t)
+        gyre_init_state!(m, p, m.turbulence, Q, A, coords, center_coords, t)
     end
 end
 
@@ -433,6 +452,7 @@ initialize u,v,η with 0 and θ linearly distributed between 9 at z=0 and 1 at z
 - `Q`: state vector
 - `A`: auxiliary state vector, not used
 - `coords`: the coordidinates
+- `center_coords`: element center coordinates, not used
 - `t`: time to evaluate at, not used
 """
 function ocean_init_state!(
@@ -441,6 +461,7 @@ function ocean_init_state!(
     Q,
     A,
     coords,
+    center_coords,
     t,
 )
     @inbounds y = coords[2]
@@ -460,6 +481,7 @@ function ocean_init_state!(
     Q,
     A,
     coords,
+    center_coords,
     t,
 )
     Q.U = @SVector [-0, -0]

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -95,8 +95,8 @@ function vars_state(m::SWModel, ::Prognostic, T)
     end
 end
 
-function init_state_prognostic!(m::SWModel, state::Vars, aux::Vars, coords, t)
-    ocean_init_state!(m, m.problem, state, aux, coords, t)
+function init_state_prognostic!(m::SWModel, state::Vars, aux::Vars, coords, center_coords, t)
+    ocean_init_state!(m, m.problem, state, aux, coords, center_coords, t)
 end
 
 function vars_state(m::SWModel, ::Auxiliary, T)

--- a/src/Ocean/SplitExplicit01/BarotropicModel.jl
+++ b/src/Ocean/SplitExplicit01/BarotropicModel.jl
@@ -12,7 +12,14 @@ function vars_state(m::BarotropicModel, ::Prognostic, T)
     end
 end
 
-function init_state_prognostic!(m::BarotropicModel, Q::Vars, A::Vars, coords, t)
+function init_state_prognostic!(
+    m::BarotropicModel,
+    Q::Vars,
+    A::Vars,
+    coords,
+    center_coords,
+    t,
+)
     return ocean_init_state!(m, m.baroclinic.problem, Q, A, coords, t)
 end
 

--- a/src/Ocean/SplitExplicit01/IVDCModel.jl
+++ b/src/Ocean/SplitExplicit01/IVDCModel.jl
@@ -42,7 +42,14 @@ end
 
 vars_state(m::IVDCModel, ::Prognostic, FT) = @vars(θ::FT)
 
-function init_state_prognostic!(m::IVDCModel, Q::Vars, A::Vars, coords, t)
+function init_state_prognostic!(
+    m::IVDCModel,
+    Q::Vars,
+    A::Vars,
+    coords,
+    center_coords,
+    t,
+)
     @inbounds begin
         Q.θ = -0
     end

--- a/src/Ocean/SplitExplicit01/OceanModel.jl
+++ b/src/Ocean/SplitExplicit01/OceanModel.jl
@@ -168,8 +168,15 @@ function vars_state(m::OceanModel, ::Prognostic, T)
     end
 end
 
-function init_state_prognostic!(m::OceanModel, Q::Vars, A::Vars, coords, t)
-    return ocean_init_state!(m, m.problem, Q, A, coords, t)
+function init_state_prognostic!(
+    m::OceanModel,
+    Q::Vars,
+    A::Vars,
+    coords,
+    center_coords,
+    t,
+)
+    return ocean_init_state!(m, m.problem, Q, A, coords, center_coords, t)
 end
 
 function vars_state(m::OceanModel, ::Auxiliary, T)

--- a/test/Atmos/EDMF/bomex_edmf.jl
+++ b/test/Atmos/EDMF/bomex_edmf.jl
@@ -20,6 +20,7 @@ include("edmf_kernels.jl")
             state::Vars,
             aux::Vars,
             coords,
+            center_coords,
             t::Real,
         ) where {FT}
 
@@ -32,6 +33,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t::Real,
 ) where {FT}
     # Aliases:

--- a/test/Atmos/Model/discrete_hydrostatic_balance.jl
+++ b/test/Atmos/Model/discrete_hydrostatic_balance.jl
@@ -53,7 +53,7 @@ function atmos_init_aux!(
     atmos_init_aux!(m.hydrostatic_state, atmos, aux, tmp, geom)
 end
 
-function init_to_ref_state!(problem, bl, state, aux, coords, t)
+function init_to_ref_state!(problem, bl, state, aux, coords, center_coords, t)
     FT = eltype(state)
     state.ρ = aux.ref_state.ρ
     state.ρu = SVector{3, FT}(0, 0, 0)

--- a/test/Atmos/Model/get_atmos_ref_states.jl
+++ b/test/Atmos/Model/get_atmos_ref_states.jl
@@ -26,7 +26,7 @@ function get_atmos_ref_states(nelem_vert, N_poly, RH)
             DecayingTemperatureProfile{FT}(param_set),
             RH,
         ),
-        init_state_prognostic = (problem, bl, state, aux, (x, y, z), t) ->
+        init_state_prognostic = (problem, bl, state, aux, (x, y, z), (xc, yc, zc), t) ->
             nothing,
     )
     driver_config = ClimateMachine.SingleStackConfiguration(

--- a/test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl
@@ -32,7 +32,14 @@ function vars_state(m::KinematicModel, ::Auxiliary, FT)
     end
 end
 
-function init_kinematic_eddy!(eddy_model, state, aux, (x, y, z), t)
+function init_kinematic_eddy!(
+    eddy_model,
+    state,
+    aux,
+    (x, y, z),
+    center_coords,
+    t
+)
     FT = eltype(state)
 
     _grav::FT = grav(param_set)

--- a/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
@@ -46,7 +46,14 @@ function vars_state(m::KinematicModel, ::Auxiliary, FT)
     end
 end
 
-function init_kinematic_eddy!(eddy_model, state, aux, (x, y, z), t)
+function init_kinematic_eddy!(
+    eddy_model,
+    state,
+    aux,
+    (x, y, z),
+    center_coords,
+    t
+)
     FT = eltype(state)
 
     _grav::FT = grav(param_set)

--- a/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
@@ -208,10 +208,11 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t,
     args...,
 )
-    m.init_state_prognostic(m, state, aux, coords, t, args...)
+    m.init_state_prognostic(m, state, aux, coords, center_coords, t, args...)
 end
 
 function boundary_state!(

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -41,7 +41,7 @@ import ClimateMachine.VariableTemplates.varsindex
 #               `C_smag`
 # 8) Default settings can be found in `src/Driver/Configurations.jl`
 # ------------------------ Description ------------------------- #
-function init_risingbubble!(problem, bl, state, aux, (x, y, z), t)
+function init_risingbubble!(problem, bl, state, aux, (x, y, z), (xc, yc, zc), t)
     FT = eltype(state)
     R_gas::FT = R_d(bl.param_set)
     c_p::FT = cp_d(bl.param_set)
@@ -50,10 +50,10 @@ function init_risingbubble!(problem, bl, state, aux, (x, y, z), t)
     p0::FT = MSLP(bl.param_set)
     _grav::FT = grav(bl.param_set)
 
-    xc::FT = 1250
-    yc::FT = 1250
-    zc::FT = 1000
-    r = sqrt((x - xc)^2 + (y - yc)^2 + (z - zc)^2)
+    _xc::FT = 1250
+    _yc::FT = 1250
+    _zc::FT = 1000
+    r = sqrt((x - _xc)^2 + (y - _yc)^2 + (z - _zc)^2)
     rc::FT = 500
     θ_ref::FT = 300
     Δθ::FT = 0

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -27,7 +27,7 @@ using CLIMAParameters.Planet: grav, MSLP
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function init_sin_test!(problem, bl, state, aux, (x, y, z), t)
+function init_sin_test!(problem, bl, state, aux, (x, y, z), (xc, yc, zc), t)
     FT = eltype(state)
 
     z = FT(z)

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -30,7 +30,7 @@ Base.@kwdef struct AcousticWaveSetup{FT}
     nv::Int = 1
 end
 
-function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
+function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, center_coords, t)
     # callable to set initial conditions
     FT = eltype(state)
 

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -13,7 +13,7 @@ using CLIMAParameters.Planet: grav, MSLP
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function init_test!(problem, bl, state, aux, (x, y, z), t)
+function init_test!(problem, bl, state, aux, (x, y, z), (xc, yc, zc), t)
     FT = eltype(state)
 
     z = FT(z)

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -26,7 +26,7 @@ Base.@kwdef struct AcousticWaveSetup{FT}
     nv::Int = 1
 end
 
-function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
+function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, center_coords, t)
     # callable to set initial conditions
     FT = eltype(state)
 

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -41,7 +41,7 @@ include(joinpath(
 total_specific_enthalpy(ts::PhaseDry{FT}, e_tot::FT) where {FT <: Real} =
     zero(FT)
 
-function mms3_init_state!(problem, bl, state::Vars, aux::Vars, (x1, x2, x3), t)
+function mms3_init_state!(problem, bl, state::Vars, aux::Vars, (x1, x2, x3), center_coords, t)
     state.ρ = ρ_g(t, x1, x2, x3, Val(3))
     state.ρu = SVector(
         U_g(t, x1, x2, x3, Val(3)),

--- a/test/Land/Model/haverkamp_implicit_test.jl
+++ b/test/Land/Model/haverkamp_implicit_test.jl
@@ -45,7 +45,7 @@ haverkamp_dataset_path = get_data_folder(haverkamp_dataset)
     ClimateMachine.init()
     FT = Float64
 
-    function init_soil_water!(land, state, aux, coordinates, time)
+    function init_soil_water!(land, state, aux, coordinates, center_coordinates, time)
         myfloat = eltype(aux)
         state.soil.water.ϑ_l = myfloat(land.soil.water.initialϑ_l(aux))
         state.soil.water.θ_i = myfloat(land.soil.water.initialθ_i(aux))

--- a/test/Land/Model/haverkamp_test.jl
+++ b/test/Land/Model/haverkamp_test.jl
@@ -44,7 +44,7 @@ haverkamp_dataset_path = get_data_folder(haverkamp_dataset)
     ClimateMachine.init()
     FT = Float64
 
-    function init_soil_water!(land, state, aux, coordinates, time)
+    function init_soil_water!(land, state, aux, coordinates, center_coordinates, time)
         myfloat = eltype(aux)
         state.soil.water.ϑ_l = myfloat(land.soil.water.initialϑ_l(aux))
         state.soil.water.θ_i = myfloat(land.soil.water.initialθ_i(aux))

--- a/test/Land/Model/heat_analytic_unit_test.jl
+++ b/test/Land/Model/heat_analytic_unit_test.jl
@@ -31,7 +31,7 @@ using ClimateMachine.BalanceLaws:
     ClimateMachine.init()
     FT = Float32
 
-    function init_soil!(land, state, aux, coordinates, time)
+    function init_soil!(land, state, aux, coordinates, center_coords, time)
         myFT = eltype(state)
         ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, time)
         θ_l =

--- a/test/Land/Model/prescribed_twice.jl
+++ b/test/Land/Model/prescribed_twice.jl
@@ -30,7 +30,7 @@ using ClimateMachine.BalanceLaws:
     ClimateMachine.init()
     FT = Float64
 
-    function init_soil_water!(land, state, aux, coordinates, time) end
+    function init_soil_water!(land, state, aux, coordinates, center_coordinates, time) end
 
     soil_water_model = PrescribedWaterModel()
     soil_heat_model = PrescribedTemperatureModel()

--- a/test/Land/Model/test_bc.jl
+++ b/test/Land/Model/test_bc.jl
@@ -30,7 +30,7 @@ using ClimateMachine.BalanceLaws:
 
     FT = Float64
 
-    function init_soil_water!(land, state, aux, coordinates, time)
+    function init_soil_water!(land, state, aux, coordinates, center_coordinates, time)
         myfloat = eltype(state)
         state.soil.water.ϑ_l = myfloat(land.soil.water.initialϑ_l(aux))
         state.soil.water.θ_i = myfloat(land.soil.water.initialθ_i(aux))

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -281,7 +281,7 @@ Base.@kwdef struct AcousticWaveSetup{FT}
     nv::Int = 1
 end
 
-function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
+function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, center_coords, t)
     # callable to set initial conditions
     FT = eltype(state)
 

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -307,7 +307,7 @@ Base.@kwdef struct AcousticWaveSetup{FT}
     nv::Int = 1
 end
 
-function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
+function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, center_coords, t)
     # callable to set initial conditions
     FT = eltype(state)
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -338,6 +338,7 @@ function isentropicvortex_initialcondition!(
     state,
     aux,
     coords,
+    center_coords,
     t,
     args...,
 )

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -310,6 +310,7 @@ function isentropicvortex_initialcondition!(
     state,
     aux,
     coords,
+    center_coords,
     t,
     args...,
 )

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -295,6 +295,7 @@ function isentropicvortex_initialcondition!(
     state,
     aux,
     coords,
+    center_coords,
     t,
     args...,
 )

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -305,6 +305,7 @@ function isentropicvortex_initialcondition!(
     state,
     aux,
     coords,
+    center_coords,
     t,
     args...,
 )

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -318,6 +318,7 @@ function isentropicvortex_initialcondition!(
     state,
     aux,
     coords,
+    center_coords,
     t,
     setup,
 )

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -245,13 +245,14 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t::Real,
 )
-    initial_condition!(m.problem, state, aux, coords, t)
+    initial_condition!(m.problem, state, aux, coords, center_coords, t)
 end
 
 Neumann_data!(problem, ∇state, aux, x, t) = nothing
-Dirichlet_data!(problem, state, aux, x, t) = nothing
+Dirichlet_data!(problem, state, aux, x, xc, t) = nothing
 
 function boundary_state!(
     nf,
@@ -266,7 +267,7 @@ function boundary_state!(
     _...,
 )
     if bctype == 1 # Dirichlet
-        Dirichlet_data!(m.problem, stateP, auxP, auxP.coord, t)
+        Dirichlet_data!(m.problem, stateP, auxP, auxP.coord, nothing, t)
     elseif bctype ∈ (2, 4) # Neumann
         stateP.ρ = stateM.ρ
     elseif bctype == 3 # zero Dirichlet

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
@@ -50,6 +50,7 @@ function initial_condition!(
     state,
     aux,
     x,
+    xc,
     t,
 ) where {n, α, β, μ, δ}
     ξn = dot(n, x)

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bjfnks.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bjfnks.jl
@@ -50,6 +50,7 @@ function initial_condition!(
     state,
     aux,
     x,
+    xc,
     t,
 ) where {n, α, β, μ, δ}
     ξn = dot(n, x)

--- a/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
@@ -60,7 +60,7 @@ function init_velocity_diffusion!(
         +uφ * cos(φ),
     )
 end
-function initial_condition!(::SolidBodyRotation, state, aux, x, t)
+function initial_condition!(::SolidBodyRotation, state, aux, x, xc, t)
     λ = longitude(SphericalOrientation(), aux)
     φ = latitude(SphericalOrientation(), aux)
     state.ρ = exp(-((3λ)^2 + (3φ)^2))
@@ -88,7 +88,7 @@ init_velocity_diffusion!(
     aux::Vars,
     geom::LocalGeometry,
 ) = nothing
-function initial_condition!(::ReversingDeformationalFlow, state, aux, coord, t)
+function initial_condition!(::ReversingDeformationalFlow, state, aux, coord, center_coord, t)
     x, y, z = aux.coord
     r = norm(aux.coord)
     h_max = 0.95

--- a/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
@@ -60,6 +60,7 @@ function initial_condition!(
     state,
     aux,
     x,
+    xc,
     t,
 ) where {adv, diff, dir, topo}
     state.ρ = initial_ρ(topo, x)

--- a/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
@@ -121,9 +121,10 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t::Real,
 )
-    initial_condition!(m.problem, state, aux, coords, t)
+    initial_condition!(m.problem, state, aux, coords, center_coords, t)
 end
 
 boundary_state!(nf, ::HyperDiffusion, _...) = nothing

--- a/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
@@ -44,6 +44,7 @@ function initial_condition!(
     state,
     aux,
     x,
+    xc,
     t,
 ) where {dim, dir}
     @inbounds begin

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
@@ -44,6 +44,7 @@ function initial_condition!(
     state,
     aux,
     x,
+    xc,
     t,
 ) where {n, α, β, μ, δ}
     ξn = dot(n, x)

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
@@ -50,6 +50,7 @@ function initial_condition!(
     state,
     aux,
     x,
+    xc,
     t,
 ) where {n, α, β, μ, δ}
     ξn = dot(n, x)

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
@@ -50,6 +50,7 @@ function initial_condition!(
     state,
     aux,
     x,
+    xc,
     t,
 ) where {n, α, β, μ, δ}
     ξn = dot(n, x)

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_heat_eqn.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_heat_eqn.jl
@@ -48,6 +48,7 @@ function initial_condition!(
     state,
     aux,
     x,
+    xc,
     t,
 ) where {n, κ, A}
     ξn = dot(n, x)

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -68,6 +68,7 @@ function Initialise_Density_Current!(
     state::Vars,
     aux::Vars,
     (x1, x2, x3),
+    (xc1, xc2, xc3),
     t,
 )
     FT = eltype(state)

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -44,7 +44,7 @@ using ClimateMachine.Atmos
 total_specific_enthalpy(ts::PhaseDry{FT}, e_tot::FT) where {FT <: Real} =
     zero(FT)
 
-function mms2_init_state!(problem, bl, state::Vars, aux::Vars, (x1, x2, x3), t)
+function mms2_init_state!(problem, bl, state::Vars, aux::Vars, (x1, x2, x3), center_coords, t)
     state.ρ = ρ_g(t, x1, x2, x3, Val(2))
     state.ρu = SVector(
         U_g(t, x1, x2, x3, Val(2)),
@@ -73,7 +73,7 @@ function mms2_source!(
     source.ρe = SE_g(t, x1, x2, x3, Val(2))
 end
 
-function mms3_init_state!(problem, bl, state::Vars, aux::Vars, (x1, x2, x3), t)
+function mms3_init_state!(problem, bl, state::Vars, aux::Vars, (x1, x2, x3), center_coords, t)
     state.ρ = ρ_g(t, x1, x2, x3, Val(3))
     state.ρu = SVector(
         U_g(t, x1, x2, x3, Val(3)),

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
@@ -159,7 +159,7 @@ function boundary_state!(
     t,
     _...,
 )
-    init_state_prognostic!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
+    init_state_prognostic!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), nothing, t)
 end
 
 # FIXME: This is probably not right....
@@ -179,7 +179,7 @@ function boundary_state!(
     t,
     _...,
 )
-    init_state_prognostic!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
+    init_state_prognostic!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), nothing, t)
 end
 
 function nodal_init_state_auxiliary!(
@@ -199,6 +199,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     (x1, x2, x3),
+    center_coords,
     t,
 ) where {dim}
     state.ρ = ρ_g(t, x1, x2, x3, Val(dim))

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -72,6 +72,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coord,
+    center_coord,
     t,
 )
     state.q = rand()

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -28,7 +28,7 @@ const param_set = EarthParameterSet()
 const p∞ = 10^5
 const T∞ = 300.0
 
-function initialcondition!(problem, bl, state, aux, coords, t)
+function initialcondition!(problem, bl, state, aux, coords, center_coords, t)
     FT = eltype(state)
 
     translation_speed::FT = 150

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -490,7 +490,7 @@ Base.@kwdef struct RemainderTestSetup{FT}
     T_ref::FT = 300
 end
 
-function (setup::RemainderTestSetup)(problem, bl, state, aux, coords, t)
+function (setup::RemainderTestSetup)(problem, bl, state, aux, coords, center_coords, t)
     FT = eltype(state)
 
     # Vary around the reference state by 10% and a random velocity field

--- a/test/Numerics/DGMethods/vars_test.jl
+++ b/test/Numerics/DGMethods/vars_test.jl
@@ -47,6 +47,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coord,
+    center_coord,
     t::Real,
 )
     @inbounds state.x = coord[1]

--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -130,6 +130,7 @@ function ClimateMachine.BalanceLaws.init_state_prognostic!(
     state::Vars,
     aux::Vars,
     (x, y, z),
+    (xc, yc, zc),
     filter_direction,
     dim,
 )
@@ -221,6 +222,7 @@ function ClimateMachine.BalanceLaws.init_state_prognostic!(
     state::Vars,
     aux::Vars,
     (x, y, z),
+    (xc, yc, zc)
 )
     state.q = abs(x) - 0.1
 end

--- a/test/Numerics/Mesh/filter_TMAR.jl
+++ b/test/Numerics/Mesh/filter_TMAR.jl
@@ -56,7 +56,7 @@ init_velocity_diffusion!(::SwirlingFlow, aux::Vars, geom::LocalGeometry) =
 
 cosbell(τ, q) = τ ≤ 1 ? ((1 + cospi(τ)) / 2)^q : zero(τ)
 
-function initial_condition!(::SwirlingFlow, state, aux, coord, t)
+function initial_condition!(::SwirlingFlow, state, aux, coord, center_coord, t)
     FT = eltype(state)
     x, y, _ = aux.coord
     x0, y0 = FT(1 // 4), FT(1 // 4)

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -40,6 +40,7 @@ function Initialize_Brick_Interpolation_Test!(
     state::Vars,
     aux::Vars,
     (x, y, z),
+    (xc, yc, zc),
     t,
 )
     FT = eltype(state)
@@ -64,7 +65,7 @@ struct TestSphereSetup{DT}
     end
 end
 #----------------------------------------------------------------------------
-function (setup::TestSphereSetup)(problem, bl, state, aux, coords, t)
+function (setup::TestSphereSetup)(problem, bl, state, aux, coords, center_coords, t)
     # callable to set initial conditions
     FT = eltype(state)
     _grav::FT = grav(param_set)

--- a/test/Numerics/SystemSolvers/bandedsystem.jl
+++ b/test/Numerics/SystemSolvers/bandedsystem.jl
@@ -51,6 +51,7 @@ function initial_condition!(
     state,
     aux,
     x,
+    xc,
     t,
 ) where {n, α, β, μ, δ}
     ξn = dot(n, x)

--- a/test/Numerics/SystemSolvers/poisson.jl
+++ b/test/Numerics/SystemSolvers/poisson.jl
@@ -154,6 +154,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t,
 ) where {dim}
     state.ϕ = prod(sol1d, view(coords, 1:dim))

--- a/test/Ocean/SplitExplicit/simple_box_2dt.jl
+++ b/test/Ocean/SplitExplicit/simple_box_2dt.jl
@@ -87,7 +87,7 @@ end
     return ocean_boundary_state!(m, CoastlineNoSlip(), x...)
 end
 
-function ocean_init_state!(p::SimpleBox, Q, A, coords, t)
+function ocean_init_state!(p::SimpleBox, Q, A, coords, center_coords, t)
     @inbounds y = coords[2]
     @inbounds z = coords[3]
     @inbounds H = p.H

--- a/test/Utilities/SingleStackUtils/ssu_tests.jl
+++ b/test/Utilities/SingleStackUtils/ssu_tests.jl
@@ -50,6 +50,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t::Real,
 )
     z = aux.z

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -111,7 +111,15 @@ const param_set = EarthParameterSet()
 #md #     - `state.ρu`= 3-component vector for initial momentum profile
 #md #     - `state.ρe`= Scalar quantity for initial total-energy profile
 #md #       humidity
-function init_agnesi_hs_lin!(problem, bl, state, aux, (x, y, z), t)
+function init_agnesi_hs_lin!(
+    problem,
+    bl,
+    state,
+    aux,
+    (x, y, z),
+    (xc, yc, zc),
+    t,
+)
     ## Problem float-type
     FT = eltype(state)
 

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -107,7 +107,15 @@ const param_set = EarthParameterSet()
 #md #     - `state.ρu`= 3-component vector for initial momentum profile
 #md #     - `state.ρe`= Scalar quantity for initial total-energy profile
 #md #       humidity
-function init_agnesi_hs_lin!(problem, bl, state, aux, (x, y, z), t)
+function init_agnesi_hs_lin!(
+    problem,
+    bl,
+    state,
+    aux,
+    (x, y, z),
+    (xc, yc, zc),
+    t,
+)
     ## Problem float-type
     FT = eltype(state)
 

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -246,6 +246,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t::Real,
 )
     z = aux.coord[3]

--- a/tutorials/Atmos/burgers_single_stack_bjfnk.jl
+++ b/tutorials/Atmos/burgers_single_stack_bjfnk.jl
@@ -247,6 +247,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t::Real,
 )
     z = aux.coord[3]

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -87,7 +87,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 # - Required so functions for computation of temperature profiles.
 using ClimateMachine.TemperatureProfiles
-# - Required so functions for computation of moist thermodynamic quantities and turbulence closures 
+# - Required so functions for computation of moist thermodynamic quantities and turbulence closures
 # are available.
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TurbulenceClosures
@@ -127,7 +127,15 @@ const param_set = EarthParameterSet()
 #md #     - `state.tracers.ρχ` = Vector of four tracers (here, for demonstration
 #md #       only; we can interpret these as dye injections for visualisation
 #md #       purposes)
-function init_densitycurrent!(problem, bl, state, aux, (x, y, z), t)
+function init_densitycurrent!(
+    problem,
+    bl,
+    state,
+    aux,
+    (x, y, z),
+    center_coordinates,
+    t,
+)
     ## Problem float-type
     FT = eltype(state)
 

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -62,7 +62,7 @@ struct DryRayleighBenardConvectionDataConfig{FT}
 end
 
 # Define initial condition kernel
-function init_problem!(problem, bl, state, aux, (x, y, z), t)
+function init_problem!(problem, bl, state, aux, (x, y, z), (xc, yc, zc), t)
     dc = bl.data_config
     FT = eltype(state)
 

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -112,7 +112,15 @@ end;
 # state of our model run. In our case, we use the reference state of the
 # simulation (defined below) and add a little bit of noise. Note that the
 # initial states includes a zero initial velocity field.
-function init_heldsuarez!(problem, balance_law, state, aux, coordinates, time)
+function init_heldsuarez!(
+    problem,
+    balance_law,
+    state,
+    aux,
+    coordinates,
+    center_coordinates,
+    time,
+)
     FT = eltype(state)
 
     ## Set initial state to reference state with random perturbation

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -3,7 +3,7 @@
 # In this example, we demonstrate the usage of the `ClimateMachine`
 # [AtmosModel](@ref AtmosModel-docs) machinery to solve the fluid
 # dynamics of a thermal perturbation in a neutrally stratified background state
-# defined by its uniform potential temperature. We solve a flow in a box configuration - 
+# defined by its uniform potential temperature. We solve a flow in a box configuration -
 # this is representative of a large-eddy simulation. Several versions of the problem
 # setup may be found in literature, but the general idea is to examine the
 # vertical ascent of a thermal bubble (we can interpret these as simple
@@ -108,7 +108,15 @@ const param_set = EarthParameterSet();
 #md #     - `state.tracers.ρχ` = Vector of four tracers (here, for demonstration
 #md #       only; we can interpret these as dye injections for visualization
 #md #       purposes)
-function init_risingbubble!(problem, bl, state, aux, (x, y, z), t)
+function init_risingbubble!(
+    problem,
+    bl,
+    state,
+    aux,
+    (x, y, z),
+    center_coordinates,
+    t,
+)
     ## Problem float-type
     FT = eltype(state)
 
@@ -177,7 +185,7 @@ end
 # appropriate to the problem being considered.
 function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
 
-    ## Choose an Explicit Single-rate Solver from the existing [`ODESolvers`](@ref ClimateMachine.ODESolvers) options. 
+    ## Choose an Explicit Single-rate Solver from the existing [`ODESolvers`](@ref ClimateMachine.ODESolvers) options.
     ## Apply the outer constructor to define the `ode_solver`.
     ## The 1D-IMEX method is less appropriate for the problem given the current
     ## mesh aspect ratio (1:1).
@@ -316,19 +324,19 @@ end
 # `julia --project tutorials/Atmos/risingbubble.jl` will run the
 # experiment from the main ClimateMachine.jl directory, with diagnostics output
 # at the intervals specified in [`config_diagnostics`](@ref
-# config_diagnostics).  You can also prescribe command line arguments for 
+# config_diagnostics).  You can also prescribe command line arguments for
 # simulation update and output specifications.  For
 # rapid turnaround, we recommend that you run this experiment on a GPU.
 
-# VTK output can be controlled via command line by 
+# VTK output can be controlled via command line by
 # setting `parse_clargs=true` in the `ClimateMachine.init`
-# arguments, and then using `--vtk=<interval>`. 
+# arguments, and then using `--vtk=<interval>`.
 
 # ## [Output Visualisation](@id output-viz)
 # See the `ClimateMachine` API interface documentation
 # for generating output.
-# 
-# 
+#
+#
 # - [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit/)
 # - [Paraview](https://wci.llnl.gov/simulation/computer-codes/visit/)
 # are two commonly used programs for `.vtu` files.

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -177,6 +177,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t::Real,
 )
     state.ρcT = m.ρc * aux.T

--- a/tutorials/Land/Soil/Coupled/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Coupled/equilibrium_test.jl
@@ -259,7 +259,7 @@ bottom_heat_state = nothing;
 # specified functions of space for `T_init` and `ϑ_l0` and initializes the state
 # variables of volumetric internal energy and augmented liquid fraction. This requires
 # a conversion from `T` to `ρe_int`.
-function init_soil!(land, state, aux, coordinates, time)
+function init_soil!(land, state, aux, coordinates, center_coordinates, time)
     myFT = eltype(state)
     ϑ_l = myFT(land.soil.water.initialϑ_l(aux))
     θ_i = myFT(land.soil.water.initialθ_i(aux))

--- a/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
+++ b/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
@@ -283,7 +283,7 @@ T_init = (aux) -> eltype(aux)(275.15);
 # conditions for heat based on the temperature - `init_soil!` also
 # converts between `T` and `ρe_int`.
 
-function init_soil!(land, state, aux, coordinates, time)
+function init_soil!(land, state, aux, coordinates, center_coordinates, time)
     ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, time)
     θ_l = volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
     ρc_ds = land.soil.param_functions.ρc_ds

--- a/tutorials/Land/Soil/Water/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Water/equilibrium_test.jl
@@ -104,7 +104,14 @@ sources = ()
 # in turn calls the functions supplied to soil_water_model. The default
 # initialization for ice is zero volumetric ice fraction. This should not
 # be altered unless freeze thaw is added.
-function init_soil_water!(land, state, aux, coordinates, time)
+function init_soil_water!(
+    land,
+    state,
+    aux,
+    coordinates,
+    center_coordinates,
+    time,
+)
     FT = eltype(state)
     state.soil.water.ϑ_l = FT(land.soil.water.initialϑ_l(aux))
     state.soil.water.θ_i = FT(land.soil.water.initialθ_i(aux))

--- a/tutorials/Numerics/DGMethods/Box1D.jl
+++ b/tutorials/Numerics/DGMethods/Box1D.jl
@@ -75,6 +75,7 @@ function init_state_prognostic!(
     state::Vars,
     aux::Vars,
     coords,
+    center_coords,
     t::Real,
 )
     if aux.z_dim >= 75 && aux.z_dim <= 125


### PR DESCRIPTION
# Description

This adds center coordinates to init_state_prognostic function. I need them for my prescribed flow ice microphysics tests.

In general it would  be nice to not have to pass all the unused arguments to the init_state functions. There are many unused arguments passed around in many inits.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
