### PR TITLE
Better spatial/temporal discretization separation for SplitExplicitModel

### DIFF
--- a/experiments/OceanSplitExplicit/simple_box.jl
+++ b/experiments/OceanSplitExplicit/simple_box.jl
@@ -32,18 +32,7 @@ function config_simple_box(
         BC = boundary_conditions,
     )
 
-    add_fast_substeps = 2
-    numImplSteps = 5
-    numImplSteps > 0 ? ivdc_dt = dt_slow / FT(numImplSteps) : ivdc_dt = dt_slow
-    model_3D = OceanModel{FT}(
-        param_set,
-        problem;
-        cʰ = 1,
-        κᶜ = FT(0.1),
-        add_fast_substeps = add_fast_substeps,
-        numImplSteps = numImplSteps,
-        ivdc_dt = ivdc_dt,
-    )
+    model_3D = OceanModel{FT}(param_set, problem; cʰ = 1, κᶜ = FT(0.1))
 
     N, Nˣ, Nʸ, Nᶻ = resolution
     resolution = (Nˣ, Nʸ, Nᶻ)

--- a/src/Driver/SolverTypes/SplitExplicitSolverType.jl
+++ b/src/Driver/SolverTypes/SplitExplicitSolverType.jl
@@ -25,17 +25,30 @@ struct SplitExplicitSolverType{SM, FM, FT} <: AbstractSolverType
     dt_slow::FT
     # time step for fast method
     dt_fast::FT
+    # parameter for super timestepping 
+    add_fast_steps::FT
+    # number of implicit solves per step
+    numImplSteps::FT
 
     function SplitExplicitSolverType{FT}(
         dt_slow,
         dt_fast;
+        add_fast_steps = 2,
+        numImplSteps = 5,
         slow_method = LSRK54CarpenterKennedy,
         fast_method = LSRK54CarpenterKennedy,
     ) where {FT <: AbstractFloat}
         SM = typeof(slow_method)
         FM = typeof(fast_method)
 
-        return new{SM, FM, FT}(slow_method, fast_method, dt_slow, dt_fast)
+        return new{SM, FM, FT}(
+            slow_method,
+            fast_method,
+            dt_slow,
+            dt_fast,
+            add_fast_steps,
+            numImplSteps,
+        )
     end
 end
 
@@ -67,13 +80,20 @@ Creates an explicit ODE solver.
 function solversetup(ode_solver::SplitExplicitSolverType, dg_3D, Q_3D, _, t0, _)
     dg_2D = dg_3D.modeldata.dg_2D
     Q_2D = dg_3D.modeldata.Q_2D
+    ivdc_model = dg_3D.modeldata.ivdc_dg.balance_law
 
     fast_solver =
         ode_solver.fast_method(dg_2D, Q_2D, dt = ode_solver.dt_fast, t0 = t0)
     slow_solver =
         ode_solver.slow_method(dg_3D, Q_3D, dt = ode_solver.dt_slow, t0 = t0)
 
-    solver = SplitExplicitLSRK2nSolver(slow_solver, fast_solver)
+    solver = SplitExplicitLSRK2nSolver(
+        slow_solver,
+        fast_solver;
+        add_fast_steps = ode_solver.add_fast_steps,
+        numImplSteps = ode_solver.numImplSteps,
+        ivdc_dt = ivdc_model.ivdc_dt,
+    )
 
     return solver
 end

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -434,8 +434,15 @@ function OceanSplitExplicitConfiguration(
     )
     conti3d_Q = init_ode_state(conti3d_dg, FT(0); init_on_cpu = true)
 
+    solver_type.numImplSteps > 0 ?
+    ivdc_dt = solver_type.dt_slow / solver_type.numImplSteps :
+    ivdc_dt = solver_type.dt_slow
+
+    ivdc_model =
+        ClimateMachine.Ocean.SplitExplicit01.IVDCModel{FT}(model_3D, ivdc_dt)
+
     ivdc_dg = DGModel(
-        ClimateMachine.Ocean.SplitExplicit01.IVDCModel(model_3D),
+        ivdc_model,
         grid_3D,
         numerical_flux_first_order,
         numerical_flux_second_order,

--- a/src/Ocean/SplitExplicit01/Communication.jl
+++ b/src/Ocean/SplitExplicit01/Communication.jl
@@ -15,11 +15,11 @@ import ...BalanceLaws:
     slow_dt,
     fast_time_rec,
     fast_steps,
+    add,
 )
 
     #- inverse ratio of additional fast time steps (for weighted average)
     #  --> do 1/add more time-steps and average from: 1 - 1/add up to: 1 + 1/add
