### PR TITLE
Testing three-line change hacky approach for index coords in aux that I am finding useful in inner code debug, and that may be useful for others?

### DIFF
--- a/src/Numerics/Mesh/Geometry.jl
+++ b/src/Numerics/Mesh/Geometry.jl
@@ -41,6 +41,10 @@ struct LocalGeometry{T, P}
     coord::SVector{3, T}
     "Jacobian from Cartesian to element coordinates: `invJ[i,j]` is ``∂ξ_i/∂x_j``"
     invJ::SMatrix{3, 3, T, 9}
+    "element local node index"
+    n::Integer
+    "process local element index"
+    e::Integer
 end
 
 function LocalGeometry(
@@ -56,7 +60,7 @@ function LocalGeometry(
         vgeo[n, _ξ3x1, e] vgeo[n, _ξ3x2, e] vgeo[n, _ξ3x3, e]
     ]
 
-    LocalGeometry(polynomial, coord, invJ)
+    LocalGeometry(polynomial, coord, invJ, n, e)
 end
 
 """


### PR DESCRIPTION
# Description

Test impact of small change that adds index information I have been finding useful for 

- kernel debugging/verification and 
- precise inner numerical term budgets 

with aux variables e.g.

```
function ocean_init_aux!(::SWModel, ::AbstractSimpleBoxProblem, A, geom)
    @inbounds A.y = geom.coord[2]

    A.Gᵁ = @SVector [-0, -0]
    A.Δu = @SVector [-0, -0]
    @mydebug A.n  = geom.n
    @mydebug A.e  = geom.e

    return nothing
end

```

```
@inline function compute_gradient_flux!(
    m::SWModel,
    T::ConstantViscosity,
    σ::Vars,
    δ::Grad,
    q::Vars,
    α::Vars,
    t::Real,
)
    ν = Diagonal(@SVector [T.ν, T.ν, -0])
    ∇U = δ.∇U
    σ.ν∇U = -ν * ∇U

    @mydebug my_save_grad_u(m, q.U, ∇U, ν, -ν * ∇U, α.n, α.e )

    return nothing
end
```

Change to LocalGeom may also be useful to others who are interested in knowing inner term
values for both debugging and precise budget analysis, so testing in PR to see.....


