### PR TITLE
Add source type hierarchy

### DIFF
--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -10,6 +10,29 @@ CurrentModule = ClimateMachine.BalanceLaws
 BalanceLaw
 ```
 
+## Tendency types and methods
+
+```@docs
+PrognosticVariable
+AbstractOrder
+AbstractTendencyType
+TendencyDef
+eq_tends
+prognostic_vars
+fluxes
+sources
+show_tendencies
+```
+
+## Methods for fluxes and sources
+
+```@docs
+flux
+source
+Σfluxes
+Σsources
+```
+
 ## State variable types
 
 ```@docs

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -297,7 +297,7 @@ function config_dycoms(FT, N, resolution, xmax, ymax, zmax)
     source = (
         Gravity(),
         rayleigh_sponge,
-        Subsidence{FT}(D_subsidence),
+        Subsidence(D_subsidence)...,
         geostrophic_forcing,
     )
 

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -37,6 +37,7 @@ using ..Mesh.Grids:
     Direction
 
 using ClimateMachine.BalanceLaws
+import ClimateMachine.BalanceLaws: flux, source
 using ClimateMachine.Problems
 
 import ClimateMachine.BalanceLaws:
@@ -368,6 +369,12 @@ gravitational_potential(bl, aux) = gravitational_potential(bl.orientation, aux)
 turbulence_tensors(atmos::AtmosModel, args...) =
     turbulence_tensors(atmos.turbulence, atmos, args...)
 
+include("declare_prognostic_vars.jl") # declare prognostic variables
+include("multiphysics_types.jl")      # types for multi-physics tendencies
+include("tendencies_mass.jl")         # specify mass tendencies
+include("tendencies_momentum.jl")     # specify momentum tendencies
+include("tendencies_energy.jl")       # specify energy tendencies
+include("tendencies_moisture.jl")     # specify moisture tendencies
 
 include("problem.jl")
 include("ref_state.jl")
@@ -380,6 +387,9 @@ include("tracers.jl")
 include("linear.jl")
 include("courant.jl")
 include("filters.jl")
