### PR TITLE
Use `LocalGeometry` in `init_state_prognostic!`

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -23,7 +23,7 @@ ClimateMachine.BalanceLaws.flux_first_order!(m::AtmosModel, flux::Grad, state::V
 ClimateMachine.BalanceLaws.flux_second_order!(atmos::AtmosModel, flux::Grad, state::Vars, diffusive::Vars, hyperdiffusive::Vars, aux::Vars, t::Real)
 ClimateMachine.BalanceLaws.init_state_auxiliary!(m::AtmosModel, state_auxiliary::MPIStateArray, grid, direction)
 ClimateMachine.BalanceLaws.source!(m::AtmosModel, source::Vars, state::Vars, diffusive::Vars, aux::Vars, t::Real, direction)
-ClimateMachine.BalanceLaws.init_state_prognostic!(m::AtmosModel, state::Vars, aux::Vars, coords, t, args...)
+ClimateMachine.BalanceLaws.init_state_prognostic!(m::AtmosModel, state::Vars, aux::Vars, localgeo, t, args...)
 ```
 
 ## Reference states

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -39,7 +39,7 @@ using CLIMAParameters.Planet:
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function init_heldsuarez!(problem, bl, state, aux, coords, t)
+function init_heldsuarez!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     # parameters 

--- a/experiments/AtmosGCM/isothermal_zonal_flow.jl
+++ b/experiments/AtmosGCM/isothermal_zonal_flow.jl
@@ -32,7 +32,7 @@ CLIMAParameters.Planet.Omega(::EarthParameterSet) = 0.0
 CLIMAParameters.Planet.planet_radius(::EarthParameterSet) = 6.371e6 / 125.0
 CLIMAParameters.Planet.MSLP(::EarthParameterSet) = 1e5
 
-function init_isothermal_zonal_flow!(problem, bl, state, aux, coords, t)
+function init_isothermal_zonal_flow!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     φ = latitude(bl.orientation, aux)

--- a/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
+++ b/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
@@ -40,7 +40,7 @@ CLIMAParameters.Planet.press_triple(::EarthParameterSet) = 610.78
 # driver-specific parameters added here
 T_sfc_pole(::EarthParameterSet) = 271.0
 
-function init_baroclinic_wave!(problem, bl, state, aux, coords, t)
+function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     # parameters

--- a/experiments/AtmosGCM/nonhydrostatic_gravity_wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic_gravity_wave.jl
@@ -33,7 +33,7 @@ CLIMAParameters.Planet.planet_radius(::EarthParameterSet) = 6.371e6 / 125.0
 CLIMAParameters.Planet.MSLP(::EarthParameterSet) = 1e5
 
 
-function init_nonhydrostatic_gravity_wave!(problem, bl, state, aux, coords, t)
+function init_nonhydrostatic_gravity_wave!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     # grid

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -288,7 +288,8 @@ end
 """
   Initial Condition for BOMEX LES
 """
-function init_bomex!(problem, bl, state, aux, (x, y, z), t)
+function init_bomex!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
     # This experiment runs the BOMEX LES Configuration
     # (Shallow cumulus cloud regime)
     # x,y,z imply eastward, northward and altitude coordinates in `[m]`
@@ -382,7 +383,7 @@ function init_bomex!(problem, bl, state, aux, (x, y, z), t)
         state.ρe += rand() * ρe_tot / 100
         state.moisture.ρq_tot += rand() * ρ * q_tot / 100
     end
-    init_state_prognostic!(bl.turbconv, bl, state, aux, (x, y, z), t)
+    init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
 end
 
 function bomex_model(

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -193,8 +193,10 @@ URL = {https://doi.org/10.1175/MWR2930.1},
 eprint = {https://doi.org/10.1175/MWR2930.1}
 }
 """
-function init_dycoms!(problem, bl, state, aux, (x, y, z), t)
+function init_dycoms!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
+
+    (x, y, z) = localgeo.coord
 
     z = altitude(bl, aux)
 

--- a/experiments/AtmosLES/schar_scalar_advection.jl
+++ b/experiments/AtmosLES/schar_scalar_advection.jl
@@ -44,9 +44,11 @@ const param_set = EarthParameterSet()
 #}
 
 # ## [Initial Conditions]
-function init_schar!(problem, bl, state, aux, (x, y, z), t)
+function init_schar!(problem, bl, state, aux, localgeo, t)
     ## Problem float-type
     FT = eltype(state)
+
+    (x, y, z) = localgeo.coord
 
     ## Unpack constant parameters
     R_gas::FT = R_d(bl.param_set)

--- a/experiments/AtmosLES/stable_bl_kosovic.jl
+++ b/experiments/AtmosLES/stable_bl_kosovic.jl
@@ -150,7 +150,8 @@ end
 """
   Initial Condition for StableBoundaryLayer LES
 """
-function init_problem!(problem, bl, state, aux, (x, y, z), t)
+function init_problem!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
     # Problem floating point precision
     FT = eltype(state)
     R_gas::FT = R_d(bl.param_set)

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -39,7 +39,8 @@ const param_set = EarthParameterSet()
 """
   Surface Driven Thermal Bubble
 """
-function init_surfacebubble!(problem, bl, state, aux, (x, y, z), t)
+function init_surfacebubble!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
     FT = eltype(state)
     R_gas::FT = R_d(bl.param_set)
     c_p::FT = cp_d(bl.param_set)

--- a/experiments/AtmosLES/taylor_green.jl
+++ b/experiments/AtmosLES/taylor_green.jl
@@ -65,7 +65,9 @@ journal = {AIAA Aviation 7th AIAA theoretical fluid mechanics conference},
 year = {2014},
 }
 """
-function init_greenvortex!(problem, bl, state, aux, (x, y, z), t)
+function init_greenvortex!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     # Problem float-type
     FT = eltype(state)
 

--- a/experiments/AtmosLES/unstable_bl_kitamura.jl
+++ b/experiments/AtmosLES/unstable_bl_kitamura.jl
@@ -152,7 +152,9 @@ end
 """
   Initial Condition for UnstableBoundaryLayer LES
 """
-function init_problem!(problem, bl, state, aux, (x, y, z), t)
+function init_problem!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     # Problem floating point precision
     FT = eltype(state)
     R_gas::FT = R_d(bl.param_set)

--- a/experiments/TestCase/baroclinic_wave.jl
+++ b/experiments/TestCase/baroclinic_wave.jl
@@ -27,7 +27,7 @@ using CLIMAParameters.Planet: MSLP, R_d, day, grav, Omega, planet_radius
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function init_baroclinic_wave!(problem, bl, state, aux, coords, t)
+function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     # parameters

--- a/experiments/TestCase/risingbubble.jl
+++ b/experiments/TestCase/risingbubble.jl
@@ -20,9 +20,11 @@ using CLIMAParameters.Planet: R_d, cp_d, cv_d, MSLP, grav
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet();
 
-function init_risingbubble!(problem, bl, state, aux, (x, y, z), t)
+function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     ## Problem float-type
     FT = eltype(state)
+
+    (x, y, z) = localgeo.coord
 
     ## Unpack constant parameters
     R_gas::FT = R_d(bl.param_set)

--- a/experiments/TestCase/solid_body_rotation.jl
+++ b/experiments/TestCase/solid_body_rotation.jl
@@ -27,7 +27,7 @@ using CLIMAParameters.Planet: day, planet_radius
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function init_solid_body_rotation!(problem, bl, state, aux, coords, t)
+function init_solid_body_rotation!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     # initial velocity profile (we need to transform the vector into the Cartesian

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -747,7 +747,7 @@ end
         m::AtmosModel,
         state::Vars,
         aux::Vars,
-        coords,
+        localgeo,
         t,
         args...,
     )
@@ -760,7 +760,7 @@ function init_state_prognostic!(
     m::AtmosModel,
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t,
     args...,
 )
@@ -769,7 +769,7 @@ function init_state_prognostic!(
         m,
         state,
         aux,
-        coords,
+        localgeo,
         t,
         args...,
     )

--- a/src/Atmos/Model/bc_initstate.jl
+++ b/src/Atmos/Model/bc_initstate.jl
@@ -1,3 +1,4 @@
+using ..Mesh.Grids: _x1, _x2, _x3
 """
     InitStateBC
 
@@ -21,7 +22,8 @@ function atmos_boundary_state!(
     t,
     _...,
 )
-    init_state_prognostic!(m, state⁺, aux⁺, aux⁺.coord, t)
+    # Put cood in a NamedTuple to mimmic LocalGeometry
+    init_state_prognostic!(m, state⁺, aux⁺, (coord = aux⁺.coord,), t)
 end
 
 function atmos_normal_boundary_flux_second_order!(
@@ -78,5 +80,6 @@ function boundary_state!(
     t,
     args...,
 )
-    init_state_prognostic!(m, state⁺, aux⁺, aux⁺.coord, t)
+    # Put cood in a NamedTuple to mimmic LocalGeometry
+    init_state_prognostic!(m, state⁺, aux⁺, (coord = aux⁺.coord,), t)
 end

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -180,7 +180,7 @@ init_state_prognostic!(
     lm::AtmosLinearModel,
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t,
 ) = nothing
 

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -146,7 +146,7 @@ function init_state_prognostic!(
     ::PressureGradientModel,
     state::Vars,
     aux::Vars,
-    coord,
+    localgeo,
     t,
 ) end
 function flux_first_order!(

--- a/src/BalanceLaws/Problems.jl
+++ b/src/BalanceLaws/Problems.jl
@@ -19,7 +19,7 @@ abstract type AbstractProblem end
         ::BalanceLaw,
         state_prognostic::Vars,
         state_auxiliary::Vars,
-        coords,
+        localgeo,
         t,
         args...,
     )

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -68,7 +68,7 @@ vars_state(::BalanceLaw, ::AbstractStateType, FT) = @vars()
         ::BL,
         state_prognostic::Vars,
         state_auxiliary::Vars,
-        coords,
+        localgeo,
         args...,
     )
 

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -142,7 +142,7 @@ function init_state_prognostic!(
     bl::BalanceLaw,
     state,
     aux,
-    (x, y, z),
+    localgeo,
     t,
 ) end
 

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -1500,7 +1500,6 @@ end
     n = (I - 1) % Np + 1
 
     @inbounds begin
-        coords = SVector(vgeo[n, _x1, e], vgeo[n, _x2, e], vgeo[n, _x3, e])
         @unroll for s in 1:num_state_auxiliary
             local_state_auxiliary[s] = state_auxiliary[n, s, e]
         end
@@ -1513,7 +1512,7 @@ end
             Vars{vars_state(balance_law, Auxiliary(), FT)}(
                 local_state_auxiliary,
             ),
-            coords,
+            LocalGeometry{Np, N}(vgeo, n, e),
             args...,
         )
         @unroll for s in 1:num_state_prognostic

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -1574,7 +1574,7 @@ See [`BalanceLaw`](@ref) for usage.
                 local_state_auxiliary,
             ),
             Vars{vars_state_temporary}(local_state_temporary),
-            LocalGeometry(Val(polyorder), vgeo, n, e),
+            LocalGeometry{Np, N}(vgeo, n, e),
         )
 
         @unroll for s in 1:num_state_auxiliary

--- a/src/Numerics/Mesh/Geometry.jl
+++ b/src/Numerics/Mesh/Geometry.jl
@@ -62,15 +62,18 @@ struct LocalGeometry{Np, N, AT, IT}
         new{Np, N, AT, IT}(vgeo, n, e)
 end
 
-function Base.getproperty(geo::LocalGeometry{Np, N}, sym::Symbol) where {Np, N}
+@inline function Base.getproperty(
+    geo::LocalGeometry{Np, N},
+    sym::Symbol,
+) where {Np, N}
     if sym === :polyorder
         return N
     elseif sym === :coord
-        vgeo, n, e = geo.vgeo, geo.n, geo.e
+        vgeo, n, e = getfield(geo, :vgeo), getfield(geo, :n), getfield(geo, :e)
         FT = eltype(vgeo)
         return @SVector FT[vgeo[n, _x1, e], vgeo[n, _x2, e], vgeo[n, _x3, e]]
     elseif sym === :invJ
-        vgeo, n, e = geo.vgeo, geo.n, geo.e
+        vgeo, n, e = getfield(geo, :vgeo), getfield(geo, :n), getfield(geo, :e)
         FT = eltype(vgeo)
         return @SMatrix FT[
             vgeo[n, _ξ1x1, e] vgeo[n, _ξ1x2, e] vgeo[n, _ξ1x3, e]
@@ -78,7 +81,7 @@ function Base.getproperty(geo::LocalGeometry{Np, N}, sym::Symbol) where {Np, N}
             vgeo[n, _ξ3x1, e] vgeo[n, _ξ3x2, e] vgeo[n, _ξ3x3, e]
         ]
     elseif sym === :center_coord
-        vgeo, n, e = geo.vgeo, geo.n, geo.e
+        vgeo, n, e = getfield(geo, :vgeo), getfield(geo, :n), getfield(geo, :e)
         FT = eltype(vgeo)
         coords = SVector(vgeo[n, _x1, e], vgeo[n, _x2, e], vgeo[n, _x3, e])
         V = FT(0)

--- a/src/Numerics/Mesh/Geometry.jl
+++ b/src/Numerics/Mesh/Geometry.jl
@@ -101,9 +101,9 @@ end
 """
     resolutionmetric(g::LocalGeometry)
 
-The metric tensor of the discretisation resolution. Given a unit vector `u` in Cartesian
-coordinates and `M = resolutionmetric(g)`, `sqrt(u'*M*u)` is the degree-of-freedom density
-in the direction of `u`.
+The metric tensor of the discretisation resolution. Given a unit vector `u` in
+Cartesian coordinates and `M = resolutionmetric(g)`, `sqrt(u'*M*u)` is the
+degree-of-freedom density in the direction of `u`.
 """
 function resolutionmetric(g::LocalGeometry)
     S = g.polyorder * g.invJ / 2

--- a/src/Numerics/Mesh/Geometry.jl
+++ b/src/Numerics/Mesh/Geometry.jl
@@ -1,6 +1,7 @@
 module Geometry
 
 using StaticArrays, LinearAlgebra, DocStringExtensions
+using KernelAbstractions.Extras: @unroll
 using ..Grids:
     _ξ1x1,
     _ξ2x1,
@@ -17,6 +18,7 @@ using ..Grids:
     _x2,
     _x3,
     _JcV
+
 export LocalGeometry, lengthscale, resolutionmetric
 
 """
@@ -26,41 +28,74 @@ The local geometry at a nodal point.
 
 # Constructors
 
-    LocalGeometry(polynomial::Val, vgeo::AbstractArray{T}, n::Integer, e::Integer)
+    LocalGeometry{Np, N}(vgeo::AbstractArray{T}, n::Integer, e::Integer)
 
-Extracts a `LocalGeometry` object from the `vgeo` array at node `n` in element `e`.
+Extracts a `LocalGeometry` object from the `vgeo` array at node `n` in element
+`e` with `Np` being the number of points in the element and `N` being the
+polynomial order
 
 # Fields
 
+- `polyorder`
+
+   polynomial order of the element
+
+- `coord`
+
+   local degree of freedom Cartesian coordinate 
+
+- `invJ`
+
+   Jacobian from Cartesian to element coordinates: `invJ[i,j]` is ``∂ξ_i / ∂x_j``
+
 $(DocStringExtensions.FIELDS)
 """
-struct LocalGeometry{T, P}
-    "Polynomial interpolant: currently this is assumed to be `Val{polyorder}`, but this may change in future."
-    polynomial::P
-    "Cartesian coordinates"
-    coord::SVector{3, T}
-    "Jacobian from Cartesian to element coordinates: `invJ[i,j]` is ``∂ξ_i/∂x_j``"
-    invJ::SMatrix{3, 3, T, 9}
-    "element local node index"
-    n::Integer
+struct LocalGeometry{Np, N, AT, IT}
+    "Global volume geometry array"
+    vgeo::AT
+    "element local linear node index"
+    n::IT
     "process local element index"
-    e::Integer
+    e::IT
+
+    LocalGeometry{Np, N}(vgeo::AT, n::IT, e::IT) where {Np, N, AT, IT} =
+        new{Np, N, AT, IT}(vgeo, n, e)
 end
 
-function LocalGeometry(
-    polynomial::Val,
-    vgeo::AbstractArray{T},
-    n::Integer,
-    e::Integer,
-) where {T}
-    coord = @SVector T[vgeo[n, _x1, e], vgeo[n, _x2, e], vgeo[n, _x3, e]]
-    invJ = @SMatrix T[
-        vgeo[n, _ξ1x1, e] vgeo[n, _ξ1x2, e] vgeo[n, _ξ1x3, e]
-        vgeo[n, _ξ2x1, e] vgeo[n, _ξ2x2, e] vgeo[n, _ξ2x3, e]
-        vgeo[n, _ξ3x1, e] vgeo[n, _ξ3x2, e] vgeo[n, _ξ3x3, e]
-    ]
-
-    LocalGeometry(polynomial, coord, invJ, n, e)
+function Base.getproperty(geo::LocalGeometry{Np, N}, sym::Symbol) where {Np, N}
+    if sym === :polyorder
+        return N
+    elseif sym === :coord
+        vgeo, n, e = geo.vgeo, geo.n, geo.e
+        FT = eltype(vgeo)
+        return @SVector FT[vgeo[n, _x1, e], vgeo[n, _x2, e], vgeo[n, _x3, e]]
+    elseif sym === :invJ
+        vgeo, n, e = geo.vgeo, geo.n, geo.e
+        FT = eltype(vgeo)
+        return @SMatrix FT[
+            vgeo[n, _ξ1x1, e] vgeo[n, _ξ1x2, e] vgeo[n, _ξ1x3, e]
+            vgeo[n, _ξ2x1, e] vgeo[n, _ξ2x2, e] vgeo[n, _ξ2x3, e]
+            vgeo[n, _ξ3x1, e] vgeo[n, _ξ3x2, e] vgeo[n, _ξ3x3, e]
+        ]
+    elseif sym === :center_coord
+        vgeo, n, e = geo.vgeo, geo.n, geo.e
+        FT = eltype(vgeo)
+        coords = SVector(vgeo[n, _x1, e], vgeo[n, _x2, e], vgeo[n, _x3, e])
+        V = FT(0)
+        xc = FT(0)
+        yc = FT(0)
+        zc = FT(0)
+        @unroll for i in 1:Np
+            M = vgeo[i, _M, e]
+            V += M
+            xc += M * vgeo[i, _x1, e]
+            yc += M * vgeo[i, _x2, e]
+            zc += M * vgeo[i, _x3, e]
+        end
+        return SVector(xc / V, yc / V, zc / V)
+    else
+        return getfield(geo, sym)
+    end
 end
 
 """
@@ -70,10 +105,8 @@ The metric tensor of the discretisation resolution. Given a unit vector `u` in C
 coordinates and `M = resolutionmetric(g)`, `sqrt(u'*M*u)` is the degree-of-freedom density
 in the direction of `u`.
 """
-function resolutionmetric(
-    g::LocalGeometry{T, Val{polyorder}},
-) where {T, polyorder}
-    S = polyorder * g.invJ / 2
+function resolutionmetric(g::LocalGeometry)
+    S = g.polyorder * g.invJ / 2
     S' * S # TODO: return an eigendecomposition / symmetric object?
 end
 
@@ -82,8 +115,6 @@ end
 
 The effective grid resolution at the point.
 """
-function lengthscale(g::LocalGeometry{T, Val{polyorder}}) where {T, polyorder}
-    2 / (cbrt(det(g.invJ)) * polyorder)
-end
+lengthscale(g::LocalGeometry) = 2 / (cbrt(det(g.invJ)) * g.polyorder)
 
 end # module

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -147,8 +147,8 @@ end
 sets the initial value for state variables
 dispatches to ocean_init_state! which is defined in a problem file such as SimpleBoxProblem.jl
 """
-function init_state_prognostic!(m::HBModel, Q::Vars, A::Vars, coords, t)
-    return ocean_init_state!(m, m.problem, Q, A, coords, t)
+function init_state_prognostic!(m::HBModel, Q::Vars, A::Vars, localgeo, t)
+    return ocean_init_state!(m, m.problem, Q, A, localgeo, t)
 end
 
 """

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -48,7 +48,8 @@ init_state_auxiliary!(
     grid,
     direction,
 ) = nothing
-init_state_prognostic!(lm::LinearHBModel, Q::Vars, A::Vars, coords, t) = nothing
+init_state_prognostic!(lm::LinearHBModel, Q::Vars, A::Vars, localgeo, t) =
+    nothing
 
 """
     compute_gradient_argument!(::LinearHBModel)

--- a/src/Ocean/OceanProblems/SimpleBoxProblem.jl
+++ b/src/Ocean/OceanProblems/SimpleBoxProblem.jl
@@ -173,9 +173,10 @@ function ocean_init_state!(
     p::SimpleBox,
     Q,
     A,
-    coords,
+    localgeo,
     t,
 )
+    coords = localgeo.coord
     k = (2π / p.Lˣ, 2π / p.Lʸ, 2π / p.H)
     ν = viscosity(m)
 
@@ -202,9 +203,10 @@ function ocean_init_state!(
     p::SimpleBox,
     Q,
     A,
-    coords,
+    localgeo,
     t,
 )
+    coords = localgeo.coord
     k = (2π / p.Lˣ, 2π / p.Lʸ, 2π / p.H)
     ν = (m.νʰ, m.νʰ, m.νᶻ)
 
@@ -341,10 +343,10 @@ initialize u,v with random values, η with 0, and θ with a constant (20)
 - `p`: HomogeneousBox problem object, used to dispatch on
 - `Q`: state vector
 - `A`: auxiliary state vector, not used
-- `coords`: the coordidinates, not used
+- `localgeo`: the local geometry, not used
 - `t`: time to evaluate at, not used
 """
-function ocean_init_state!(m::HBModel, p::HomogeneousBox, Q, A, coords, t)
+function ocean_init_state!(m::HBModel, p::HomogeneousBox, Q, A, localgeo, t)
     Q.u = @SVector [0, 0]
     Q.η = 0
     Q.θ = 20
@@ -354,7 +356,8 @@ end
 
 include("ShallowWaterInitialStates.jl")
 
-function ocean_init_state!(m::SWModel, p::HomogeneousBox, Q, A, coords, t)
+function ocean_init_state!(m::SWModel, p::HomogeneousBox, Q, A, localgeo, t)
+    coords = localgeo.coord
     if t == 0
         null_init_state!(p, m.turbulence, Q, A, coords, 0)
     else
@@ -432,7 +435,7 @@ initialize u,v,η with 0 and θ linearly distributed between 9 at z=0 and 1 at z
 - `p`: OceanGyre problem object, used to dispatch on and obtain ocean height H
 - `Q`: state vector
 - `A`: auxiliary state vector, not used
-- `coords`: the coordidinates
+- `localgeo`: the local geometry information
 - `t`: time to evaluate at, not used
 """
 function ocean_init_state!(
@@ -440,9 +443,10 @@ function ocean_init_state!(
     p::OceanGyre,
     Q,
     A,
-    coords,
+    localgeo,
     t,
 )
+    coords = localgeo.coord
     @inbounds y = coords[2]
     @inbounds z = coords[3]
     @inbounds H = p.H
@@ -459,7 +463,7 @@ function ocean_init_state!(
     ::OceanGyre,
     Q,
     A,
-    coords,
+    localgeo,
     t,
 )
     Q.U = @SVector [-0, -0]

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -95,8 +95,8 @@ function vars_state(m::SWModel, ::Prognostic, T)
     end
 end
 
-function init_state_prognostic!(m::SWModel, state::Vars, aux::Vars, coords, t)
-    ocean_init_state!(m, m.problem, state, aux, coords, t)
+function init_state_prognostic!(m::SWModel, state::Vars, aux::Vars, localgeo, t)
+    ocean_init_state!(m, m.problem, state, aux, localgeo, t)
 end
 
 function vars_state(m::SWModel, ::Auxiliary, T)

--- a/src/Ocean/SplitExplicit01/BarotropicModel.jl
+++ b/src/Ocean/SplitExplicit01/BarotropicModel.jl
@@ -12,8 +12,14 @@ function vars_state(m::BarotropicModel, ::Prognostic, T)
     end
 end
 
-function init_state_prognostic!(m::BarotropicModel, Q::Vars, A::Vars, coords, t)
-    return ocean_init_state!(m, m.baroclinic.problem, Q, A, coords, t)
+function init_state_prognostic!(
+    m::BarotropicModel,
+    Q::Vars,
+    A::Vars,
+    localgeo,
+    t,
+)
+    return ocean_init_state!(m, m.baroclinic.problem, Q, A, localgeo, t)
 end
 
 function vars_state(m::BarotropicModel, ::Auxiliary, T)

--- a/src/Ocean/SplitExplicit01/IVDCModel.jl
+++ b/src/Ocean/SplitExplicit01/IVDCModel.jl
@@ -42,7 +42,7 @@ end
 
 vars_state(m::IVDCModel, ::Prognostic, FT) = @vars(θ::FT)
 
-function init_state_prognostic!(m::IVDCModel, Q::Vars, A::Vars, coords, t)
+function init_state_prognostic!(m::IVDCModel, Q::Vars, A::Vars, localgeo, t)
     @inbounds begin
         Q.θ = -0
     end

--- a/src/Ocean/SplitExplicit01/OceanModel.jl
+++ b/src/Ocean/SplitExplicit01/OceanModel.jl
@@ -168,8 +168,8 @@ function vars_state(m::OceanModel, ::Prognostic, T)
     end
 end
 
-function init_state_prognostic!(m::OceanModel, Q::Vars, A::Vars, coords, t)
-    return ocean_init_state!(m, m.problem, Q, A, coords, t)
+function init_state_prognostic!(m::OceanModel, Q::Vars, A::Vars, localgeo, t)
+    return ocean_init_state!(m, m.problem, Q, A, localgeo, t)
 end
 
 function vars_state(m::OceanModel, ::Auxiliary, T)

--- a/test/Atmos/EDMF/bomex_edmf.jl
+++ b/test/Atmos/EDMF/bomex_edmf.jl
@@ -19,7 +19,7 @@ include("edmf_kernels.jl")
             m::AtmosModel{FT},
             state::Vars,
             aux::Vars,
-            coords,
+            localgeo,
             t::Real,
         ) where {FT}
 
@@ -31,7 +31,7 @@ function init_state_prognostic!(
     m::AtmosModel{FT},
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t::Real,
 ) where {FT}
     # Aliases:

--- a/test/Atmos/Model/discrete_hydrostatic_balance.jl
+++ b/test/Atmos/Model/discrete_hydrostatic_balance.jl
@@ -53,7 +53,7 @@ function atmos_init_aux!(
     atmos_init_aux!(m.hydrostatic_state, atmos, aux, tmp, geom)
 end
 
-function init_to_ref_state!(problem, bl, state, aux, coords, t)
+function init_to_ref_state!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
     state.ρ = aux.ref_state.ρ
     state.ρu = SVector{3, FT}(0, 0, 0)

--- a/test/Atmos/Model/get_atmos_ref_states.jl
+++ b/test/Atmos/Model/get_atmos_ref_states.jl
@@ -26,7 +26,7 @@ function get_atmos_ref_states(nelem_vert, N_poly, RH)
             DecayingTemperatureProfile{FT}(param_set),
             RH,
         ),
-        init_state_prognostic = (problem, bl, state, aux, (x, y, z), t) ->
+        init_state_prognostic = (problem, bl, state, aux, localgeo, t) ->
             nothing,
     )
     driver_config = ClimateMachine.SingleStackConfiguration(

--- a/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
@@ -63,7 +63,9 @@ function vars_state(m::KinematicModel, ::Auxiliary, FT)
     end
 end
 
-function init_kinematic_eddy!(eddy_model, state, aux, (x, y, z), t, spline_fun)
+function init_kinematic_eddy!(eddy_model, state, aux, localgeo, t, spline_fun)
+    (x, y, z) = localgeo.coord
+
     FT = eltype(state)
     _grav::FT = grav(param_set)
 

--- a/test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl
@@ -32,7 +32,9 @@ function vars_state(m::KinematicModel, ::Auxiliary, FT)
     end
 end
 
-function init_kinematic_eddy!(eddy_model, state, aux, (x, y, z), t)
+function init_kinematic_eddy!(eddy_model, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     FT = eltype(state)
 
     _grav::FT = grav(param_set)

--- a/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
@@ -46,7 +46,9 @@ function vars_state(m::KinematicModel, ::Auxiliary, FT)
     end
 end
 
-function init_kinematic_eddy!(eddy_model, state, aux, (x, y, z), t)
+function init_kinematic_eddy!(eddy_model, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     FT = eltype(state)
 
     _grav::FT = grav(param_set)

--- a/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
@@ -207,11 +207,11 @@ function init_state_prognostic!(
     m::KinematicModel,
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t,
     args...,
 )
-    m.init_state_prognostic(m, state, aux, coords, t, args...)
+    m.init_state_prognostic(m, state, aux, localgeo, t, args...)
 end
 
 function boundary_state!(

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -41,7 +41,9 @@ import ClimateMachine.VariableTemplates.varsindex
 #               `C_smag`
 # 8) Default settings can be found in `src/Driver/Configurations.jl`
 # ------------------------ Description ------------------------- #
-function init_risingbubble!(problem, bl, state, aux, (x, y, z), t)
+function init_risingbubble!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     FT = eltype(state)
     R_gas::FT = R_d(bl.param_set)
     c_p::FT = cp_d(bl.param_set)

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -27,7 +27,9 @@ using CLIMAParameters.Planet: grav, MSLP
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function init_sin_test!(problem, bl, state, aux, (x, y, z), t)
+function init_sin_test!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     FT = eltype(state)
 
     z = FT(z)

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -30,7 +30,7 @@ Base.@kwdef struct AcousticWaveSetup{FT}
     nv::Int = 1
 end
 
-function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
+function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     # callable to set initial conditions
     FT = eltype(state)
 

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -13,7 +13,9 @@ using CLIMAParameters.Planet: grav, MSLP
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function init_test!(problem, bl, state, aux, (x, y, z), t)
+function init_test!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     FT = eltype(state)
 
     z = FT(z)

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -26,7 +26,7 @@ Base.@kwdef struct AcousticWaveSetup{FT}
     nv::Int = 1
 end
 
-function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
+function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     # callable to set initial conditions
     FT = eltype(state)
 

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -41,7 +41,8 @@ include(joinpath(
 total_specific_enthalpy(ts::PhaseDry{FT}, e_tot::FT) where {FT <: Real} =
     zero(FT)
 
-function mms3_init_state!(problem, bl, state::Vars, aux::Vars, (x1, x2, x3), t)
+function mms3_init_state!(problem, bl, state::Vars, aux::Vars, localgeo, t)
+    (x1, x2, x3) = localgeo.coord
     state.ρ = ρ_g(t, x1, x2, x3, Val(3))
     state.ρu = SVector(
         U_g(t, x1, x2, x3, Val(3)),

--- a/test/Land/Model/haverkamp_implicit_test.jl
+++ b/test/Land/Model/haverkamp_implicit_test.jl
@@ -45,7 +45,7 @@ haverkamp_dataset_path = get_data_folder(haverkamp_dataset)
     ClimateMachine.init()
     FT = Float64
 
-    function init_soil_water!(land, state, aux, coordinates, time)
+    function init_soil_water!(land, state, aux, localgeo, time)
         myfloat = eltype(aux)
         state.soil.water.ϑ_l = myfloat(land.soil.water.initialϑ_l(aux))
         state.soil.water.θ_i = myfloat(land.soil.water.initialθ_i(aux))

--- a/test/Land/Model/haverkamp_test.jl
+++ b/test/Land/Model/haverkamp_test.jl
@@ -44,7 +44,7 @@ haverkamp_dataset_path = get_data_folder(haverkamp_dataset)
     ClimateMachine.init()
     FT = Float64
 
-    function init_soil_water!(land, state, aux, coordinates, time)
+    function init_soil_water!(land, state, aux, localgeo, time)
         myfloat = eltype(aux)
         state.soil.water.ϑ_l = myfloat(land.soil.water.initialϑ_l(aux))
         state.soil.water.θ_i = myfloat(land.soil.water.initialθ_i(aux))

--- a/test/Land/Model/heat_analytic_unit_test.jl
+++ b/test/Land/Model/heat_analytic_unit_test.jl
@@ -31,7 +31,7 @@ using ClimateMachine.BalanceLaws:
     ClimateMachine.init()
     FT = Float32
 
-    function init_soil!(land, state, aux, coordinates, time)
+    function init_soil!(land, state, aux, localgeo, time)
         myFT = eltype(state)
         ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, time)
         θ_l =

--- a/test/Land/Model/prescribed_twice.jl
+++ b/test/Land/Model/prescribed_twice.jl
@@ -30,7 +30,7 @@ using ClimateMachine.BalanceLaws:
     ClimateMachine.init()
     FT = Float64
 
-    function init_soil_water!(land, state, aux, coordinates, time) end
+    function init_soil_water!(land, state, aux, localgeo, time) end
 
     soil_water_model = PrescribedWaterModel()
     soil_heat_model = PrescribedTemperatureModel()

--- a/test/Land/Model/test_bc.jl
+++ b/test/Land/Model/test_bc.jl
@@ -30,7 +30,7 @@ using ClimateMachine.BalanceLaws:
 
     FT = Float64
 
-    function init_soil_water!(land, state, aux, coordinates, time)
+    function init_soil_water!(land, state, aux, localgeo, time)
         myfloat = eltype(state)
         state.soil.water.ϑ_l = myfloat(land.soil.water.initialϑ_l(aux))
         state.soil.water.θ_i = myfloat(land.soil.water.initialθ_i(aux))

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -281,7 +281,7 @@ Base.@kwdef struct AcousticWaveSetup{FT}
     nv::Int = 1
 end
 
-function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
+function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     # callable to set initial conditions
     FT = eltype(state)
 

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -307,7 +307,7 @@ Base.@kwdef struct AcousticWaveSetup{FT}
     nv::Int = 1
 end
 
-function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
+function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     # callable to set initial conditions
     FT = eltype(state)
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -337,13 +337,13 @@ function isentropicvortex_initialcondition!(
     bl,
     state,
     aux,
-    coords,
+    localgeo,
     t,
     args...,
 )
     setup = first(args)
     FT = eltype(state)
-    x = MVector(coords)
+    x = MVector(localgeo.coord)
 
     ρ∞ = setup.ρ∞
     p∞ = setup.p∞

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -309,13 +309,13 @@ function isentropicvortex_initialcondition!(
     bl,
     state,
     aux,
-    coords,
+    localgeo,
     t,
     args...,
 )
     setup = bl.ref_state.setup
     FT = eltype(state)
-    x = MVector(coords)
+    x = MVector(localgeo.coord)
 
     ρ∞ = setup.ρ∞
     p∞ = setup.p∞

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -294,13 +294,13 @@ function isentropicvortex_initialcondition!(
     bl,
     state,
     aux,
-    coords,
+    localgeo,
     t,
     args...,
 )
     setup = bl.ref_state.setup
     FT = eltype(state)
-    x = MVector(coords)
+    x = MVector(localgeo.coord)
 
     ρ∞ = setup.ρ∞
     p∞ = setup.p∞

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -304,13 +304,13 @@ function isentropicvortex_initialcondition!(
     bl,
     state,
     aux,
-    coords,
+    localgeo,
     t,
     args...,
 )
     setup = bl.ref_state.setup
     FT = eltype(state)
-    x = MVector(coords)
+    x = MVector(localgeo.coord)
 
     ρ∞ = setup.ρ∞
     p∞ = setup.p∞

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -317,12 +317,12 @@ function isentropicvortex_initialcondition!(
     bl,
     state,
     aux,
-    coords,
+    localgeo,
     t,
     setup,
 )
     FT = eltype(state)
-    x = MVector(coords)
+    x = MVector(localgeo.coord)
 
     ρ∞ = setup.ρ∞
     p∞ = setup.p∞

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -244,10 +244,10 @@ function init_state_prognostic!(
     m::AdvectionDiffusion,
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t::Real,
 )
-    initial_condition!(m.problem, state, aux, coords, t)
+    initial_condition!(m.problem, state, aux, localgeo, t)
 end
 
 Neumann_data!(problem, ∇state, aux, x, t) = nothing
@@ -266,7 +266,7 @@ function boundary_state!(
     _...,
 )
     if bctype == 1 # Dirichlet
-        Dirichlet_data!(m.problem, stateP, auxP, auxP.coord, t)
+        Dirichlet_data!(m.problem, stateP, auxP, (coord = auxP.coord,), t)
     elseif bctype ∈ (2, 4) # Neumann
         stateP.ρ = stateM.ρ
     elseif bctype == 3 # zero Dirichlet

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
@@ -49,11 +49,11 @@ function initial_condition!(
     ::Pseudo1D{n, α, β, μ, δ},
     state,
     aux,
-    x,
+    localgeo,
     t,
 ) where {n, α, β, μ, δ}
-    ξn = dot(n, x)
-    # ξT = SVector(x) - ξn * n
+    ξn = dot(n, localgeo.coord)
+    # ξT = SVector(localgeo.coord) - ξn * n
     state.ρ = exp(-(ξn - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
 end
 Dirichlet_data!(P::Pseudo1D, x...) = initial_condition!(P, x...)

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bjfnks.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bjfnks.jl
@@ -49,11 +49,11 @@ function initial_condition!(
     ::Pseudo1D{n, α, β, μ, δ},
     state,
     aux,
-    x,
+    localgeo,
     t,
 ) where {n, α, β, μ, δ}
-    ξn = dot(n, x)
-    # ξT = SVector(x) - ξn * n
+    ξn = dot(n, localgeo.coord)
+    # ξT = SVector(localgeo.coord) - ξn * n
     state.ρ = exp(-(ξn - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
 end
 Dirichlet_data!(P::Pseudo1D, x...) = initial_condition!(P, x...)

--- a/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
@@ -60,7 +60,7 @@ function init_velocity_diffusion!(
         +uφ * cos(φ),
     )
 end
-function initial_condition!(::SolidBodyRotation, state, aux, x, t)
+function initial_condition!(::SolidBodyRotation, state, aux, localgeo, t)
     λ = longitude(SphericalOrientation(), aux)
     φ = latitude(SphericalOrientation(), aux)
     state.ρ = exp(-((3λ)^2 + (3φ)^2))

--- a/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
@@ -59,10 +59,10 @@ function initial_condition!(
     ::TestProblem{adv, diff, dir, topo},
     state,
     aux,
-    x,
+    localgeo,
     t,
 ) where {adv, diff, dir, topo}
-    state.ρ = initial_ρ(topo, x)
+    state.ρ = initial_ρ(topo, localgeo.coord)
 end
 
 function create_topology(::Box{dim}, mpicomm, Ne, FT) where {dim}

--- a/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_model.jl
@@ -120,10 +120,10 @@ function init_state_prognostic!(
     m::HyperDiffusion,
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t::Real,
 )
-    initial_condition!(m.problem, state, aux, coords, t)
+    initial_condition!(m.problem, state, aux, localgeo, t)
 end
 
 boundary_state!(nf, ::HyperDiffusion, _...) = nothing

--- a/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
@@ -43,7 +43,7 @@ function initial_condition!(
     problem::ConstantHyperDiffusion{dim, dir},
     state,
     aux,
-    x,
+    localgeo,
     t,
 ) where {dim, dir}
     @inbounds begin
@@ -58,6 +58,7 @@ function initial_condition!(
         elseif dir === VerticalDirection()
             c = k[dim]^2 * kD[dim, dim]
         end
+        x = localgeo.coord
         state.ρ = sin(dot(k[SOneTo(dim)], x[SOneTo(dim)])) * exp(-c * t)
     end
 end

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
@@ -43,11 +43,11 @@ function initial_condition!(
     ::Pseudo1D{n, α, β, μ, δ},
     state,
     aux,
-    x,
+    localgeo,
     t,
 ) where {n, α, β, μ, δ}
-    ξn = dot(n, x)
-    # ξT = SVector(x) - ξn * n
+    ξn = dot(n, localgeo.coord)
+    # ξT = SVector(localgeo.coord) - ξn * n
     state.ρ = exp(-(ξn - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
 end
 Dirichlet_data!(P::Pseudo1D, x...) = initial_condition!(P, x...)

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
@@ -49,11 +49,11 @@ function initial_condition!(
     ::Pseudo1D{n, α, β, μ, δ},
     state,
     aux,
-    x,
+    localgeo,
     t,
 ) where {n, α, β, μ, δ}
-    ξn = dot(n, x)
-    # ξT = SVector(x) - ξn * n
+    ξn = dot(n, localgeo.coord)
+    # ξT = SVector(localgeo.coord) - ξn * n
     state.ρ = exp(-(ξn - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
 end
 Dirichlet_data!(P::Pseudo1D, x...) = initial_condition!(P, x...)

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
@@ -49,11 +49,11 @@ function initial_condition!(
     ::Pseudo1D{n, α, β, μ, δ},
     state,
     aux,
-    x,
+    localgeo,
     t,
 ) where {n, α, β, μ, δ}
-    ξn = dot(n, x)
-    # ξT = SVector(x) - ξn * n
+    ξn = dot(n, localgeo.coord)
+    # ξT = SVector(localgeo.coord) - ξn * n
     state.ρ = exp(-(ξn - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
 end
 Dirichlet_data!(P::Pseudo1D, x...) = initial_condition!(P, x...)

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_heat_eqn.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_heat_eqn.jl
@@ -47,10 +47,10 @@ function initial_condition!(
     ::HeatEqn{n, κ, A},
     state,
     aux,
-    x,
+    localgeo,
     t,
 ) where {n, κ, A}
-    ξn = dot(n, x)
+    ξn = dot(n, localgeo.coord)
     state.ρ = ξn + sum(A .* cos.(κ * ξn) .* exp.(-κ .^ 2 * t))
 end
 Dirichlet_data!(P::HeatEqn, x...) = initial_condition!(P, x...)

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -67,9 +67,10 @@ function Initialise_Density_Current!(
     bl,
     state::Vars,
     aux::Vars,
-    (x1, x2, x3),
+    localgeo,
     t,
 )
+    (x1, x2, x3) = localgeo.coord
     FT = eltype(state)
     _R_d::FT = R_d(param_set)
     _grav::FT = grav(param_set)

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -44,7 +44,8 @@ using ClimateMachine.Atmos
 total_specific_enthalpy(ts::PhaseDry{FT}, e_tot::FT) where {FT <: Real} =
     zero(FT)
 
-function mms2_init_state!(problem, bl, state::Vars, aux::Vars, (x1, x2, x3), t)
+function mms2_init_state!(problem, bl, state::Vars, aux::Vars, localgeo, t)
+    (x1, x2, x3) = localgeo.coord
     state.ρ = ρ_g(t, x1, x2, x3, Val(2))
     state.ρu = SVector(
         U_g(t, x1, x2, x3, Val(2)),
@@ -73,7 +74,8 @@ function mms2_source!(
     source.ρe = SE_g(t, x1, x2, x3, Val(2))
 end
 
-function mms3_init_state!(problem, bl, state::Vars, aux::Vars, (x1, x2, x3), t)
+function mms3_init_state!(problem, bl, state::Vars, aux::Vars, localgeo, t)
+    (x1, x2, x3) = localgeo.coord
     state.ρ = ρ_g(t, x1, x2, x3, Val(3))
     state.ρu = SVector(
         U_g(t, x1, x2, x3, Val(3)),

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_model.jl
@@ -159,7 +159,13 @@ function boundary_state!(
     t,
     _...,
 )
-    init_state_prognostic!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
+    init_state_prognostic!(
+        bl,
+        stateP,
+        auxP,
+        (coord = (auxM.x1, auxM.x2, auxM.x3),),
+        t,
+    )
 end
 
 # FIXME: This is probably not right....
@@ -179,7 +185,13 @@ function boundary_state!(
     t,
     _...,
 )
-    init_state_prognostic!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
+    init_state_prognostic!(
+        bl,
+        stateP,
+        auxP,
+        (coord = (auxM.x1, auxM.x2, auxM.x3),),
+        t,
+    )
 end
 
 function nodal_init_state_auxiliary!(
@@ -198,9 +210,10 @@ function init_state_prognostic!(
     bl::MMSModel{dim},
     state::Vars,
     aux::Vars,
-    (x1, x2, x3),
+    localgeo,
     t,
 ) where {dim}
+    (x1, x2, x3) = localgeo.coord
     state.ρ = ρ_g(t, x1, x2, x3, Val(dim))
     state.ρu = U_g(t, x1, x2, x3, Val(dim))
     state.ρv = V_g(t, x1, x2, x3, Val(dim))

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -71,7 +71,7 @@ function init_state_prognostic!(
     ::ConservationTestModel,
     state::Vars,
     aux::Vars,
-    coord,
+    localgeo,
     t,
 )
     state.q = rand()

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -28,15 +28,17 @@ const param_set = EarthParameterSet()
 const p∞ = 10^5
 const T∞ = 300.0
 
-function initialcondition!(problem, bl, state, aux, coords, t)
+function initialcondition!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
+
+    coord = localgeo.coord
 
     translation_speed::FT = 150
     translation_angle::FT = pi / 4
     α = translation_angle
     u∞ = SVector(
-        FT(translation_speed * coords[1]),
-        FT(translation_speed * coords[1]),
+        FT(translation_speed * coord[1]),
+        FT(translation_speed * coord[1]),
         FT(0),
     )
     _kappa_d::FT = kappa_d(param_set)

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -490,7 +490,7 @@ Base.@kwdef struct RemainderTestSetup{FT}
     T_ref::FT = 300
 end
 
-function (setup::RemainderTestSetup)(problem, bl, state, aux, coords, t)
+function (setup::RemainderTestSetup)(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     # Vary around the reference state by 10% and a random velocity field

--- a/test/Numerics/DGMethods/vars_test.jl
+++ b/test/Numerics/DGMethods/vars_test.jl
@@ -46,11 +46,11 @@ function init_state_prognostic!(
     m::VarsTestModel,
     state::Vars,
     aux::Vars,
-    coord,
+    localgeo,
     t::Real,
 )
-    @inbounds state.x = coord[1]
-    state.coord = coord
+    @inbounds state.x = localgeo.coord[1]
+    state.coord = localgeo.coord
 end
 
 function nodal_init_state_auxiliary!(

--- a/test/Numerics/Mesh/Geometry.jl
+++ b/test/Numerics/Mesh/Geometry.jl
@@ -47,9 +47,11 @@ MPI.Initialized() || MPI.Init()
     Savg = cbrt(prod(S))
     M = SDiagonal(S .^ -2)
 
+    N = polynomialorder
+    Np = (N + 1)^3
     for e in 1:size(grid.vgeo, 3)
         for n in 1:size(grid.vgeo, 1)
-            g = LocalGeometry(Val(polynomialorder), grid.vgeo, n, e)
+            g = LocalGeometry{Np, N}(grid.vgeo, n, e)
             @test lengthscale(g) ≈ Savg
             @test Geometry.resolutionmetric(g) ≈ M
         end

--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -129,10 +129,11 @@ function ClimateMachine.BalanceLaws.init_state_prognostic!(
     ::FilterTestModel{4},
     state::Vars,
     aux::Vars,
-    (x, y, z),
+    localgeo,
     filter_direction,
     dim,
 )
+    (x, y, z) = localgeo.coord
     state.q1 = low(x, y, z) + high(x, y, z)
     state.q2 = low(x, y, z) + high(x, y, z)
     state.q3 = low(x, y, z) + high(x, y, z)
@@ -220,8 +221,9 @@ function ClimateMachine.BalanceLaws.init_state_prognostic!(
     ::FilterTestModel{1},
     state::Vars,
     aux::Vars,
-    (x, y, z),
+    localgeo,
 )
+    (x, y, z) = localgeo.coord
     state.q = abs(x) - 0.1
 end
 

--- a/test/Numerics/Mesh/filter_TMAR.jl
+++ b/test/Numerics/Mesh/filter_TMAR.jl
@@ -56,7 +56,7 @@ init_velocity_diffusion!(::SwirlingFlow, aux::Vars, geom::LocalGeometry) =
 
 cosbell(τ, q) = τ ≤ 1 ? ((1 + cospi(τ)) / 2)^q : zero(τ)
 
-function initial_condition!(::SwirlingFlow, state, aux, coord, t)
+function initial_condition!(::SwirlingFlow, state, aux, localgeo, t)
     FT = eltype(state)
     x, y, _ = aux.coord
     x0, y0 = FT(1 // 4), FT(1 // 4)

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -39,7 +39,7 @@ function Initialize_Brick_Interpolation_Test!(
     bl,
     state::Vars,
     aux::Vars,
-    (x, y, z),
+    localgeo,
     t,
 )
     FT = eltype(state)

--- a/test/Numerics/SystemSolvers/bandedsystem.jl
+++ b/test/Numerics/SystemSolvers/bandedsystem.jl
@@ -50,10 +50,10 @@ function initial_condition!(
     ::Pseudo1D{n, α, β, μ, δ},
     state,
     aux,
-    x,
+    localgeo,
     t,
 ) where {n, α, β, μ, δ}
-    ξn = dot(n, x)
+    ξn = dot(n, localgeo.coord)
     # ξT = SVector(x) - ξn * n
     state.ρ = exp(-(ξn - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
 end

--- a/test/Numerics/SystemSolvers/poisson.jl
+++ b/test/Numerics/SystemSolvers/poisson.jl
@@ -153,9 +153,10 @@ function init_state_prognostic!(
     ::PoissonModel{dim},
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t,
 ) where {dim}
+    coords = localgeo.coord
     state.ϕ = prod(sol1d, view(coords, 1:dim))
 end
 

--- a/test/Ocean/SplitExplicit/simple_box_2dt.jl
+++ b/test/Ocean/SplitExplicit/simple_box_2dt.jl
@@ -87,7 +87,8 @@ end
     return ocean_boundary_state!(m, CoastlineNoSlip(), x...)
 end
 
-function ocean_init_state!(p::SimpleBox, Q, A, coords, t)
+function ocean_init_state!(p::SimpleBox, Q, A, localgeo, t)
+    coords = localgeo.coord
     @inbounds y = coords[2]
     @inbounds z = coords[3]
     @inbounds H = p.H

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -111,7 +111,9 @@ const param_set = EarthParameterSet()
 #md #     - `state.ρu`= 3-component vector for initial momentum profile
 #md #     - `state.ρe`= Scalar quantity for initial total-energy profile
 #md #       humidity
-function init_agnesi_hs_lin!(problem, bl, state, aux, (x, y, z), t)
+function init_agnesi_hs_lin!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     ## Problem float-type
     FT = eltype(state)
 

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -107,7 +107,9 @@ const param_set = EarthParameterSet()
 #md #     - `state.ρu`= 3-component vector for initial momentum profile
 #md #     - `state.ρe`= Scalar quantity for initial total-energy profile
 #md #       humidity
-function init_agnesi_hs_lin!(problem, bl, state, aux, (x, y, z), t)
+function init_agnesi_hs_lin!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     ## Problem float-type
     FT = eltype(state)
 

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -245,7 +245,7 @@ function init_state_prognostic!(
     m::BurgersEquation,
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t::Real,
 )
     z = aux.coord[3]

--- a/tutorials/Atmos/burgers_single_stack_bjfnk.jl
+++ b/tutorials/Atmos/burgers_single_stack_bjfnk.jl
@@ -246,7 +246,7 @@ function init_state_prognostic!(
     m::BurgersEquation,
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t::Real,
 )
     z = aux.coord[3]

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -127,7 +127,9 @@ const param_set = EarthParameterSet()
 #md #     - `state.tracers.ρχ` = Vector of four tracers (here, for demonstration
 #md #       only; we can interpret these as dye injections for visualisation
 #md #       purposes)
-function init_densitycurrent!(problem, bl, state, aux, (x, y, z), t)
+function init_densitycurrent!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     ## Problem float-type
     FT = eltype(state)
 

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -62,7 +62,9 @@ struct DryRayleighBenardConvectionDataConfig{FT}
 end
 
 # Define initial condition kernel
-function init_problem!(problem, bl, state, aux, (x, y, z), t)
+function init_problem!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     dc = bl.data_config
     FT = eltype(state)
 

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -112,7 +112,7 @@ end;
 # state of our model run. In our case, we use the reference state of the
 # simulation (defined below) and add a little bit of noise. Note that the
 # initial states includes a zero initial velocity field.
-function init_heldsuarez!(problem, balance_law, state, aux, coordinates, time)
+function init_heldsuarez!(problem, balance_law, state, aux, localgeo, time)
     FT = eltype(state)
 
     ## Set initial state to reference state with random perturbation

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -108,7 +108,9 @@ const param_set = EarthParameterSet();
 #md #     - `state.tracers.ρχ` = Vector of four tracers (here, for demonstration
 #md #       only; we can interpret these as dye injections for visualization
 #md #       purposes)
-function init_risingbubble!(problem, bl, state, aux, (x, y, z), t)
+function init_risingbubble!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+
     ## Problem float-type
     FT = eltype(state)
 

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -176,7 +176,7 @@ function init_state_prognostic!(
     m::HeatModel,
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t::Real,
 )
     state.ρcT = m.ρc * aux.T

--- a/tutorials/Land/Soil/Coupled/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Coupled/equilibrium_test.jl
@@ -259,7 +259,7 @@ bottom_heat_state = nothing;
 # specified functions of space for `T_init` and `ϑ_l0` and initializes the state
 # variables of volumetric internal energy and augmented liquid fraction. This requires
 # a conversion from `T` to `ρe_int`.
-function init_soil!(land, state, aux, coordinates, time)
+function init_soil!(land, state, aux, localgeo, time)
     myFT = eltype(state)
     ϑ_l = myFT(land.soil.water.initialϑ_l(aux))
     θ_i = myFT(land.soil.water.initialθ_i(aux))

--- a/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
+++ b/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
@@ -283,7 +283,7 @@ T_init = (aux) -> eltype(aux)(275.15);
 # conditions for heat based on the temperature - `init_soil!` also
 # converts between `T` and `ρe_int`.
 
-function init_soil!(land, state, aux, coordinates, time)
+function init_soil!(land, state, aux, localgeo, time)
     ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, time)
     θ_l = volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
     ρc_ds = land.soil.param_functions.ρc_ds

--- a/tutorials/Land/Soil/Water/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Water/equilibrium_test.jl
@@ -104,7 +104,7 @@ sources = ()
 # in turn calls the functions supplied to soil_water_model. The default
 # initialization for ice is zero volumetric ice fraction. This should not
 # be altered unless freeze thaw is added.
-function init_soil_water!(land, state, aux, coordinates, time)
+function init_soil_water!(land, state, aux, localgeo, time)
     FT = eltype(state)
     state.soil.water.ϑ_l = FT(land.soil.water.initialϑ_l(aux))
     state.soil.water.θ_i = FT(land.soil.water.initialθ_i(aux))

--- a/tutorials/Numerics/DGMethods/Box1D.jl
+++ b/tutorials/Numerics/DGMethods/Box1D.jl
@@ -74,7 +74,7 @@ function init_state_prognostic!(
     m::Box1D,
     state::Vars,
     aux::Vars,
-    coords,
+    localgeo,
     t::Real,
 )
     if aux.z_dim >= 75 && aux.z_dim <= 125


### PR DESCRIPTION
This updates `LocalGeometry` to be

```julia
struct LocalGeometry{Np, N, AT, IT}
    "Global volume geometry array"
    vgeo::AT
    "linear degree of freedom index"
    n::IT
    "element number"
    e::IT
end
```

and then allows pulling out of `coord`, `invJ`, and `center_coord` as needed through a custom `getproperty`.

This also switches `knl_init_state_prognostic!` to use `LocalGeometry` which unifies the interface with `kernel_nodal_init_state_auxiliary!`

This supersedes #1623 and #1624.

This closes #1625 (for now at least)