### PR TITLE
Add broadcast rule to param_set in thermo

### DIFF
--- a/src/Common/Thermodynamics/Thermodynamics.jl
+++ b/src/Common/Thermodynamics/Thermodynamics.jl
@@ -34,6 +34,8 @@ using CLIMAParameters: AbstractParameterSet
 using CLIMAParameters.Planet
 const APS = AbstractParameterSet
 
+Base.broadcastable(param_set::APS) = Ref(param_set)
+
 # Allow users to skip error on non-convergence
 # by importing:
 # ```julia
@@ -53,5 +55,7 @@ print_warning() = true
 include("states.jl")
 include("relations.jl")
 include("isentropic.jl")
+
+Base.broadcastable(dap::DryAdiabaticProcess) = Ref(dap)
 
 end #module Thermodynamics.jl

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -60,10 +60,8 @@ include("data_tests.jl")
         @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
         # Test state for thermodynamic consistency (with ideal gas law)
-        @test all(
-            T .≈
-            air_temperature_from_ideal_gas_law.(Ref(param_set), p, ρ, q_pt),
-        )
+        T_idgl = air_temperature_from_ideal_gas_law.(param_set, p, ρ, q_pt)
+        @test all(T .≈ T_idgl)
 
         Φ = FT(1)
         Random.seed!(15)
@@ -71,25 +69,16 @@ include("data_tests.jl")
 
         # TODO: Use reasonable values for ambient temperature/pressure
         T∞, p∞ = T .* perturbation, p .* perturbation
-        @test air_temperature.(
-            Ref(param_set),
-            p,
-            θ_liq_ice,
-            Ref(DryAdiabaticProcess()),
-        ) ≈ (p ./ _MSLP) .^ (_R_d / _cp_d) .* θ_liq_ice
+        @test air_temperature.(param_set, p, θ_liq_ice, DryAdiabaticProcess()) ≈
+              (p ./ _MSLP) .^ (_R_d / _cp_d) .* θ_liq_ice
         @test air_pressure_given_θ.(
-            Ref(param_set),
+            param_set,
             θ_liq_ice,
             Φ,
-            Ref(DryAdiabaticProcess()),
+            DryAdiabaticProcess(),
         ) ≈ _MSLP .* (1 .- Φ ./ (θ_liq_ice .* _cp_d)) .^ (_cp_d / _R_d)
-        @test air_pressure.(
-            Ref(param_set),
-            T,
-            T∞,
-            p∞,
-            Ref(DryAdiabaticProcess()),
-        ) ≈ p∞ .* (T ./ T∞) .^ (FT(1) / _kappa_d)
+        @test air_pressure.(param_set, T, T∞, p∞, DryAdiabaticProcess()) ≈
+              p∞ .* (T ./ T∞) .^ (FT(1) / _kappa_d)
     end
 end
 
@@ -421,7 +410,7 @@ end
 
         RH_sat_mask = or.(RH .> 1, RH .≈ 1)
         RH_unsat_mask = .!or.(RH .> 1, RH .≈ 1)
-        ts = PhaseEquil.(Ref(param_set), e_int, ρ, q_tot)
+        ts = PhaseEquil.(param_set, e_int, ρ, q_tot)
         @test all(saturated.(ts[RH_sat_mask]))
         @test !any(saturated.(ts[RH_unsat_mask]))
 
@@ -429,7 +418,7 @@ end
         _T_freeze = FT(T_freeze(param_set))
         e_int_upper =
             internal_energy_sat.(
-                Ref(param_set),
+                param_set,
                 Ref(_T_freeze + sqrt(eps(FT))),
                 ρ,
                 q_tot,
@@ -437,20 +426,20 @@ end
             )
         e_int_lower =
             internal_energy_sat.(
-                Ref(param_set),
+                param_set,
                 Ref(_T_freeze - sqrt(eps(FT))),
                 ρ,
                 q_tot,
                 phase_type,
             )
         _e_int = (e_int_upper .+ e_int_lower) / 2
