### PR TITLE
Add supersaturation interface method

### DIFF
--- a/src/Common/Thermodynamics/Thermodynamics.jl
+++ b/src/Common/Thermodynamics/Thermodynamics.jl
@@ -57,5 +57,6 @@ include("relations.jl")
 include("isentropic.jl")
 
 Base.broadcastable(dap::DryAdiabaticProcess) = Ref(dap)
+Base.broadcastable(phase::Phase) = Ref(phase)
 
 end #module Thermodynamics.jl

--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -899,12 +899,15 @@ end
 """
     supersaturation(param_set, q, ρ, T, Liquid())
     supersaturation(param_set, q, ρ, T, Ice())
+    supersaturation(ts, Ice())
+    supersaturation(ts, Liquid())
 
  - `param_set` - abstract set with earth parameters
  - `q` - phase partition
  - `ρ` - air density,
  - `T` - air temperature
  - `Liquid()`, `Ice()` - liquid or ice phase to dispatch over.
+ - `ts` thermodynamic state
 
 Returns supersaturation (qv/qv_sat -1) over water or ice.
 """
@@ -934,6 +937,13 @@ function supersaturation(
 
     return q_vap / q_sat - FT(1)
 end
+supersaturation(ts::ThermodynamicState, phase::Phase) = supersaturation(
+    ts.param_set,
+    PhasePartition(ts),
+    air_density(ts),
+    air_temperature(ts),
+    phase,
+)
 
 """
     saturation_excess(param_set, T, ρ, phase_type, q::PhasePartition)

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -1032,6 +1032,8 @@ end
         @test typeof.(exner.(ts)) == typeof.(e_int)
         @test typeof.(liquid_ice_pottemp_sat.(ts)) == typeof.(e_int)
         @test typeof.(specific_volume.(ts)) == typeof.(e_int)
+        @test typeof.(supersaturation.(ts, Ice())) == typeof.(e_int)
+        @test typeof.(supersaturation.(ts, Liquid())) == typeof.(e_int)
         @test typeof.(virtual_pottemp.(ts)) == typeof.(e_int)
         @test eltype.(gas_constants.(ts)) == typeof.(e_int)
 
@@ -1077,6 +1079,10 @@ end
     @test all(internal_energy.(ts_eq) .≈ internal_energy.(ts_dry))
     @test all(internal_energy_sat.(ts_eq) .≈ internal_energy_sat.(ts_dry))
     @test all(soundspeed_air.(ts_eq) .≈ soundspeed_air.(ts_dry))
+    @test all(supersaturation.(ts_eq, Ice()) .≈ supersaturation.(ts_dry, Ice()))
+    @test all(
+        supersaturation.(ts_eq, Liquid()) .≈ supersaturation.(ts_dry, Liquid()),
+    )
     @test all(latent_heat_vapor.(ts_eq) .≈ latent_heat_vapor.(ts_dry))
     @test all(latent_heat_sublim.(ts_eq) .≈ latent_heat_sublim.(ts_dry))
     @test all(latent_heat_fusion.(ts_eq) .≈ latent_heat_fusion.(ts_dry))
@@ -1094,12 +1100,12 @@ end
     @test all(exner.(ts_eq) .≈ exner.(ts_dry))
 
     @test all(
-        saturation_vapor_pressure.(ts_eq, Ref(Ice())) .≈
-        saturation_vapor_pressure.(ts_dry, Ref(Ice())),
+        saturation_vapor_pressure.(ts_eq, Ice()) .≈
+        saturation_vapor_pressure.(ts_dry, Ice()),
     )
     @test all(
-        saturation_vapor_pressure.(ts_eq, Ref(Liquid())) .≈
-        saturation_vapor_pressure.(ts_dry, Ref(Liquid())),
+        saturation_vapor_pressure.(ts_eq, Liquid()) .≈
+        saturation_vapor_pressure.(ts_dry, Liquid()),
     )
     @test all(first.(gas_constants.(ts_eq)) ≈ first.(gas_constants.(ts_dry)))
     @test all(last.(gas_constants.(ts_eq)) ≈ last.(gas_constants.(ts_dry)))


### PR DESCRIPTION
### Description

This PR adds a `supersaturation(ts::ThermodynamicState, phase::Phase)` method.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