-    add = slow.add_fast_substeps
 
     #- set time-step and number of sub-steps we need
     #  will time-average fast over: fast_steps[1] , fast_steps[3]

--- a/src/Ocean/SplitExplicit01/IVDCModel.jl
+++ b/src/Ocean/SplitExplicit01/IVDCModel.jl
@@ -27,11 +27,23 @@ using ClimateMachine.DGMethods.NumericalFluxes:
 # Create a new child linear model instance, attached to whatever parent
 # BalanceLaw instantiates this.
 # (Not sure we need parent, but maybe we will get some parameters from it)
-struct IVDCModel{M, FT} <: AbstractOceanModel
-    parent_om::M
+struct IVDCModel{FT} <: AbstractOceanModel
+    κᶻ::FT
+    κᶜ::FT
+    cʰ::FT
+    cᶻ::FT
     ivdc_dt::FT
-    function IVDCModel{FT}(parent_om::M, ivdc_dt) where {FT <: AbstractFloat, M}
-        return new{M, FT}(parent_om, ivdc_dt)
+    function IVDCModel{FT}(
+        parent_om::AbstractOceanModel,
+        ivdc_dt,
+    ) where {FT <: AbstractFloat}
+        return new{FT}(
+            parent_om.κᶻ,
+            parent_om.κᶜ,
+            parent_om.cʰ,
+            parent_om.cᶻ,
+            ivdc_dt,
+        )
     end
 end
 
@@ -95,8 +107,8 @@ vars_state(m::IVDCModel, ::GradientFlux, FT) = @vars(κ∇θ::SVector{3, FT})
 end
 
 @inline function diffusivity_tensor(m::IVDCModel, ∂θ∂z)
-    κᶻ = m.parent_om.κᶻ * 0.5
-    κᶜ = m.parent_om.κᶜ
+    κᶻ = m.κᶻ * 0.5
+    κᶜ = m.κᶜ
     ∂θ∂z < 0 ? κ = (@SVector [0, 0, κᶜ]) : κ = (@SVector [0, 0, κᶻ])
     # ∂θ∂z <= 1e-10 ? κ = (@SVector [0, 0, κᶜ]) : κ = (@SVector [0, 0, κᶻ])
 
@@ -137,27 +149,17 @@ function flux_second_order!(
     t,
 )
     F.θ += D.κ∇θ
-    # F.θ = 0
 
+    return nothing
 end
 
 function wavespeed(m::IVDCModel, n⁻, _...)