-        ts = PhaseEquil.(Ref(param_set), _e_int, ρ, q_tot)
+        ts = PhaseEquil.(param_set, _e_int, ρ, q_tot)
         @test all(air_temperature.(ts) .== Ref(_T_freeze))
 
         # Args needs to be in sync with PhaseEquil:
         ts =
             PhaseEquil.(
-                Ref(param_set),
+                param_set,
                 _e_int,
                 ρ,
                 q_tot,
@@ -461,8 +450,8 @@ end
         @test all(air_temperature.(ts) .== Ref(_T_freeze))
 
         # PhaseEquil
-        ts_exact = PhaseEquil.(Ref(param_set), e_int, ρ, q_tot, 100, FT(1e-3))
-        ts = PhaseEquil.(Ref(param_set), e_int, ρ, q_tot)
+        ts_exact = PhaseEquil.(param_set, e_int, ρ, q_tot, 100, FT(1e-3))
+        ts = PhaseEquil.(param_set, e_int, ρ, q_tot)
         @test all(isapprox.(T, air_temperature.(ts), rtol = rtol_temperature))
 
         # Should be machine accurate (because ts contains `e_int`,`ρ`,`q_tot`):
@@ -512,7 +501,7 @@ end
         # PhaseEquil
         ts_exact =
             PhaseEquil.(
-                Ref(param_set),
+                param_set,
                 e_int,
                 ρ,
                 q_tot,
@@ -522,7 +511,7 @@ end
             )
         ts =
             PhaseEquil.(
-                Ref(param_set),
+                param_set,
                 e_int,
                 ρ,
                 q_tot,
@@ -550,16 +539,8 @@ end
         ))
 
         # PhaseEquil_ρθq
-        ts_exact =
-            PhaseEquil_ρθq.(
-                Ref(param_set),
-                ρ,
-                θ_liq_ice,
-                q_tot,
-                45,
-                FT(1e-3),
-            )
-        ts = PhaseEquil_ρθq.(Ref(param_set), ρ, θ_liq_ice, q_tot)
+        ts_exact = PhaseEquil_ρθq.(param_set, ρ, θ_liq_ice, q_tot, 45, FT(1e-3))
+        ts = PhaseEquil_ρθq.(param_set, ρ, θ_liq_ice, q_tot)
         # Should be machine accurate:
         @test all(air_density.(ts) .≈ air_density.(ts_exact))
         @test all(
@@ -584,22 +565,8 @@ end
         ))
 
         # PhaseEquil_pθq
