### PR TITLE
Improve thermo names

### DIFF
--- a/docs/src/APIs/Common/Thermodynamics.md
+++ b/docs/src/APIs/Common/Thermodynamics.md
@@ -14,18 +14,18 @@ PhasePartition
 PhasePartition_equil
 ThermodynamicState
 PhaseDry
-PhaseDry_given_pT
-PhaseDry_given_pθ
-PhaseDry_given_ρT
+PhaseDry_pT
+PhaseDry_pθ
+PhaseDry_ρT
 PhaseEquil
+PhaseEquil_ρTq
+PhaseEquil_pTq
+PhaseEquil_pθq
+PhaseEquil_ρθq
 PhaseNonEquil
-TemperatureSHumEquil
-TemperatureSHumNonEquil
-TemperatureSHumEquil_given_pressure
-LiquidIcePotTempSHumEquil
-LiquidIcePotTempSHumNonEquil
-LiquidIcePotTempSHumNonEquil_given_pressure
-LiquidIcePotTempSHumEquil_given_pressure
+PhaseNonEquil_ρTq
+PhaseNonEquil_ρθq
+PhaseNonEquil_pθq
 ```
 
 ## Thermodynamic state methods

--- a/docs/src/Theory/Atmos/Microphysics.md
+++ b/docs/src/Theory/Atmos/Microphysics.md
@@ -719,7 +719,7 @@ end
 # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
 function rain_evap_empirical(q_rai::DT, q::PhasePartition, T::DT, p::DT, ρ::DT) where {DT<:Real}
 
-    ts_neq = TemperatureSHumNonEquil(param_set, T, ρ, q)
+    ts_neq = PhaseNonEquil_ρTq(param_set, ρ, T, q)
     q_sat  = q_vap_saturation(ts_neq)
     q_vap  = q.tot - q.liq
     rr     = q_rai / (DT(1) - q.tot)

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -353,7 +353,7 @@ function init_bomex!(problem, bl, state, aux, (x, y, z), t)
     P = P_sfc * exp(-z / H)
 
     # Establish thermodynamic state and moist phase partitioning
-    TS = LiquidIcePotTempSHumEquil_given_pressure(bl.param_set, θ_liq, P, q_tot)
+    TS = PhaseEquil_pθq(bl.param_set, P, θ_liq, q_tot)
     T = air_temperature(TS)
     ρ = air_density(TS)
     q_pt = PhasePartition(TS)

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -236,7 +236,7 @@ function init_dycoms!(problem, bl, state, aux, (x, y, z), t)
 
     # Density, Temperature
 
-    ts = LiquidIcePotTempSHumEquil_given_pressure(bl.param_set, θ_liq, p, q_tot)
+    ts = PhaseEquil_pθq(bl.param_set, p, θ_liq, q_tot)
     ρ = air_density(ts)
 
     e_kin = FT(1 / 2) * FT((u^2 + v^2 + w^2))

--- a/experiments/AtmosLES/stable_bl_kosovic.jl
+++ b/experiments/AtmosLES/stable_bl_kosovic.jl
@@ -177,7 +177,7 @@ function init_problem!(problem, bl, state, aux, (x, y, z), t)
     π_exner = FT(1) - _grav / (c_p * θ) * z # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
     # Establish thermodynamic state and moist phase partitioning
-    TS = LiquidIcePotTempSHumEquil(bl.param_set, θ_liq, ρ, q_tot)
+    TS = PhaseEquil_ρθq(bl.param_set, ρ, θ_liq, q_tot)
 
     # Compute momentum contributions
     ρu = ρ * u
@@ -205,7 +205,7 @@ function surface_temperature_variation(state, aux, t)
     ρ = state.ρ
     q_tot = state.moisture.ρq_tot / ρ
     θ_liq_sfc = FT(265) - FT(1 / 4) * (t / 3600)
-    TS = LiquidIcePotTempSHumEquil(param_set, θ_liq_sfc, ρ, q_tot)
+    TS = PhaseEquil_ρθq(param_set, ρ, θ_liq_sfc, q_tot)
     return air_temperature(TS)
 end
 

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -60,7 +60,7 @@ function init_surfacebubble!(problem, bl, state, aux, (x, y, z), t)
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
 
     q_tot = FT(0)
-    ts = LiquidIcePotTempSHumEquil(bl.param_set, θ, ρ, q_tot)
+    ts = PhaseEquil_ρθq(bl.param_set, ρ, θ, q_tot)
     q_pt = PhasePartition(ts)
 
     ρu = SVector(FT(0), FT(0), FT(0))

--- a/experiments/AtmosLES/unstable_bl_kitamura.jl
+++ b/experiments/AtmosLES/unstable_bl_kitamura.jl
@@ -175,7 +175,7 @@ function init_problem!(problem, bl, state, aux, (x, y, z), t)
     π_exner = FT(1) - _grav / (c_p * θ) * z # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
     # Establish thermodynamic state and moist phase partitioning
-    TS = LiquidIcePotTempSHumEquil(bl.param_set, θ_liq, ρ, q_tot)
+    TS = PhaseEquil_ρθq(bl.param_set, ρ, θ_liq, q_tot)
 
     # Compute momentum contributions
     ρu = ρ * u
@@ -203,7 +203,7 @@ function surface_temperature_variation(state, aux, t)
     ρ = state.ρ
     q_tot = state.moisture.ρq_tot / ρ
     θ_liq_sfc = FT(291.15) + FT(20) * sinpi(FT(t / 12 / 3600))
-    TS = LiquidIcePotTempSHumEquil(param_set, θ_liq_sfc, ρ, q_tot)
+    TS = PhaseEquil_ρθq(param_set, ρ, θ_liq_sfc, q_tot)
     return air_temperature(TS)
 end
 

--- a/src/Atmos/Model/bc_energy.jl
+++ b/src/Atmos/Model/bc_energy.jl
@@ -162,7 +162,7 @@ function atmos_energy_normal_boundary_flux_second_order!(
     T, q_tot = bc_energy.fn_T_and_q_tot(state⁻, aux⁻, t)
 
     # calculate MSE from the states at the boundary and at the interior point
-    ts = TemperatureSHumEquil(atmos.param_set, T, state⁻.ρ, q_tot)
+    ts = PhaseEquil_ρTq(atmos.param_set, state⁻.ρ, T, q_tot)
     ts_int = recover_thermo_state(atmos, atmos.moisture, state_int⁻, aux_int⁻)
     e_pot = gravitational_potential(atmos.orientation, aux⁻)
     e_pot_int = gravitational_potential(atmos.orientation, aux_int⁻)

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -101,9 +101,9 @@ function atmos_init_aux!(
     q_liq = q_pt.liq
     q_ice = q_pt.ice
     if atmos.moisture isa DryModel
-        ts = PhaseDry_given_ρT(atmos.param_set, ρ, T)
+        ts = PhaseDry_ρT(atmos.param_set, ρ, T)
     else
-        ts = TemperatureSHumEquil(atmos.param_set, T, ρ, q_tot)
+        ts = PhaseEquil_ρTq(atmos.param_set, ρ, T, q_tot)
     end
 
     aux.ref_state.ρq_tot = ρ * q_tot

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -209,7 +209,7 @@ function atmos_source!(
 
     # phase partition corresponding to the current T and q.tot
     # (this is not the same as phase partition from saturation adjustment)
-    ts_eq = TemperatureSHumEquil(atmos.param_set, T, state.ρ, q.tot)
+    ts_eq = PhaseEquil_ρTq(atmos.param_set, state.ρ, T, q.tot)
     q_eq = PhasePartition(ts_eq)
 
     # cloud condensate as relaxation source terms

--- a/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
@@ -133,10 +133,10 @@ function new_thermo_state_up(
         θ_liq_up = ρaθ_liq_up / ρa_up
         q_tot_up = ρaq_tot_up / ρa_up
 
-        LiquidIcePotTempSHumEquil_given_pressure(
+        PhaseEquil_pθq(
             m.param_set,
-            θ_liq_up,
             p,
+            θ_liq_up,
             q_tot_up,
         )
     end
@@ -171,10 +171,10 @@ function new_thermo_state_en(
         @print("q_tot_en = ", q_tot_en, "\n")
         error("Environment q_tot_en out-of-bounds in new_thermo_state_en")
     end
-    ts_en = LiquidIcePotTempSHumEquil_given_pressure(
+    ts_en = PhaseEquil_pθq(
         m.param_set,
-        θ_liq_en,
         p,
+        θ_liq_en,
         q_tot_en,
     )
     return ts_en

--- a/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
@@ -180,7 +180,7 @@ function nodal_update_auxiliary_state!(
         # supersaturation
         q = PhasePartition(aux.q_tot, aux.q_liq, aux.q_ice)
         aux.T = air_temperature(param_set, aux.e_int, q)
-        ts_neq = TemperatureSHumNonEquil(param_set, aux.T, state.ρ, q)
+        ts_neq = PhaseNonEquil_ρTq(param_set, state.ρ, aux.T, q)
         # TODO: add super_saturation method in moist thermo
         aux.S = max(0, aux.q_vap / q_vap_saturation(ts_neq) - FT(1)) * FT(100)
         aux.RH = relative_humidity(ts_neq) * FT(100)
@@ -191,7 +191,7 @@ function nodal_update_auxiliary_state!(
             terminal_velocity(param_set, snow_param_set, state.ρ, aux.q_sno)
 
         # more diagnostics
-        ts_eq = TemperatureSHumEquil(param_set, aux.T, state.ρ, aux.q_tot)
+        ts_eq = PhaseEquil_ρTq(param_set, state.ρ, aux.T, aux.q_tot)
         q_eq = PhasePartition(ts_eq)
 
         aux.src_cloud_liq = conv_q_vap_to_q_liq_ice(liquid_param_set, q_eq, q)
@@ -466,7 +466,7 @@ function source!(
         T = air_temperature(param_set, e_int, q)
         _Lf = latent_heat_fusion(param_set, T)
         # equilibrium state at current T
-        ts_eq = TemperatureSHumEquil(param_set, T, state.ρ, q_tot)
+        ts_eq = PhaseEquil_ρTq(param_set, state.ρ, T, q_tot)
         q_eq = PhasePartition(ts_eq)
 
         # zero out the source terms

--- a/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
@@ -115,7 +115,7 @@ function nodal_update_auxiliary_state!(
         # supersaturation
         q = PhasePartition(aux.q_tot, aux.q_liq, aux.q_ice)
         aux.T = air_temperature(param_set, aux.e_int, q)
-        ts_neq = TemperatureSHumNonEquil(param_set, aux.T, state.ρ, q)
+        ts_neq = PhaseNonEquil_ρTq(param_set, state.ρ, aux.T, q)
         # TODO: add super_saturation method in moist thermo
         aux.S = max(0, aux.q_vap / q_vap_saturation(ts_neq) - FT(1)) * FT(100)
         aux.RH = relative_humidity(ts_neq) * FT(100)
@@ -124,7 +124,7 @@ function nodal_update_auxiliary_state!(
             terminal_velocity(param_set, rain_param_set, state.ρ, aux.q_rai)
 
         # more diagnostics
-        ts_eq = TemperatureSHumEquil(param_set, aux.T, state.ρ, aux.q_tot)
+        ts_eq = PhaseEquil_ρTq(param_set, state.ρ, aux.T, aux.q_tot)
         q_eq = PhasePartition(ts_eq)
 
         aux.src_cloud_liq = conv_q_vap_to_q_liq_ice(liquid_param_set, q_eq, q)
@@ -276,7 +276,7 @@ function source!(
         q = PhasePartition(q_tot, q_liq, q_ice)
         T = air_temperature(param_set, e_int, q)
         # equilibrium state at current T
-        ts_eq = TemperatureSHumEquil(param_set, T, state.ρ, q_tot)
+        ts_eq = PhaseEquil_ρTq(param_set, state.ρ, T, q_tot)
         q_eq = PhasePartition(ts_eq)
 
         # zero out the source terms

--- a/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
@@ -43,8 +43,8 @@ using ClimateMachine.Thermodynamics:
     internal_energy,
     q_vap_saturation,
     relative_humidity,
-    TemperatureSHumEquil,
-    TemperatureSHumNonEquil,
+    PhaseEquil_ρTq,
+    PhaseNonEquil_ρTq,
     air_temperature,
     latent_heat_fusion
 

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -549,17 +549,17 @@ end
             rtol = rtol_temperature,
         ))
 
-        # LiquidIcePotTempSHumEquil
+        # PhaseEquil_ρθq
         ts_exact =
-            LiquidIcePotTempSHumEquil.(
+            PhaseEquil_ρθq.(
                 Ref(param_set),
-                θ_liq_ice,
                 ρ,
+                θ_liq_ice,
                 q_tot,
                 45,
                 FT(1e-3),
             )
-        ts = LiquidIcePotTempSHumEquil.(Ref(param_set), θ_liq_ice, ρ, q_tot)
+        ts = PhaseEquil_ρθq.(Ref(param_set), ρ, θ_liq_ice, q_tot)
         # Should be machine accurate:
         @test all(air_density.(ts) .≈ air_density.(ts_exact))
         @test all(
@@ -583,21 +583,21 @@ end
             rtol = rtol_temperature,
         ))
 
-        # LiquidIcePotTempSHumEquil_given_pressure
+        # PhaseEquil_pθq
         ts_exact =
-            LiquidIcePotTempSHumEquil_given_pressure.(
+            PhaseEquil_pθq.(
                 Ref(param_set),
-                θ_liq_ice,
                 p,
+                θ_liq_ice,
                 q_tot,
                 40,
                 FT(1e-3),
             )
         ts =
-            LiquidIcePotTempSHumEquil_given_pressure.(
+            PhaseEquil_pθq.(
                 Ref(param_set),
-                θ_liq_ice,
                 p,
+                θ_liq_ice,
                 q_tot,
             )
         # Should be machine accurate:
@@ -627,17 +627,17 @@ end
             rtol = rtol_temperature,
         ))
 
-        # LiquidIcePotTempSHumNonEquil
+        # PhaseNonEquil_ρθq
         ts_exact =
-            LiquidIcePotTempSHumNonEquil.(
+            PhaseNonEquil_ρθq.(
                 Ref(param_set),
-                θ_liq_ice,
                 ρ,
+                θ_liq_ice,
                 q_pt,
                 40,
                 FT(1e-3),
             )
-        ts = LiquidIcePotTempSHumNonEquil.(Ref(param_set), θ_liq_ice, ρ, q_pt)
+        ts = PhaseNonEquil_ρθq.(Ref(param_set), ρ, θ_liq_ice, q_pt)
         # Should be machine accurate:
         @test all(
             getproperty.(PhasePartition.(ts), :tot) .≈
@@ -758,16 +758,16 @@ end
         @test all(internal_energy.(ts) .≈ e_int)
         @test all(air_density.(ts) .≈ ρ)
 
-        ts_p = PhaseDry_given_pT.(Ref(param_set), p, T)
+        ts_p = PhaseDry_pT.(Ref(param_set), p, T)
         @test all(internal_energy.(ts_p) .≈ internal_energy.(Ref(param_set), T))
         @test all(air_density.(ts_p) .≈ ρ)
 
         θ_dry = dry_pottemp.(Ref(param_set), T, ρ)
-        ts_p = PhaseDry_given_pθ.(Ref(param_set), p, θ_dry)
+        ts_p = PhaseDry_pθ.(Ref(param_set), p, θ_dry)
         @test all(internal_energy.(ts_p) .≈ internal_energy.(Ref(param_set), T))
         @test all(air_density.(ts_p) .≈ ρ)
 
-        ts = PhaseDry_given_ρT.(Ref(param_set), ρ, T)
+        ts = PhaseDry_ρT.(Ref(param_set), ρ, T)
 
         @test all(air_density.(ts_p) .≈ air_density.(ts))
         @test all(internal_energy.(ts_p) .≈ internal_energy.(ts))
@@ -834,7 +834,7 @@ end
             θ_liq_ice,
         )
 
-        # Accurate but expensive `LiquidIcePotTempSHumNonEquil` constructor (Non-linear temperature from θ_liq_ice)
+        # Accurate but expensive `PhaseNonEquil_ρθq` constructor (Non-linear temperature from θ_liq_ice)
         T_non_linear =
             air_temperature_from_liquid_ice_pottemp_non_linear.(
                 Ref(param_set),
@@ -861,12 +861,12 @@ end
             rtol = rtol_temperature,
         ))
 
-        # LiquidIcePotTempSHumEquil
+        # PhaseEquil_ρθq
         ts =
-            LiquidIcePotTempSHumEquil.(
+            PhaseEquil_ρθq.(
                 Ref(param_set),
-                θ_liq_ice,
                 ρ,
+                θ_liq_ice,
                 q_tot,
                 45,
                 FT(1e-3),
@@ -879,17 +879,17 @@ end
         @test all(isapprox.(air_density.(ts), ρ, rtol = rtol_density))
         @test all(getproperty.(PhasePartition.(ts), :tot) .≈ q_tot)
 
-        # The LiquidIcePotTempSHumEquil_given_pressure constructor
+        # The PhaseEquil_pθq constructor
         # passes the consistency test within sufficient physical precision,
         # however, it fails to satisfy the consistency test within machine
         # precision for the input pressure.
 
-        # LiquidIcePotTempSHumEquil_given_pressure
+        # PhaseEquil_pθq
         ts =
-            LiquidIcePotTempSHumEquil_given_pressure.(
+            PhaseEquil_pθq.(
                 Ref(param_set),
-                θ_liq_ice,
                 p,
+                θ_liq_ice,
                 q_tot,
                 35,
                 FT(1e-3),
@@ -904,12 +904,12 @@ end
         )
         @test all(isapprox.(air_pressure.(ts), p, atol = atol_pressure))
 
-        # LiquidIcePotTempSHumNonEquil_given_pressure
+        # PhaseNonEquil_pθq
         ts =
-            LiquidIcePotTempSHumNonEquil_given_pressure.(
+            PhaseNonEquil_pθq.(
                 Ref(param_set),
-                θ_liq_ice,
                 p,
+                θ_liq_ice,
                 q_pt,
             )
         @test all(liquid_ice_pottemp.(ts) .≈ θ_liq_ice)
@@ -924,12 +924,12 @@ end
             getproperty.(PhasePartition.(ts), :ice) .≈ getproperty.(q_pt, :ice),
         )
 
-        # LiquidIcePotTempSHumNonEquil
+        # PhaseNonEquil_ρθq
         ts =
-            LiquidIcePotTempSHumNonEquil.(
+            PhaseNonEquil_ρθq.(
                 Ref(param_set),
-                θ_liq_ice,
                 ρ,
+                θ_liq_ice,
                 q_pt,
                 5,
                 FT(1e-3),
@@ -1050,23 +1050,23 @@ end
 
     θ_dry = dry_pottemp.(Ref(param_set), T, ρ)
     ts_dry = PhaseDry.(Ref(param_set), e_int, ρ)
-    ts_dry_pT = PhaseDry_given_pT.(Ref(param_set), p, T)
-    ts_dry_pθ = PhaseDry_given_pθ.(Ref(param_set), p, θ_dry)
+    ts_dry_pT = PhaseDry_pT.(Ref(param_set), p, T)
+    ts_dry_pθ = PhaseDry_pθ.(Ref(param_set), p, θ_dry)
     ts_eq = PhaseEquil.(Ref(param_set), e_int, ρ, q_tot, 15, FT(1e-1))
     e_tot = total_energy.(e_kin, e_pot, ts_eq)
 
     ts_T =
-        TemperatureSHumEquil.(
+        PhaseEquil_ρTq.(
             Ref(param_set),
-            air_temperature.(ts_dry),
             air_density.(ts_dry),
+            air_temperature.(ts_dry),
             q_tot,
         )
     ts_Tp =
-        TemperatureSHumEquil_given_pressure.(
+        PhaseEquil_pTq.(
             Ref(param_set),
-            air_temperature.(ts_dry),
             air_pressure.(ts_dry),
+            air_temperature.(ts_dry),
             q_tot,
         )
 
@@ -1075,33 +1075,33 @@ end
     @test all(total_specific_humidity.(ts_T) .≈ total_specific_humidity.(ts_Tp))
 
     ts_neq = PhaseNonEquil.(Ref(param_set), e_int, ρ, q_pt)
-    ts_T_neq = TemperatureSHumNonEquil.(Ref(param_set), T, ρ, q_pt)
+    ts_T_neq = PhaseNonEquil_ρTq.(Ref(param_set), ρ, T, q_pt)
 
     ts_θ_liq_ice_eq =
-        LiquidIcePotTempSHumEquil.(
+        PhaseEquil_ρθq.(
             Ref(param_set),
-            θ_liq_ice,
             ρ,
+            θ_liq_ice,
             q_tot,
             45,
             FT(1e-3),
         )
     ts_θ_liq_ice_eq_p =
-        LiquidIcePotTempSHumEquil_given_pressure.(
+        PhaseEquil_pθq.(
             Ref(param_set),
-            θ_liq_ice,
             p,
+            θ_liq_ice,
             q_tot,
             40,
             FT(1e-3),
         )
     ts_θ_liq_ice_neq =
-        LiquidIcePotTempSHumNonEquil.(Ref(param_set), θ_liq_ice, ρ, q_pt)
+        PhaseNonEquil_ρθq.(Ref(param_set), ρ, θ_liq_ice, q_pt)
     ts_θ_liq_ice_neq_p =
-        LiquidIcePotTempSHumNonEquil_given_pressure.(
+        PhaseNonEquil_pθq.(
             Ref(param_set),
-            θ_liq_ice,
             p,
+            θ_liq_ice,
             q_pt,
         )
 

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -67,7 +67,7 @@ function init_risingbubble!(problem, bl, state, aux, (x, y, z), t)
     π_exner = FT(1) - _grav / (c_p * θ) * z # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
     q_tot = FT(0)
-    ts = LiquidIcePotTempSHumEquil(bl.param_set, θ, ρ, q_tot)
+    ts = PhaseEquil_ρθq(bl.param_set, ρ, θ, q_tot)
     q_pt = PhasePartition(ts)
 
     ρu = SVector(FT(0), FT(0), FT(0))

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -70,7 +70,7 @@ function init_sin_test!(problem, bl, state, aux, (x, y, z), t)
     p = P_sfc * exp(-z / H)
 
     # Density, Temperature
-    ts = LiquidIcePotTempSHumEquil_given_pressure(bl.param_set, θ_liq, p, q_tot)
+    ts = PhaseEquil_pθq(bl.param_set, p, θ_liq, q_tot)
     #ρ = air_density(ts)
     ρ = one(FT)
 

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -44,7 +44,7 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
 
-    ts = PhaseDry_given_pT(bl.param_set, p, setup.T_ref)
+    ts = PhaseDry_pT(bl.param_set, p, setup.T_ref)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -43,7 +43,7 @@ function init_test!(problem, bl, state, aux, (x, y, z), t)
     p = P_sfc * exp(-z / H)
 
     # Density, Temperature
-    ts = LiquidIcePotTempSHumEquil_given_pressure(bl.param_set, θ_liq, p, q_tot)
+    ts = PhaseEquil_pθq(bl.param_set, p, θ_liq, q_tot)
     ρ = air_density(ts)
 
     e_kin = FT(1 / 2) * FT((u^2 + v^2 + w^2))

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -40,7 +40,7 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
 
-    ts = PhaseDry_given_pT(bl.param_set, p, setup.T_ref)
+    ts = PhaseDry_pT(bl.param_set, p, setup.T_ref)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -19,7 +19,7 @@ using ClimateMachine.Thermodynamics:
     air_density,
     soundspeed_air,
     internal_energy,
-    PhaseDry_given_pT,
+    PhaseDry_pT,
     PhasePartition
 using ClimateMachine.TemperatureProfiles: IsothermalProfile
 using ClimateMachine.Atmos:
@@ -295,7 +295,7 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
 
-    ts = PhaseDry_given_pT(bl.param_set, p, setup.T_ref)
+    ts = PhaseDry_pT(bl.param_set, p, setup.T_ref)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -23,7 +23,7 @@ using ClimateMachine.Thermodynamics:
     air_density,
     soundspeed_air,
     internal_energy,
-    PhaseDry_given_pT,
+    PhaseDry_pT,
     PhasePartition
 using ClimateMachine.TemperatureProfiles: IsothermalProfile
 using ClimateMachine.Atmos:
@@ -321,7 +321,7 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, coords, t)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
 
-    ts = PhaseDry_given_pT(bl.param_set, p, setup.T_ref)
+    ts = PhaseDry_pT(bl.param_set, p, setup.T_ref)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -371,7 +371,7 @@ function isentropicvortex_initialcondition!(
     T = T∞ * (1 - _kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
     # adiabatic/isentropic relation
     p = p∞ * (T / T∞)^(FT(1) / _kappa_d)
-    ts = PhaseDry_given_pT(bl.param_set, p, T)
+    ts = PhaseDry_pT(bl.param_set, p, T)
     ρ = air_density(ts)
 
     e_pot = FT(0)

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -97,7 +97,7 @@ function Initialise_Density_Current!(
     π_exner = FT(1) - _grav / (_cp_d * θ) * x3 # exner pressure
     ρ = _MSLP / (_R_d * θ) * (π_exner)^(_cv_d / _R_d) # density
 
-    ts = LiquidIcePotTempSHumEquil(bl.param_set, θ, ρ, q_tot)
+    ts = PhaseEquil_ρθq(bl.param_set, ρ, θ, q_tot)
     q_pt = PhasePartition(ts)
 
     U, V, W = FT(0), FT(0), FT(0)  # momentum components

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -39,7 +39,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.Thermodynamics:
-    TemperatureSHumEquil_given_pressure, internal_energy
+    PhaseEquil_pTq, internal_energy
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
 
@@ -86,7 +86,7 @@ function init_problem!(problem, bl, state, aux, (x, y, z), t)
 
     q_tot = FT(0)
     e_pot = gravitational_potential(bl.orientation, aux)
-    ts = TemperatureSHumEquil_given_pressure(bl.param_set, T, P, q_tot)
+    ts = PhaseEquil_pTq(bl.param_set, P, T, q_tot)
 
     ρu, ρv, ρw = FT(0), FT(0), ρ * δw
 


### PR DESCRIPTION
# Description

I know that verbosity is good, but the names of thermo state constructors have gotten a bit out of hand. Thoughts on these changes? The proposed convention is: `PhaseName_{inputvariables}`. Without the suffix implies that you're calling the default constructor. We could write wrappers for these, too, but the ultimate solution here is to use kwargs, once this proves to be performant. And then we'll only have 3 names: `PhaseDry`, `PhaseEquil`, `PhaseNonEquil` with kwargs specifying the inputs. The other nice side effect of this is that users can easily locally check that the order of the input variables are correct.

Old names:

```
PhaseDry
PhaseDry_given_pT
PhaseDry_given_pθ
PhaseDry_given_ρT
PhaseEquil
PhaseNonEquil
TemperatureSHumEquil
TemperatureSHumNonEquil
TemperatureSHumEquil_given_pressure
LiquidIcePotTempSHumEquil
LiquidIcePotTempSHumNonEquil
LiquidIcePotTempSHumNonEquil_given_pressure
LiquidIcePotTempSHumEquil_given_pressure
```
New names (not necessarily in the same order)
```
PhaseDry
PhaseDry_pT
PhaseDry_pθ
PhaseDry_ρT
PhaseEquil
PhaseEquil_ρTq
PhaseEquil_pTq
PhaseEquil_pθq
PhaseEquil_ρθq
PhaseNonEquil
PhaseNonEquil_ρTq
PhaseNonEquil_ρθq
PhaseNonEquil_pθq
```

I also moved around the constructors to group the 3 fundamental types. This PR also swaps the order of the arguments to be of the form (ρ/p,T/θ,q).

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