-    C = abs(SVector(m.parent_om.cʰ, m.parent_om.cʰ, m.parent_om.cᶻ)' * n⁻)
-    # C = abs(SVector(m.parent_om.cʰ, m.parent_om.cʰ, 50)' * n⁻)
-    # C = abs(SVector(1, 1, 1)' * n⁻)
-    ### C = abs(SVector(10, 10, 10)' * n⁻)
-    # C = abs(SVector(50, 50, 50)' * n⁻)
-    # C = abs(SVector( 0,  0,  0)' * n⁻)
-    return C
+    return abs(SVector(m.cʰ, m.cʰ, m.cᶻ)' * n⁻)
 end
 
 function boundary_state!(
-    nf::Union{
-        NumericalFluxFirstOrder,
-        NumericalFluxGradient,
-        CentralNumericalFluxGradient,
-    },
-    m::IVDCModel,
+    ::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
+    ::IVDCModel,
     Q⁺,
     A⁺,
     n,
@@ -188,8 +190,8 @@ end
 ###    )
 
 function boundary_state!(
-    nf::Union{NumericalFluxSecondOrder, CentralNumericalFluxSecondOrder},
-    m::IVDCModel,
+    ::NumericalFluxSecondOrder,
+    ::IVDCModel,
     Q⁺,
     D⁺,
     A⁺,
@@ -203,8 +205,6 @@ function boundary_state!(
 )
     Q⁺.θ = Q⁻.θ
     D⁺.κ∇θ = n⁻ * -0
-    # D⁺.κ∇θ = n⁻ * -0 + 7000
-    # D⁺.κ∇θ = -D⁻.κ∇θ
 
     return nothing
 end

--- a/src/Ocean/SplitExplicit01/IVDCModel.jl
+++ b/src/Ocean/SplitExplicit01/IVDCModel.jl
@@ -27,10 +27,11 @@ using ClimateMachine.DGMethods.NumericalFluxes:
 # Create a new child linear model instance, attached to whatever parent
 # BalanceLaw instantiates this.
 # (Not sure we need parent, but maybe we will get some parameters from it)
-struct IVDCModel{M} <: AbstractOceanModel
+struct IVDCModel{M, FT} <: AbstractOceanModel
     parent_om::M
-    function IVDCModel(parent_om::M;) where {M}
-        return new{M}(parent_om)
+    ivdc_dt::FT
+    function IVDCModel{FT}(parent_om::M, ivdc_dt) where {FT <: AbstractFloat, M}
+        return new{M, FT}(parent_om, ivdc_dt)
     end
 end
 
@@ -113,11 +114,10 @@ end
     t,
     direction,
 )
-    #ivdc_dt = m.ivdc_dt
-    ivdc_dt = m.parent_om.ivdc_dt
+    ivdc_dt = m.ivdc_dt
     @inbounds begin
         S.θ = Q.θ / ivdc_dt
-        # S.θ = 0
+
     end
 
     return nothing

--- a/src/Ocean/SplitExplicit01/OceanModel.jl
+++ b/src/Ocean/SplitExplicit01/OceanModel.jl
@@ -4,9 +4,6 @@ struct OceanModel{PS, P, T} <: AbstractOceanModel
     ρₒ::T
     cʰ::T
     cᶻ::T
-    add_fast_substeps::T
-    numImplSteps::T
-    ivdc_dt::T
     αᵀ::T
     νʰ::T
     νᶻ::T
@@ -21,9 +18,6 @@ struct OceanModel{PS, P, T} <: AbstractOceanModel
         ρₒ = FT(1000),  # kg/m^3
         cʰ = FT(0),     # m/s
         cᶻ = FT(0),     # m/s
-        add_fast_substeps = 0,
-        numImplSteps = 0,
-        ivdc_dt = FT(1),
         αᵀ = FT(2e-4),  # 1/K
         νʰ = FT(5e3),   # m^2/s
         νᶻ = FT(5e-3),  # m^2/s
@@ -39,9 +33,6 @@ struct OceanModel{PS, P, T} <: AbstractOceanModel
             ρₒ,
             cʰ,
             cᶻ,
-            add_fast_substeps,
-            numImplSteps,
-            ivdc_dt,
             αᵀ,
             νʰ,
             νᶻ,
@@ -252,16 +243,7 @@ end
 @inline viscosity_tensor(m::OceanModel) = Diagonal(@SVector [m.νʰ, m.νʰ, m.νᶻ])
 
 @inline function diffusivity_tensor(m::OceanModel, ∂θ∂z)
-
-    if m.numImplSteps > 0
-        κ = (@SVector [m.κʰ, m.κʰ, m.κᶻ * 0.5])
-    else
-        ∂θ∂z < 0 ? κ = (@SVector [m.κʰ, m.κʰ, m.κᶜ]) : κ = (@SVector [
-            m.κʰ,
-            m.κʰ,
-            m.κᶻ,
-        ])
-    end
+    κ = (@SVector [m.κʰ, m.κʰ, m.κᶻ * 0.5])
 
     return Diagonal(κ)
 end

--- a/src/Ocean/SplitExplicit01/OceanModel.jl
+++ b/src/Ocean/SplitExplicit01/OceanModel.jl
@@ -74,6 +74,7 @@ function OceanDGModel(
     numfluxnondiff,
     numfluxdiff,
     gradnumflux;
+    ivdc_dt = -1,
     kwargs...,
 )
     vert_filter = CutoffFilter(grid, polynomialorder(grid) - 1)
@@ -106,7 +107,7 @@ function OceanDGModel(
     conti3d_Q = init_ode_state(conti3d_dg, FT(0); init_on_cpu = true)
 
     ivdc_dg = DGModel(
-        IVDCModel(bl),
+        IVDCModel{FT}(bl, ivdc_dt),
         grid,
         numfluxnondiff,
         numfluxdiff,

--- a/src/Ocean/SplitExplicit01/SplitExplicitLSRK2nMethod.jl
+++ b/src/Ocean/SplitExplicit01/SplitExplicitLSRK2nMethod.jl
@@ -67,7 +67,7 @@ mutable struct SplitExplicitLSRK2nSolver{SS, FS, RT, MSA} <: AbstractODESolver
         t0 = slow_solver.t,
         add_fast_steps = 0,
         numImplSteps = 0,
-        ivdc_dt = FT(1),
+        ivdc_dt = 1,
     ) where {AT <: AbstractArray}
         SS = typeof(slow_solver)
         FS = typeof(fast_solver)

--- a/src/Ocean/SplitExplicit01/SplitExplicitLSRK2nMethod.jl
+++ b/src/Ocean/SplitExplicit01/SplitExplicitLSRK2nMethod.jl
@@ -52,6 +52,12 @@ mutable struct SplitExplicitLSRK2nSolver{SS, FS, RT, MSA} <: AbstractODESolver
     steps::Int
     "storage for transfer tendency"
     dQ2fast::MSA
+    "parameter for super timestepping"
+    add_fast_steps::RT
+    "number of implicit solves per step"
+    numImplSteps::RT
+    "timestep for implicit solve"
+    ivdc_dt::RT
 
     function SplitExplicitLSRK2nSolver(
         slow_solver::LSRK2N,
@@ -59,6 +65,9 @@ mutable struct SplitExplicitLSRK2nSolver{SS, FS, RT, MSA} <: AbstractODESolver
         Q = nothing;
         dt = getdt(slow_solver),
         t0 = slow_solver.t,
+        add_fast_steps = 0,
+        numImplSteps = 0,
+        ivdc_dt = FT(1),
     ) where {AT <: AbstractArray}
         SS = typeof(slow_solver)
         FS = typeof(fast_solver)
@@ -74,6 +83,9 @@ mutable struct SplitExplicitLSRK2nSolver{SS, FS, RT, MSA} <: AbstractODESolver
             RT(t0),
             0,
             dQ2fast,
+            add_fast_steps,
+            numImplSteps,
+            ivdc_dt,
         )
     end
 end
@@ -125,6 +137,7 @@ function dostep!(
             fract_dt,
             fast_time_rec,
             fast_steps,
+            split.add_fast_steps,
         )
         # Initialize tentency adjustment before evaluation of slow mode
         initialize_adjustment!(
@@ -212,7 +225,7 @@ function dostep!(
     updatedt!(fast, fast_dt_in)
 
     # now do implicit mixing step
-    nImplSteps = slow_bl.numImplSteps
+    nImplSteps = split.numImplSteps
     if nImplSteps > 0
         # 1. get implicit mising model, model state variable array and solver handles
         ivdc_dg = slow.rhs!.modeldata.ivdc_dg
@@ -222,7 +235,7 @@ function dostep!(
         # ivdc_solver_dt = getdt(ivdc_solver) # would work if solver time-step was set
         # FT = typeof(slow_dt)
         # ivdc_solver_dt = slow_dt / FT(nImplSteps) # just recompute time-step
-        ivdc_solver_dt = ivdc_bl.parent_om.ivdc_dt
+        ivdc_solver_dt = split.ivdc_dt
         # println("ivdc_solver_dt = ",ivdc_solver_dt )
         # 2. setup start RHS, initial guess and values for computing mixing coeff
         ivdc_Q.θ .= Qslow.θ

--- a/test/Ocean/SplitExplicit/simple_box_2dt.jl
+++ b/test/Ocean/SplitExplicit/simple_box_2dt.jl
@@ -169,17 +169,15 @@ function main()
     #- set model time-step:
     dt_fast = 240
     dt_slow = 5400
-    # dt_fast = 300
-    # dt_slow = 300
+
     nout = ceil(Int64, tout / dt_slow)
     dt_slow = tout / nout
-    numImplSteps > 0 ? ivdc_dt = dt_slow / FT(numImplSteps) : ivdc_dt = dt_slow
 
     model = OceanModel{FT}(
         prob,
         grav = gravity,
         cʰ = cʰ,
-        add_fast_substeps = add_fast_substeps,
+        νʰ = FT(1e-3), # m^2/s # double standard value to account for implicit solve stuff
     )
     # model = OceanModel{FT}(prob, cʰ = cʰ, fₒ = FT(0), β = FT(0) )
     # model = OceanModel{FT}(prob, cʰ = cʰ, νʰ = FT(1e3), νᶻ = FT(1e-3) )
@@ -244,7 +242,11 @@ function main()
     lsrk_barotropic =
         LSRK54CarpenterKennedy(barotropic_dg, Q_2D, dt = dt_fast, t0 = 0)
 
-    odesolver = SplitExplicitLSRK2nSolver(lsrk_ocean, lsrk_barotropic)
+    odesolver = SplitExplicitLSRK2nSolver(
+        lsrk_ocean,
+        lsrk_barotropic;
+        add_fast_steps = add_fast_substeps,
+    )
 
     #-- Set up State Check call back for config state arrays, called every ntFreq time steps
     ntFreq = 1

--- a/test/Ocean/SplitExplicit/simple_box_ivd.jl
+++ b/test/Ocean/SplitExplicit/simple_box_ivd.jl
@@ -65,17 +65,8 @@ function main(BC)
 
     nout = ceil(Int64, tout / dt_slow)
     dt_slow = tout / nout
-    numImplSteps > 0 ? ivdc_dt = dt_slow / FT(numImplSteps) : ivdc_dt = dt_slow
 
-    model = OceanModel{FT}(
-        param_set,
-        prob,
-        cʰ = cʰ,
-        add_fast_substeps = add_fast_substeps,
-        numImplSteps = numImplSteps,
-        ivdc_dt = ivdc_dt,
-        κᶜ = FT(0.1),
-    )
+    model = OceanModel{FT}(param_set, prob, cʰ = cʰ, κᶜ = FT(0.1))
     # model = OceanModel{FT}(prob, cʰ = cʰ, fₒ = FT(0), β = FT(0) )	
     # model = OceanModel{FT}(prob, cʰ = cʰ, νʰ = FT(1e3), νᶻ = FT(1e-3) )	
     # model = OceanModel{FT}(prob, cʰ = cʰ, νʰ = FT(0), fₒ = FT(0), β = FT(0) )
@@ -122,6 +113,8 @@ function main(BC)
 
     Q_2D = init_ode_state(barotropic_dg, FT(0); init_on_cpu = true)
 
+
+    numImplSteps > 0 ? ivdc_dt = dt_slow / FT(numImplSteps) : ivdc_dt = dt_slow
     dg = OceanDGModel(
         model,
         grid_3D,
@@ -129,6 +122,7 @@ function main(BC)
         CentralNumericalFluxSecondOrder(),
         CentralNumericalFluxGradient();
         modeldata = (barotropic_dg, Q_2D),
+        ivdc_dt = ivdc_dt,
     )
 
     Q_3D = init_ode_state(dg, FT(0); init_on_cpu = true)
@@ -137,7 +131,13 @@ function main(BC)
     lsrk_barotropic =
         LSRK54CarpenterKennedy(barotropic_dg, Q_2D, dt = dt_fast, t0 = 0)
 
-    odesolver = SplitExplicitLSRK2nSolver(lsrk_ocean, lsrk_barotropic)
+    odesolver = SplitExplicitLSRK2nSolver(
+        lsrk_ocean,
+        lsrk_barotropic;
+        add_fast_steps = add_fast_substeps,
+        numImplSteps = numImplSteps,
+        ivdc_dt = ivdc_dt,
+    )
 
     #-- Set up State Check call back for config state arrays, called every ntFreq time steps
     ntFreq = 1


### PR DESCRIPTION
### Description

Moves all timestepping related parameters into the SplitExplicitLSRK2nMethod and has the IVDCModel store parameters extracted from its parent model. The first change is for easier composability of models and timesteppers, while the second change is to enable the IVDCModel to be used with the explicit HBModel as well (will actually implement in a future PR). 

No numerics or physics should change as a result of this PR.

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