-        ts_exact =
-            PhaseEquil_pθq.(
-                Ref(param_set),
-                p,
-                θ_liq_ice,
-                q_tot,
-                40,
-                FT(1e-3),
-            )
-        ts =
-            PhaseEquil_pθq.(
-                Ref(param_set),
-                p,
-                θ_liq_ice,
-                q_tot,
-            )
+        ts_exact = PhaseEquil_pθq.(param_set, p, θ_liq_ice, q_tot, 40, FT(1e-3))
+        ts = PhaseEquil_pθq.(param_set, p, θ_liq_ice, q_tot)
         # Should be machine accurate:
         @test all(
             getproperty.(PhasePartition.(ts), :tot) .≈
@@ -629,15 +596,8 @@ end
 
         # PhaseNonEquil_ρθq
         ts_exact =
-            PhaseNonEquil_ρθq.(
-                Ref(param_set),
-                ρ,
-                θ_liq_ice,
-                q_pt,
-                40,
-                FT(1e-3),
-            )
-        ts = PhaseNonEquil_ρθq.(Ref(param_set), ρ, θ_liq_ice, q_pt)
+            PhaseNonEquil_ρθq.(param_set, ρ, θ_liq_ice, q_pt, 40, FT(1e-3))
+        ts = PhaseNonEquil_ρθq.(param_set, ρ, θ_liq_ice, q_pt)
         # Should be machine accurate:
         @test all(
             getproperty.(PhasePartition.(ts), :tot) .≈
@@ -681,7 +641,7 @@ end
     @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
     @test_throws ErrorException MT.saturation_adjustment.(
-        Ref(param_set),
+        param_set,
         e_int,
         ρ,
         q_tot,
@@ -691,7 +651,7 @@ end
     )
 
     @test_throws ErrorException MT.saturation_adjustment_SecantMethod.(
-        Ref(param_set),
+        param_set,
         e_int,
         ρ,
         q_tot,
@@ -702,7 +662,7 @@ end
 
     T_virt = T # should not matter: testing for non-convergence
     @test_throws ErrorException temperature_and_humidity_from_virtual_temperature.(
-        Ref(param_set),
+        param_set,
         T_virt,
         ρ,
         RH,
@@ -712,7 +672,7 @@ end
     )
 
     @test_throws ErrorException air_temperature_from_liquid_ice_pottemp_non_linear.(
-        Ref(param_set),
+        param_set,
         θ_liq_ice,
         ρ,
         2,
@@ -721,7 +681,7 @@ end
     )
 
     @test_throws ErrorException MT.saturation_adjustment_q_tot_θ_liq_ice.(
-        Ref(param_set),
+        param_set,
         θ_liq_ice,
         ρ,
         q_tot,
@@ -731,7 +691,7 @@ end
     )
 
     @test_throws ErrorException MT.saturation_adjustment_q_tot_θ_liq_ice_given_pressure.(
-        Ref(param_set),
+        param_set,
         θ_liq_ice,
         p,
         q_tot,
@@ -754,20 +714,20 @@ end
         @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
         # PhaseDry
-        ts = PhaseDry.(Ref(param_set), e_int, ρ)
+        ts = PhaseDry.(param_set, e_int, ρ)
         @test all(internal_energy.(ts) .≈ e_int)
         @test all(air_density.(ts) .≈ ρ)
 
-        ts_p = PhaseDry_pT.(Ref(param_set), p, T)
-        @test all(internal_energy.(ts_p) .≈ internal_energy.(Ref(param_set), T))
+        ts_p = PhaseDry_pT.(param_set, p, T)
+        @test all(internal_energy.(ts_p) .≈ internal_energy.(param_set, T))
         @test all(air_density.(ts_p) .≈ ρ)
 
-        θ_dry = dry_pottemp.(Ref(param_set), T, ρ)
-        ts_p = PhaseDry_pθ.(Ref(param_set), p, θ_dry)
-        @test all(internal_energy.(ts_p) .≈ internal_energy.(Ref(param_set), T))
+        θ_dry = dry_pottemp.(param_set, T, ρ)
+        ts_p = PhaseDry_pθ.(param_set, p, θ_dry)
+        @test all(internal_energy.(ts_p) .≈ internal_energy.(param_set, T))
         @test all(air_density.(ts_p) .≈ ρ)
 
-        ts = PhaseDry_ρT.(Ref(param_set), ρ, T)
+        ts = PhaseDry_ρT.(param_set, ρ, T)
 
         @test all(air_density.(ts_p) .≈ air_density.(ts))
         @test all(internal_energy.(ts_p) .≈ internal_energy.(ts))
@@ -778,7 +738,7 @@ end
         # PhaseEquil
         ts =
             PhaseEquil.(
-                Ref(param_set),
+                param_set,
                 e_int,
                 ρ,
                 q_tot,
@@ -790,13 +750,13 @@ end
         @test all(getproperty.(PhasePartition.(ts), :tot) .≈ q_tot)
         @test all(air_density.(ts) .≈ ρ)
 
-        ts = PhaseEquil.(Ref(param_set), e_int, ρ, q_tot)
+        ts = PhaseEquil.(param_set, e_int, ρ, q_tot)
         @test all(internal_energy.(ts) .≈ e_int)
         @test all(getproperty.(PhasePartition.(ts), :tot) .≈ q_tot)
         @test all(air_density.(ts) .≈ ρ)
 
         # PhaseNonEquil
-        ts = PhaseNonEquil.(Ref(param_set), e_int, ρ, q_pt)
+        ts = PhaseNonEquil.(param_set, e_int, ρ, q_pt)
         @test all(internal_energy.(ts) .≈ e_int)
         @test all(
             getproperty.(PhasePartition.(ts), :tot) .≈ getproperty.(q_pt, :tot),
@@ -810,11 +770,10 @@ end
         @test all(air_density.(ts) .≈ ρ)
 
         # air_temperature_from_liquid_ice_pottemp_given_pressure-liquid_ice_pottemp inverse
-        θ_liq_ice_ =
-            liquid_ice_pottemp_given_pressure.(Ref(param_set), T, p, q_pt)
+        θ_liq_ice_ = liquid_ice_pottemp_given_pressure.(param_set, T, p, q_pt)
         @test all(
             air_temperature_from_liquid_ice_pottemp_given_pressure.(
-                Ref(param_set),
+                param_set,
                 θ_liq_ice_,
                 p,
                 q_pt,
@@ -824,20 +783,20 @@ end
         # liquid_ice_pottemp-air_temperature_from_liquid_ice_pottemp_given_pressure inverse
         T =
             air_temperature_from_liquid_ice_pottemp_given_pressure.(
-                Ref(param_set),
+                param_set,
                 θ_liq_ice,
                 p,
                 q_pt,
             )
         @test all(
-            liquid_ice_pottemp_given_pressure.(Ref(param_set), T, p, q_pt) .≈
+            liquid_ice_pottemp_given_pressure.(param_set, T, p, q_pt) .≈
             θ_liq_ice,
         )
 
         # Accurate but expensive `PhaseNonEquil_ρθq` constructor (Non-linear temperature from θ_liq_ice)
         T_non_linear =
             air_temperature_from_liquid_ice_pottemp_non_linear.(
-                Ref(param_set),
+                param_set,
                 θ_liq_ice,
                 ρ,
                 20,
@@ -846,14 +805,14 @@ end
             )
         T_expansion =
             air_temperature_from_liquid_ice_pottemp.(
-                Ref(param_set),
+                param_set,
                 θ_liq_ice,
                 ρ,
                 q_pt,
             )
         @test all(isapprox.(T_non_linear, T_expansion, rtol = rtol_temperature))
-        e_int_ = internal_energy.(Ref(param_set), T_non_linear, q_pt)
-        ts = PhaseNonEquil.(Ref(param_set), e_int_, ρ, q_pt)
+        e_int_ = internal_energy.(param_set, T_non_linear, q_pt)
+        ts = PhaseNonEquil.(param_set, e_int_, ρ, q_pt)
         @test all(T_non_linear .≈ air_temperature.(ts))
         @test all(isapprox(
             θ_liq_ice,
@@ -862,15 +821,7 @@ end
         ))
 
         # PhaseEquil_ρθq
-        ts =
-            PhaseEquil_ρθq.(
-                Ref(param_set),
-                ρ,
-                θ_liq_ice,
-                q_tot,
-                45,
-                FT(1e-3),
-            )
+        ts = PhaseEquil_ρθq.(param_set, ρ, θ_liq_ice, q_tot, 45, FT(1e-3))
         @test all(isapprox.(
             liquid_ice_pottemp.(ts),
             θ_liq_ice,
@@ -885,15 +836,7 @@ end
         # precision for the input pressure.
 
         # PhaseEquil_pθq
-        ts =
-            PhaseEquil_pθq.(
-                Ref(param_set),
-                p,
-                θ_liq_ice,
-                q_tot,
-                35,
-                FT(1e-3),
-            )
+        ts = PhaseEquil_pθq.(param_set, p, θ_liq_ice, q_tot, 35, FT(1e-3))
         @test all(isapprox.(
             liquid_ice_pottemp.(ts),
             θ_liq_ice,
@@ -905,13 +848,7 @@ end
         @test all(isapprox.(air_pressure.(ts), p, atol = atol_pressure))
 
         # PhaseNonEquil_pθq
-        ts =
-            PhaseNonEquil_pθq.(
-                Ref(param_set),
-                p,
-                θ_liq_ice,
-                q_pt,
-            )
+        ts = PhaseNonEquil_pθq.(param_set, p, θ_liq_ice, q_pt)
         @test all(liquid_ice_pottemp.(ts) .≈ θ_liq_ice)
         @test all(air_pressure.(ts) .≈ p)
         @test all(
@@ -925,15 +862,7 @@ end
         )
 
         # PhaseNonEquil_ρθq
-        ts =
-            PhaseNonEquil_ρθq.(
-                Ref(param_set),
-                ρ,
-                θ_liq_ice,
-                q_pt,
-                5,
-                FT(1e-3),
-            )
+        ts = PhaseNonEquil_ρθq.(param_set, ρ, θ_liq_ice, q_pt, 5, FT(1e-3))
         @test all(isapprox.(
             θ_liq_ice,
             liquid_ice_pottemp.(ts),
@@ -955,7 +884,7 @@ end
         @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
 
         # Test that relative humidity is 1 for saturated conditions
-        q_sat = q_vap_saturation.(Ref(param_set), T, ρ, Ref(phase_type))
+        q_sat = q_vap_saturation.(param_set, T, ρ, Ref(phase_type))
         q_pt_sat = PhasePartition.(q_sat)
         q_vap = vapor_specific_humidity.(q_pt_sat)
         @test all(getproperty.(q_pt_sat, :liq) .≈ 0)
@@ -963,46 +892,34 @@ end
         @test all(q_vap .≈ q_sat)
 
         # Compute thermodynamic consistent pressure
-        p_sat = air_pressure.(Ref(param_set), T, ρ, q_pt_sat)
+        p_sat = air_pressure.(param_set, T, ρ, q_pt_sat)
 
         # Test that density remains consistent
-        ρ_rec = air_density.(Ref(param_set), T, p_sat, q_pt_sat)
+        ρ_rec = air_density.(param_set, T, p_sat, q_pt_sat)
         @test all.(ρ_rec ≈ ρ)
 
         RH_sat =
-            relative_humidity.(
-                Ref(param_set),
-                T,
-                p_sat,
-                Ref(phase_type),
-                q_pt_sat,
-            )
+            relative_humidity.(param_set, T, p_sat, Ref(phase_type), q_pt_sat)
 
         # TODO: Add this test back in
         @test all(RH_sat .≈ 1)
 
         # Test that RH is zero for dry conditions
         q_pt_dry = PhasePartition.(zeros(FT, length(T)))
-        p_dry = air_pressure.(Ref(param_set), T, ρ, q_pt_dry)
+        p_dry = air_pressure.(param_set, T, ρ, q_pt_dry)
         RH_dry =
-            relative_humidity.(
-                Ref(param_set),
-                T,
-                p_dry,
-                Ref(phase_type),
-                q_pt_dry,
-            )
+            relative_humidity.(param_set, T, p_dry, Ref(phase_type), q_pt_dry)
         @test all(RH_dry .≈ 0)
 
 
         # Test virtual temperature and inverse functions:
         _R_d = FT(R_d(param_set))
-        T_virt = virtual_temperature.(Ref(param_set), T, ρ, q_pt)
-        @test all(T_virt ≈ gas_constant_air.(Ref(param_set), q_pt) ./ _R_d .* T)
+        T_virt = virtual_temperature.(param_set, T, ρ, q_pt)
+        @test all(T_virt ≈ gas_constant_air.(param_set, q_pt) ./ _R_d .* T)
 
         T_rec_qpt_rec =
             temperature_and_humidity_from_virtual_temperature.(
-                Ref(param_set),
+                param_set,
                 T_virt,
                 ρ,
                 RH,
@@ -1015,7 +932,7 @@ end
         # Test convergence of virtual temperature iterations
         @test all(isapprox.(
             T_virt,
-            virtual_temperature.(Ref(param_set), T_rec, ρ, q_pt_rec),
+            virtual_temperature.(param_set, T_rec, ρ, q_pt_rec),
             atol = sqrt(eps(FT)),
         ))
 
@@ -1027,8 +944,7 @@ end
 
         # Update temperature to be exactly consistent with
         # p, ρ, q_pt_rec; test that this is equal to T_rec
-        T_local =
-            air_temperature_from_ideal_gas_law.(Ref(param_set), p, ρ, q_pt_rec)
+        T_local = air_temperature_from_ideal_gas_law.(param_set, p, ρ, q_pt_rec)
         @test all(isapprox.(T_local, T_rec, atol = sqrt(eps(FT))))
     end
 
@@ -1048,23 +964,23 @@ end
     @test typeof.(internal_energy.(ρ, ρ .* e_int, Ref(ρu), e_pot)) ==
           typeof.(e_int)
 
-    θ_dry = dry_pottemp.(Ref(param_set), T, ρ)
-    ts_dry = PhaseDry.(Ref(param_set), e_int, ρ)
-    ts_dry_pT = PhaseDry_pT.(Ref(param_set), p, T)
-    ts_dry_pθ = PhaseDry_pθ.(Ref(param_set), p, θ_dry)
-    ts_eq = PhaseEquil.(Ref(param_set), e_int, ρ, q_tot, 15, FT(1e-1))
+    θ_dry = dry_pottemp.(param_set, T, ρ)
+    ts_dry = PhaseDry.(param_set, e_int, ρ)
+    ts_dry_pT = PhaseDry_pT.(param_set, p, T)
+    ts_dry_pθ = PhaseDry_pθ.(param_set, p, θ_dry)
+    ts_eq = PhaseEquil.(param_set, e_int, ρ, q_tot, 15, FT(1e-1))
     e_tot = total_energy.(e_kin, e_pot, ts_eq)
 
     ts_T =
         PhaseEquil_ρTq.(
-            Ref(param_set),
+            param_set,
             air_density.(ts_dry),
             air_temperature.(ts_dry),
             q_tot,
         )
     ts_Tp =
         PhaseEquil_pTq.(
-            Ref(param_set),
+            param_set,
             air_pressure.(ts_dry),
             air_temperature.(ts_dry),
             q_tot,
@@ -1074,36 +990,15 @@ end
     # @test all(isapprox.(air_pressure.(ts_T), air_pressure.(ts_Tp), atol = _MSLP * 2e-2)) # TODO: Fails, needs fixing / better test
     @test all(total_specific_humidity.(ts_T) .≈ total_specific_humidity.(ts_Tp))
 
-    ts_neq = PhaseNonEquil.(Ref(param_set), e_int, ρ, q_pt)
-    ts_T_neq = PhaseNonEquil_ρTq.(Ref(param_set), ρ, T, q_pt)
+    ts_neq = PhaseNonEquil.(param_set, e_int, ρ, q_pt)
+    ts_T_neq = PhaseNonEquil_ρTq.(param_set, ρ, T, q_pt)
 
     ts_θ_liq_ice_eq =
-        PhaseEquil_ρθq.(
-            Ref(param_set),
-            ρ,
-            θ_liq_ice,
-            q_tot,
-            45,
-            FT(1e-3),
-        )
+        PhaseEquil_ρθq.(param_set, ρ, θ_liq_ice, q_tot, 45, FT(1e-3))
     ts_θ_liq_ice_eq_p =
-        PhaseEquil_pθq.(
-            Ref(param_set),
-            p,
-            θ_liq_ice,
-            q_tot,
-            40,
-            FT(1e-3),
-        )
-    ts_θ_liq_ice_neq =
-        PhaseNonEquil_ρθq.(Ref(param_set), ρ, θ_liq_ice, q_pt)
-    ts_θ_liq_ice_neq_p =
-        PhaseNonEquil_pθq.(
-            Ref(param_set),
-            p,
-            θ_liq_ice,
-            q_pt,
-        )
+        PhaseEquil_pθq.(param_set, p, θ_liq_ice, q_tot, 40, FT(1e-3))
+    ts_θ_liq_ice_neq = PhaseNonEquil_ρθq.(param_set, ρ, θ_liq_ice, q_pt)
+    ts_θ_liq_ice_neq_p = PhaseNonEquil_pθq.(param_set, p, θ_liq_ice, q_pt)
 
     for ts in (
         ts_dry,
@@ -1171,8 +1066,8 @@ end
     @test PhasePartition(ts_eq).liq ≈ PhasePartition(ts_dry).liq
     @test PhasePartition(ts_eq).ice ≈ PhasePartition(ts_dry).ice
 
-    ts_dry = PhaseDry.(Ref(param_set), e_int, ρ)
-    ts_eq = PhaseEquil.(Ref(param_set), e_int, ρ, q_tot .* 0)
+    ts_dry = PhaseDry.(param_set, e_int, ρ)
+    ts_eq = PhaseEquil.(param_set, e_int, ρ, q_tot .* 0)
 
     @test all(gas_constant_air.(ts_eq) .≈ gas_constant_air.(ts_dry))
     @test all(relative_humidity.(ts_eq) .≈ relative_humidity.(ts_dry))


### PR DESCRIPTION
# Description

This PR applies a broadcast rule for thermodynamic's `param_set`. This cleans up some code in Thermo's `runtests.jl` that was a bit hammered by the formatter.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
