### PR TITLE
Make `recover_thermo_state` call `new_thermo_state`

### DIFF
--- a/docs/src/HowToGuides/Atmos/MoistureModelChoices.md
+++ b/docs/src/HowToGuides/Atmos/MoistureModelChoices.md
@@ -48,6 +48,12 @@ Because the assumed relaxation timescale for condensation/evaporation and
 
 ## Implementation notes
 
+!!! warn
+    While `recover_thermo_state` is an ideal long-term solution,
+    right now we are directly calling new_thermo_state to avoid
+    inconsistent aux states in kernels where the aux states are
+    out of sync with the boundary state.
+
 The moisture models rely on the
   [new\_thermo\_state](https://clima.github.io/ClimateMachine.jl/latest/APIs/Atmos/AtmosModel/#ClimateMachine.Atmos.new_thermo_state)
   and

--- a/src/Atmos/Model/thermo_states.jl
+++ b/src/Atmos/Model/thermo_states.jl
@@ -66,15 +66,20 @@ end
 """
     recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars)
 
-Recover the thermodynamic state, based on the `state` _and_
-the `aux` state, based on the existing temperature.
+An atmospheric thermodynamic state.
 
-!!! note
-    This method does _not_ call the iterative saturation adjustment
-    procedure.
+!!! warn
+    While recover_thermo_state is an ideal long-term solution,
+    right now we are directly calling new_thermo_state to avoid
+    inconsistent aux states in kernels where the aux states are
+    out of sync with the boundary state.
+
+# TODO:
+    - Allow a safe way to call
+    `recover_thermo_state(state, moist::EquilMoist, ...)`
 """
 recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
-    recover_thermo_state(atmos, atmos.moisture, state, aux)
+    new_thermo_state(atmos, atmos.moisture, state, aux)
 
 function recover_thermo_state(
     atmos::AtmosModel,


### PR DESCRIPTION
### Description

See #1648.

This PR should make thermodynamics consistent on the boundaries.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