+
+include("atmos_tendencies.jl")        # specify atmos tendencies
+include("get_prognostic_vars.jl")     # get tuple of prognostic variables
 
 """
     flux_first_order!(
@@ -401,25 +411,15 @@ equations.
     t::Real,
     direction,
 )
-    ρ = state.ρ
-    ρinv = 1 / ρ
-    ρu = state.ρu
-    u = ρinv * ρu
-
-    # advective terms
-    flux.ρ = ρ * u
-    flux.ρu = ρ * u .* u'
-    flux.ρe = u * state.ρe
+    ρu_pad = SVector(1, 1, 1)
+    ts = recover_thermo_state(m, state, aux)
+    tend = Flux{FirstOrder}()
+    args = (m, state, aux, t, ts, direction)
+    flux.ρ = Σfluxes(eq_tends(Mass(), m, tend), args...)
+    flux.ρu = Σfluxes(eq_tends(Momentum(), m, tend), args...) .* ρu_pad
+    flux.ρe = Σfluxes(eq_tends(Energy(), m, tend), args...)
 
     # pressure terms
-    ts = recover_thermo_state(m, state, aux)
-    p = air_pressure(ts)
-    if m.ref_state isa HydrostaticState
-        flux.ρu += (p - aux.ref_state.p) * I
-    else
-        flux.ρu += p * I
-    end
-    flux.ρe += u * p
     flux_radiation!(m.radiation, m, flux, state, aux, t)
     flux_moisture!(m.moisture, m, flux, state, aux, t)
     flux_tracers!(m.tracers, m, flux, state, aux, t)
@@ -740,6 +740,18 @@ function source!(
     t::Real,
     direction,
 )
+    ρu_pad = SVector(1, 1, 1)
+    tend = Source()
+    ts = recover_thermo_state(m, state, aux)
+    args = (m, state, aux, t, ts, direction, diffusive)
+    source.ρ = Σsources(eq_tends(Mass(), m, tend), args...)
+    source.ρu = Σsources(eq_tends(Momentum(), m, tend), args...) .* ρu_pad
+    source.ρe = Σsources(eq_tends(Energy(), m, tend), args...)
+    if !(m.moisture isa DryModel)
+        source.moisture.ρq_tot =
+            Σsources(eq_tends(TotalMoisture(), m, tend), args...)
+    end
+
     atmos_source!(m.source, m, source, state, diffusive, aux, t, direction)
 end
 

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -1,0 +1,37 @@
+#####
+##### Tendency specification
+#####
+
+import ..BalanceLaws: eq_tends
+
+# --------- Some of these methods are generic or
+#           temporary during transition to new specification:
+filter_source(pv::PrognosticVariable, s) = nothing
+# Sources that have been added to new specification:
+filter_source(pv::PV, s::Subsidence{PV}) where {PV <: PrognosticVariable} = s
+
+# Filter sources / empty elements
+filter_sources(t::Tuple) = filter(x -> !(x == nothing), t)
+filter_sources(pv::PrognosticVariable, srcs) =
+    filter_sources(map(s -> filter_source(pv, s), srcs))
+
+# Entry point
+eq_tends(pv::PrognosticVariable, m::AtmosModel, ::Source) =
+    filter_sources(pv, m.source)
+# ---------
+
+# Mass
+eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Mass} =
+    (Advect{PV}(),)
+
+# Momentum
+eq_tends(pv::PV, m::AtmosModel, ::Flux{FirstOrder}) where {PV <: Momentum} =
+    (Advect{PV}(), PressureGradient{PV}())
+
+# Energy
+eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Energy} =
+    (Advect{PV}(), Pressure{PV}())
+
+# TotalMoisture
+eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: TotalMoisture} =
+    ()

--- a/src/Atmos/Model/declare_prognostic_vars.jl
+++ b/src/Atmos/Model/declare_prognostic_vars.jl
@@ -1,0 +1,13 @@
+##### Prognostic variable
+
+export Mass, Momentum, Energy
+export TotalMoisture, LiquidMoisture, IceMoisture
+export Tracers
+
+struct Mass <: PrognosticVariable end
+struct Momentum <: PrognosticVariable end
+struct Energy <: PrognosticVariable end
+struct TotalMoisture <: PrognosticVariable end
+struct LiquidMoisture <: PrognosticVariable end
+struct IceMoisture <: PrognosticVariable end
+struct Tracers <: PrognosticVariable end

--- a/src/Atmos/Model/get_prognostic_vars.jl
+++ b/src/Atmos/Model/get_prognostic_vars.jl
@@ -1,0 +1,10 @@
+##### Get prognostic variable list
+
+import ..BalanceLaws: prognostic_vars
+
+prognostic_vars(::DryModel) = ()
+prognostic_vars(::EquilMoist) = (TotalMoisture(),)
+prognostic_vars(::NonEquilMoist) =
+    (TotalMoisture(), LiquidMoisture(), IceMoisture())
+prognostic_vars(m::AtmosModel) =
+    (Mass(), Momentum(), Energy(), prognostic_vars(m.moisture)...)

--- a/src/Atmos/Model/multiphysics_types.jl
+++ b/src/Atmos/Model/multiphysics_types.jl
@@ -1,0 +1,21 @@
+##### Multi-physics types
+
+export Subsidence
+struct Subsidence{PV, FT} <: TendencyDef{Source, PV}
+    D::FT
+end
+
+# Subsidence includes tendencies in Mass, Energy and TotalMoisture equations:
+Subsidence(D::FT) where {FT} = (
+    Subsidence{Mass, FT}(D),
+    Subsidence{Energy, FT}(D),
+    Subsidence{TotalMoisture, FT}(D),
+)
+
+subsidence_velocity(subsidence::Subsidence{PV, FT}, z::FT) where {PV, FT} =
+    -subsidence.D * z
+
+struct PressureGradient{PV <: Momentum} <: TendencyDef{Flux{FirstOrder}, PV} end
+struct Pressure{PV <: Energy} <: TendencyDef{Flux{FirstOrder}, PV} end
+
+struct Advect{PV} <: TendencyDef{Flux{FirstOrder}, PV} end

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -4,7 +4,6 @@ using CLIMAParameters.Planet: Omega, e_int_i0, cv_l, cv_i, T_0
 export AbstractSource,
     Gravity,
     RayleighSponge,
-    Subsidence,
     GeostrophicForcing,
     Coriolis,
     RemovePrecipitation,
@@ -74,10 +73,6 @@ function atmos_source!(
     source.ρu -= SVector(0, 0, 2 * _Omega) × state.ρu
 end
 
-struct Subsidence{FT} <: AbstractSource
-    D::FT
-end
-
 function atmos_source!(
     subsidence::Subsidence,
     atmos::AtmosModel,
@@ -88,19 +83,8 @@ function atmos_source!(
     t::Real,
     direction,
 )
-    ρ = state.ρ
-    z = altitude(atmos, aux)
-    w_sub = subsidence_velocity(subsidence, z)
-    k̂ = vertical_unit_vector(atmos, aux)
-
-    source.ρe -= ρ * w_sub * dot(k̂, diffusive.∇h_tot)
-    source.moisture.ρq_tot -= ρ * w_sub * dot(k̂, diffusive.moisture.∇q_tot)
-    source.ρ -= ρ * w_sub * dot(k̂, diffusive.moisture.∇q_tot)
+    # Migrated to Σsources
 end
-
-subsidence_velocity(subsidence::Subsidence{FT}, z::FT) where {FT} =
-    -subsidence.D * z
-
 
 struct GeostrophicForcing{FT} <: AbstractSource
     f_coriolis::FT

--- a/src/Atmos/Model/tendencies_energy.jl
+++ b/src/Atmos/Model/tendencies_energy.jl
@@ -1,0 +1,33 @@
+##### Energy tendencies
+
+#####
+##### First order fluxes
+#####
+
+function flux(::Advect{Energy}, m, state, aux, t, ts, direction)
+    return (state.ρu / state.ρ) * state.ρe
+end
+
+function flux(::Pressure{Energy}, m, state, aux, t, ts, direction)
+    return state.ρu / state.ρ * air_pressure(ts)
+end
+
+#####
+##### Sources
+#####
+
+function source(
+    s::Subsidence{Energy},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+    diffusive,
+)
+    z = altitude(m, aux)
+    w_sub = subsidence_velocity(s, z)
+    k̂ = vertical_unit_vector(m, aux)
+    return -state.ρ * w_sub * dot(k̂, diffusive.∇h_tot)
+end

--- a/src/Atmos/Model/tendencies_mass.jl
+++ b/src/Atmos/Model/tendencies_mass.jl
@@ -1,0 +1,16 @@
+##### Mass tendencies
+
+function flux(::Advect{Mass}, m, state, aux, t, ts, direction)
+    return state.ρu
+end
+
+#####
+##### Sources
+#####
+
+function source(s::Subsidence{Mass}, m, state, aux, t, ts, direction, diffusive)
+    z = altitude(m, aux)
+    w_sub = subsidence_velocity(s, z)
+    k̂ = vertical_unit_vector(m, aux)
+    return -state.ρ * w_sub * dot(k̂, diffusive.moisture.∇q_tot)
+end

--- a/src/Atmos/Model/tendencies_moisture.jl
+++ b/src/Atmos/Model/tendencies_moisture.jl
@@ -1,0 +1,21 @@
+##### Moisture tendencies
+
+#####
+##### Sources
+#####
+
+function source(
+    s::Subsidence{TotalMoisture},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+    diffusive,
+)
+    z = altitude(m, aux)
+    w_sub = subsidence_velocity(s, z)
+    k̂ = vertical_unit_vector(m, aux)
+    return -state.ρ * w_sub * dot(k̂, diffusive.moisture.∇q_tot)
+end

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -1,0 +1,13 @@
+##### Momentum tendencies
+
+function flux(::Advect{Momentum}, m, state, aux, t, ts, direction)
+    return state.ρu .* (state.ρu / state.ρ)'
+end
+
+function flux(::PressureGradient{Momentum}, m, state, aux, t, ts, direction)
+    if m.ref_state isa HydrostaticState
+        return (air_pressure(ts) - aux.ref_state.p) * I
+    else
+        return air_pressure(ts) * I
+    end
+end

--- a/src/BalanceLaws/BalanceLaws.jl
+++ b/src/BalanceLaws/BalanceLaws.jl
@@ -28,5 +28,8 @@ export BalanceLaw,
 
 include("state_types.jl")
 include("interface.jl")
+include("tendency_types.jl")
+include("show_tendencies.jl")
+include("sum_tendencies.jl")
 
 end

--- a/src/BalanceLaws/show_tendencies.jl
+++ b/src/BalanceLaws/show_tendencies.jl
@@ -1,0 +1,64 @@
+##### Show tendencies
+
+export show_tendencies
+
+using PrettyTables
+
+first_param(t::TendencyDef{TT, PV}) where {TT, PV} = PV
+
+function format_tend(tend_type, include_params)
+    t = "$(nameof(typeof(tend_type)))"
+    return include_params ? t * "{$(first_param(tend_type))}" : t
+end
+
+format_tends(tend_types, include_params) =
+    "(" * join(format_tend.(tend_types, include_params), ", ") * ")"
+
+"""
+    show_tendencies(bl; include_params = false)
+
+Show a table of the tendencies for each
+prognostic variable for the given balance law.
+
+Using `include_params = true` will include the type
+parameters for each of the tendency fluxes
+and sources.
+
+Requires definitions for
+ - [`prognostic_vars`](@ref)
+ - [`eq_tends`](@ref)
+for the balance law.
+"""
+function show_tendencies(bl; include_params = false)
+    ip = include_params
+    prog_vars = prognostic_vars(bl)
+    if !isempty(prog_vars)
+        # TODO: add Flux{SecondOrder}
+        header = [
+            "Equation" "Flux{FirstOrder}" "Source"
+            "(Y_i)" "(F_1)" "(S)"
+        ]
+        eqs = collect(string.(nameof.(typeof.(prog_vars))))
+        fmt_tends(tt) = map(prog_vars) do pv
+            format_tends(eq_tends(pv, bl, tt), ip)
+        end |> collect
+        F1 = fmt_tends(Flux{FirstOrder}())
+        S = fmt_tends(Source())
+        data = hcat(eqs, F1, S)
+        @warn "This table is temporarily incomplete"
+        println("\nPDE: ∂_t Y_i + (∇•F_1(Y))_i + (∇•F_2(Y,G)))_i = (S(Y,G))_i")
+        pretty_table(
+            data,
+            header,
+            header_crayon = crayon"yellow bold",
+            subheader_crayon = crayon"green bold",
+        )
+        println("")
+    else
+        msg = "Defining `prognostic_vars` and\n"
+        msg *= "`eq_tends` for $(nameof(typeof(bl))) will\n"
+        msg *= "enable printing a table of tendencies."
+        @info msg
+    end
+    return nothing
+end

--- a/src/BalanceLaws/sum_tendencies.jl
+++ b/src/BalanceLaws/sum_tendencies.jl
@@ -1,0 +1,51 @@
+##### Sum wrapper
+
+export Σfluxes, Σsources
+
+"""
+    flux
+
+An individual flux.
+See [`BalanceLaw`](@ref) for more info.
+"""
+function flux end
+
+"""
+    source
+
+An individual source.
+See [`BalanceLaw`](@ref) for more info.
+"""
+function source end
+
+"""
+    Σfluxes(fluxes::NTuple, args...)
+
+Sum of the fluxes where
+ - `fluxes` is an `NTuple{N, TendencyDef{Flux{O}, PV}} where {N, PV, O}`
+"""
+function Σfluxes(
+    fluxes::NTuple{N, TendencyDef{Flux{O}, PV}},
+    args...,
+) where {N, PV, O}
+    return sum(ntuple(Val(length(fluxes))) do i
+        flux(fluxes[i], args...)
+    end)
+end
+Σfluxes(fluxes::Tuple{}, args...) = 0
+
+"""
+    Σsources(sources::NTuple, args...)
+
+Sum of the sources where
+ - `sources` is an `NTuple{N, TendencyDef{Source, PV}} where {N, PV}`
+"""
+function Σsources(
+    sources::NTuple{N, TendencyDef{Source, PV}},
+    args...,
+) where {N, PV}
+    return sum(ntuple(Val(length(sources))) do i
+        source(sources[i], args...)
+    end)
+end
+Σsources(sources::Tuple{}, args...) = 0

--- a/src/BalanceLaws/tendency_types.jl
+++ b/src/BalanceLaws/tendency_types.jl
@@ -1,0 +1,123 @@
+#### Tendency types
+
+# Terminology:
+#
+# `∂_t Yᵢ + (∇•F₁(Y))ᵢ + (∇•F₂(Y,G)))ᵢ = (S(Y,G))ᵢ`
+# `__Tᵤ__   ____T₁____   ______T₂______   ___S___`
+#
+#  - `Yᵢ` - the i-th prognostic variable
+#  - `Y` - the prognostic state (column vector)
+#  - `G = ∇Y` - the gradient of the prognostic state (rank 2 tensor)
+#  - `F₁` - the first order tendency flux (rank 2 tensor)
+#  - `F₂` - the second order tendency flux (rank 2 tensor)
+#  - `Tᵤ` - the unsteady tendency (column vector)
+#  - `T₁` - the first order flux tendency (column vector)
+#  - `T₂` - the second order flux tendency (column vector)
+#  - `S` - the non-conservative tendency source (column vector)
+
+export PrognosticVariable
+export FirstOrder, SecondOrder
+export Flux, Source
+export TendencyDef
+
+"""
+    PrognosticVariable
+
+Subtypes are used for specifying
+each prognostic variable.
+"""
+abstract type PrognosticVariable end
+
+"""
+    AbstractOrder
+
+Subtypes are used for dispatching
+on the flux order.
+"""
+abstract type AbstractOrder end
+struct FirstOrder <: AbstractOrder end
+struct SecondOrder <: AbstractOrder end
+
+"""
+    AbstractTendencyType
+
+Subtypes are used for specifying a
+tuple of tendencies to be accumulated.
+"""
+abstract type AbstractTendencyType end
+struct Flux{O <: AbstractOrder} <: AbstractTendencyType end
+struct Source <: AbstractTendencyType end
+
+"""
+    TendencyDef
+
+Subtypes are used for specifying
+each tendency definition.
+"""
+abstract type TendencyDef{TT <: AbstractTendencyType, PV <: PrognosticVariable} end
+
+"""
+    eq_tends(::PrognosticVariable, ::BalanceLaw, ::AbstractTendencyType)
+
+A tuple of `TendencyDef`s given
+ - `PrognosticVariable` prognostic variable
+ - `AbstractTendencyType` tendency type
+ - `BalanceLaw` balance law
+
+i.e., a tuple of `TendencyDef`s corresponding
+to `F₁`, `F₂`, **or** `S` for a single
+prognostic variable in:
+
+    `∂_t Yᵢ + (∇•F₁(Y))ᵢ + (∇•F₂(Y,G)))ᵢ = (S(Y,G))ᵢ`
+"""
+function eq_tends end
+
+"""
+    prognostic_vars(::BalanceLaw)
+
+A tuple of `PrognosticVariable`s given
+the `BalanceLaw`.
+
+i.e., a tuple of `PrognosticVariable`s
+corresponding to the column-vector `Yᵢ` in:
+
+    `∂_t Yᵢ + (∇•F₁(Y))ᵢ + (∇•F₂(Y,G)))ᵢ = (S(Y,G))ᵢ`
+"""
+prognostic_vars(::BalanceLaw) = ()
+
+export sources
+"""
+    sources(bl::BalanceLaw)
+
+A tuple of `TendencyDef{Source}`s
+given the `BalanceLaw`.
+
+i.e., a tuple of `TendencyDef{Source}`s
+corresponding to the column-vector `S` in:
+
+    `∂_t Yᵢ + (∇•F₁(Y))ᵢ + (∇•F₂(Y,G)))ᵢ = (S(Y,G))ᵢ`
+"""
+function sources(bl::BalanceLaw)
+    tend = eq_tends.(prognostic_vars(bl), Ref(bl), Ref(Source()))
+    tend = filter(x -> x ≠ nothing, tend)
+    return Tuple(Iterators.flatten(tend))
+end
+
+export fluxes
+"""
+    fluxes(bl::BalanceLaw, order::O) where {O <: AbstractOrder}
+
+A tuple of `TendencyDef{Flux{O}}`s
+given the `BalanceLaw` and the `order::O`.
+
+i.e., a tuple of `TendencyDef{Flux{O}}`s
+corresponding to the column-vector `F₁`
+or `F₂` given the flux order `order::O` in:
+
+    `∂_t Yᵢ + (∇•F₁(Y))ᵢ + (∇•F₂(Y,G)))ᵢ = (S(Y,G))ᵢ`
+"""
+function fluxes(bl::BalanceLaw, order::O) where {O <: AbstractOrder}
+    tend = eq_tends.(prognostic_vars(bl), Ref(bl), Ref(Flux{O}()))
+    tend = filter(x -> x ≠ nothing, tend)
+    return Tuple(Iterators.flatten(tend))
+end

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -105,6 +105,7 @@ function print_model_info(model)
             )
     end
     @info msg
+    show_tendencies(model)
 end
 
 function AtmosLESConfiguration(

--- a/test/BalanceLaws/runtests.jl
+++ b/test/BalanceLaws/runtests.jl
@@ -1,0 +1,29 @@
+using Test
+using ClimateMachine.BalanceLaws
+
+import ClimateMachine.BalanceLaws: eq_tends, prognostic_vars
+
+struct TestBL <: BalanceLaw end
+struct X <: PrognosticVariable end
+struct Y <: PrognosticVariable end
+struct F1{PV} <: TendencyDef{Flux{FirstOrder}, PV} end
+struct F2{PV} <: TendencyDef{Flux{SecondOrder}, PV} end
+struct S{PV} <: TendencyDef{Source, PV} end
+
+prognostic_vars(::TestBL) = (X(), Y())
+eq_tends(::X, ::TestBL, ::Flux{FirstOrder}) = (F1{X}(),)
+eq_tends(::Y, ::TestBL, ::Flux{FirstOrder}) = (F1{Y}(),)
+eq_tends(::X, ::TestBL, ::Flux{SecondOrder}) = (F2{X}(),)
+eq_tends(::Y, ::TestBL, ::Flux{SecondOrder}) = (F2{Y}(),)
+eq_tends(::X, ::TestBL, ::Source) = (S{X}(),)
+eq_tends(::Y, ::TestBL, ::Source) = (S{Y}(),)
+
+@testset "BalanceLaws" begin
+    bl = TestBL()
+    @test prognostic_vars(bl) == (X(), Y())
+    @test fluxes(bl, FirstOrder()) == (F1{X}(), F1{Y}())
+    @test fluxes(bl, SecondOrder()) == (F2{X}(), F2{Y}())
+    @test sources(bl) == (S{X}(), S{Y}())
+    show_tendencies(bl)
+    show_tendencies(bl; include_params = true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ end
         "Utilities",
         "Common",
         "Arrays",
+        "BalanceLaws",
         "Atmos",
         "Land",
         "Numerics",


### PR DESCRIPTION
# Description

This is a first step towards fixing #395, #1527, #1036, and #1633.

It seems that all sources could be written this way. I think this has a few advantages:
 - Users can overload `eq_tends` and add / remove terms in a hierarchical fashion, while not affecting the other flux terms
 - `flux` and `source` can be used by diagnostics to export/monitor the budget.
 - This could also be used for specifying time-explicit/implicit source terms more easily via types
 - We can remove the generated functions in `Atmos/Model/source.jl`

This is just a prototype for now. I figured I'd open this PR to get feedback. This seems to work fine for `experiments/AtmosLES/bomex_single_stack.jl` (both on CPU and GPU)

One potential concern is, can we continue to unroll the tendencies if the number of sources gets large. @vchuravy? I can't imagine we'll reach over 100 (ever), but I could imagine reaching/needing granularity of, say 20.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
