### PR TITLE
Update mesh to handle multiple polynomial orders

### DIFF
--- a/experiments/OceanBoxGCM/simple_box.jl
+++ b/experiments/OceanBoxGCM/simple_box.jl
@@ -4,7 +4,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.VariableTemplates
-using ClimateMachine.Mesh.Grids: polynomialorder
+using ClimateMachine.Mesh.Grids: polynomialorders
 using ClimateMachine.BalanceLaws
 using ClimateMachine.Ocean
 using ClimateMachine.Ocean.HydrostaticBoussinesq
@@ -66,7 +66,12 @@ function run_simple_box(
         config_simple_box(name, resolution, dimensions, problem; BC = BC)
 
     grid = driver_config.grid
-    vert_filter = CutoffFilter(grid, polynomialorder(grid) - 1)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
+    vert_filter = CutoffFilter(grid, N - 1)
     exp_filter = ExponentialFilter(grid, 1, 8)
     modeldata = (vert_filter = vert_filter, exp_filter = exp_filter)
 

--- a/experiments/OceanSplitExplicit/simple_box.jl
+++ b/experiments/OceanSplitExplicit/simple_box.jl
@@ -4,7 +4,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.VariableTemplates
-using ClimateMachine.Mesh.Grids: polynomialorder
+using ClimateMachine.Mesh.Grids: polynomialorders
 using ClimateMachine.BalanceLaws
 using ClimateMachine.Ocean
 using ClimateMachine.Ocean.SplitExplicit01

--- a/src/Diagnostics/atmos_common.jl
+++ b/src/Diagnostics/atmos_common.jl
@@ -14,7 +14,11 @@ function atmos_collect_onetime(mpicomm, dg, Q)
         FT = eltype(Q)
         grid = dg.grid
         topology = grid.topology
-        N = polynomialorder(grid)
+        # XXX: Needs updating for multiple polynomial orders
+        N = polynomialorders(grid)
+        # Currently only support single polynomial order
+        @assert all(N[1] .== N)
+        N = N[1]
         Nq = N + 1
         Nqk = dimensionality(grid) == 2 ? 1 : Nq
         nrealelem = length(topology.realelems)

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -242,7 +242,11 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
     mpirank = MPI.Comm_rank(mpicomm)
     grid = dg.grid
     topology = grid.topology
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(dg.grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     Nqk = dimensionality(grid) == 2 ? 1 : Nq
     npoints = Nq * Nq * Nqk

--- a/src/Diagnostics/atmos_les_core.jl
+++ b/src/Diagnostics/atmos_les_core.jl
@@ -208,7 +208,11 @@ function atmos_les_core_collect(dgngrp::DiagnosticsGroup, currtime)
     # extract grid information
     grid = dg.grid
     topology = grid.topology
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(dg.grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     Nqk = dimensionality(grid) == 2 ? 1 : Nq
     npoints = Nq * Nq * Nqk

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -377,7 +377,11 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     bl = dg.balance_law
     grid = dg.grid
     topology = grid.topology
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(dg.grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     Nqk = dimensionality(grid) == 2 ? 1 : Nq
     npoints = Nq * Nq * Nqk
@@ -390,13 +394,17 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
         state_data = Q.realdata
         aux_data = dg.state_auxiliary.realdata
         vgeo = grid.vgeo
-        ω = grid.ω
+        # Currently only support single polynomial order
+        # XXX: Needs updating for multiple polynomial orders
+        ω = grid.ω[1]
         gradflux_data = dg.state_gradient_flux.realdata
     else
         state_data = Array(Q.realdata)
         aux_data = Array(dg.state_auxiliary.realdata)
         vgeo = Array(grid.vgeo)
-        ω = Array(grid.ω)
+        # Currently only support single polynomial order
+        # XXX: Needs updating for multiple polynomial orders
+        ω = Array(grid.ω[1])
         gradflux_data = Array(dg.state_gradient_flux.realdata)
     end
     FT = eltype(state_data)

--- a/src/Diagnostics/atmos_les_default_perturbations.jl
+++ b/src/Diagnostics/atmos_les_default_perturbations.jl
@@ -260,7 +260,11 @@ function atmos_les_default_perturbations_collect(
     mpirank = MPI.Comm_rank(mpicomm)
     grid = dg.grid
     topology = grid.topology
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     Nqk = dimensionality(grid) == 2 ? 1 : Nq
     npoints = Nq * Nq * Nqk

--- a/src/Diagnostics/atmos_refstate_perturbations.jl
+++ b/src/Diagnostics/atmos_refstate_perturbations.jl
@@ -188,7 +188,11 @@ function atmos_refstate_perturbations_collect(
     mpirank = MPI.Comm_rank(mpicomm)
     grid = dg.grid
     topology = grid.topology
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(dg.grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     Nqk = dimensionality(grid) == 2 ? 1 : Nq
     npoints = Nq * Nq * Nqk

--- a/src/Diagnostics/diagnostic_fields.jl
+++ b/src/Diagnostics/diagnostic_fields.jl
@@ -92,7 +92,11 @@ This constructor computes the spatial gradients of the velocity field.
 function VectorGradients(dg::DGModel, Q::MPIStateArray)
     bl = dg.balance_law
     FT = eltype(dg.grid)
-    N = polynomialorder(dg.grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(dg.grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     npoints = Nq^3
     nrealelem = length(dg.grid.topology.realelems)
@@ -113,7 +117,8 @@ function VectorGradients(dg::DGModel, Q::MPIStateArray)
     kernel = vector_gradients_kernel!(device, workgroup)
     event = kernel(
         Q.realdata,
-        dg.grid.D,
+        # XXX: Needs updating for multiple polynomial orders
+        dg.grid.D[1],
         dg.grid.vgeo,
         g,
         data,
@@ -336,7 +341,11 @@ This function computes the vorticity of the velocity field.
 function Vorticity(dg::DGModel, vgrad::VectorGradients)
     bl = dg.balance_law
     FT = eltype(dg.grid)
-    N = polynomialorder(dg.grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(dg.grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     npoints = Nq^3
     nrealelem = length(dg.grid.topology.realelems)

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -406,7 +406,12 @@ function OceanSplitExplicitConfiguration(
 
     Q_2D = init_ode_state(dg_2D, FT(0); init_on_cpu = true)
 
-    vert_filter = CutoffFilter(grid_3D, polynomialorder(grid_3D) - 1)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid_3D)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
+    vert_filter = CutoffFilter(grid_3D, N - 1)
     exp_filter = ExponentialFilter(grid_3D, 1, 8)
 
     flowintegral_dg = DGModel(

--- a/src/InputOutput/VTK/writevtk.jl
+++ b/src/InputOutput/VTK/writevtk.jl
@@ -105,7 +105,11 @@ function writevtk_helper(
     @assert number_sample_points >= 0
 
     dim = dimensionality(grid)
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
 
     nelem = size(Q)[end]
@@ -124,7 +128,8 @@ function writevtk_helper(
     # Interpolate to an equally spaced grid if necessary
     if number_sample_points > 0
         FT = eltype(Q)
-        ξsrc = referencepoints(grid)
+        # XXX: Needs updating for multiple polynomial orders
+        ξsrc = referencepoints(grid)[1]
         ξdst = range(FT(-1); length = number_sample_points, stop = 1)
         I1d = interpolationmatrix(ξsrc, ξdst)
         I = kron(ntuple(i -> I1d, dim)...)
@@ -174,7 +179,11 @@ may also contain a directory path.
 """
 function writevtk(prefix, grid::DiscontinuousSpectralElementGrid)
     dim = dimensionality(grid)
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(dg.grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
 
     vgeo = grid.vgeo isa Array ? grid.vgeo : Array(grid.vgeo)

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -62,7 +62,11 @@ function basic_grid_info(dg::DGModel)
     topology = grid.topology
 
     dim = dimensionality(grid)
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
 
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
@@ -113,7 +117,12 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
     topology = grid.topology
 
     dim = dimensionality(grid)
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
+
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
     Nfp = Nq * Nqk
@@ -195,7 +204,8 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             state_auxiliary.data,
             grid.vgeo,
             t,
-            grid.D,
+            # XXX: Needs updating for multiple polynomial orders
+            grid.D[1],
             Val(hypervisc_indexmap),
             topology.realelems,
             ndrange = (Nq * nrealelem, Nq),
@@ -310,7 +320,8 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
                 Qhypervisc_grad.data,
                 Qhypervisc_div.data,
                 grid.vgeo,
-                grid.D,
+                # XXX: Needs updating for multiple polynomial orders
+                grid.D[1],
                 topology.realelems;
                 ndrange = ndrange_volume,
                 dependencies = (comp_stream,),
@@ -383,8 +394,9 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
                 state_prognostic.data,
                 state_auxiliary.data,
                 grid.vgeo,
-                grid.ω,
-                grid.D,
+                # XXX: Needs updating for multiple polynomial orders
+                grid.ω[1],
+                grid.D[1],
                 topology.realelems,
                 t;
                 ndrange = ndrange_volume,
@@ -466,8 +478,9 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
         state_auxiliary.data,
         grid.vgeo,
         t,
-        grid.ω,
-        grid.D,
+        # XXX: Needs updating for multiple polynomial orders
+        grid.ω[1],
+        grid.D[1],
         topology.realelems,
         α,
         β;
@@ -601,7 +614,11 @@ function init_ode_state(
 
     state_auxiliary = dg.state_auxiliary
     dim = dimensionality(grid)
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     nrealelem = length(topology.realelems)
 
     if !init_on_cpu
@@ -702,7 +719,11 @@ function init_state_auxiliary!(
     topology = grid.topology
     dim = dimensionality(grid)
     Np = dofs_per_element(grid)
-    polyorder = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     vgeo = grid.vgeo
     device = array_device(state_auxiliary)
     nrealelem = length(topology.realelems)
@@ -715,7 +736,7 @@ function init_state_auxiliary!(
     )(
         balance_law,
         Val(dim),
-        Val(polyorder),
+        Val(N),
         init_f!,
         state_auxiliary.data,
         isnothing(state_temporary) ? nothing : state_temporary.data,
@@ -761,7 +782,11 @@ function indefinite_stack_integral!(
     topology = grid.topology
 
     dim = dimensionality(grid)
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
 
@@ -781,7 +806,8 @@ function indefinite_stack_integral!(
         state_prognostic.data,
         state_auxiliary.data,
         grid.vgeo,
-        grid.Imat,
+        # XXX: Needs updating for multiple polynomial orders
+        grid.Imat[1],
         horzelems;
         ndrange = (length(horzelems) * Nq, Nqk),
         dependencies = (event,),
@@ -804,7 +830,11 @@ function reverse_indefinite_stack_integral!(
     topology = grid.topology
 
     dim = dimensionality(grid)
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
 
@@ -851,7 +881,11 @@ function update_auxiliary_state!(
     topology = grid.topology
 
     dim = dimensionality(grid)
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     nelem = length(elems)
 
@@ -924,7 +958,11 @@ function courant(
     nrealelem = length(topology.realelems)
 
     if nrealelem > 0
-        N = polynomialorder(grid)
+        # XXX: Needs updating for multiple polynomial orders
+        N = polynomialorders(grid)
+        # Currently only support single polynomial order
+        @assert all(N[1] .== N)
+        N = N[1]
         dim = dimensionality(grid)
         Nq = N + 1
         Nqk = dim == 2 ? 1 : Nq
@@ -1014,7 +1052,11 @@ function continuous_field_gradient!(
     topology = grid.topology
     nrealelem = length(topology.realelems)
 
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     dim = dimensionality(grid)
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
@@ -1034,8 +1076,9 @@ function continuous_field_gradient!(
         ∇state.data,
         state.data,
         grid.vgeo,
-        grid.D,
-        grid.ω,
+        # XXX: Needs updating for multiple polynomial orders
+        grid.D[1],
+        grid.ω[1],
         Val(I),
         Val(O),
         ndrange = (nrealelem * Nq, Nq, Nqk),

--- a/src/Numerics/Mesh/Filters.jl
+++ b/src/Numerics/Mesh/Filters.jl
@@ -148,8 +148,12 @@ struct ExponentialFilter <: AbstractSpectralFilter
         α = -log(eps(eltype(grid))),
     )
         AT = arraytype(grid)
-        N = polynomialorder(grid)
-        ξ = referencepoints(grid)
+        # XXX: Needs updating for multiple polynomial orders
+        N = polynomialorders(grid)
+        # Currently only support single polynomial order
+        @assert all(N[1] .== N)
+        N = N[1]
+        ξ = referencepoints(grid)[1]
 
         @assert iseven(s)
         @assert 0 <= Nc <= N
@@ -195,8 +199,12 @@ struct BoydVandevenFilter <: AbstractSpectralFilter
 
     function BoydVandevenFilter(grid, Nc = 0, s = 32)
         AT = arraytype(grid)
-        N = polynomialorder(grid)
-        ξ = referencepoints(grid)
+        # XXX: Needs updating for multiple polynomial orders
+        N = polynomialorders(grid)
+        # Currently only support single polynomial order
+        @assert all(N[1] .== N)
+        N = N[1]
+        ξ = referencepoints(grid)[1]
 
         @assert iseven(s)
         @assert 0 <= Nc <= N
@@ -212,7 +220,7 @@ struct BoydVandevenFilter <: AbstractSpectralFilter
 end
 
 """
-    CutoffFilter(grid, Nc=polynomialorder(grid))
+    CutoffFilter(grid, Nc=polynomialorders(grid))
 
 Returns the spectral filter that zeros out polynomial modes greater than or
 equal to `Nc`.
@@ -221,9 +229,13 @@ struct CutoffFilter <: AbstractSpectralFilter
     "filter matrix"
     filter
 
-    function CutoffFilter(grid, Nc = polynomialorder(grid))
+    function CutoffFilter(grid, Nc = polynomialorders(grid))
+        # XXX: Needs updating for multiple polynomial orders
+        # Currently only support single polynomial order
+        @assert all(Nc[1] .== Nc)
+        Nc = Nc[1]
         AT = arraytype(grid)
-        ξ = referencepoints(grid)
+        ξ = referencepoints(grid)[1]
 
         σ(η) = 0
         filter = spectral_filter_matrix(ξ, Nc, σ)
@@ -293,7 +305,11 @@ function apply!(
     topology = grid.topology
 
     dim = dimensionality(grid)
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
 
     filtermatrix = filter.filter
     device = typeof(Q.data) <: Array ? CPU() : CUDADevice()
@@ -340,7 +356,11 @@ function apply!(
     device = typeof(Q.data) <: Array ? CPU() : CUDADevice()
 
     dim = dimensionality(grid)
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq
 

--- a/src/Numerics/Mesh/Interpolation.jl
+++ b/src/Numerics/Mesh/Interpolation.jl
@@ -136,7 +136,11 @@ struct InterpolationBrick{
         DA = arraytype(grid)                    # device array
         device = arraytype(grid) <: Array ? CPU() : CUDADevice()
 
-        poly_order = polynomialorder(grid)
+        # XXX: Needs updating for multiple polynomial orders
+        poly_order = polynomialorders(grid)
+        # Currently only support single polynomial order
+        @assert all(poly_order[1] .== poly_order)
+        poly_order = poly_order[1]
         qm1 = poly_order + 1
         ndim = 3
         toler = 4 * eps(FT) # tolerance
@@ -733,7 +737,11 @@ struct InterpolationCubedSphere{
 
         DA = arraytype(grid)                    # device array
         device = arraytype(grid) <: Array ? CPU() : CUDADevice()
-        poly_order = polynomialorder(grid)
+        # XXX: Needs updating for multiple polynomial orders
+        poly_order = polynomialorders(grid)
+        # Currently only support single polynomial order
+        @assert all(poly_order[1] .== poly_order)
+        poly_order = poly_order[1]
         qm1 = poly_order + 1
         toler1 = FT(eps(FT) * vert_range[1] * 2.0) # tolerance for unwarp function
         toler2 = FT(eps(FT) * 4.0)                 # tolerance

--- a/src/Numerics/Mesh/Metrics.jl
+++ b/src/Numerics/Mesh/Metrics.jl
@@ -1,131 +1,97 @@
 module Metrics
 
 """
-    creategrid!(x1, elemtocoord, r)
+    creategrid!(x1, elemtocoord, ξ1)
 
 Create a 1-D grid using `elemtocoord` (see [`brickmesh`](@ref)) using the 1-D
-`(-1, 1)` reference coordinates `r`. The element grids are filled using linear
+`(-1, 1)` reference coordinates `ξ1`. The element grids are filled using linear
 interpolation of the element coordinates.
 
-If `Nq = length(r)` and `nelem = size(elemtocoord, 3)` then the preallocated
+If `Nq = length(ξ1)` and `nelem = size(elemtocoord, 3)` then the preallocated
 array `x1` should be `Nq * nelem == length(x1)`.
 """
-function creategrid!(x1, e2c, r)
+function creategrid!(x1, e2c, ξ1)
     (d, nvert, nelem) = size(e2c)
     @assert d == 1
-    Nq = length(r)
+    Nq = length(ξ1)
     x1 = reshape(x1, (Nq, nelem))
 
     # linear blend
     @inbounds for e in 1:nelem
         for i in 1:Nq
             x1[i, e] =
-                ((1 - r[i]) * e2c[1, 1, e] + (1 + r[i]) * e2c[1, 2, e]) / 2
+                ((1 - ξ1[i]) * e2c[1, 1, e] + (1 + ξ1[i]) * e2c[1, 2, e]) / 2
         end
     end
     nothing
 end
 
 """
-    creategrid!(x1, x2, elemtocoord, r)
+    creategrid!(x1, x2, elemtocoord, ξ1, ξ2)
 
 Create a 2-D tensor product grid using `elemtocoord` (see [`brickmesh`](@ref))
-using the 1-D `(-1, 1)` reference coordinates `r`. The element grids are filled
-using bilinear interpolation of the element coordinates.
+using the 1-D `(-1, 1)` reference coordinates `ξ1` and `ξ2`. The element grids
+are filled using bilinear interpolation of the element coordinates.
 
-If `Nq = length(r)` and `nelem = size(elemtocoord, 3)` then the preallocated
-arrays `x1` and `x2` should be `Nq^2 * nelem == size(x1) == size(x2)`.
+If `Nq = (length(ξ1), length(ξ2))` and `nelem = size(elemtocoord, 3)` then the
+preallocated arrays `x1` and `x2` should be
+`prod(Nq) * nelem == size(x1) == size(x2)`.
 """
-function creategrid!(x1, x2, e2c, r)
+function creategrid!(x1, x2, e2c, ξ1, ξ2)
     (d, nvert, nelem) = size(e2c)
     @assert d == 2
-    Nq = length(r)
-    x1 = reshape(x1, (Nq, Nq, nelem))
-    x2 = reshape(x2, (Nq, Nq, nelem))
+    Nq = (length(ξ1), length(ξ2))
+    x1 = reshape(x1, (Nq..., nelem))
+    x2 = reshape(x2, (Nq..., nelem))
 
-    # bilinear blend of corners
+    # # bilinear blend of corners
     @inbounds for (f, n) in zip((x1, x2), 1:d)
-        for e in 1:nelem
-            for j in 1:Nq
-                for i in 1:Nq
-                    f[i, j, e] =
-                        (
-                            (1 - r[i]) * (1 - r[j]) * e2c[n, 1, e] +
-                            (1 + r[i]) * (1 - r[j]) * e2c[n, 2, e] +
-                            (1 - r[i]) * (1 + r[j]) * e2c[n, 3, e] +
-                            (1 + r[i]) * (1 + r[j]) * e2c[n, 4, e]
-                        ) / 4
-                end
-            end
+        for e in 1:nelem, j in 1:Nq[2], i in 1:Nq[1]
+            f[i, j, e] =
+                (
+                    (1 - ξ1[i]) * (1 - ξ2[j]) * e2c[n, 1, e] +
+                    (1 + ξ1[i]) * (1 - ξ2[j]) * e2c[n, 2, e] +
+                    (1 - ξ1[i]) * (1 + ξ2[j]) * e2c[n, 3, e] +
+                    (1 + ξ1[i]) * (1 + ξ2[j]) * e2c[n, 4, e]
+                ) / 4
         end
     end
     nothing
 end
 
 """
-    creategrid!(x1, x2, x3, elemtocoord, r)
+    creategrid!(x1, x2, x3, elemtocoord, ξ1, ξ2, ξ3)
 
 Create a 3-D tensor product grid using `elemtocoord` (see [`brickmesh`](@ref))
-using the 1-D `(-1, 1)` reference coordinates `r`. The element grids are filled
+using the 1-D `(-1, 1)` reference coordinates `ξ1`. The element grids are filled
 using trilinear interpolation of the element coordinates.
 
-If `Nq = length(r)` and `nelem = size(elemtocoord, 3)` then the preallocated
-arrays `x1`, `x2`, and `x3` should be `Nq^3 * nelem == size(x1) == size(x2) ==
-size(x3)`.
+If `Nq = (length(ξ1), length(ξ2), length(ξ3))` and
+`nelem = size(elemtocoord, 3)` then the preallocated arrays `x1`, `x2`, and `x3`
+should be `prod(Nq) * nelem == size(x1) == size(x2) == size(x3)`.
 """
-function creategrid!(x1, x2, x3, e2c, r)
+function creategrid!(x1, x2, x3, e2c, ξ1, ξ2, ξ3)
     (d, nvert, nelem) = size(e2c)
     @assert d == 3
-    # TODO: Add asserts?
-    Nq = length(r)
-    x1 = reshape(x1, (Nq, Nq, Nq, nelem))
-    x2 = reshape(x2, (Nq, Nq, Nq, nelem))
-    x3 = reshape(x3, (Nq, Nq, Nq, nelem))
+    Nq = (length(ξ1), length(ξ2), length(ξ3))
+    x1 = reshape(x1, (Nq..., nelem))
+    x2 = reshape(x2, (Nq..., nelem))
+    x3 = reshape(x3, (Nq..., nelem))
 
     # trilinear blend of corners
     @inbounds for (f, n) in zip((x1, x2, x3), 1:d)
-        for e in 1:nelem
-            for k in 1:Nq
-                for j in 1:Nq
-                    for i in 1:Nq
-                        f[i, j, k, e] =
-                            (
-                                (1 - r[i]) *
-                                (1 - r[j]) *
-                                (1 - r[k]) *
-                                e2c[n, 1, e] +
-                                (1 + r[i]) *
-                                (1 - r[j]) *
-                                (1 - r[k]) *
-                                e2c[n, 2, e] +
-                                (1 - r[i]) *
-                                (1 + r[j]) *
-                                (1 - r[k]) *
-                                e2c[n, 3, e] +
-                                (1 + r[i]) *
-                                (1 + r[j]) *
-                                (1 - r[k]) *
-                                e2c[n, 4, e] +
-                                (1 - r[i]) *
-                                (1 - r[j]) *
-                                (1 + r[k]) *
-                                e2c[n, 5, e] +
-                                (1 + r[i]) *
-                                (1 - r[j]) *
-                                (1 + r[k]) *
-                                e2c[n, 6, e] +
-                                (1 - r[i]) *
-                                (1 + r[j]) *
-                                (1 + r[k]) *
-                                e2c[n, 7, e] +
-                                (1 + r[i]) *
-                                (1 + r[j]) *
-                                (1 + r[k]) *
-                                e2c[n, 8, e]
-                            ) / 8
-                    end
-                end
-            end
+        for e in 1:nelem, k in 1:Nq[3], j in 1:Nq[2], i in 1:Nq[1]
+            f[i, j, k, e] =
+                (
+                    (1 - ξ1[i]) * (1 - ξ2[j]) * (1 - ξ3[k]) * e2c[n, 1, e] +
+                    (1 + ξ1[i]) * (1 - ξ2[j]) * (1 - ξ3[k]) * e2c[n, 2, e] +
+                    (1 - ξ1[i]) * (1 + ξ2[j]) * (1 - ξ3[k]) * e2c[n, 3, e] +
+                    (1 + ξ1[i]) * (1 + ξ2[j]) * (1 - ξ3[k]) * e2c[n, 4, e] +
+                    (1 - ξ1[i]) * (1 - ξ2[j]) * (1 + ξ3[k]) * e2c[n, 5, e] +
+                    (1 + ξ1[i]) * (1 - ξ2[j]) * (1 + ξ3[k]) * e2c[n, 6, e] +
+                    (1 - ξ1[i]) * (1 + ξ2[j]) * (1 + ξ3[k]) * e2c[n, 7, e] +
+                    (1 + ξ1[i]) * (1 + ξ2[j]) * (1 + ξ3[k]) * e2c[n, 8, e]
+                ) / 8
         end
     end
     nothing
@@ -136,7 +102,7 @@ end
 
 Compute the 1-D metric terms from the element grid arrays `x1`. All the arrays
 are preallocated by the user and the (square) derivative matrix `D` should be
-consistent with the reference grid `r` used in [`creategrid!`](@ref).
+consistent with the reference grid `ξ1` used in [`creategrid!`](@ref).
 
 If `Nq = size(D, 1)` and `nelem = div(length(x1), Nq)` then the volume arrays
 `x1`, `J`, and `ξ1x1` should all have length `Nq * nelem`.  Similarly, the face
@@ -164,42 +130,46 @@ function computemetric!(x1, J, ξ1x1, sJ, n1, D)
 end
 
 """
-    computemetric!(x1, x2, J, ξ1x1, ξ2x1, ξ1x2, ξ2x2, sJ, n1, n2, D)
+    computemetric!(x1, x2, J, ξ1x1, ξ2x1, ξ1x2, ξ2x2, sJ, n1, n2, D1, D2)
 
 Compute the 2-D metric terms from the element grid arrays `x1` and `x2`. All the
-arrays are preallocated by the user and the (square) derivative matrix `D`
-should be consistent with the reference grid `r` used in [`creategrid!`](@ref).
+arrays are preallocated by the user and the (square) derivative matrice `D1` and
+D2 should be consistent with the reference grid `ξ1` and `ξ2` used in
+[`creategrid!`](@ref).
 
-If `Nq = size(D, 1)` and `nelem = div(length(x1), Nq^2)` then the volume arrays
-`x1`, `x2`, `J`, `ξ1x1`, `ξ2x1`, `ξ1x2`, and `ξ2x2` should all be of size `(Nq, Nq,
-nelem)`.  Similarly, the face arrays `sJ`, `n1`, and `n2` should be of size
-`(Nq, nface, nelem)` with `nface = 4`.
+If `Nq = (size(D1, 1), size(D2, 1))` and `nelem = div(length(x1), prod(Nq))`
+then the volume arrays `x1`, `x2`, `J`, `ξ1x1`, `ξ2x1`, `ξ1x2`, and `ξ2x2`
+should all be of size `(Nq..., nelem)`.  Similarly, the face arrays `sJ`, `n1`,
+and `n2` should be of size `(maximum(Nq), nface, nelem)` with `nface = 4`
 """
-function computemetric!(x1, x2, J, ξ1x1, ξ2x1, ξ1x2, ξ2x2, sJ, n1, n2, D)
+function computemetric!(x1, x2, J, ξ1x1, ξ2x1, ξ1x2, ξ2x2, sJ, n1, n2, D1, D2)
     T = eltype(x1)
-    Nq = size(D, 1)
-    nelem = div(length(J), Nq^2)
-    x1 = reshape(x1, (Nq, Nq, nelem))
-    x2 = reshape(x2, (Nq, Nq, nelem))
-    J = reshape(J, (Nq, Nq, nelem))
-    ξ1x1 = reshape(ξ1x1, (Nq, Nq, nelem))
-    ξ2x1 = reshape(ξ2x1, (Nq, Nq, nelem))
-    ξ1x2 = reshape(ξ1x2, (Nq, Nq, nelem))
-    ξ2x2 = reshape(ξ2x2, (Nq, Nq, nelem))
+    Nq = (size(D1, 1), size(D2, 1))
+    nelem = div(length(J), prod(Nq))
+    x1 = reshape(x1, (Nq..., nelem))
+    x2 = reshape(x2, (Nq..., nelem))
+    J = reshape(J, (Nq..., nelem))
+    ξ1x1 = reshape(ξ1x1, (Nq..., nelem))
+    ξ2x1 = reshape(ξ2x1, (Nq..., nelem))
+    ξ1x2 = reshape(ξ1x2, (Nq..., nelem))
+    ξ2x2 = reshape(ξ2x2, (Nq..., nelem))
     nface = 4
-    n1 = reshape(n1, (Nq, nface, nelem))
-    n2 = reshape(n2, (Nq, nface, nelem))
-    sJ = reshape(sJ, (Nq, nface, nelem))
+    Nfp = div.(prod(Nq), Nq)
+    n1 = reshape(n1, (maximum(Nfp), nface, nelem))
+    n2 = reshape(n2, (maximum(Nfp), nface, nelem))
+    sJ = reshape(sJ, (maximum(Nfp), nface, nelem))
 
-    @inbounds for e in 1:nelem
-        for j in 1:Nq, i in 1:Nq
+    for e in 1:nelem
+        for j in 1:Nq[2], i in 1:Nq[1]
             x1ξ1 = x1ξ2 = zero(T)
             x2ξ1 = x2ξ2 = zero(T)
-            for n in 1:Nq
-                x1ξ1 += D[i, n] * x1[n, j, e]
-                x1ξ2 += D[j, n] * x1[i, n, e]
-                x2ξ1 += D[i, n] * x2[n, j, e]
-                x2ξ2 += D[j, n] * x2[i, n, e]
+            for n in 1:Nq[1]
+                x1ξ1 += D1[i, n] * x1[n, j, e]
+                x2ξ1 += D1[i, n] * x2[n, j, e]
+            end
+            for n in 1:Nq[2]
+                x1ξ2 += D2[j, n] * x1[i, n, e]
+                x2ξ2 += D2[j, n] * x2[i, n, e]
             end
             J[i, j, e] = x1ξ1 * x2ξ2 - x2ξ1 * x1ξ2
             ξ1x1[i, j, e] = x2ξ2 / J[i, j, e]
@@ -208,15 +178,25 @@ function computemetric!(x1, x2, J, ξ1x1, ξ2x1, ξ1x2, ξ2x2, sJ, n1, n2, D)
             ξ2x2[i, j, e] = x1ξ1 / J[i, j, e]
         end
 
-        for i in 1:Nq
-            n1[i, 1, e] = -J[1, i, e] * ξ1x1[1, i, e]
-            n2[i, 1, e] = -J[1, i, e] * ξ1x2[1, i, e]
-            n1[i, 2, e] = J[Nq, i, e] * ξ1x1[Nq, i, e]
-            n2[i, 2, e] = J[Nq, i, e] * ξ1x2[Nq, i, e]
-            n1[i, 3, e] = -J[i, 1, e] * ξ2x1[i, 1, e]
-            n2[i, 3, e] = -J[i, 1, e] * ξ2x2[i, 1, e]
-            n1[i, 4, e] = J[i, Nq, e] * ξ2x1[i, Nq, e]
-            n2[i, 4, e] = J[i, Nq, e] * ξ2x2[i, Nq, e]
+        for i in 1:maximum(Nfp)
+            if i <= Nfp[1]
+                n1[i, 1, e] = -J[1, i, e] * ξ1x1[1, i, e]
+                n2[i, 1, e] = -J[1, i, e] * ξ1x2[1, i, e]
+                n1[i, 2, e] = J[Nq[1], i, e] * ξ1x1[Nq[1], i, e]
+                n2[i, 2, e] = J[Nq[1], i, e] * ξ1x2[Nq[1], i, e]
+            else
+                n1[i, 1:2, e] .= NaN
+                n2[i, 1:2, e] .= NaN
+            end
+            if i <= Nfp[2]
+                n1[i, 3, e] = -J[i, 1, e] * ξ2x1[i, 1, e]
+                n2[i, 3, e] = -J[i, 1, e] * ξ2x2[i, 1, e]
+                n1[i, 4, e] = J[i, Nq[2], e] * ξ2x1[i, Nq[2], e]
+                n2[i, 4, e] = J[i, Nq[2], e] * ξ2x2[i, Nq[2], e]
+            else
+                n1[i, 3:4, e] .= NaN
+                n2[i, 3:4, e] .= NaN
+            end
 
             for n in 1:nface
                 sJ[i, n, e] = hypot(n1[i, n, e], n2[i, n, e])
@@ -235,7 +215,7 @@ end
 
 Compute the 3-D metric terms from the element grid arrays `x1`, `x2`, and `x3`.
 All the arrays are preallocated by the user and the (square) derivative matrix
-`D` should be consistent with the reference grid `r` used in
+`D` should be consistent with the reference grid `ξ1` used in
 [`creategrid!`](@ref).
 
 If `Nq = size(D, 1)` and `nelem = div(length(x1), Nq^3)` then the volume arrays
@@ -269,34 +249,38 @@ function computemetric!(
     n1,
     n2,
     n3,
-    D,
+    D1,
+    D2,
+    D3,
 )
     T = eltype(x1)
 
-    Nq = size(D, 1)
-    nelem = div(length(J), Nq^3)
+    Nq = (size(D1, 1), size(D2, 1), size(D3, 1))
+    Np = prod(Nq)
+    Nfp = div.(Np, Nq)
+    nelem = div(length(J), Np)
 
-    x1 = reshape(x1, (Nq, Nq, Nq, nelem))
-    x2 = reshape(x2, (Nq, Nq, Nq, nelem))
-    x3 = reshape(x3, (Nq, Nq, Nq, nelem))
-    J = reshape(J, (Nq, Nq, Nq, nelem))
-    ξ1x1 = reshape(ξ1x1, (Nq, Nq, Nq, nelem))
-    ξ2x1 = reshape(ξ2x1, (Nq, Nq, Nq, nelem))
-    ξ3x1 = reshape(ξ3x1, (Nq, Nq, Nq, nelem))
-    ξ1x2 = reshape(ξ1x2, (Nq, Nq, Nq, nelem))
-    ξ2x2 = reshape(ξ2x2, (Nq, Nq, Nq, nelem))
-    ξ3x2 = reshape(ξ3x2, (Nq, Nq, Nq, nelem))
-    ξ1x3 = reshape(ξ1x3, (Nq, Nq, Nq, nelem))
-    ξ2x3 = reshape(ξ2x3, (Nq, Nq, Nq, nelem))
-    ξ3x3 = reshape(ξ3x3, (Nq, Nq, Nq, nelem))
+    x1 = reshape(x1, (Nq..., nelem))
+    x2 = reshape(x2, (Nq..., nelem))
+    x3 = reshape(x3, (Nq..., nelem))
+    J = reshape(J, (Nq..., nelem))
+    ξ1x1 = reshape(ξ1x1, (Nq..., nelem))
+    ξ2x1 = reshape(ξ2x1, (Nq..., nelem))
+    ξ3x1 = reshape(ξ3x1, (Nq..., nelem))
+    ξ1x2 = reshape(ξ1x2, (Nq..., nelem))
+    ξ2x2 = reshape(ξ2x2, (Nq..., nelem))
+    ξ3x2 = reshape(ξ3x2, (Nq..., nelem))
+    ξ1x3 = reshape(ξ1x3, (Nq..., nelem))
+    ξ2x3 = reshape(ξ2x3, (Nq..., nelem))
+    ξ3x3 = reshape(ξ3x3, (Nq..., nelem))
 
     nface = 6
-    n1 = reshape(n1, Nq, Nq, nface, nelem)
-    n2 = reshape(n2, Nq, Nq, nface, nelem)
-    n3 = reshape(n3, Nq, Nq, nface, nelem)
-    sJ = reshape(sJ, Nq, Nq, nface, nelem)
+    n1 = reshape(n1, maximum(Nfp), nface, nelem)
+    n2 = reshape(n2, maximum(Nfp), nface, nelem)
+    n3 = reshape(n3, maximum(Nfp), nface, nelem)
+    sJ = reshape(sJ, maximum(Nfp), nface, nelem)
 
-    JI2 = similar(J, (Nq, Nq, Nq))
+    JI2 = similar(J, Nq...)
     (yzr, yzs, yzt) = (similar(JI2), similar(JI2), similar(JI2))
     (zxr, zxs, zxt) = (similar(JI2), similar(JI2), similar(JI2))
     (xyr, xys, xyt) = (similar(JI2), similar(JI2), similar(JI2))
@@ -311,21 +295,30 @@ function computemetric!(
     ξ2x3 .= zero(T)
     ξ3x3 .= zero(T)
 
+    fill!(n1, NaN)
+    fill!(n2, NaN)
+    fill!(n3, NaN)
+    fill!(sJ, NaN)
+
     @inbounds for e in 1:nelem
-        for k in 1:Nq, j in 1:Nq, i in 1:Nq
+        for k in 1:Nq[3], j in 1:Nq[2], i in 1:Nq[1]
             x1ξ1 = x1ξ2 = x1ξ3 = zero(T)
             x2ξ1 = x2ξ2 = x2ξ3 = zero(T)
             x3ξ1 = x3ξ2 = x3ξ3 = zero(T)
-            for n in 1:Nq
-                x1ξ1 += D[i, n] * x1[n, j, k, e]
-                x1ξ2 += D[j, n] * x1[i, n, k, e]
-                x1ξ3 += D[k, n] * x1[i, j, n, e]
-                x2ξ1 += D[i, n] * x2[n, j, k, e]
-                x2ξ2 += D[j, n] * x2[i, n, k, e]
-                x2ξ3 += D[k, n] * x2[i, j, n, e]
-                x3ξ1 += D[i, n] * x3[n, j, k, e]
-                x3ξ2 += D[j, n] * x3[i, n, k, e]
-                x3ξ3 += D[k, n] * x3[i, j, n, e]
+            for n in 1:Nq[1]
+                x1ξ1 += D1[i, n] * x1[n, j, k, e]
+                x2ξ1 += D1[i, n] * x2[n, j, k, e]
+                x3ξ1 += D1[i, n] * x3[n, j, k, e]
+            end
+            for n in 1:Nq[2]
+                x1ξ2 += D2[j, n] * x1[i, n, k, e]
+                x2ξ2 += D2[j, n] * x2[i, n, k, e]
+                x3ξ2 += D2[j, n] * x3[i, n, k, e]
+            end
+            for n in 1:Nq[3]
+                x1ξ3 += D3[k, n] * x1[i, j, n, e]
+                x2ξ3 += D3[k, n] * x2[i, j, n, e]
+                x3ξ3 += D3[k, n] * x3[i, j, n, e]
             end
             J[i, j, k, e] = (
                 x1ξ1 * (x2ξ2 * x3ξ3 - x3ξ2 * x2ξ3) +
@@ -346,26 +339,30 @@ function computemetric!(
             xyt[i, j, k] = x1[i, j, k, e] * x2ξ3 - x2[i, j, k, e] * x1ξ3
         end
 
-        for k in 1:Nq, j in 1:Nq, i in 1:Nq
-            for n in 1:Nq
-                ξ1x1[i, j, k, e] += D[j, n] * yzt[i, n, k]
-                ξ1x1[i, j, k, e] -= D[k, n] * yzs[i, j, n]
-                ξ2x1[i, j, k, e] += D[k, n] * yzr[i, j, n]
-                ξ2x1[i, j, k, e] -= D[i, n] * yzt[n, j, k]
-                ξ3x1[i, j, k, e] += D[i, n] * yzs[n, j, k]
-                ξ3x1[i, j, k, e] -= D[j, n] * yzr[i, n, k]
-                ξ1x2[i, j, k, e] += D[j, n] * zxt[i, n, k]
-                ξ1x2[i, j, k, e] -= D[k, n] * zxs[i, j, n]
-                ξ2x2[i, j, k, e] += D[k, n] * zxr[i, j, n]
-                ξ2x2[i, j, k, e] -= D[i, n] * zxt[n, j, k]
-                ξ3x2[i, j, k, e] += D[i, n] * zxs[n, j, k]
-                ξ3x2[i, j, k, e] -= D[j, n] * zxr[i, n, k]
-                ξ1x3[i, j, k, e] += D[j, n] * xyt[i, n, k]
-                ξ1x3[i, j, k, e] -= D[k, n] * xys[i, j, n]
-                ξ2x3[i, j, k, e] += D[k, n] * xyr[i, j, n]
-                ξ2x3[i, j, k, e] -= D[i, n] * xyt[n, j, k]
-                ξ3x3[i, j, k, e] += D[i, n] * xys[n, j, k]
-                ξ3x3[i, j, k, e] -= D[j, n] * xyr[i, n, k]
+        for k in 1:Nq[3], j in 1:Nq[2], i in 1:Nq[1]
+            for n in 1:Nq[1]
+                ξ2x1[i, j, k, e] -= D1[i, n] * yzt[n, j, k]
+                ξ3x1[i, j, k, e] += D1[i, n] * yzs[n, j, k]
+                ξ2x2[i, j, k, e] -= D1[i, n] * zxt[n, j, k]
+                ξ3x2[i, j, k, e] += D1[i, n] * zxs[n, j, k]
+                ξ2x3[i, j, k, e] -= D1[i, n] * xyt[n, j, k]
+                ξ3x3[i, j, k, e] += D1[i, n] * xys[n, j, k]
+            end
+            for n in 1:Nq[2]
+                ξ1x1[i, j, k, e] += D2[j, n] * yzt[i, n, k]
+                ξ3x1[i, j, k, e] -= D2[j, n] * yzr[i, n, k]
+                ξ1x2[i, j, k, e] += D2[j, n] * zxt[i, n, k]
+                ξ3x2[i, j, k, e] -= D2[j, n] * zxr[i, n, k]
+                ξ1x3[i, j, k, e] += D2[j, n] * xyt[i, n, k]
+                ξ3x3[i, j, k, e] -= D2[j, n] * xyr[i, n, k]
+            end
+            for n in 1:Nq[3]
+                ξ1x1[i, j, k, e] -= D3[k, n] * yzs[i, j, n]
+                ξ2x1[i, j, k, e] += D3[k, n] * yzr[i, j, n]
+                ξ1x2[i, j, k, e] -= D3[k, n] * zxs[i, j, n]
+                ξ2x2[i, j, k, e] += D3[k, n] * zxr[i, j, n]
+                ξ1x3[i, j, k, e] -= D3[k, n] * xys[i, j, n]
+                ξ2x3[i, j, k, e] += D3[k, n] * xyr[i, j, n]
             end
             ξ1x1[i, j, k, e] *= JI2[i, j, k]
             ξ2x1[i, j, k, e] *= JI2[i, j, k]
@@ -378,6 +375,55 @@ function computemetric!(
             ξ3x3[i, j, k, e] *= JI2[i, j, k]
         end
 
+        # faces 1 & 2
+        for k in 1:Nq[3], j in 1:Nq[2]
+            n = j + (k - 1) * Nq[2]
+            n1[n, 1, e] = -J[1, j, k, e] * ξ1x1[1, j, k, e]
+            n2[n, 1, e] = -J[1, j, k, e] * ξ1x2[1, j, k, e]
+            n3[n, 1, e] = -J[1, j, k, e] * ξ1x3[1, j, k, e]
+            n1[n, 2, e] = J[Nq[1], j, k, e] * ξ1x1[Nq[1], j, k, e]
+            n2[n, 2, e] = J[Nq[1], j, k, e] * ξ1x2[Nq[1], j, k, e]
+            n3[n, 2, e] = J[Nq[1], j, k, e] * ξ1x3[Nq[1], j, k, e]
+            for f in 1:2
+                sJ[n, f, e] = hypot(n1[n, f, e], n2[n, f, e], n3[n, f, e])
+                n1[n, f, e] /= sJ[n, f, e]
+                n2[n, f, e] /= sJ[n, f, e]
+                n3[n, f, e] /= sJ[n, f, e]
+            end
+        end
+        # faces 3 & 4
+        for k in 1:Nq[3], i in 1:Nq[1]
+            n = i + (k - 1) * Nq[1]
+            n1[n, 3, e] = -J[i, 1, k, e] * ξ2x1[i, 1, k, e]
+            n2[n, 3, e] = -J[i, 1, k, e] * ξ2x2[i, 1, k, e]
+            n3[n, 3, e] = -J[i, 1, k, e] * ξ2x3[i, 1, k, e]
+            n1[n, 4, e] = J[i, Nq[2], k, e] * ξ2x1[i, Nq[2], k, e]
+            n2[n, 4, e] = J[i, Nq[2], k, e] * ξ2x2[i, Nq[2], k, e]
+            n3[n, 4, e] = J[i, Nq[2], k, e] * ξ2x3[i, Nq[2], k, e]
+            for f in 3:4
+                sJ[n, f, e] = hypot(n1[n, f, e], n2[n, f, e], n3[n, f, e])
+                n1[n, f, e] /= sJ[n, f, e]
+                n2[n, f, e] /= sJ[n, f, e]
+                n3[n, f, e] /= sJ[n, f, e]
+            end
+        end
+        # faces 5 & 6
+        for j in 1:Nq[2], i in 1:Nq[1]
+            n = i + (j - 1) * Nq[1]
+            n1[n, 5, e] = -J[i, j, 1, e] * ξ3x1[i, j, 1, e]
+            n2[n, 5, e] = -J[i, j, 1, e] * ξ3x2[i, j, 1, e]
+            n3[n, 5, e] = -J[i, j, 1, e] * ξ3x3[i, j, 1, e]
+            n1[n, 6, e] = J[i, j, Nq[3], e] * ξ3x1[i, j, Nq[3], e]
+            n2[n, 6, e] = J[i, j, Nq[3], e] * ξ3x2[i, j, Nq[3], e]
+            n3[n, 6, e] = J[i, j, Nq[3], e] * ξ3x3[i, j, Nq[3], e]
+            for f in 5:6
+                sJ[n, f, e] = hypot(n1[n, f, e], n2[n, f, e], n3[n, f, e])
+                n1[n, f, e] /= sJ[n, f, e]
+                n2[n, f, e] /= sJ[n, f, e]
+                n3[n, f, e] /= sJ[n, f, e]
+            end
+        end
+        #=
         for j in 1:Nq, i in 1:Nq
             n1[i, j, 1, e] = -J[1, i, j, e] * ξ1x1[1, i, j, e]
             n1[i, j, 2, e] = J[Nq, i, j, e] * ξ1x1[Nq, i, j, e]
@@ -406,21 +452,22 @@ function computemetric!(
                 n3[i, j, n, e] /= sJ[i, j, n, e]
             end
         end
+        =#
     end
 
     nothing
 end
 
-creategrid1d(elemtocoord, r) = creategrid(Val(1), elemtocoord, r)
-creategrid2d(elemtocoord, r) = creategrid(Val(2), elemtocoord, r)
-creategrid3d(elemtocoord, r) = creategrid(Val(3), elemtocoord, r)
+creategrid1d(elemtocoord, x...) = creategrid(Val(1), elemtocoord, x...)
+creategrid2d(elemtocoord, x...) = creategrid(Val(2), elemtocoord, x...)
+creategrid3d(elemtocoord, x...) = creategrid(Val(3), elemtocoord, x...)
 
 """
     creategrid(::Val{1}, elemtocoord::AbstractArray{S, 3},
-               r::AbstractVector{T}) where {S, T}
+               ξ1::AbstractVector{T}) where {S, T}
 
 Create a grid using `elemtocoord` (see [`brickmesh`](@ref)) using the 1-D `(-1,
-1)` reference coordinates `r`. The element grids are filled using bilinear
+1)` reference coordinates `ξ1`. The element grids are filled using bilinear
 interpolation of the element coordinates.
 
 The grid is returned as a tuple of with `x1` array
@@ -428,22 +475,22 @@ The grid is returned as a tuple of with `x1` array
 function creategrid(
     ::Val{1},
     e2c::AbstractArray{S, 3},
-    r::AbstractVector{T},
+    ξ1::AbstractVector{T},
 ) where {S, T}
     (d, nvert, nelem) = size(e2c)
     @assert d == 1
-    Nq = length(r)
+    Nq = length(ξ1)
     x1 = Array{T, 2}(undef, Nq, nelem)
-    creategrid!(x1, e2c, r)
+    creategrid!(x1, e2c, ξ1)
     (x1 = x1,)
 end
 
 """
   creategrid(::Val{2}, elemtocoord::AbstractArray{S, 3},
-             r::AbstractVector{T}) where {S, T}
+             ξ1::AbstractVector{T}) where {S, T}
 
 Create a 2-D tensor product grid using `elemtocoord` (see [`brickmesh`](@ref))
-using the 1-D `(-1, 1)` reference coordinates `r`. The element grids are filled
+using the 1-D `(-1, 1)` reference coordinates `ξ1`. The element grids are filled
 using bilinear interpolation of the element coordinates.
 
 The grid is returned as a tuple of the `x1` and `x2` arrays
@@ -451,23 +498,24 @@ The grid is returned as a tuple of the `x1` and `x2` arrays
 function creategrid(
     ::Val{2},
     e2c::AbstractArray{S, 3},
-    r::AbstractVector{T},
+    ξ1::AbstractVector{T},
+    ξ2::AbstractVector{T},
 ) where {S, T}
     (d, nvert, nelem) = size(e2c)
     @assert d == 2
-    Nq = length(r)
-    x1 = Array{T, 3}(undef, Nq, Nq, nelem)
-    x2 = Array{T, 3}(undef, Nq, Nq, nelem)
-    creategrid!(x1, x2, e2c, r)
+    Nq = (length(ξ1), length(ξ2))
+    x1 = Array{T, 3}(undef, Nq[1], Nq[2], nelem)
+    x2 = Array{T, 3}(undef, Nq[1], Nq[2], nelem)
+    creategrid!(x1, x2, e2c, ξ1, ξ2)
     (x1 = x1, x2 = x2)
 end
 
 """
   creategrid(::Val{3}, elemtocoord::AbstractArray{S, 3},
-             r::AbstractVector{T}) where {S, T}
+             ξ1::AbstractVector{T}) where {S, T}
 
 Create a 3-D tensor product grid using `elemtocoord` (see [`brickmesh`](@ref))
-using the 1-D `(-1, 1)` reference coordinates `r`. The element grids are filled
+using the 1-D `(-1, 1)` reference coordinates `ξ1`. The element grids are filled
 using bilinear interpolation of the element coordinates.
 
 The grid is returned as a tuple of the `x1`, `x2`, `x3` arrays
@@ -475,15 +523,17 @@ The grid is returned as a tuple of the `x1`, `x2`, `x3` arrays
 function creategrid(
     ::Val{3},
     e2c::AbstractArray{S, 3},
-    r::AbstractVector{T},
+    ξ1::AbstractVector{T},
+    ξ2::AbstractVector{T},
+    ξ3::AbstractVector{T},
 ) where {S, T}
     (d, nvert, nelem) = size(e2c)
     @assert d == 3
-    Nq = length(r)
-    x1 = Array{T, 4}(undef, Nq, Nq, Nq, nelem)
-    x2 = Array{T, 4}(undef, Nq, Nq, Nq, nelem)
-    x3 = Array{T, 4}(undef, Nq, Nq, Nq, nelem)
-    creategrid!(x1, x2, x3, e2c, r)
+    Nq = (length(ξ1), length(ξ2), length(ξ3))
+    x1 = Array{T, 4}(undef, Nq[1], Nq[2], Nq[3], nelem)
+    x2 = Array{T, 4}(undef, Nq[1], Nq[2], Nq[3], nelem)
+    x3 = Array{T, 4}(undef, Nq[1], Nq[2], Nq[3], nelem)
+    creategrid!(x1, x2, x3, e2c, ξ1, ξ2, ξ3)
     (x1 = x1, x2 = x2, x3 = x3)
 end
 
@@ -492,12 +542,12 @@ end
 
 Compute the 1-D metric terms from the element grid array `x1` using the
 derivative matrix `D`. The derivative matrix `D` should be consistent with the
-reference grid `r` used in [`creategrid!`](@ref).
+reference grid `ξ1` used in [`creategrid!`](@ref).
 
 The metric terms are returned as a 'NamedTuple` of the following arrays:
 
 - `J` the Jacobian determinant
-- `ξ1x1` derivative ∂r / ∂x1'
+- `ξ1x1` derivative ∂ξ1 / ∂x1'
 - `sJ` the surface Jacobian
 - 'n1` outward pointing unit normal in \$x1\$-direction
 """
@@ -525,7 +575,7 @@ end
 
 Compute the 2-D metric terms from the element grid arrays `x1` and `x2` using
 the derivative matrix `D`. The derivative matrix `D` should be consistent with
-the reference grid `r` used in [`creategrid!`](@ref).
+the reference grid `ξ1` used in [`creategrid!`](@ref).
 
 The metric terms are returned as a 'NamedTuple` of the following arrays:
 
@@ -578,7 +628,7 @@ end
 
 Compute the 3-D metric terms from the element grid arrays `x1`, `x2`, and `x3`
 using the derivative matrix `D`. The derivative matrix `D` should be consistent
-with the reference grid `r` used in [`creategrid!`](@ref).
+with the reference grid `ξ1` used in [`creategrid!`](@ref).
 
 The metric terms are returned as a 'NamedTuple` of the following arrays:
 

--- a/src/Numerics/SystemSolvers/SystemSolvers.jl
+++ b/src/Numerics/SystemSolvers/SystemSolvers.jl
@@ -4,7 +4,7 @@ using ..MPIStateArrays
 using ..MPIStateArrays: array_device, realview
 
 using ..Mesh.Grids
-import ..Mesh.Grids: polynomialorder, dimensionality
+import ..Mesh.Grids: polynomialorders, dimensionality
 using ..Mesh.Topologies
 using ..DGMethods
 using ..DGMethods: DGModel

--- a/src/Numerics/SystemSolvers/batched_generalized_minimal_residual_solver.jl
+++ b/src/Numerics/SystemSolvers/batched_generalized_minimal_residual_solver.jl
@@ -235,8 +235,13 @@ function BatchedGeneralizedMinimalResidual(
     topology = grid.topology
     dim = dimensionality(grid)
 
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     # Number of Gauss-Lobatto quadrature points in 1D
-    Nq = polynomialorder(grid) + 1
+    Nq = N + 1
 
     # Assumes same number of quadrature points in all spatial directions
     Np = Tuple([Nq for i in 1:dim])

--- a/src/Numerics/SystemSolvers/columnwise_lu_solver.jl
+++ b/src/Numerics/SystemSolvers/columnwise_lu_solver.jl
@@ -303,7 +303,11 @@ function empty_banded_matrix(
     device = array_device(Q)
 
     nstate = number_states(bl, Prognostic())
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
 
     # p is lower bandwidth
@@ -387,7 +391,11 @@ function update_banded_matrix!(
     device = array_device(Q)
 
     nstate = number_states(bl, Prognostic())
-    N = polynomialorder(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
     Nq = N + 1
 
     # p is lower bandwidth

--- a/src/Ocean/SplitExplicit01/OceanModel.jl
+++ b/src/Ocean/SplitExplicit01/OceanModel.jl
@@ -85,7 +85,12 @@ function OceanDGModel(
     gradnumflux;
     kwargs...,
 )
-    vert_filter = CutoffFilter(grid, polynomialorder(grid) - 1)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
+    vert_filter = CutoffFilter(grid, N - 1)
     exp_filter = ExponentialFilter(grid, 1, 8)
 
     flowintegral_dg = DGModel(

--- a/src/Ocean/SplitExplicit01/SplitExplicitModel.jl
+++ b/src/Ocean/SplitExplicit01/SplitExplicitModel.jl
@@ -17,7 +17,7 @@ using ...MPIStateArrays
 using ...DGMethods: init_ode_state, basic_grid_info
 using ...Mesh.Filters: CutoffFilter, apply!, ExponentialFilter
 using ...Mesh.Grids:
-    polynomialorder,
+    polynomialorders,
     dimensionality,
     dofs_per_element,
     VerticalDirection,

--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -21,7 +21,7 @@ using ..VariableTemplates
 
 """
     get_vars_from_nodal_stack(
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
         Q::MPIStateArray,
         vars;
         vrange::UnitRange = 1:size(Q, 3),
@@ -29,7 +29,7 @@ using ..VariableTemplates
         j::Int = 1,
         exclude::Vector{String} = String[],
         interp = false,
-    ) where {T, dim, N}
+    ) where {T, dim, Ns}
 
 Return a dictionary whose keys are the `flattenednames()` of the variables
 specified in `vars` (as returned by e.g. `vars_state`), and
@@ -41,7 +41,7 @@ the horizontal nodal coordinates.
 Variables listed in `exclude` are skipped.
 """
 function get_vars_from_nodal_stack(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     vars;
     vrange::UnitRange = 1:size(Q, 3),
@@ -49,7 +49,12 @@ function get_vars_from_nodal_stack(
     j::Int = 1,
     exclude::Vector{String} = String[],
     interp = false,
-) where {T, dim, N}
+) where {T, dim, Ns}
+
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
 
     # extract grid information and bring `Q` to the host if needed
     FT = eltype(Q)
@@ -116,13 +121,13 @@ end
 
 """
     get_vars_from_element_stack(
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
         Q::MPIStateArray,
         vars;
         vrange::UnitRange = 1:size(Q, 3),
         exclude::Vector{String} = String[],
         interp = false,
-    ) where {T, dim, N}
+    ) where {T, dim, Ns}
 
 Return an array of [`get_vars_from_nodal_stack()`](@ref)s whose dimensions
 are the number of nodal points per element in the horizontal plane.
@@ -130,13 +135,19 @@ are the number of nodal points per element in the horizontal plane.
 Variables listed in `exclude` are skipped.
 """
 function get_vars_from_element_stack(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     vars;
     vrange::UnitRange = 1:size(Q, 3),
     exclude::Vector{String} = String[],
     interp = false,
-) where {T, dim, N}
+) where {T, dim, Ns}
+
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
+
     Nq = N + 1
     return [
         get_vars_from_nodal_stack(
@@ -154,13 +165,13 @@ end
 
 """
     get_horizontal_mean(
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
         Q::MPIStateArray,
         vars;
         vrange::UnitRange = 1:size(Q, 3),
         exclude::Vector{String} = String[],
         interp = false,
-    ) where {T, dim, N}
+    ) where {T, dim, Ns}
 
 Return a dictionary whose keys are the `flattenednames()` of the variables
 specified in `vars` (as returned by e.g. `vars_state`), and
@@ -171,13 +182,19 @@ horizontal as this is intended for the single stack configuration.
 Variables listed in `exclude` are skipped.
 """
 function get_horizontal_mean(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     vars;
     vrange::UnitRange = 1:size(Q, 3),
     exclude::Vector{String} = String[],
     interp = false,
-) where {T, dim, N}
+) where {T, dim, Ns}
+
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
+
     Nq = N + 1
     vars_avg = OrderedDict()
     vars_sq = OrderedDict()
@@ -202,13 +219,13 @@ end
 
 """
     get_horizontal_variance(
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
         Q::MPIStateArray,
         vars;
         vrange::UnitRange = 1:size(Q, 3),
         exclude::Vector{String} = String[],
         interp = false,
-    ) where {T, dim, N}
+    ) where {T, dim, Ns}
 
 Return a dictionary whose keys are the `flattenednames()` of the variables
 specified in `vars` (as returned by e.g. `vars_state`), and
@@ -219,13 +236,19 @@ horizontal as this is intended for the single stack configuration.
 Variables listed in `exclude` are skipped.
 """
 function get_horizontal_variance(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     vars;
     vrange::UnitRange = 1:size(Q, 3),
     exclude::Vector{String} = String[],
     interp = false,
-) where {T, dim, N}
+) where {T, dim, Ns}
+
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
+
     Nq = N + 1
     vars_avg = OrderedDict()
     vars_sq = OrderedDict()
@@ -256,12 +279,12 @@ end
 """
     reduce_nodal_stack(
         op::Function,
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
         Q::MPIStateArray,
         vars::NamedTuple,
         var::String;
         vrange::UnitRange = 1:size(Q, 3),
-    ) where {T, dim, N}
+    ) where {T, dim, Ns}
 
 Reduce `var` from `vars` within `Q` over all nodal points in the specified
 `vrange` of elements with `op`. Return a tuple `(result, z)` where `result` is
@@ -270,14 +293,20 @@ the final value returned by `op` and `z` is the index within `vrange` where the
 """
 function reduce_nodal_stack(
     op::Function,
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     vars::Type,
     var::String;
     vrange::UnitRange = 1:size(Q, 3),
     i::Int = 1,
     j::Int = 1,
-) where {T, dim, N}
+) where {T, dim, Ns}
+
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
+
     Nq = N + 1
     Nqk = dimensionality(grid) == 2 ? 1 : Nq
 
@@ -307,12 +336,12 @@ end
 """
     reduce_element_stack(
         op::Function,
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
         Q::MPIStateArray,
         vars::NamedTuple,
         var::String;
         vrange::UnitRange = 1:size(Q, 3),
-    ) where {T, dim, N}
+    ) where {T, dim, Ns}
 
 Reduce `var` from `vars` within `Q` over all nodal points in the specified
 `vrange` of elements with `op`. Return a tuple `(result, z)` where `result` is
@@ -321,12 +350,18 @@ the final value returned by `op` and `z` is the index within `vrange` where the
 """
 function reduce_element_stack(
     op::Function,
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     vars::Type,
     var::String;
     vrange::UnitRange = 1:size(Q, 3),
-) where {T, dim, N}
+) where {T, dim, Ns}
+
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
+
     Nq = N + 1
     return [
         reduce_nodal_stack(
@@ -344,10 +379,10 @@ end
 
 """
     horizontally_average!(
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
         Q::MPIStateArray,
         i_vars,
-    ) where {T, dim, N}
+    ) where {T, dim, Ns}
 
 Horizontally average variables, from variable
 indexes `i_vars`, in `MPIStateArray` `Q`.
@@ -358,10 +393,16 @@ indexes `i_vars`, in `MPIStateArray` `Q`.
     no horizontal fluxes for a single stack configuration.
 """
 function horizontally_average!(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     i_vars,
-) where {T, dim, N}
+) where {T, dim, Ns}
+
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
+
     Nq = N + 1
     ArrType = typeof(Q.data)
     state_data = array_device(Q) isa CPU ? Q.realdata : Array(Q.realdata)

--- a/test/Numerics/Mesh/BrickMesh.jl
+++ b/test/Numerics/Mesh/BrickMesh.jl
@@ -674,7 +674,8 @@ end
         commfaces .= false
         nabrtocomm = [1:2, 3:3]
 
-        vmapC, nabrtovmapC = commmapping(N, commelems, commfaces, nabrtocomm)
+        vmapC, nabrtovmapC =
+            commmapping(ntuple(j -> N, d), commelems, commfaces, nabrtocomm)
 
         @test vmapC == Int[]
         @test nabrtovmapC == UnitRange{Int64}[1:0, 1:0]
@@ -694,12 +695,14 @@ end
         ])
         nabrtocomm = [1:2, 3:3]
 
-        vmapC, nabrtovmapC = commmapping(N, commelems, commfaces, nabrtocomm)
+        vmapC, nabrtovmapC =
+            commmapping(ntuple(j -> N, d), commelems, commfaces, nabrtocomm)
 
         @test vmapC == [5, 6, 8, 19, 20]
         @test nabrtovmapC == UnitRange{Int64}[1:3, 4:5]
     end
 
+    # 2D, single polynomial order
     let
         N = 2
         d = 2
@@ -714,12 +717,55 @@ end
         ])
         nabrtocomm = [1:1, 2:3]
 
-        vmapC, nabrtovmapC = commmapping(N, commelems, commfaces, nabrtocomm)
+        vmapC, nabrtovmapC =
+            commmapping(ntuple(j -> N, d), commelems, commfaces, nabrtocomm)
 
         @test vmapC == [10, 13, 16, 28, 29, 30, 31, 34, 37, 38, 39, 43, 44, 45]
         @test nabrtovmapC == UnitRange{Int64}[1:3, 4:14]
     end
 
+    # 2D, multiple polynomial orders
+    let
+        N = (2, 3)
+        Np = prod(N .+ 1)
+        d = length(N)
+        nface = 2d
+
+        commelems = [2, 4, 5]
+        #! format: off
+        commfaces = BitArray([
+             true  true false false # faces of commelems[1] to send
+            false false false  true # faces of commelems[2] to send
+             true false false  true # faces of commelems[3] to send
+        ]')
+        #! format: on
+        nabrtocomm = [1:1, 2:3]
+        vmapC, nabrtovmapC = commmapping(N, commelems, commfaces, nabrtocomm)
+
+        @test vmapC == [
+            (commelems[1] - 1) * Np + 1
+            (commelems[1] - 1) * Np + 3
+            (commelems[1] - 1) * Np + 4
+            (commelems[1] - 1) * Np + 6
+            (commelems[1] - 1) * Np + 7
+            (commelems[1] - 1) * Np + 9
+            (commelems[1] - 1) * Np + 10
+            (commelems[1] - 1) * Np + 12
+            (commelems[2] - 1) * Np + 10
+            (commelems[2] - 1) * Np + 11
+            (commelems[2] - 1) * Np + 12
+            (commelems[3] - 1) * Np + 1
+            (commelems[3] - 1) * Np + 4
+            (commelems[3] - 1) * Np + 7
+            (commelems[3] - 1) * Np + 10
+            (commelems[3] - 1) * Np + 11
+            (commelems[3] - 1) * Np + 12
+        ]
+
+        @test nabrtovmapC == UnitRange{Int64}[1:8, 9:17]
+    end
+
+    # 3D, single polynomial order
     let
         N = 2
         d = 3
@@ -736,79 +782,64 @@ end
         ])
         nabrtocomm = [1:1, 2:4]
 
+        vmapC, nabrtovmapC =
+            commmapping(ntuple(j -> N, d), commelems, commfaces, nabrtocomm)
+
+        #! format: off
+        @test vmapC == [
+            55, 58, 61, 64, 67, 70, 73, 76, 79, 82, 83, 84, 85, 86, 87, 88, 89,
+            90, 91, 92, 93, 94, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
+            106, 107, 108, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172,
+            175, 178, 181, 184, 187, 217, 218, 219, 220, 221, 222, 223, 224,
+            225, 235, 236, 237, 238, 239, 240, 241, 242, 243,
+        ]
+        #! format: on
+        @test nabrtovmapC == UnitRange{Int64}[1:9, 10:68]
+    end
+
+    # 3D, multiple polynomial order
+    let
+        N = (2, 3, 4)
+        Nq = N .+ 1
+        Np = prod(Nq)
+        d = length(N)
+        nface = 2d
+
+        commelems = [3, 4, 7, 9]
+        commfaces = BitArray([
+            true true true false
+            false true false false
+            false true false false
+            false true false false
+            false true true true
+            false true false true
+        ])
+
+        p = reshape(1:Np, ntuple(j -> Nq[j], d))
+        fmask = (
+            p[1, :, :][:],     # Face 1
+            p[Nq[1], :, :][:], # Face 2
+            p[:, 1, :][:],     # Face 3
+            p[:, Nq[2], :][:], # Face 4
+            p[:, :, 1][:],     # Face 5
+            p[:, :, Nq[3]][:], # Face 6
+        )
+
+        nabrtocomm = [1:1, 2:4]
+
         vmapC, nabrtovmapC = commmapping(N, commelems, commfaces, nabrtocomm)
 
-        @test vmapC == [
-            55,
-            58,
-            61,
-            64,
-            67,
-            70,
-            73,
-            76,
-            79,
-            82,
-            83,
-            84,
-            85,
-            86,
-            87,
-            88,
-            89,
-            90,
-            91,
-            92,
-            93,
-            94,
-            96,
-            97,
-            98,
-            99,
-            100,
-            101,
-            102,
-            103,
-            104,
-            105,
-            106,
-            107,
-            108,
-            163,
-            164,
-            165,
-            166,
-            167,
-            168,
-            169,
-            170,
-            171,
-            172,
-            175,
-            178,
-            181,
-            184,
-            187,
-            217,
-            218,
-            219,
-            220,
-            221,
-            222,
-            223,
-            224,
-            225,
-            235,
-            236,
-            237,
-            238,
-            239,
-            240,
-            241,
-            242,
-            243,
+        #! format: off
+        @test vmapC == 
+        [
+         sort(unique(vcat(fmask[commfaces[:, 1]]...))) .+ (commelems[1] - 1) *Np
+         sort(unique(vcat(fmask[commfaces[:, 2]]...))) .+ (commelems[2] - 1) *Np
+         sort(unique(vcat(fmask[commfaces[:, 3]]...))) .+ (commelems[3] - 1) *Np
+         sort(unique(vcat(fmask[commfaces[:, 4]]...))) .+ (commelems[4] - 1) *Np
         ]
-        @test nabrtovmapC == UnitRange{Int64}[1:9, 10:68]
+        #! format: on
+
+        @test nabrtovmapC == UnitRange{Int64}[1:20, 21:126]
     end
 
 end

--- a/test/Numerics/Mesh/Metrics.jl
+++ b/test/Numerics/Mesh/Metrics.jl
@@ -24,54 +24,53 @@ const VGEO3D = (
 const SGEO3D = (sJ = 1, n1 = 2, n2 = 3, n3 = 4)
 
 @testset "1-D Metric terms" begin
-    for T in (Float32, Float64)
+    for FT in (Float32, Float64)
         #{{{
         let
             N = 4
 
-            r, w = Elements.lglpoints(T, N)
-            D = Elements.spectralderivative(r)
+            ξ1, w = Elements.lglpoints(FT, N)
+            D = Elements.spectralderivative(ξ1)
             Nq = N + 1
 
-            d = 1
-            nfaces = 4
-            e2c = Array{T, 3}(undef, 1, 2, 2)
+            dim = 1
+            e2c = Array{FT, 3}(undef, 1, 2, 2)
             e2c[:, :, 1] = [-1 0]
             e2c[:, :, 2] = [0 10]
             nelem = size(e2c, 3)
 
-            (x1,) = Metrics.creategrid1d(e2c, r)
-            @test x1[:, 1] ≈ (r .- 1) / 2
-            @test x1[:, 2] ≈ 5 * (r .+ 1)
+            (x1,) = Metrics.creategrid1d(e2c, ξ1)
+            @test x1[:, 1] ≈ (ξ1 .- 1) / 2
+            @test x1[:, 2] ≈ 5 * (ξ1 .+ 1)
 
             metric = Metrics.computemetric(x1, D)
-            @test metric.J[:, 1] ≈ ones(T, Nq) / 2
-            @test metric.J[:, 2] ≈ 5 * ones(T, Nq)
-            @test metric.ξ1x1[:, 1] ≈ 2 * ones(T, Nq)
-            @test metric.ξ1x1[:, 2] ≈ ones(T, Nq) / 5
-            @test metric.n1[1, 1, :] ≈ -ones(T, nelem)
-            @test metric.n1[1, 2, :] ≈ ones(T, nelem)
-            @test metric.sJ[1, 1, :] ≈ ones(T, nelem)
-            @test metric.sJ[1, 2, :] ≈ ones(T, nelem)
+            @test metric.J[:, 1] ≈ ones(FT, Nq) / 2
+            @test metric.J[:, 2] ≈ 5 * ones(FT, Nq)
+            @test metric.ξ1x1[:, 1] ≈ 2 * ones(FT, Nq)
+            @test metric.ξ1x1[:, 2] ≈ ones(FT, Nq) / 5
+            @test metric.n1[1, 1, :] ≈ -ones(FT, nelem)
+            @test metric.n1[1, 2, :] ≈ ones(FT, nelem)
+            @test metric.sJ[1, 1, :] ≈ ones(FT, nelem)
+            @test metric.sJ[1, 2, :] ≈ ones(FT, nelem)
         end
         #}}}
     end
 end
 
 @testset "2-D Metric terms" begin
-    for T in (Float32, Float64)
+    for FT in (Float32, Float64)
         # linear and rotation test
         #{{{
         let
             N = 2
 
-            r, w = Elements.lglpoints(T, N)
-            D = Elements.spectralderivative(r)
+            ξ1, w = Elements.lglpoints(FT, N)
+            D = Elements.spectralderivative(ξ1)
             Nq = N + 1
 
-            d = 2
-            nfaces = 4
-            e2c = Array{T, 3}(undef, 2, 4, 4)
+            dim = 2
+            nface = 2dim
+            e2c = Array{FT, 3}(undef, 2, 4, 4)
             e2c[:, :, 1] = [0 2 0 2; 0 0 2 2]
             e2c[:, :, 2] = [2 2 0 0; 0 2 0 2]
             e2c[:, :, 3] = [2 0 2 0; 2 2 0 0]
@@ -108,9 +107,9 @@ end
             ξ2x2_exact[:, :, 1] .= 1
             ξ2x2_exact[:, :, 3] .= -1
 
-            sJ_exact = ones(Int, Nq, nfaces, nelem)
+            sJ_exact = ones(Int, Nq, nface, nelem)
 
-            nx_exact = zeros(Int, Nq, nfaces, nelem)
+            nx_exact = zeros(Int, Nq, nface, nelem)
             nx_exact[:, 1, 1] .= -1
             nx_exact[:, 2, 1] .= 1
             nx_exact[:, 3, 2] .= 1
@@ -120,7 +119,7 @@ end
             nx_exact[:, 3, 4] .= -1
             nx_exact[:, 4, 4] .= 1
 
-            ny_exact = zeros(Int, Nq, nfaces, nelem)
+            ny_exact = zeros(Int, Nq, nface, nelem)
             ny_exact[:, 3, 1] .= -1
             ny_exact[:, 4, 1] .= 1
             ny_exact[:, 1, 2] .= -1
@@ -130,9 +129,13 @@ end
             ny_exact[:, 1, 4] .= 1
             ny_exact[:, 2, 4] .= -1
 
-            vgeo = Array{T, 4}(undef, Nq, Nq, length(VGEO2D), nelem)
-            sgeo = Array{T, 4}(undef, Nq, nfaces, length(SGEO2D), nelem)
-            Metrics.creategrid!(ntuple(j -> (@view vgeo[:, :, j, :]), d)..., e2c, r)
+            vgeo = Array{FT, 4}(undef, Nq, Nq, length(VGEO2D), nelem)
+            sgeo = Array{FT, 4}(undef, Nq, nface, length(SGEO2D), nelem)
+            Metrics.creategrid!(
+                ntuple(j -> (@view vgeo[:, :, j, :]), dim)...,
+                e2c,
+                ξ1,
+            )
             Metrics.computemetric!(
                 ntuple(j -> (@view vgeo[:, :, j, :]), length(VGEO2D))...,
                 ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO2D))...,
@@ -159,32 +162,39 @@ end
         let
             N = 4
 
-            f(r, s) = (
-                9 .* r - (1 .+ r) .* s .^ 2 +
-                (r .- 1) .^ 2 .* (1 .- s .^ 2 .+ s .^ 3),
-                10 .* s .+ r .^ 4 .* (1 .- s) .+ r .^ 2 .* s .* (1 .+ s),
+            f(ξ1, ξ2) = (
+                9 .* ξ1 - (1 .+ ξ1) .* ξ2 .^ 2 +
+                (ξ1 .- 1) .^ 2 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3),
+                10 .* ξ2 .+ ξ1 .^ 4 .* (1 .- ξ2) .+ ξ1 .^ 2 .* ξ2 .* (1 .+ ξ2),
             )
-            fx1ξ1(r, s) =
-                7 .+ s .^ 2 .- 2 .* s .^ 3 .+ 2 .* r .* (1 .- s .^ 2 .+ s .^ 3)
-            fx1ξ2(r, s) =
-                -2 .* (1 .+ r) .* s .+ (-1 .+ r) .^ 2 .* s .* (-2 .+ 3 .* s)
-            fx2ξ1(r, s) = -4 .* r .^ 3 .* (-1 .+ s) .+ 2 .* r .* s .* (1 .+ s)
-            fx2ξ2(r, s) = 10 .- r .^ 4 .+ r .^ 2 .* (1 .+ 2 .* s)
+            fx1ξ1(ξ1, ξ2) =
+                7 .+ ξ2 .^ 2 .- 2 .* ξ2 .^ 3 .+
+                2 .* ξ1 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3)
+            fx1ξ2(ξ1, ξ2) =
+                -2 .* (1 .+ ξ1) .* ξ2 .+
+                (-1 .+ ξ1) .^ 2 .* ξ2 .* (-2 .+ 3 .* ξ2)
+            fx2ξ1(ξ1, ξ2) =
+                -4 .* ξ1 .^ 3 .* (-1 .+ ξ2) .+ 2 .* ξ1 .* ξ2 .* (1 .+ ξ2)
+            fx2ξ2(ξ1, ξ2) = 10 .- ξ1 .^ 4 .+ ξ1 .^ 2 .* (1 .+ 2 .* ξ2)
 
-            r, w = Elements.lglpoints(T, N)
-            D = Elements.spectralderivative(r)
+            ξ1, w = Elements.lglpoints(FT, N)
+            D = Elements.spectralderivative(ξ1)
             Nq = N + 1
 
-            d = 2
-            nfaces = 4
-            e2c = Array{T, 3}(undef, 2, 4, 1)
+            dim = 2
+            nface = 2dim
+            e2c = Array{FT, 3}(undef, 2, 4, 1)
             e2c[:, :, 1] = [-1 1 -1 1; -1 -1 1 1]
             nelem = size(e2c, 3)
 
-            vgeo = Array{T, 4}(undef, Nq, Nq, length(VGEO2D), nelem)
-            sgeo = Array{T, 4}(undef, Nq, nfaces, length(SGEO2D), nelem)
+            vgeo = Array{FT, 4}(undef, Nq, Nq, length(VGEO2D), nelem)
+            sgeo = Array{FT, 4}(undef, Nq, nface, length(SGEO2D), nelem)
 
-            Metrics.creategrid!(ntuple(j -> (@view vgeo[:, :, j, :]), d)..., e2c, r)
+            Metrics.creategrid!(
+                ntuple(j -> (@view vgeo[:, :, j, :]), dim)...,
+                e2c,
+                ξ1,
+            )
             x1 = @view vgeo[:, :, VGEO2D.x1, :]
             x2 = @view vgeo[:, :, VGEO2D.x2, :]
 
@@ -208,7 +218,7 @@ end
             n1 = @view sgeo[:, :, SGEO2D.n1, :]
             n2 = @view sgeo[:, :, SGEO2D.n2, :]
             sJ = @view sgeo[:, :, SGEO2D.sJ, :]
-            @test hypot.(n1, n2) ≈ ones(T, size(n1))
+            @test hypot.(n1, n2) ≈ ones(FT, size(n1))
             @test sJ[:, 1, :] .* n1[:, 1, :] ≈ -x2ξ2[1, :, :]
             @test sJ[:, 1, :] .* n2[:, 1, :] ≈ x1ξ2[1, :, :]
             @test sJ[:, 2, :] .* n1[:, 2, :] ≈ x2ξ2[Nq, :, :]
@@ -224,29 +234,31 @@ end
         let
             N = 4
 
-            f(r, s) = (
-                9 .* r - (1 .+ r) .* s .^ 2 +
-                (r .- 1) .^ 2 .* (1 .- s .^ 2 .+ s .^ 3),
-                10 .* s .+ r .^ 4 .* (1 .- s) .+ r .^ 2 .* s .* (1 .+ s),
+            f(ξ1, ξ2) = (
+                9 .* ξ1 - (1 .+ ξ1) .* ξ2 .^ 2 +
+                (ξ1 .- 1) .^ 2 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3),
+                10 .* ξ2 .+ ξ1 .^ 4 .* (1 .- ξ2) .+ ξ1 .^ 2 .* ξ2 .* (1 .+ ξ2),
             )
-            fx1ξ1(r, s) =
-                7 .+ s .^ 2 .- 2 .* s .^ 3 .+ 2 .* r .* (1 .- s .^ 2 .+ s .^ 3)
-            fx1ξ2(r, s) =
-                -2 .* (1 .+ r) .* s .+ (-1 .+ r) .^ 2 .* s .* (-2 .+ 3 .* s)
-            fx2ξ1(r, s) = -4 .* r .^ 3 .* (-1 .+ s) .+ 2 .* r .* s .* (1 .+ s)
-            fx2ξ2(r, s) = 10 .- r .^ 4 .+ r .^ 2 .* (1 .+ 2 .* s)
+            fx1ξ1(ξ1, ξ2) =
+                7 .+ ξ2 .^ 2 .- 2 .* ξ2 .^ 3 .+
+                2 .* ξ1 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3)
+            fx1ξ2(ξ1, ξ2) =
+                -2 .* (1 .+ ξ1) .* ξ2 .+
+                (-1 .+ ξ1) .^ 2 .* ξ2 .* (-2 .+ 3 .* ξ2)
+            fx2ξ1(ξ1, ξ2) =
+                -4 .* ξ1 .^ 3 .* (-1 .+ ξ2) .+ 2 .* ξ1 .* ξ2 .* (1 .+ ξ2)
+            fx2ξ2(ξ1, ξ2) = 10 .- ξ1 .^ 4 .+ ξ1 .^ 2 .* (1 .+ 2 .* ξ2)
 
-            r, w = Elements.lglpoints(T, N)
-            D = Elements.spectralderivative(r)
+            ξ1, w = Elements.lglpoints(FT, N)
+            D = Elements.spectralderivative(ξ1)
             Nq = N + 1
 
-            d = 2
-            nfaces = 4
-            e2c = Array{T, 3}(undef, 2, 4, 1)
+            dim = 2
+            e2c = Array{FT, 3}(undef, 2, 4, 1)
             e2c[:, :, 1] = [-1 1 -1 1; -1 -1 1 1]
             nelem = size(e2c, 3)
 
-            (x1, x2) = Metrics.creategrid2d(e2c, r)
+            (x1, x2) = Metrics.creategrid2d(e2c, ξ1)
 
             (x1ξ1, x1ξ2, x2ξ1, x2ξ2) =
                 (fx1ξ1(x1, x2), fx1ξ2(x1, x2), fx2ξ1(x1, x2), fx2ξ2(x1, x2))
@@ -264,7 +276,7 @@ end
             n1 = metric.n1
             n2 = metric.n2
             sJ = metric.sJ
-            @test hypot.(n1, n2) ≈ ones(T, size(n1))
+            @test hypot.(n1, n2) ≈ ones(FT, size(n1))
             @test sJ[:, 1, :] .* n1[:, 1, :] ≈ -x2ξ2[1, :, :]
             @test sJ[:, 1, :] .* n2[:, 1, :] ≈ x1ξ2[1, :, :]
             @test sJ[:, 2, :] .* n1[:, 2, :] ≈ x2ξ2[Nq, :, :]
@@ -281,34 +293,35 @@ end
     #{{{
     let
         N = 4
-        T = Float64
+        FT = Float64
 
-        f(r, s) = (
-            9 .* r - (1 .+ r) .* s .^ 2 +
-            (r .- 1) .^ 2 .* (1 .- s .^ 2 .+ s .^ 3),
-            10 .* s .+ r .^ 4 .* (1 .- s) .+ r .^ 2 .* s .* (1 .+ s),
+        f(ξ1, ξ2) = (
+            9 .* ξ1 - (1 .+ ξ1) .* ξ2 .^ 2 +
+            (ξ1 .- 1) .^ 2 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3),
+            10 .* ξ2 .+ ξ1 .^ 4 .* (1 .- ξ2) .+ ξ1 .^ 2 .* ξ2 .* (1 .+ ξ2),
         )
-        fx1ξ1(r, s) =
-            7 .+ s .^ 2 .- 2 .* s .^ 3 .+ 2 .* r .* (1 .- s .^ 2 .+ s .^ 3)
-        fx1ξ2(r, s) =
-            -2 .* (1 .+ r) .* s .+ (-1 .+ r) .^ 2 .* s .* (-2 .+ 3 .* s)
-        fx2ξ1(r, s) = -4 .* r .^ 3 .* (-1 .+ s) .+ 2 .* r .* s .* (1 .+ s)
-        fx2ξ2(r, s) = 10 .- r .^ 4 .+ r .^ 2 .* (1 .+ 2 .* s)
+        fx1ξ1(ξ1, ξ2) =
+            7 .+ ξ2 .^ 2 .- 2 .* ξ2 .^ 3 .+ 2 .* ξ1 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3)
+        fx1ξ2(ξ1, ξ2) =
+            -2 .* (1 .+ ξ1) .* ξ2 .+ (-1 .+ ξ1) .^ 2 .* ξ2 .* (-2 .+ 3 .* ξ2)
+        fx2ξ1(ξ1, ξ2) =
+            -4 .* ξ1 .^ 3 .* (-1 .+ ξ2) .+ 2 .* ξ1 .* ξ2 .* (1 .+ ξ2)
+        fx2ξ2(ξ1, ξ2) = 10 .- ξ1 .^ 4 .+ ξ1 .^ 2 .* (1 .+ 2 .* ξ2)
 
-        r, w = Elements.lglpoints(T, N)
-        D = Elements.spectralderivative(r)
+        ξ1, w = Elements.lglpoints(FT, N)
+        D = Elements.spectralderivative(ξ1)
         Nq = N + 1
 
-        d = 2
-        nfaces = 4
-        e2c = Array{T, 3}(undef, 2, 4, 1)
+        dim = 2
+        nface = 2dim
+        e2c = Array{FT, 3}(undef, 2, 4, 1)
         e2c[:, :, 1] = [-1 1 -1 1; -1 -1 1 1]
         nelem = size(e2c, 3)
 
-        vgeo = Array{T, 4}(undef, Nq, Nq, length(VGEO2D), nelem)
-        sgeo = Array{T, 4}(undef, Nq, nfaces, length(SGEO2D), nelem)
+        vgeo = Array{FT, 4}(undef, Nq, Nq, length(VGEO2D), nelem)
+        sgeo = Array{FT, 4}(undef, Nq, nface, length(SGEO2D), nelem)
 
-        Metrics.creategrid!(ntuple(j -> (@view vgeo[:, :, j, :]), d)..., e2c, r)
+        Metrics.creategrid!(ntuple(j -> (@view vgeo[:, :, j, :]), dim)..., e2c, ξ1)
         x1 = @view vgeo[:, :, VGEO2D.x1, :]
         x2 = @view vgeo[:, :, VGEO2D.x2, :]
 
@@ -320,7 +333,7 @@ end
             D,
         )
 
-        (Cx1, Cx2) = (zeros(T, Nq, Nq), zeros(T, Nq, Nq))
+        (Cx1, Cx2) = (zeros(FT, Nq, Nq), zeros(FT, Nq, Nq))
 
         J = @view vgeo[:, :, VGEO2D.J, :]
         ξ1x1 = @view vgeo[:, :, VGEO2D.ξ1x1, :]
@@ -336,8 +349,8 @@ end
             Cx2[:, n] += D * (J[:, n, e] .* ξ1x2[:, n, e])
             Cx2[n, :] += D * (J[n, :, e] .* ξ2x2[n, :, e])
         end
-        @test maximum(abs.(Cx1)) ≤ 1000 * eps(T)
-        @test maximum(abs.(Cx2)) ≤ 1000 * eps(T)
+        @test maximum(abs.(Cx1)) ≤ 1000 * eps(FT)
+        @test maximum(abs.(Cx2)) ≤ 1000 * eps(FT)
     end
     #}}}
 end
@@ -345,17 +358,17 @@ end
 @testset "3-D Metric terms" begin
     # linear test
     #{{{
-    for T in (Float32, Float64)
+    for FT in (Float32, Float64)
         let
             N = 2
 
-            r, w = Elements.lglpoints(T, N)
-            D = Elements.spectralderivative(r)
+            ξ1, w = Elements.lglpoints(FT, N)
+            D = Elements.spectralderivative(ξ1)
             Nq = N + 1
 
-            d = 3
-            nfaces = 6
-            e2c = Array{T, 3}(undef, d, 8, 2)
+            dim = 3
+            nface = 2dim
+            e2c = Array{FT, 3}(undef, dim, 8, 2)
             e2c[:, :, 1] = [
                 0 2 0 2 0 2 0 2
                 0 0 2 2 0 0 2 2
@@ -406,37 +419,37 @@ end
 
             J_exact = ones(Int, 3, 3, 3, nelem)
 
-            sJ_exact = ones(Int, Nq, Nq, nfaces, nelem)
+            sJ_exact = ones(Int, Nq, Nq, nface, nelem)
 
-            nx_exact = zeros(Int, Nq, Nq, nfaces, nelem)
+            nx_exact = zeros(Int, Nq, Nq, nface, nelem)
             nx_exact[:, :, 1, 1] .= -1
             nx_exact[:, :, 2, 1] .= 1
             nx_exact[:, :, 3, 2] .= 1
             nx_exact[:, :, 4, 2] .= -1
 
-            ny_exact = zeros(Int, Nq, Nq, nfaces, nelem)
+            ny_exact = zeros(Int, Nq, Nq, nface, nelem)
             ny_exact[:, :, 3, 1] .= -1
             ny_exact[:, :, 4, 1] .= 1
             ny_exact[:, :, 1, 2] .= -1
             ny_exact[:, :, 2, 2] .= 1
 
-            nz_exact = zeros(Int, Nq, Nq, nfaces, nelem)
+            nz_exact = zeros(Int, Nq, Nq, nface, nelem)
             nz_exact[:, :, 5, 1:2] .= -1
             nz_exact[:, :, 6, 1:2] .= 1
 
-            vgeo = Array{T, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
-            sgeo = Array{T, 4}(undef, Nq^2, nfaces, length(SGEO3D), nelem)
+            vgeo = Array{FT, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
+            sgeo = Array{FT, 4}(undef, Nq^2, nface, length(SGEO3D), nelem)
             Metrics.creategrid!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), d)...,
+                ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
                 e2c,
-                r,
+                ξ1,
             )
             Metrics.computemetric!(
                 ntuple(j -> (@view vgeo[:, :, :, j, :]), length(VGEO3D))...,
                 ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
                 D,
             )
-            sgeo = reshape(sgeo, Nq, Nq, nfaces, length(SGEO3D), nelem)
+            sgeo = reshape(sgeo, Nq, Nq, nface, length(SGEO3D), nelem)
 
             @test (@view vgeo[:, :, :, VGEO3D.x1, :]) ≈ x_exact
             @test (@view vgeo[:, :, :, VGEO3D.x2, :]) ≈ y_exact
@@ -450,7 +463,7 @@ end
                 :,
                 VGEO3D.ξ1x3,
                 :,
-            ])) ≤ 10 * eps(T)
+            ])) ≤ 10 * eps(FT)
             @test (@view vgeo[:, :, :, VGEO3D.ξ2x1, :]) ≈ ξ2x1_exact
             @test (@view vgeo[:, :, :, VGEO3D.ξ2x2, :]) ≈ ξ2x2_exact
             @test maximum(abs.(@view vgeo[
@@ -459,21 +472,21 @@ end
                 :,
                 VGEO3D.ξ2x3,
                 :,
-            ])) ≤ 10 * eps(T)
+            ])) ≤ 10 * eps(FT)
             @test maximum(abs.(@view vgeo[
                 :,
                 :,
                 :,
                 VGEO3D.ξ3x1,
                 :,
-            ])) ≤ 10 * eps(T)
+            ])) ≤ 10 * eps(FT)
             @test maximum(abs.(@view vgeo[
                 :,
                 :,
                 :,
                 VGEO3D.ξ3x2,
                 :,
-            ])) ≤ 10 * eps(T)
+            ])) ≤ 10 * eps(FT)
             @test (@view vgeo[:, :, :, VGEO3D.ξ3x3, :]) ≈ ξ3x3_exact
             @test (@view sgeo[:, :, :, SGEO3D.sJ, :]) ≈ sJ_exact
             @test (@view sgeo[:, :, :, SGEO3D.n1, :]) ≈ nx_exact
@@ -485,19 +498,19 @@ end
 
     # linear test with rotation
     #{{{
-    for T in (Float32, Float64)
-        θ1 = 2 * T(π) * T(0.9)
-        θ2 = 2 * T(π) * T(-0.56)
-        θ3 = 2 * T(π) * T(0.33)
+    for FT in (Float32, Float64)
+        θ1 = 2 * FT(π) * FT(0.9)
+        θ2 = 2 * FT(π) * FT(-0.56)
+        θ3 = 2 * FT(π) * FT(0.33)
         #=
-        θ1 = 2 * T(π) * rand(T)
-        θ2 = 2 * T(π) * rand(T)
-        θ3 = 2 * T(π) * rand(T)
+        θ1 = 2 * FT(π) * rand(FT)
+        θ2 = 2 * FT(π) * rand(FT)
+        θ3 = 2 * FT(π) * rand(FT)
         =#
         #=
-        θ1 = T(π) / 6
-        θ2 = T(π) / 12
-        θ3 = 4 * T(π) / 5
+        θ1 = FT(π) / 6
+        θ2 = FT(π) / 12
+        θ3 = 4 * FT(π) / 5
         =#
         Q = [cos(θ1) -sin(θ1) 0; sin(θ1) cos(θ1) 0; 0 0 1]
         Q *= [cos(θ2) 0 -sin(θ2); 0 1 0; sin(θ2) 0 cos(θ2)]
@@ -505,13 +518,13 @@ end
         let
             N = 2
 
-            r, w = Elements.lglpoints(T, N)
-            D = Elements.spectralderivative(r)
+            ξ1, w = Elements.lglpoints(FT, N)
+            D = Elements.spectralderivative(ξ1)
             Nq = N + 1
 
-            d = 3
-            nfaces = 6
-            e2c = Array{T, 3}(undef, d, 8, 1)
+            dim = 3
+            nface = 2dim
+            e2c = Array{FT, 3}(undef, dim, 8, 1)
             e2c[:, :, 1] = [
                 0 2 0 2 0 2 0 2
                 0 0 2 2 0 0 2 2
@@ -524,17 +537,17 @@ end
 
             nelem = size(e2c, 3)
 
-            x1e = Array{T, 4}(undef, 3, 3, 3, nelem)
+            x1e = Array{FT, 4}(undef, 3, 3, 3, nelem)
             x1e[1, :, :, 1] .= 0
             x1e[2, :, :, 1] .= 1
             x1e[3, :, :, 1] .= 2
 
-            x2e = Array{T, 4}(undef, 3, 3, 3, nelem)
+            x2e = Array{FT, 4}(undef, 3, 3, 3, nelem)
             x2e[:, 1, :, 1] .= 0
             x2e[:, 2, :, 1] .= 1
             x2e[:, 3, :, 1] .= 2
 
-            x3e = Array{T, 4}(undef, 3, 3, 3, nelem)
+            x3e = Array{FT, 4}(undef, 3, 3, 3, nelem)
             x3e[:, :, 1, 1] .= 0
             x3e[:, :, 2, 1] .= 1
             x3e[:, :, 3, 1] .= 2
@@ -557,11 +570,11 @@ end
             ξ3x2e = fill(Q[2, 3], 3, 3, 3, nelem)
             ξ3x3e = fill(Q[3, 3], 3, 3, 3, nelem)
 
-            sJe = ones(Int, Nq, Nq, nfaces, nelem)
+            sJe = ones(Int, Nq, Nq, nface, nelem)
 
-            n1e = zeros(T, Nq, Nq, nfaces, nelem)
-            n2e = zeros(T, Nq, Nq, nfaces, nelem)
-            n3e = zeros(T, Nq, Nq, nfaces, nelem)
+            n1e = zeros(FT, Nq, Nq, nface, nelem)
+            n2e = zeros(FT, Nq, Nq, nface, nelem)
+            n3e = zeros(FT, Nq, Nq, nface, nelem)
 
             fill!(@view(n1e[:, :, 1, :]), -Q[1, 1])
             fill!(@view(n1e[:, :, 2, :]), Q[1, 1])
@@ -582,19 +595,19 @@ end
             fill!(@view(n3e[:, :, 5, :]), -Q[3, 3])
             fill!(@view(n3e[:, :, 6, :]), Q[3, 3])
 
-            vgeo = Array{T, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
-            sgeo = Array{T, 4}(undef, Nq^2, nfaces, length(SGEO3D), nelem)
+            vgeo = Array{FT, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
+            sgeo = Array{FT, 4}(undef, Nq^2, nface, length(SGEO3D), nelem)
             Metrics.creategrid!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), d)...,
+                ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
                 e2c,
-                r,
+                ξ1,
             )
             Metrics.computemetric!(
                 ntuple(j -> (@view vgeo[:, :, :, j, :]), length(VGEO3D))...,
                 ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
                 D,
             )
-            sgeo = reshape(sgeo, Nq, Nq, nfaces, length(SGEO3D), nelem)
+            sgeo = reshape(sgeo, Nq, Nq, nface, length(SGEO3D), nelem)
 
             @test (@view vgeo[:, :, :, VGEO3D.x1, :]) ≈ x1e
             @test (@view vgeo[:, :, :, VGEO3D.x2, :]) ≈ x2e
@@ -619,37 +632,40 @@ end
 
     # Polynomial 3-D test
     #{{{
-    for T in (Float32, Float64)
-        f(r, s, t) = @.( (
-            s + r * t - (r^2 * s^2 * t^2) / 4,
-            t - ((r * s * t) / 2 + 1 / 2)^3 + 1,
-            r + (r / 2 + 1 / 2)^6 * (s / 2 + 1 / 2)^6 * (t / 2 + 1 / 2)^6,
+    for FT in (Float32, Float64)
+        f(ξ1, ξ2, ξ3) = @.( (
+            ξ2 + ξ1 * ξ3 - (ξ1^2 * ξ2^2 * ξ3^2) / 4,
+            ξ3 - ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^3 + 1,
+            ξ1 + (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^6,
         ))
 
-        fx1ξ1(r, s, t) = @.(t - (r * s^2 * t^2) / 2)
-        fx1ξ2(r, s, t) = @.(1 - (r^2 * s * t^2) / 2)
-        fx1ξ3(r, s, t) = @.(r - (r^2 * s^2 * t) / 2)
-        fx2ξ1(r, s, t) = @.(-(3 * s * t * ((r * s * t) / 2 + 1 / 2)^2) / 2)
-        fx2ξ2(r, s, t) = @.(-(3 * r * t * ((r * s * t) / 2 + 1 / 2)^2) / 2)
-        fx2ξ3(r, s, t) = @.(1 - (3 * r * s * ((r * s * t) / 2 + 1 / 2)^2) / 2)
-        fx3ξ1(r, s, t) = @.(
-            3 * (r / 2 + 1 / 2)^5 * (s / 2 + 1 / 2)^6 * (t / 2 + 1 / 2)^6 + 1
+        fx1ξ1(ξ1, ξ2, ξ3) = @.(ξ3 - (ξ1 * ξ2^2 * ξ3^2) / 2)
+        fx1ξ2(ξ1, ξ2, ξ3) = @.(1 - (ξ1^2 * ξ2 * ξ3^2) / 2)
+        fx1ξ3(ξ1, ξ2, ξ3) = @.(ξ1 - (ξ1^2 * ξ2^2 * ξ3) / 2)
+        fx2ξ1(ξ1, ξ2, ξ3) =
+            @.(-(3 * ξ2 * ξ3 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
+        fx2ξ2(ξ1, ξ2, ξ3) =
+            @.(-(3 * ξ1 * ξ3 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
+        fx2ξ3(ξ1, ξ2, ξ3) =
+            @.(1 - (3 * ξ1 * ξ2 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
+        fx3ξ1(ξ1, ξ2, ξ3) = @.(
+            3 * (ξ1 / 2 + 1 / 2)^5 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^6 + 1
         )
-        fx3ξ2(r, s, t) =
-            @.(3 * (r / 2 + 1 / 2)^6 * (s / 2 + 1 / 2)^5 * (t / 2 + 1 / 2)^6)
-        fx3ξ3(r, s, t) =
-            @.(3 * (r / 2 + 1 / 2)^6 * (s / 2 + 1 / 2)^6 * (t / 2 + 1 / 2)^5)
+        fx3ξ2(ξ1, ξ2, ξ3) =
+            @.(3 * (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^5 * (ξ3 / 2 + 1 / 2)^6)
+        fx3ξ3(ξ1, ξ2, ξ3) =
+            @.(3 * (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^5)
 
         let
             N = 9
 
-            r, w = Elements.lglpoints(T, N)
-            D = Elements.spectralderivative(r)
+            ξ1, w = Elements.lglpoints(FT, N)
+            D = Elements.spectralderivative(ξ1)
             Nq = N + 1
 
-            d = 3
-            nfaces = 6
-            e2c = Array{T, 3}(undef, d, 8, 1)
+            dim = 3
+            nface = 2dim
+            e2c = Array{FT, 3}(undef, dim, 8, 1)
             e2c[:, :, 1] = [
                 -1 1 -1 1 -1 1 -1 1
                 -1 -1 1 1 -1 -1 1 1
@@ -658,12 +674,12 @@ end
 
             nelem = size(e2c, 3)
 
-            vgeo = Array{T, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
-            sgeo = Array{T, 4}(undef, Nq^2, nfaces, length(SGEO3D), nelem)
+            vgeo = Array{FT, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
+            sgeo = Array{FT, 4}(undef, Nq^2, nface, length(SGEO3D), nelem)
             Metrics.creategrid!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), d)...,
+                ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
                 e2c,
-                r,
+                ξ1,
             )
             x1 = @view vgeo[:, :, :, VGEO3D.x1, :]
             x2 = @view vgeo[:, :, :, VGEO3D.x2, :]
@@ -706,7 +722,7 @@ end
                 ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
                 D,
             )
-            sgeo = reshape(sgeo, Nq, Nq, nfaces, length(SGEO3D), nelem)
+            sgeo = reshape(sgeo, Nq, Nq, nface, length(SGEO3D), nelem)
 
             @test (@view vgeo[:, :, :, VGEO3D.J, :]) ≈ J
             @test (@view vgeo[:, :, :, VGEO3D.ξ1x1, :]) ≈ ξ1x1
@@ -722,7 +738,7 @@ end
             n2 = @view sgeo[:, :, :, SGEO3D.n2, :]
             n3 = @view sgeo[:, :, :, SGEO3D.n3, :]
             sJ = @view sgeo[:, :, :, SGEO3D.sJ, :]
-            @test hypot.(n1, n2, n3) ≈ ones(T, size(n1))
+            @test hypot.(n1, n2, n3) ≈ ones(FT, size(n1))
             @test (
                 [
                     sJ[:, :, 1, :] .* n1[:, :, 1, :],
@@ -774,37 +790,39 @@ end
     #}}}
 
     #{{{
-    for T in (Float32, Float64)
-        f(r, s, t) = @.( (
-            s + r * t - (r^2 * s^2 * t^2) / 4,
-            t - ((r * s * t) / 2 + 1 / 2)^3 + 1,
-            r + (r / 2 + 1 / 2)^6 * (s / 2 + 1 / 2)^6 * (t / 2 + 1 / 2)^6,
+    for FT in (Float32, Float64)
+        f(ξ1, ξ2, ξ3) = @.( (
+            ξ2 + ξ1 * ξ3 - (ξ1^2 * ξ2^2 * ξ3^2) / 4,
+            ξ3 - ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^3 + 1,
+            ξ1 + (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^6,
         ))
 
-        fx1ξ1(r, s, t) = @.(t - (r * s^2 * t^2) / 2)
-        fx1ξ2(r, s, t) = @.(1 - (r^2 * s * t^2) / 2)
-        fx1ξ3(r, s, t) = @.(r - (r^2 * s^2 * t) / 2)
-        fx2ξ1(r, s, t) = @.(-(3 * s * t * ((r * s * t) / 2 + 1 / 2)^2) / 2)
-        fx2ξ2(r, s, t) = @.(-(3 * r * t * ((r * s * t) / 2 + 1 / 2)^2) / 2)
-        fx2ξ3(r, s, t) = @.(1 - (3 * r * s * ((r * s * t) / 2 + 1 / 2)^2) / 2)
-        fx3ξ1(r, s, t) = @.(
-            3 * (r / 2 + 1 / 2)^5 * (s / 2 + 1 / 2)^6 * (t / 2 + 1 / 2)^6 + 1
+        fx1ξ1(ξ1, ξ2, ξ3) = @.(ξ3 - (ξ1 * ξ2^2 * ξ3^2) / 2)
+        fx1ξ2(ξ1, ξ2, ξ3) = @.(1 - (ξ1^2 * ξ2 * ξ3^2) / 2)
+        fx1ξ3(ξ1, ξ2, ξ3) = @.(ξ1 - (ξ1^2 * ξ2^2 * ξ3) / 2)
+        fx2ξ1(ξ1, ξ2, ξ3) =
+            @.(-(3 * ξ2 * ξ3 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
+        fx2ξ2(ξ1, ξ2, ξ3) =
+            @.(-(3 * ξ1 * ξ3 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
+        fx2ξ3(ξ1, ξ2, ξ3) =
+            @.(1 - (3 * ξ1 * ξ2 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
+        fx3ξ1(ξ1, ξ2, ξ3) = @.(
+            3 * (ξ1 / 2 + 1 / 2)^5 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^6 + 1
         )
-        fx3ξ2(r, s, t) =
-            @.(3 * (r / 2 + 1 / 2)^6 * (s / 2 + 1 / 2)^5 * (t / 2 + 1 / 2)^6)
-        fx3ξ3(r, s, t) =
-            @.(3 * (r / 2 + 1 / 2)^6 * (s / 2 + 1 / 2)^6 * (t / 2 + 1 / 2)^5)
+        fx3ξ2(ξ1, ξ2, ξ3) =
+            @.(3 * (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^5 * (ξ3 / 2 + 1 / 2)^6)
+        fx3ξ3(ξ1, ξ2, ξ3) =
+            @.(3 * (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^5)
 
         let
             N = 9
 
-            r, w = Elements.lglpoints(T, N)
-            D = Elements.spectralderivative(r)
+            ξ1, w = Elements.lglpoints(FT, N)
+            D = Elements.spectralderivative(ξ1)
             Nq = N + 1
 
-            d = 3
-            nfaces = 6
-            e2c = Array{T, 3}(undef, d, 8, 1)
+            dim = 3
+            e2c = Array{FT, 3}(undef, dim, 8, 1)
             e2c[:, :, 1] = [
                 -1 1 -1 1 -1 1 -1 1
                 -1 -1 1 1 -1 -1 1 1
@@ -813,7 +831,7 @@ end
 
             nelem = size(e2c, 3)
 
-            (x1, x2, x3) = Metrics.creategrid3d(e2c, r)
+            (x1, x2, x3) = Metrics.creategrid3d(e2c, ξ1)
 
             (x1ξ1, x1ξ2, x1ξ3, x2ξ1, x2ξ2, x2ξ3, x3ξ1, x3ξ2, x3ξ3) = (
                 fx1ξ1(x1, x2, x3),
@@ -864,7 +882,7 @@ end
             n2 = metric.n2
             n3 = metric.n3
             sJ = metric.sJ
-            @test hypot.(n1, n2, n3) ≈ ones(T, size(n1))
+            @test hypot.(n1, n2, n3) ≈ ones(FT, size(n1))
             @test (
                 [
                     sJ[ind, 1, :] .* n1[ind, 1, :],
@@ -918,22 +936,22 @@ end
 
     # Constant preserving test
     #{{{
-    for T in (Float32, Float64)
-        f(r, s, t) = @.( (
-            s + r * t - (r^2 * s^2 * t^2) / 4,
-            t - ((r * s * t) / 2 + 1 / 2)^3 + 1,
-            r + (r / 2 + 1 / 2)^6 * (s / 2 + 1 / 2)^6 * (t / 2 + 1 / 2)^6,
+    for FT in (Float32, Float64)
+        f(ξ1, ξ2, ξ3) = @.( (
+            ξ2 + ξ1 * ξ3 - (ξ1^2 * ξ2^2 * ξ3^2) / 4,
+            ξ3 - ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^3 + 1,
+            ξ1 + (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^6,
         ))
         let
             N = 5
 
-            r, w = Elements.lglpoints(T, N)
-            D = Elements.spectralderivative(r)
+            ξ1, w = Elements.lglpoints(FT, N)
+            D = Elements.spectralderivative(ξ1)
             Nq = N + 1
 
-            d = 3
-            nfaces = 6
-            e2c = Array{T, 3}(undef, d, 8, 1)
+            dim = 3
+            nface = 2dim
+            e2c = Array{FT, 3}(undef, dim, 8, 1)
             e2c[:, :, 1] = [
                 -1 1 -1 1 -1 1 -1 1
                 -1 -1 1 1 -1 -1 1 1
@@ -942,12 +960,12 @@ end
 
             nelem = size(e2c, 3)
 
-            vgeo = Array{T, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
-            sgeo = Array{T, 4}(undef, Nq^2, nfaces, length(SGEO3D), nelem)
+            vgeo = Array{FT, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
+            sgeo = Array{FT, 4}(undef, Nq^2, nface, length(SGEO3D), nelem)
             Metrics.creategrid!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), d)...,
+                ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
                 e2c,
-                r,
+                ξ1,
             )
             x1 = @view vgeo[:, :, :, VGEO3D.x1, :]
             x2 = @view vgeo[:, :, :, VGEO3D.x2, :]
@@ -963,12 +981,12 @@ end
                 ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
                 D,
             )
-            sgeo = reshape(sgeo, Nq, Nq, nfaces, length(SGEO3D), nelem)
+            sgeo = reshape(sgeo, Nq, Nq, nface, length(SGEO3D), nelem)
 
             (Cx1, Cx2, Cx3) = (
-                zeros(T, Nq, Nq, Nq),
-                zeros(T, Nq, Nq, Nq),
-                zeros(T, Nq, Nq, Nq),
+                zeros(FT, Nq, Nq, Nq),
+                zeros(FT, Nq, Nq, Nq),
+                zeros(FT, Nq, Nq, Nq),
             )
 
             J = @view vgeo[:, :, :, VGEO3D.J, :]
@@ -998,9 +1016,9 @@ end
                     Cx3[n, m, :] += D * (J[n, m, :, e] .* ξ3x3[n, m, :, e])
                 end
             end
-            @test maximum(abs.(Cx1)) ≤ 1000 * eps(T)
-            @test maximum(abs.(Cx2)) ≤ 1000 * eps(T)
-            @test maximum(abs.(Cx3)) ≤ 1000 * eps(T)
+            @test maximum(abs.(Cx1)) ≤ 1000 * eps(FT)
+            @test maximum(abs.(Cx2)) ≤ 1000 * eps(FT)
+            @test maximum(abs.(Cx3)) ≤ 1000 * eps(FT)
         end
     end
     #}}}

--- a/test/Numerics/Mesh/Metrics.jl
+++ b/test/Numerics/Mesh/Metrics.jl
@@ -1,7 +1,7 @@
 using ClimateMachine.Mesh.Elements
 using ClimateMachine.Mesh.Metrics
 using Test
-
+using Random: MersenneTwister
 
 const VGEO2D = (x1 = 1, x2 = 2, J = 3, ξ1x1 = 4, ξ2x1 = 5, ξ1x2 = 6, ξ2x2 = 7)
 const SGEO2D = (sJ = 1, n1 = 2, n2 = 3)
@@ -27,11 +27,18 @@ const SGEO3D = (sJ = 1, n1 = 2, n2 = 3, n3 = 4)
     for FT in (Float32, Float64)
         #{{{
         let
-            N = 4
+            N = (4,)
+            Nq = N .+ 1
+            Np = prod(Nq)
 
-            ξ1, w = Elements.lglpoints(FT, N)
-            D = Elements.spectralderivative(ξ1)
-            Nq = N + 1
+            dim = length(N)
+            nface = 2dim
+
+            # Create element operators for each polynomial order
+            ξω = ntuple(j -> Elements.lglpoints(FT, N[j]), dim)
+            ξ, ω = ntuple(j -> map(x -> x[j], ξω), 2)
+
+            D = ntuple(j -> Elements.spectralderivative(ξ[j]), dim)
 
             dim = 1
             e2c = Array{FT, 3}(undef, 1, 2, 2)
@@ -39,11 +46,11 @@ const SGEO3D = (sJ = 1, n1 = 2, n2 = 3, n3 = 4)
             e2c[:, :, 2] = [0 10]
             nelem = size(e2c, 3)
 
-            (x1,) = Metrics.creategrid1d(e2c, ξ1)
-            @test x1[:, 1] ≈ (ξ1 .- 1) / 2
-            @test x1[:, 2] ≈ 5 * (ξ1 .+ 1)
+            (x1,) = Metrics.creategrid1d(e2c, ξ...)
+            @test x1[:, 1] ≈ (ξ[1] .- 1) / 2
+            @test x1[:, 2] ≈ 5 * (ξ[1] .+ 1)
 
-            metric = Metrics.computemetric(x1, D)
+            metric = Metrics.computemetric(x1, D...)
             @test metric.J[:, 1] ≈ ones(FT, Nq) / 2
             @test metric.J[:, 2] ≈ 5 * ones(FT, Nq)
             @test metric.ξ1x1[:, 1] ≈ 2 * ones(FT, Nq)
@@ -58,88 +65,116 @@ const SGEO3D = (sJ = 1, n1 = 2, n2 = 3, n3 = 4)
 end
 
 @testset "2-D Metric terms" begin
-    for FT in (Float32, Float64)
+    # for FT in (Float32, Float64)
+    for FT in (Float32, Float64), N in ((4, 4), (4, 6), (6, 4))
+        Nq = N .+ 1
+        Np = prod(Nq)
+        Nfp = div.(Np, Nq)
+
+        dim = length(N)
+        nface = 2dim
+
+        # Create element operators for each polynomial order
+        ξω = ntuple(j -> Elements.lglpoints(FT, N[j]), dim)
+        ξ, ω = ntuple(j -> map(x -> x[j], ξω), 2)
+        D = ntuple(j -> Elements.spectralderivative(ξ[j]), dim)
+
         # linear and rotation test
         #{{{
         let
-            N = 2
-
-            ξ1, w = Elements.lglpoints(FT, N)
-            D = Elements.spectralderivative(ξ1)
-            Nq = N + 1
-
-            dim = 2
-            nface = 2dim
             e2c = Array{FT, 3}(undef, 2, 4, 4)
-            e2c[:, :, 1] = [0 2 0 2; 0 0 2 2]
-            e2c[:, :, 2] = [2 2 0 0; 0 2 0 2]
-            e2c[:, :, 3] = [2 0 2 0; 2 2 0 0]
-            e2c[:, :, 4] = [0 0 2 2; 2 0 2 0]
+            e2c[:, :, 1] = [
+                0 2 0 2
+                0 0 2 2
+            ]
+            e2c[:, :, 2] = [
+                2 2 0 0
+                0 2 0 2
+            ]
+            e2c[:, :, 3] = [
+                2 0 2 0
+                2 2 0 0
+            ]
+            e2c[:, :, 4] = [
+                0 0 2 2
+                2 0 2 0
+            ]
             nelem = size(e2c, 3)
 
-            x_exact = Array{Int, 3}(undef, 3, 3, 4)
-            x_exact[:, :, 1] = [0 0 0; 1 1 1; 2 2 2]
-            x_exact[:, :, 2] = rotr90(x_exact[:, :, 1])
-            x_exact[:, :, 3] = rotr90(x_exact[:, :, 2])
-            x_exact[:, :, 4] = rotr90(x_exact[:, :, 3])
+            x_exact = Array{FT, 3}(undef, Nq..., 4)
+            x_exact[:, :, 1] .= 1 .+ ξ[1]
+            x_exact[:, :, 2] .= 1 .- ξ[2]'
+            x_exact[:, :, 3] .= 1 .- ξ[1]
+            x_exact[:, :, 4] .= 1 .+ ξ[2]'
 
-            y_exact = Array{Int, 3}(undef, 3, 3, 4)
-            y_exact[:, :, 1] = [0 1 2; 0 1 2; 0 1 2]
-            y_exact[:, :, 2] = rotr90(y_exact[:, :, 1])
-            y_exact[:, :, 3] = rotr90(y_exact[:, :, 2])
-            y_exact[:, :, 4] = rotr90(y_exact[:, :, 3])
+            y_exact = Array{FT, 3}(undef, Nq..., 4)
+            y_exact[:, :, 1] .= 1 .+ ξ[2]'
+            y_exact[:, :, 2] .= 1 .+ ξ[1]
+            y_exact[:, :, 3] .= 1 .- ξ[2]'
+            y_exact[:, :, 4] .= 1 .- ξ[1]
 
-            J_exact = ones(Int, 3, 3, 4)
+            J_exact = ones(FT, Nq..., 4)
 
-            ξ1x1_exact = zeros(Int, 3, 3, 4)
+            ξ1x1_exact = zeros(FT, Nq..., 4)
             ξ1x1_exact[:, :, 1] .= 1
             ξ1x1_exact[:, :, 3] .= -1
 
-            ξ1x2_exact = zeros(Int, 3, 3, 4)
+            ξ1x2_exact = zeros(FT, Nq..., 4)
             ξ1x2_exact[:, :, 2] .= 1
             ξ1x2_exact[:, :, 4] .= -1
 
-            ξ2x1_exact = zeros(Int, 3, 3, 4)
+            ξ2x1_exact = zeros(FT, Nq..., 4)
             ξ2x1_exact[:, :, 2] .= -1
             ξ2x1_exact[:, :, 4] .= 1
 
-            ξ2x2_exact = zeros(Int, 3, 3, 4)
+            ξ2x2_exact = zeros(FT, Nq..., 4)
             ξ2x2_exact[:, :, 1] .= 1
             ξ2x2_exact[:, :, 3] .= -1
 
-            sJ_exact = ones(Int, Nq, nface, nelem)
+            sJ_exact = fill(FT(NaN), maximum(Nfp), nface, nelem)
+            sJ_exact[1:Nfp[1], 1, :] .= 1
+            sJ_exact[1:Nfp[1], 2, :] .= 1
+            sJ_exact[1:Nfp[2], 3, :] .= 1
+            sJ_exact[1:Nfp[2], 4, :] .= 1
 
-            nx_exact = zeros(Int, Nq, nface, nelem)
-            nx_exact[:, 1, 1] .= -1
-            nx_exact[:, 2, 1] .= 1
-            nx_exact[:, 3, 2] .= 1
-            nx_exact[:, 4, 2] .= -1
-            nx_exact[:, 1, 3] .= 1
-            nx_exact[:, 2, 3] .= -1
-            nx_exact[:, 3, 4] .= -1
-            nx_exact[:, 4, 4] .= 1
+            nx_exact = fill(FT(NaN), maximum(Nfp), nface, nelem)
+            nx_exact[1:Nfp[1], 1:2, :] .= 0
+            nx_exact[1:Nfp[2], 3:4, :] .= 0
 
-            ny_exact = zeros(Int, Nq, nface, nelem)
-            ny_exact[:, 3, 1] .= -1
-            ny_exact[:, 4, 1] .= 1
-            ny_exact[:, 1, 2] .= -1
-            ny_exact[:, 2, 2] .= 1
-            ny_exact[:, 3, 3] .= 1
-            ny_exact[:, 4, 3] .= -1
-            ny_exact[:, 1, 4] .= 1
-            ny_exact[:, 2, 4] .= -1
+            nx_exact[1:Nfp[1], 1, 1] .= -1
+            nx_exact[1:Nfp[1], 2, 1] .= 1
+            nx_exact[1:Nfp[2], 3, 2] .= 1
+            nx_exact[1:Nfp[2], 4, 2] .= -1
+            nx_exact[1:Nfp[1], 1, 3] .= 1
+            nx_exact[1:Nfp[1], 2, 3] .= -1
+            nx_exact[1:Nfp[2], 3, 4] .= -1
+            nx_exact[1:Nfp[2], 4, 4] .= 1
 
-            vgeo = Array{FT, 4}(undef, Nq, Nq, length(VGEO2D), nelem)
-            sgeo = Array{FT, 4}(undef, Nq, nface, length(SGEO2D), nelem)
+            ny_exact = fill(FT(NaN), maximum(Nfp), nface, nelem)
+            ny_exact[1:Nfp[1], 1:2, :] .= 0
+            ny_exact[1:Nfp[2], 3:4, :] .= 0
+
+            ny_exact[1:Nfp[2], 3, 1] .= -1
+            ny_exact[1:Nfp[2], 4, 1] .= 1
+            ny_exact[1:Nfp[1], 1, 2] .= -1
+            ny_exact[1:Nfp[1], 2, 2] .= 1
+            ny_exact[1:Nfp[2], 3, 3] .= 1
+            ny_exact[1:Nfp[2], 4, 3] .= -1
+            ny_exact[1:Nfp[1], 1, 4] .= 1
+            ny_exact[1:Nfp[1], 2, 4] .= -1
+
+            vgeo = Array{FT, 4}(undef, Nq..., length(VGEO2D), nelem)
+            sgeo =
+                Array{FT, 4}(undef, maximum(Nfp), nface, length(SGEO2D), nelem)
             Metrics.creategrid!(
                 ntuple(j -> (@view vgeo[:, :, j, :]), dim)...,
                 e2c,
-                ξ1,
+                ξ...,
             )
             Metrics.computemetric!(
                 ntuple(j -> (@view vgeo[:, :, j, :]), length(VGEO2D))...,
                 ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO2D))...,
-                D,
+                D...,
             )
 
             @test (@view vgeo[:, :, VGEO2D.x1, :]) ≈ x_exact
@@ -149,9 +184,10 @@ end
             @test (@view vgeo[:, :, VGEO2D.ξ1x2, :]) ≈ ξ1x2_exact
             @test (@view vgeo[:, :, VGEO2D.ξ2x1, :]) ≈ ξ2x1_exact
             @test (@view vgeo[:, :, VGEO2D.ξ2x2, :]) ≈ ξ2x2_exact
-            @test (@view sgeo[:, :, SGEO2D.sJ, :]) ≈ sJ_exact
-            @test (@view sgeo[:, :, SGEO2D.n1, :]) ≈ nx_exact
-            @test (@view sgeo[:, :, SGEO2D.n2, :]) ≈ ny_exact
+            msk = isfinite.(sJ_exact)
+            @test sgeo[:, :, SGEO2D.sJ, :][msk] ≈ sJ_exact[msk]
+            @test sgeo[:, :, SGEO2D.n1, :][msk] ≈ nx_exact[msk]
+            @test sgeo[:, :, SGEO2D.n2, :][msk] ≈ ny_exact[msk]
 
             nothing
         end
@@ -160,8 +196,6 @@ end
         # Polynomial 2-D test
         #{{{
         let
-            N = 4
-
             f(ξ1, ξ2) = (
                 9 .* ξ1 - (1 .+ ξ1) .* ξ2 .^ 2 +
                 (ξ1 .- 1) .^ 2 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3),
@@ -177,23 +211,18 @@ end
                 -4 .* ξ1 .^ 3 .* (-1 .+ ξ2) .+ 2 .* ξ1 .* ξ2 .* (1 .+ ξ2)
             fx2ξ2(ξ1, ξ2) = 10 .- ξ1 .^ 4 .+ ξ1 .^ 2 .* (1 .+ 2 .* ξ2)
 
-            ξ1, w = Elements.lglpoints(FT, N)
-            D = Elements.spectralderivative(ξ1)
-            Nq = N + 1
-
-            dim = 2
-            nface = 2dim
             e2c = Array{FT, 3}(undef, 2, 4, 1)
             e2c[:, :, 1] = [-1 1 -1 1; -1 -1 1 1]
             nelem = size(e2c, 3)
 
-            vgeo = Array{FT, 4}(undef, Nq, Nq, length(VGEO2D), nelem)
-            sgeo = Array{FT, 4}(undef, Nq, nface, length(SGEO2D), nelem)
+            vgeo = Array{FT, 4}(undef, Nq..., length(VGEO2D), nelem)
+            sgeo =
+                Array{FT, 4}(undef, maximum(Nfp), nface, length(SGEO2D), nelem)
 
             Metrics.creategrid!(
                 ntuple(j -> (@view vgeo[:, :, j, :]), dim)...,
                 e2c,
-                ξ1,
+                ξ...,
             )
             x1 = @view vgeo[:, :, VGEO2D.x1, :]
             x2 = @view vgeo[:, :, VGEO2D.x2, :]
@@ -206,7 +235,7 @@ end
             Metrics.computemetric!(
                 ntuple(j -> (@view vgeo[:, :, j, :]), length(VGEO2D))...,
                 ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO2D))...,
-                D,
+                D...,
             )
             @test J ≈ (@view vgeo[:, :, VGEO2D.J, :])
             @test (@view vgeo[:, :, VGEO2D.ξ1x1, :]) ≈ x2ξ2 ./ J
@@ -218,808 +247,485 @@ end
             n1 = @view sgeo[:, :, SGEO2D.n1, :]
             n2 = @view sgeo[:, :, SGEO2D.n2, :]
             sJ = @view sgeo[:, :, SGEO2D.sJ, :]
-            @test hypot.(n1, n2) ≈ ones(FT, size(n1))
-            @test sJ[:, 1, :] .* n1[:, 1, :] ≈ -x2ξ2[1, :, :]
-            @test sJ[:, 1, :] .* n2[:, 1, :] ≈ x1ξ2[1, :, :]
-            @test sJ[:, 2, :] .* n1[:, 2, :] ≈ x2ξ2[Nq, :, :]
-            @test sJ[:, 2, :] .* n2[:, 2, :] ≈ -x1ξ2[Nq, :, :]
-            @test sJ[:, 3, :] .* n1[:, 3, :] ≈ x2ξ1[:, 1, :]
-            @test sJ[:, 3, :] .* n2[:, 3, :] ≈ -x1ξ1[:, 1, :]
-            @test sJ[:, 4, :] .* n1[:, 4, :] ≈ -x2ξ1[:, Nq, :]
-            @test sJ[:, 4, :] .* n2[:, 4, :] ≈ x1ξ1[:, Nq, :]
+            @test all(hypot.(n1[1:Nfp[1], 1:2, :], n2[1:Nfp[1], 1:2, :]) .≈ 1)
+            @test all(hypot.(n1[1:Nfp[2], 3:4, :], n2[1:Nfp[2], 3:4, :]) .≈ 1)
+            @test sJ[1:Nfp[1], 1, :] .* n1[1:Nfp[1], 1, :] ≈ -x2ξ2[1, :, :]
+            @test sJ[1:Nfp[1], 1, :] .* n2[1:Nfp[1], 1, :] ≈ x1ξ2[1, :, :]
+            @test sJ[1:Nfp[1], 2, :] .* n1[1:Nfp[1], 2, :] ≈ x2ξ2[Nq[1], :, :]
+            @test sJ[1:Nfp[1], 2, :] .* n2[1:Nfp[1], 2, :] ≈ -x1ξ2[Nq[1], :, :]
+            @test sJ[1:Nfp[2], 3, :] .* n1[1:Nfp[2], 3, :] ≈ x2ξ1[:, 1, :]
+            @test sJ[1:Nfp[2], 3, :] .* n2[1:Nfp[2], 3, :] ≈ -x1ξ1[:, 1, :]
+            @test sJ[1:Nfp[2], 4, :] .* n1[1:Nfp[2], 4, :] ≈ -x2ξ1[:, Nq[2], :]
+            @test sJ[1:Nfp[2], 4, :] .* n2[1:Nfp[2], 4, :] ≈ x1ξ1[:, Nq[2], :]
         end
         #}}}
 
+        # Constant preserving test
         #{{{
         let
-            N = 4
-
+            rng = MersenneTwister(777)
             f(ξ1, ξ2) = (
-                9 .* ξ1 - (1 .+ ξ1) .* ξ2 .^ 2 +
-                (ξ1 .- 1) .^ 2 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3),
-                10 .* ξ2 .+ ξ1 .^ 4 .* (1 .- ξ2) .+ ξ1 .^ 2 .* ξ2 .* (1 .+ ξ2),
+                ξ1 + (ξ1 * ξ2 * rand(rng) + rand(rng)) / 10,
+                ξ2 + (ξ1 * ξ2 * rand(rng) + rand(rng)) / 10,
             )
-            fx1ξ1(ξ1, ξ2) =
-                7 .+ ξ2 .^ 2 .- 2 .* ξ2 .^ 3 .+
-                2 .* ξ1 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3)
-            fx1ξ2(ξ1, ξ2) =
-                -2 .* (1 .+ ξ1) .* ξ2 .+
-                (-1 .+ ξ1) .^ 2 .* ξ2 .* (-2 .+ 3 .* ξ2)
-            fx2ξ1(ξ1, ξ2) =
-                -4 .* ξ1 .^ 3 .* (-1 .+ ξ2) .+ 2 .* ξ1 .* ξ2 .* (1 .+ ξ2)
-            fx2ξ2(ξ1, ξ2) = 10 .- ξ1 .^ 4 .+ ξ1 .^ 2 .* (1 .+ 2 .* ξ2)
 
-            ξ1, w = Elements.lglpoints(FT, N)
-            D = Elements.spectralderivative(ξ1)
-            Nq = N + 1
-
-            dim = 2
             e2c = Array{FT, 3}(undef, 2, 4, 1)
             e2c[:, :, 1] = [-1 1 -1 1; -1 -1 1 1]
             nelem = size(e2c, 3)
 
-            (x1, x2) = Metrics.creategrid2d(e2c, ξ1)
+            vgeo = Array{FT, 4}(undef, Nq..., length(VGEO2D), nelem)
+            sgeo =
+                Array{FT, 4}(undef, maximum(Nfp), nface, length(SGEO2D), nelem)
 
-            (x1ξ1, x1ξ2, x2ξ1, x2ξ2) =
-                (fx1ξ1(x1, x2), fx1ξ2(x1, x2), fx2ξ1(x1, x2), fx2ξ2(x1, x2))
-            J = x1ξ1 .* x2ξ2 - x1ξ2 .* x2ξ1
+            Metrics.creategrid!(
+                ntuple(j -> (@view vgeo[:, :, j, :]), dim)...,
+                e2c,
+                ξ...,
+            )
+            x1 = @view vgeo[:, :, VGEO2D.x1, :]
+            x2 = @view vgeo[:, :, VGEO2D.x2, :]
+
             foreach(j -> (x1[j], x2[j]) = f(x1[j], x2[j]), 1:length(x1))
 
-            metric = Metrics.computemetric(x1, x2, D)
-            @test J ≈ metric.J
-            @test metric.ξ1x1 ≈ x2ξ2 ./ J
-            @test metric.ξ2x1 ≈ -x2ξ1 ./ J
-            @test metric.ξ1x2 ≈ -x1ξ2 ./ J
-            @test metric.ξ2x2 ≈ x1ξ1 ./ J
+            Metrics.computemetric!(
+                ntuple(j -> (@view vgeo[:, :, j, :]), length(VGEO2D))...,
+                ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO2D))...,
+                D...,
+            )
 
-            # check the normals?
-            n1 = metric.n1
-            n2 = metric.n2
-            sJ = metric.sJ
-            @test hypot.(n1, n2) ≈ ones(FT, size(n1))
-            @test sJ[:, 1, :] .* n1[:, 1, :] ≈ -x2ξ2[1, :, :]
-            @test sJ[:, 1, :] .* n2[:, 1, :] ≈ x1ξ2[1, :, :]
-            @test sJ[:, 2, :] .* n1[:, 2, :] ≈ x2ξ2[Nq, :, :]
-            @test sJ[:, 2, :] .* n2[:, 2, :] ≈ -x1ξ2[Nq, :, :]
-            @test sJ[:, 3, :] .* n1[:, 3, :] ≈ x2ξ1[:, 1, :]
-            @test sJ[:, 3, :] .* n2[:, 3, :] ≈ -x1ξ1[:, 1, :]
-            @test sJ[:, 4, :] .* n1[:, 4, :] ≈ -x2ξ1[:, Nq, :]
-            @test sJ[:, 4, :] .* n2[:, 4, :] ≈ x1ξ1[:, Nq, :]
+            (Cx1, Cx2) = (zeros(FT, Nq...), zeros(FT, Nq...))
+
+            J = @view vgeo[:, :, VGEO2D.J, :]
+            ξ1x1 = @view vgeo[:, :, VGEO2D.ξ1x1, :]
+            ξ1x2 = @view vgeo[:, :, VGEO2D.ξ1x2, :]
+            ξ2x1 = @view vgeo[:, :, VGEO2D.ξ2x1, :]
+            ξ2x2 = @view vgeo[:, :, VGEO2D.ξ2x2, :]
+
+            e = 1
+            for n in 1:Nq[2]
+                Cx1[:, n] += D[1] * (J[:, n, e] .* ξ1x1[:, n, e])
+                Cx2[:, n] += D[1] * (J[:, n, e] .* ξ1x2[:, n, e])
+            end
+            for n in 1:Nq[1]
+                Cx1[n, :] += D[2] * (J[n, :, e] .* ξ2x1[n, :, e])
+                Cx2[n, :] += D[2] * (J[n, :, e] .* ξ2x2[n, :, e])
+            end
+            @test maximum(abs.(Cx1)) ≤ 100 * eps(FT)
+            @test maximum(abs.(Cx2)) ≤ 100 * eps(FT)
         end
         #}}}
     end
-
-    # Constant preserving test
-    #{{{
-    let
-        N = 4
-        FT = Float64
-
-        f(ξ1, ξ2) = (
-            9 .* ξ1 - (1 .+ ξ1) .* ξ2 .^ 2 +
-            (ξ1 .- 1) .^ 2 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3),
-            10 .* ξ2 .+ ξ1 .^ 4 .* (1 .- ξ2) .+ ξ1 .^ 2 .* ξ2 .* (1 .+ ξ2),
-        )
-        fx1ξ1(ξ1, ξ2) =
-            7 .+ ξ2 .^ 2 .- 2 .* ξ2 .^ 3 .+ 2 .* ξ1 .* (1 .- ξ2 .^ 2 .+ ξ2 .^ 3)
-        fx1ξ2(ξ1, ξ2) =
-            -2 .* (1 .+ ξ1) .* ξ2 .+ (-1 .+ ξ1) .^ 2 .* ξ2 .* (-2 .+ 3 .* ξ2)
-        fx2ξ1(ξ1, ξ2) =
-            -4 .* ξ1 .^ 3 .* (-1 .+ ξ2) .+ 2 .* ξ1 .* ξ2 .* (1 .+ ξ2)
-        fx2ξ2(ξ1, ξ2) = 10 .- ξ1 .^ 4 .+ ξ1 .^ 2 .* (1 .+ 2 .* ξ2)
-
-        ξ1, w = Elements.lglpoints(FT, N)
-        D = Elements.spectralderivative(ξ1)
-        Nq = N + 1
-
-        dim = 2
-        nface = 2dim
-        e2c = Array{FT, 3}(undef, 2, 4, 1)
-        e2c[:, :, 1] = [-1 1 -1 1; -1 -1 1 1]
-        nelem = size(e2c, 3)
-
-        vgeo = Array{FT, 4}(undef, Nq, Nq, length(VGEO2D), nelem)
-        sgeo = Array{FT, 4}(undef, Nq, nface, length(SGEO2D), nelem)
-
-        Metrics.creategrid!(ntuple(j -> (@view vgeo[:, :, j, :]), dim)..., e2c, ξ1)
-        x1 = @view vgeo[:, :, VGEO2D.x1, :]
-        x2 = @view vgeo[:, :, VGEO2D.x2, :]
-
-        foreach(j -> (x1[j], x2[j]) = f(x1[j], x2[j]), 1:length(x1))
-
-        Metrics.computemetric!(
-            ntuple(j -> (@view vgeo[:, :, j, :]), length(VGEO2D))...,
-            ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO2D))...,
-            D,
-        )
-
-        (Cx1, Cx2) = (zeros(FT, Nq, Nq), zeros(FT, Nq, Nq))
-
-        J = @view vgeo[:, :, VGEO2D.J, :]
-        ξ1x1 = @view vgeo[:, :, VGEO2D.ξ1x1, :]
-        ξ1x2 = @view vgeo[:, :, VGEO2D.ξ1x2, :]
-        ξ2x1 = @view vgeo[:, :, VGEO2D.ξ2x1, :]
-        ξ2x2 = @view vgeo[:, :, VGEO2D.ξ2x2, :]
-
-        e = 1
-        for n in 1:Nq
-            Cx1[:, n] += D * (J[:, n, e] .* ξ1x1[:, n, e])
-            Cx1[n, :] += D * (J[n, :, e] .* ξ2x1[n, :, e])
-
-            Cx2[:, n] += D * (J[:, n, e] .* ξ1x2[:, n, e])
-            Cx2[n, :] += D * (J[n, :, e] .* ξ2x2[n, :, e])
-        end
-        @test maximum(abs.(Cx1)) ≤ 1000 * eps(FT)
-        @test maximum(abs.(Cx2)) ≤ 1000 * eps(FT)
-    end
-    #}}}
 end
 
 @testset "3-D Metric terms" begin
     # linear test
     #{{{
-    for FT in (Float32, Float64)
-        let
-            N = 2
+    for FT in (Float32, Float64), N in ((2, 2, 2), (2, 3, 4), (4, 3, 2))
+        Nq = N .+ 1
+        Np = prod(Nq)
+        Nfp = div.(Np, Nq)
 
-            ξ1, w = Elements.lglpoints(FT, N)
-            D = Elements.spectralderivative(ξ1)
-            Nq = N + 1
+        dim = length(N)
+        nface = 2dim
 
-            dim = 3
-            nface = 2dim
-            e2c = Array{FT, 3}(undef, dim, 8, 2)
-            e2c[:, :, 1] = [
-                0 2 0 2 0 2 0 2
-                0 0 2 2 0 0 2 2
-                0 0 0 0 2 2 2 2
-            ]
-            e2c[:, :, 2] = [
-                2 2 0 0 2 2 0 0
-                0 2 0 2 0 2 0 2
-                0 0 0 0 2 2 2 2
-            ]
+        # Create element operators for each polynomial order
+        ξω = ntuple(j -> Elements.lglpoints(FT, N[j]), dim)
+        ξ, ω = ntuple(j -> map(x -> x[j], ξω), 2)
+        D = ntuple(j -> Elements.spectralderivative(ξ[j]), dim)
 
-            nelem = size(e2c, 3)
+        e2c = Array{FT, 3}(undef, dim, 8, 2)
+        e2c[:, :, 1] = [
+            0 2 0 2 0 2 0 2
+            0 0 2 2 0 0 2 2
+            0 0 0 0 2 2 2 2
+        ]
+        e2c[:, :, 2] = [
+            2 2 0 0 2 2 0 0
+            0 2 0 2 0 2 0 2
+            0 0 0 0 2 2 2 2
+        ]
 
-            x_exact = Array{Int, 4}(undef, 3, 3, 3, nelem)
-            x_exact[1, :, :, 1] .= 0
-            x_exact[2, :, :, 1] .= 1
-            x_exact[3, :, :, 1] .= 2
-            x_exact[:, 1, :, 2] .= 2
-            x_exact[:, 2, :, 2] .= 1
-            x_exact[:, 3, :, 2] .= 0
+        nelem = size(e2c, 3)
 
-            ξ1x1_exact = zeros(Int, 3, 3, 3, nelem)
-            ξ1x1_exact[:, :, :, 1] .= 1
+        x_exact = Array{FT, 4}(undef, Nq..., nelem)
+        x_exact[:, :, :, 1] .= 1 .+ ξ[1]
+        x_exact[:, :, :, 2] .= 1 .- ξ[2]'
 
-            ξ1x2_exact = zeros(Int, 3, 3, 3, nelem)
-            ξ1x2_exact[:, :, :, 2] .= 1
+        ξ1x1_exact = zeros(Int, Nq..., nelem)
+        ξ1x1_exact[:, :, :, 1] .= 1
 
-            ξ2x1_exact = zeros(Int, 3, 3, 3, nelem)
-            ξ2x1_exact[:, :, :, 2] .= -1
+        ξ1x2_exact = zeros(Int, Nq..., nelem)
+        ξ1x2_exact[:, :, :, 2] .= 1
 
-            ξ2x2_exact = zeros(Int, 3, 3, 3, nelem)
-            ξ2x2_exact[:, :, :, 1] .= 1
+        ξ2x1_exact = zeros(Int, Nq..., nelem)
+        ξ2x1_exact[:, :, :, 2] .= -1
 
-            ξ3x3_exact = ones(Int, 3, 3, 3, nelem)
+        ξ2x2_exact = zeros(Int, Nq..., nelem)
+        ξ2x2_exact[:, :, :, 1] .= 1
 
-            y_exact = Array{Int, 4}(undef, 3, 3, 3, nelem)
-            y_exact[:, 1, :, 1] .= 0
-            y_exact[:, 2, :, 1] .= 1
-            y_exact[:, 3, :, 1] .= 2
-            y_exact[1, :, :, 2] .= 0
-            y_exact[2, :, :, 2] .= 1
-            y_exact[3, :, :, 2] .= 2
+        ξ3x3_exact = ones(Int, Nq..., nelem)
 
-            z_exact = Array{Int, 4}(undef, 3, 3, 3, nelem)
-            z_exact[:, :, 1, 1:2] .= 0
-            z_exact[:, :, 2, 1:2] .= 1
-            z_exact[:, :, 3, 1:2] .= 2
+        y_exact = Array{FT, 4}(undef, Nq..., nelem)
+        y_exact[:, :, :, 1] .= 1 .+ ξ[2]'
+        y_exact[:, :, :, 2] .= 1 .+ ξ[1]
 
-            J_exact = ones(Int, 3, 3, 3, nelem)
+        z_exact = Array{FT, 4}(undef, Nq..., nelem)
+        z_exact[:, :, :, :] .= reshape(1 .+ ξ[3], 1, 1, Nq[3])
 
-            sJ_exact = ones(Int, Nq, Nq, nface, nelem)
+        J_exact = ones(Int, Nq..., nelem)
 
-            nx_exact = zeros(Int, Nq, Nq, nface, nelem)
-            nx_exact[:, :, 1, 1] .= -1
-            nx_exact[:, :, 2, 1] .= 1
-            nx_exact[:, :, 3, 2] .= 1
-            nx_exact[:, :, 4, 2] .= -1
+        sJ_exact = ones(Int, maximum(Nfp), nface, nelem)
 
-            ny_exact = zeros(Int, Nq, Nq, nface, nelem)
-            ny_exact[:, :, 3, 1] .= -1
-            ny_exact[:, :, 4, 1] .= 1
-            ny_exact[:, :, 1, 2] .= -1
-            ny_exact[:, :, 2, 2] .= 1
+        nx_exact = zeros(Int, maximum(Nfp), nface, nelem)
+        nx_exact[:, 1, 1] .= -1
+        nx_exact[:, 2, 1] .= 1
+        nx_exact[:, 3, 2] .= 1
+        nx_exact[:, 4, 2] .= -1
 
-            nz_exact = zeros(Int, Nq, Nq, nface, nelem)
-            nz_exact[:, :, 5, 1:2] .= -1
-            nz_exact[:, :, 6, 1:2] .= 1
+        ny_exact = zeros(Int, maximum(Nfp), nface, nelem)
+        ny_exact[:, 3, 1] .= -1
+        ny_exact[:, 4, 1] .= 1
+        ny_exact[:, 1, 2] .= -1
+        ny_exact[:, 2, 2] .= 1
 
-            vgeo = Array{FT, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
-            sgeo = Array{FT, 4}(undef, Nq^2, nface, length(SGEO3D), nelem)
-            Metrics.creategrid!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
-                e2c,
-                ξ1,
-            )
-            Metrics.computemetric!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), length(VGEO3D))...,
-                ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
-                D,
-            )
-            sgeo = reshape(sgeo, Nq, Nq, nface, length(SGEO3D), nelem)
+        nz_exact = zeros(Int, maximum(Nfp), nface, nelem)
+        nz_exact[:, 5, 1:2] .= -1
+        nz_exact[:, 6, 1:2] .= 1
 
-            @test (@view vgeo[:, :, :, VGEO3D.x1, :]) ≈ x_exact
-            @test (@view vgeo[:, :, :, VGEO3D.x2, :]) ≈ y_exact
-            @test (@view vgeo[:, :, :, VGEO3D.x3, :]) ≈ z_exact
-            @test (@view vgeo[:, :, :, VGEO3D.J, :]) ≈ J_exact
-            @test (@view vgeo[:, :, :, VGEO3D.ξ1x1, :]) ≈ ξ1x1_exact
-            @test (@view vgeo[:, :, :, VGEO3D.ξ1x2, :]) ≈ ξ1x2_exact
-            @test maximum(abs.(@view vgeo[
-                :,
-                :,
-                :,
-                VGEO3D.ξ1x3,
-                :,
-            ])) ≤ 10 * eps(FT)
-            @test (@view vgeo[:, :, :, VGEO3D.ξ2x1, :]) ≈ ξ2x1_exact
-            @test (@view vgeo[:, :, :, VGEO3D.ξ2x2, :]) ≈ ξ2x2_exact
-            @test maximum(abs.(@view vgeo[
-                :,
-                :,
-                :,
-                VGEO3D.ξ2x3,
-                :,
-            ])) ≤ 10 * eps(FT)
-            @test maximum(abs.(@view vgeo[
-                :,
-                :,
-                :,
-                VGEO3D.ξ3x1,
-                :,
-            ])) ≤ 10 * eps(FT)
-            @test maximum(abs.(@view vgeo[
-                :,
-                :,
-                :,
-                VGEO3D.ξ3x2,
-                :,
-            ])) ≤ 10 * eps(FT)
-            @test (@view vgeo[:, :, :, VGEO3D.ξ3x3, :]) ≈ ξ3x3_exact
-            @test (@view sgeo[:, :, :, SGEO3D.sJ, :]) ≈ sJ_exact
-            @test (@view sgeo[:, :, :, SGEO3D.n1, :]) ≈ nx_exact
-            @test (@view sgeo[:, :, :, SGEO3D.n2, :]) ≈ ny_exact
-            @test (@view sgeo[:, :, :, SGEO3D.n3, :]) ≈ nz_exact
-        end
-    end
-    #}}}
+        vgeo = Array{FT, 5}(undef, Nq..., length(VGEO3D), nelem)
+        sgeo = Array{FT, 4}(undef, maximum(Nfp), nface, length(SGEO3D), nelem)
+        Metrics.creategrid!(
+            ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
+            e2c,
+            ξ...,
+        )
+        Metrics.computemetric!(
+            ntuple(j -> (@view vgeo[:, :, :, j, :]), length(VGEO3D))...,
+            ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
+            D...,
+        )
 
-    # linear test with rotation
-    #{{{
-    for FT in (Float32, Float64)
-        θ1 = 2 * FT(π) * FT(0.9)
-        θ2 = 2 * FT(π) * FT(-0.56)
-        θ3 = 2 * FT(π) * FT(0.33)
-        #=
-        θ1 = 2 * FT(π) * rand(FT)
-        θ2 = 2 * FT(π) * rand(FT)
-        θ3 = 2 * FT(π) * rand(FT)
-        =#
-        #=
-        θ1 = FT(π) / 6
-        θ2 = FT(π) / 12
-        θ3 = 4 * FT(π) / 5
-        =#
-        Q = [cos(θ1) -sin(θ1) 0; sin(θ1) cos(θ1) 0; 0 0 1]
-        Q *= [cos(θ2) 0 -sin(θ2); 0 1 0; sin(θ2) 0 cos(θ2)]
-        Q *= [1 0 0; 0 cos(θ3) -sin(θ3); 0 sin(θ3) cos(θ3)]
-        let
-            N = 2
-
-            ξ1, w = Elements.lglpoints(FT, N)
-            D = Elements.spectralderivative(ξ1)
-            Nq = N + 1
-
-            dim = 3
-            nface = 2dim
-            e2c = Array{FT, 3}(undef, dim, 8, 1)
-            e2c[:, :, 1] = [
-                0 2 0 2 0 2 0 2
-                0 0 2 2 0 0 2 2
-                0 0 0 0 2 2 2 2
-            ]
-            @views (x1, x2, x3) = (e2c[1, :, 1], e2c[2, :, 1], e2c[3, :, 1])
-            for i in 1:length(x1)
-                (x1[i], x2[i], x3[i]) = Q * [x1[i]; x2[i]; x3[i]]
+        @test (@view vgeo[:, :, :, VGEO3D.x1, :]) ≈ x_exact
+        @test (@view vgeo[:, :, :, VGEO3D.x2, :]) ≈ y_exact
+        @test (@view vgeo[:, :, :, VGEO3D.x3, :]) ≈ z_exact
+        @test (@view vgeo[:, :, :, VGEO3D.J, :]) ≈ J_exact
+        @test (@view vgeo[:, :, :, VGEO3D.ξ1x1, :]) ≈ ξ1x1_exact
+        @test (@view vgeo[:, :, :, VGEO3D.ξ1x2, :]) ≈ ξ1x2_exact
+        @test maximum(abs.(@view vgeo[:, :, :, VGEO3D.ξ1x3, :])) ≤ 100 * eps(FT)
+        @test (@view vgeo[:, :, :, VGEO3D.ξ2x1, :]) ≈ ξ2x1_exact
+        @test (@view vgeo[:, :, :, VGEO3D.ξ2x2, :]) ≈ ξ2x2_exact
+        @test maximum(abs.(@view vgeo[:, :, :, VGEO3D.ξ2x3, :])) ≤ 100 * eps(FT)
+        @test maximum(abs.(@view vgeo[:, :, :, VGEO3D.ξ3x1, :])) ≤ 100 * eps(FT)
+        @test maximum(abs.(@view vgeo[:, :, :, VGEO3D.ξ3x2, :])) ≤ 100 * eps(FT)
+        @test (@view vgeo[:, :, :, VGEO3D.ξ3x3, :]) ≈ ξ3x3_exact
+        for d in 1:dim
+            for f in (2d - 1):(2d)
+                @test isapprox(
+                    (@view sgeo[1:Nfp[d], f, SGEO3D.sJ, :]),
+                    sJ_exact[1:Nfp[d], f, :];
+                    atol = √eps(FT),
+                    rtol = √eps(FT),
+                )
+                @test isapprox(
+                    (@view sgeo[1:Nfp[d], f, SGEO3D.n1, :]),
+                    nx_exact[1:Nfp[d], f, :];
+                    atol = √eps(FT),
+                    rtol = √eps(FT),
+                )
+                @test isapprox(
+                    (@view sgeo[1:Nfp[d], f, SGEO3D.n2, :]),
+                    ny_exact[1:Nfp[d], f, :];
+                    atol = √eps(FT),
+                    rtol = √eps(FT),
+                )
+                @test isapprox(
+                    (@view sgeo[1:Nfp[d], f, SGEO3D.n3, :]),
+                    nz_exact[1:Nfp[d], f, :];
+                    atol = √eps(FT),
+                    rtol = √eps(FT),
+                )
             end
-
-            nelem = size(e2c, 3)
-
-            x1e = Array{FT, 4}(undef, 3, 3, 3, nelem)
-            x1e[1, :, :, 1] .= 0
-            x1e[2, :, :, 1] .= 1
-            x1e[3, :, :, 1] .= 2
-
-            x2e = Array{FT, 4}(undef, 3, 3, 3, nelem)
-            x2e[:, 1, :, 1] .= 0
-            x2e[:, 2, :, 1] .= 1
-            x2e[:, 3, :, 1] .= 2
-
-            x3e = Array{FT, 4}(undef, 3, 3, 3, nelem)
-            x3e[:, :, 1, 1] .= 0
-            x3e[:, :, 2, 1] .= 1
-            x3e[:, :, 3, 1] .= 2
-
-            for i in 1:length(x1e)
-                (x1e[i], x2e[i], x3e[i]) = Q * [x1e[i]; x2e[i]; x3e[i]]
-            end
-
-            Je = ones(Int, 3, 3, 3, nelem)
-
-            # By construction
-            # Q = [x1ξ1 x1ξ2 x2ξ2; x2ξ1 x2ξ2 x2ξ3; x3ξ1 x3ξ2 x3ξ3] = [ξ1x1 ξ2x1 ξ3x1; ξ1x2 ξ2x2 ξ3x2; ξ1x3 ξ2x3 ξ3x3]
-            ξ1x1e = fill(Q[1, 1], 3, 3, 3, nelem)
-            ξ1x2e = fill(Q[2, 1], 3, 3, 3, nelem)
-            ξ1x3e = fill(Q[3, 1], 3, 3, 3, nelem)
-            ξ2x1e = fill(Q[1, 2], 3, 3, 3, nelem)
-            ξ2x2e = fill(Q[2, 2], 3, 3, 3, nelem)
-            ξ2x3e = fill(Q[3, 2], 3, 3, 3, nelem)
-            ξ3x1e = fill(Q[1, 3], 3, 3, 3, nelem)
-            ξ3x2e = fill(Q[2, 3], 3, 3, 3, nelem)
-            ξ3x3e = fill(Q[3, 3], 3, 3, 3, nelem)
-
-            sJe = ones(Int, Nq, Nq, nface, nelem)
-
-            n1e = zeros(FT, Nq, Nq, nface, nelem)
-            n2e = zeros(FT, Nq, Nq, nface, nelem)
-            n3e = zeros(FT, Nq, Nq, nface, nelem)
-
-            fill!(@view(n1e[:, :, 1, :]), -Q[1, 1])
-            fill!(@view(n1e[:, :, 2, :]), Q[1, 1])
-            fill!(@view(n1e[:, :, 3, :]), -Q[1, 2])
-            fill!(@view(n1e[:, :, 4, :]), Q[1, 2])
-            fill!(@view(n1e[:, :, 5, :]), -Q[1, 3])
-            fill!(@view(n1e[:, :, 6, :]), Q[1, 3])
-            fill!(@view(n2e[:, :, 1, :]), -Q[2, 1])
-            fill!(@view(n2e[:, :, 2, :]), Q[2, 1])
-            fill!(@view(n2e[:, :, 3, :]), -Q[2, 2])
-            fill!(@view(n2e[:, :, 4, :]), Q[2, 2])
-            fill!(@view(n2e[:, :, 5, :]), -Q[2, 3])
-            fill!(@view(n2e[:, :, 6, :]), Q[2, 3])
-            fill!(@view(n3e[:, :, 1, :]), -Q[3, 1])
-            fill!(@view(n3e[:, :, 2, :]), Q[3, 1])
-            fill!(@view(n3e[:, :, 3, :]), -Q[3, 2])
-            fill!(@view(n3e[:, :, 4, :]), Q[3, 2])
-            fill!(@view(n3e[:, :, 5, :]), -Q[3, 3])
-            fill!(@view(n3e[:, :, 6, :]), Q[3, 3])
-
-            vgeo = Array{FT, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
-            sgeo = Array{FT, 4}(undef, Nq^2, nface, length(SGEO3D), nelem)
-            Metrics.creategrid!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
-                e2c,
-                ξ1,
-            )
-            Metrics.computemetric!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), length(VGEO3D))...,
-                ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
-                D,
-            )
-            sgeo = reshape(sgeo, Nq, Nq, nface, length(SGEO3D), nelem)
-
-            @test (@view vgeo[:, :, :, VGEO3D.x1, :]) ≈ x1e
-            @test (@view vgeo[:, :, :, VGEO3D.x2, :]) ≈ x2e
-            @test (@view vgeo[:, :, :, VGEO3D.x3, :]) ≈ x3e
-            @test (@view vgeo[:, :, :, VGEO3D.J, :]) ≈ Je
-            @test (@view vgeo[:, :, :, VGEO3D.ξ1x1, :]) ≈ ξ1x1e
-            @test (@view vgeo[:, :, :, VGEO3D.ξ1x2, :]) ≈ ξ1x2e
-            @test (@view vgeo[:, :, :, VGEO3D.ξ1x3, :]) ≈ ξ1x3e
-            @test (@view vgeo[:, :, :, VGEO3D.ξ2x1, :]) ≈ ξ2x1e
-            @test (@view vgeo[:, :, :, VGEO3D.ξ2x2, :]) ≈ ξ2x2e
-            @test (@view vgeo[:, :, :, VGEO3D.ξ2x3, :]) ≈ ξ2x3e
-            @test (@view vgeo[:, :, :, VGEO3D.ξ3x1, :]) ≈ ξ3x1e
-            @test (@view vgeo[:, :, :, VGEO3D.ξ3x2, :]) ≈ ξ3x2e
-            @test (@view vgeo[:, :, :, VGEO3D.ξ3x3, :]) ≈ ξ3x3e
-            @test (@view sgeo[:, :, :, SGEO3D.sJ, :]) ≈ sJe
-            @test (@view sgeo[:, :, :, SGEO3D.n1, :]) ≈ n1e
-            @test (@view sgeo[:, :, :, SGEO3D.n2, :]) ≈ n2e
-            @test (@view sgeo[:, :, :, SGEO3D.n3, :]) ≈ n3e
         end
     end
     #}}}
 
     # Polynomial 3-D test
     #{{{
-    for FT in (Float32, Float64)
+    for FT in (Float32, Float64), N in ((9, 9, 9), (9, 9, 10), (10, 9, 11))
+        Nq = N .+ 1
+        Np = prod(Nq)
+        Nfp = div.(Np, Nq)
+
+        dim = length(N)
+        nface = 2dim
+
+        # Create element operators for each polynomial order
+        ξω = ntuple(j -> Elements.lglpoints(FT, N[j]), dim)
+        ξ, ω = ntuple(j -> map(x -> x[j], ξω), 2)
+        D = ntuple(j -> Elements.spectralderivative(ξ[j]), dim)
+
         f(ξ1, ξ2, ξ3) = @.( (
             ξ2 + ξ1 * ξ3 - (ξ1^2 * ξ2^2 * ξ3^2) / 4,
-            ξ3 - ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^3 + 1,
-            ξ1 + (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^6,
+            ξ3 - ((ξ1 * ξ2 * ξ3 + 1) / 2)^3 + 1,
+            ξ1 + 2 * ((ξ1 + 1) / 2)^6 * ((ξ2 + 1) / 2)^6 * ((ξ3 + 1) / 2)^6,
         ))
 
         fx1ξ1(ξ1, ξ2, ξ3) = @.(ξ3 - (ξ1 * ξ2^2 * ξ3^2) / 2)
         fx1ξ2(ξ1, ξ2, ξ3) = @.(1 - (ξ1^2 * ξ2 * ξ3^2) / 2)
         fx1ξ3(ξ1, ξ2, ξ3) = @.(ξ1 - (ξ1^2 * ξ2^2 * ξ3) / 2)
-        fx2ξ1(ξ1, ξ2, ξ3) =
-            @.(-(3 * ξ2 * ξ3 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
-        fx2ξ2(ξ1, ξ2, ξ3) =
-            @.(-(3 * ξ1 * ξ3 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
+        fx2ξ1(ξ1, ξ2, ξ3) = @.(-(3 * ξ2 * ξ3 * ((ξ1 * ξ2 * ξ3 + 1) / 2)^2) / 2)
+        fx2ξ2(ξ1, ξ2, ξ3) = @.(-(3 * ξ1 * ξ3 * ((ξ1 * ξ2 * ξ3 + 1) / 2)^2) / 2)
         fx2ξ3(ξ1, ξ2, ξ3) =
-            @.(1 - (3 * ξ1 * ξ2 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
-        fx3ξ1(ξ1, ξ2, ξ3) = @.(
-            3 * (ξ1 / 2 + 1 / 2)^5 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^6 + 1
-        )
+            @.(1 - (3 * ξ1 * ξ2 * ((ξ1 * ξ2 * ξ3 + 1) / 2)^2) / 2)
+        fx3ξ1(ξ1, ξ2, ξ3) =
+            @.(6 * ((ξ1 + 1) / 2)^5 * ((ξ2 + 1) / 2)^6 * ((ξ3 + 1) / 2)^6 + 1)
         fx3ξ2(ξ1, ξ2, ξ3) =
-            @.(3 * (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^5 * (ξ3 / 2 + 1 / 2)^6)
+            @.(6 * ((ξ1 + 1) / 2)^6 * ((ξ2 + 1) / 2)^5 * ((ξ3 + 1) / 2)^6)
         fx3ξ3(ξ1, ξ2, ξ3) =
-            @.(3 * (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^5)
+            @.(6 * ((ξ1 + 1) / 2)^6 * ((ξ2 + 1) / 2)^6 * ((ξ3 + 1) / 2)^5)
 
-        let
-            N = 9
+        e2c = Array{FT, 3}(undef, dim, 8, 1)
+        e2c[:, :, 1] = [
+            -1 1 -1 1 -1 1 -1 1
+            -1 -1 1 1 -1 -1 1 1
+            -1 -1 -1 -1 1 1 1 1
+        ]
 
-            ξ1, w = Elements.lglpoints(FT, N)
-            D = Elements.spectralderivative(ξ1)
-            Nq = N + 1
+        nelem = size(e2c, 3)
 
-            dim = 3
-            nface = 2dim
-            e2c = Array{FT, 3}(undef, dim, 8, 1)
-            e2c[:, :, 1] = [
-                -1 1 -1 1 -1 1 -1 1
-                -1 -1 1 1 -1 -1 1 1
-                -1 -1 -1 -1 1 1 1 1
-            ]
+        vgeo = Array{FT, 5}(undef, Nq..., length(VGEO3D), nelem)
+        sgeo = Array{FT, 4}(undef, maximum(Nfp), nface, length(SGEO3D), nelem)
+        Metrics.creategrid!(
+            ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
+            e2c,
+            ξ...,
+        )
+        x1 = @view vgeo[:, :, :, VGEO3D.x1, :]
+        x2 = @view vgeo[:, :, :, VGEO3D.x2, :]
+        x3 = @view vgeo[:, :, :, VGEO3D.x3, :]
 
-            nelem = size(e2c, 3)
+        # Compute exact metrics
+        (x1ξ1, x1ξ2, x1ξ3, x2ξ1, x2ξ2, x2ξ3, x3ξ1, x3ξ2, x3ξ3) = (
+            fx1ξ1(x1, x2, x3),
+            fx1ξ2(x1, x2, x3),
+            fx1ξ3(x1, x2, x3),
+            fx2ξ1(x1, x2, x3),
+            fx2ξ2(x1, x2, x3),
+            fx2ξ3(x1, x2, x3),
+            fx3ξ1(x1, x2, x3),
+            fx3ξ2(x1, x2, x3),
+            fx3ξ3(x1, x2, x3),
+        )
+        J = (
+            x1ξ1 .* (x2ξ2 .* x3ξ3 - x2ξ3 .* x3ξ2) +
+            x2ξ1 .* (x3ξ2 .* x1ξ3 - x3ξ3 .* x1ξ2) +
+            x3ξ1 .* (x1ξ2 .* x2ξ3 - x1ξ3 .* x2ξ2)
+        )
 
-            vgeo = Array{FT, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
-            sgeo = Array{FT, 4}(undef, Nq^2, nface, length(SGEO3D), nelem)
-            Metrics.creategrid!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
-                e2c,
-                ξ1,
-            )
-            x1 = @view vgeo[:, :, :, VGEO3D.x1, :]
-            x2 = @view vgeo[:, :, :, VGEO3D.x2, :]
-            x3 = @view vgeo[:, :, :, VGEO3D.x3, :]
+        ξ1x1 = (x2ξ2 .* x3ξ3 - x2ξ3 .* x3ξ2) ./ J
+        ξ1x2 = (x3ξ2 .* x1ξ3 - x3ξ3 .* x1ξ2) ./ J
+        ξ1x3 = (x1ξ2 .* x2ξ3 - x1ξ3 .* x2ξ2) ./ J
+        ξ2x1 = (x2ξ3 .* x3ξ1 - x2ξ1 .* x3ξ3) ./ J
+        ξ2x2 = (x3ξ3 .* x1ξ1 - x3ξ1 .* x1ξ3) ./ J
+        ξ2x3 = (x1ξ3 .* x2ξ1 - x1ξ1 .* x2ξ3) ./ J
+        ξ3x1 = (x2ξ1 .* x3ξ2 - x2ξ2 .* x3ξ1) ./ J
+        ξ3x2 = (x3ξ1 .* x1ξ2 - x3ξ2 .* x1ξ1) ./ J
+        ξ3x3 = (x1ξ1 .* x2ξ2 - x1ξ2 .* x2ξ1) ./ J
 
-            (x1ξ1, x1ξ2, x1ξ3, x2ξ1, x2ξ2, x2ξ3, x3ξ1, x3ξ2, x3ξ3) = (
-                fx1ξ1(x1, x2, x3),
-                fx1ξ2(x1, x2, x3),
-                fx1ξ3(x1, x2, x3),
-                fx2ξ1(x1, x2, x3),
-                fx2ξ2(x1, x2, x3),
-                fx2ξ3(x1, x2, x3),
-                fx3ξ1(x1, x2, x3),
-                fx3ξ2(x1, x2, x3),
-                fx3ξ3(x1, x2, x3),
-            )
-            J = (
-                x1ξ1 .* (x2ξ2 .* x3ξ3 - x2ξ3 .* x3ξ2) +
-                x2ξ1 .* (x3ξ2 .* x1ξ3 - x3ξ3 .* x1ξ2) +
-                x3ξ1 .* (x1ξ2 .* x2ξ3 - x1ξ3 .* x2ξ2)
-            )
+        # Warp the mesh
+        foreach(
+            j -> (x1[j], x2[j], x3[j]) = f(x1[j], x2[j], x3[j]),
+            1:length(x1),
+        )
 
-            ξ1x1 = (x2ξ2 .* x3ξ3 - x2ξ3 .* x3ξ2) ./ J
-            ξ1x2 = (x3ξ2 .* x1ξ3 - x3ξ3 .* x1ξ2) ./ J
-            ξ1x3 = (x1ξ2 .* x2ξ3 - x1ξ3 .* x2ξ2) ./ J
-            ξ2x1 = (x2ξ3 .* x3ξ1 - x2ξ1 .* x3ξ3) ./ J
-            ξ2x2 = (x3ξ3 .* x1ξ1 - x3ξ1 .* x1ξ3) ./ J
-            ξ2x3 = (x1ξ3 .* x2ξ1 - x1ξ1 .* x2ξ3) ./ J
-            ξ3x1 = (x2ξ1 .* x3ξ2 - x2ξ2 .* x3ξ1) ./ J
-            ξ3x2 = (x3ξ1 .* x1ξ2 - x3ξ2 .* x1ξ1) ./ J
-            ξ3x3 = (x1ξ1 .* x2ξ2 - x1ξ2 .* x2ξ1) ./ J
+        Metrics.computemetric!(
+            ntuple(j -> (@view vgeo[:, :, :, j, :]), length(VGEO3D))...,
+            ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
+            D...,
+        )
+        sgeo = reshape(sgeo, maximum(Nfp), nface, length(SGEO3D), nelem)
 
-            foreach(
-                j -> (x1[j], x2[j], x3[j]) = f(x1[j], x2[j], x3[j]),
-                1:length(x1),
-            )
-
-            Metrics.computemetric!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), length(VGEO3D))...,
-                ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
-                D,
-            )
-            sgeo = reshape(sgeo, Nq, Nq, nface, length(SGEO3D), nelem)
-
-            @test (@view vgeo[:, :, :, VGEO3D.J, :]) ≈ J
-            @test (@view vgeo[:, :, :, VGEO3D.ξ1x1, :]) ≈ ξ1x1
-            @test (@view vgeo[:, :, :, VGEO3D.ξ1x2, :]) ≈ ξ1x2
-            @test (@view vgeo[:, :, :, VGEO3D.ξ1x3, :]) ≈ ξ1x3
-            @test (@view vgeo[:, :, :, VGEO3D.ξ2x1, :]) ≈ ξ2x1
-            @test (@view vgeo[:, :, :, VGEO3D.ξ2x2, :]) ≈ ξ2x2
-            @test (@view vgeo[:, :, :, VGEO3D.ξ2x3, :]) ≈ ξ2x3
-            @test (@view vgeo[:, :, :, VGEO3D.ξ3x1, :]) ≈ ξ3x1
-            @test (@view vgeo[:, :, :, VGEO3D.ξ3x2, :]) ≈ ξ3x2
-            @test (@view vgeo[:, :, :, VGEO3D.ξ3x3, :]) ≈ ξ3x3
-            n1 = @view sgeo[:, :, :, SGEO3D.n1, :]
-            n2 = @view sgeo[:, :, :, SGEO3D.n2, :]
-            n3 = @view sgeo[:, :, :, SGEO3D.n3, :]
-            sJ = @view sgeo[:, :, :, SGEO3D.sJ, :]
-            @test hypot.(n1, n2, n3) ≈ ones(FT, size(n1))
-            @test (
-                [
-                    sJ[:, :, 1, :] .* n1[:, :, 1, :],
-                    sJ[:, :, 1, :] .* n2[:, :, 1, :],
-                    sJ[:, :, 1, :] .* n3[:, :, 1, :],
-                ] ≈ [
-                    -J[1, :, :, :] .* ξ1x1[1, :, :, :],
-                    -J[1, :, :, :] .* ξ1x2[1, :, :, :],
-                    -J[1, :, :, :] .* ξ1x3[1, :, :, :],
-                ]
-            )
-            @test (
-                [
-                    sJ[:, :, 2, :] .* n1[:, :, 2, :],
-                    sJ[:, :, 2, :] .* n2[:, :, 2, :],
-                    sJ[:, :, 2, :] .* n3[:, :, 2, :],
-                ] ≈ [
-                    J[Nq, :, :, :] .* ξ1x1[Nq, :, :, :],
-                    J[Nq, :, :, :] .* ξ1x2[Nq, :, :, :],
-                    J[Nq, :, :, :] .* ξ1x3[Nq, :, :, :],
-                ]
-            )
-            @test sJ[:, :, 3, :] .* n1[:, :, 3, :] ≈
-                  -J[:, 1, :, :] .* ξ2x1[:, 1, :, :]
-            @test sJ[:, :, 3, :] .* n2[:, :, 3, :] ≈
-                  -J[:, 1, :, :] .* ξ2x2[:, 1, :, :]
-            @test sJ[:, :, 3, :] .* n3[:, :, 3, :] ≈
-                  -J[:, 1, :, :] .* ξ2x3[:, 1, :, :]
-            @test sJ[:, :, 4, :] .* n1[:, :, 4, :] ≈
-                  J[:, Nq, :, :] .* ξ2x1[:, Nq, :, :]
-            @test sJ[:, :, 4, :] .* n2[:, :, 4, :] ≈
-                  J[:, Nq, :, :] .* ξ2x2[:, Nq, :, :]
-            @test sJ[:, :, 4, :] .* n3[:, :, 4, :] ≈
-                  J[:, Nq, :, :] .* ξ2x3[:, Nq, :, :]
-            @test sJ[:, :, 5, :] .* n1[:, :, 5, :] ≈
-                  -J[:, :, 1, :] .* ξ3x1[:, :, 1, :]
-            @test sJ[:, :, 5, :] .* n2[:, :, 5, :] ≈
-                  -J[:, :, 1, :] .* ξ3x2[:, :, 1, :]
-            @test sJ[:, :, 5, :] .* n3[:, :, 5, :] ≈
-                  -J[:, :, 1, :] .* ξ3x3[:, :, 1, :]
-            @test sJ[:, :, 6, :] .* n1[:, :, 6, :] ≈
-                  J[:, :, Nq, :] .* ξ3x1[:, :, Nq, :]
-            @test sJ[:, :, 6, :] .* n2[:, :, 6, :] ≈
-                  J[:, :, Nq, :] .* ξ3x2[:, :, Nq, :]
-            @test sJ[:, :, 6, :] .* n3[:, :, 6, :] ≈
-                  J[:, :, Nq, :] .* ξ3x3[:, :, Nq, :]
+        @test (@view vgeo[:, :, :, VGEO3D.J, :]) ≈ J
+        @test (@view vgeo[:, :, :, VGEO3D.ξ1x1, :]) ≈ ξ1x1
+        @test (@view vgeo[:, :, :, VGEO3D.ξ1x2, :]) ≈ ξ1x2
+        @test (@view vgeo[:, :, :, VGEO3D.ξ1x3, :]) ≈ ξ1x3
+        @test (@view vgeo[:, :, :, VGEO3D.ξ2x1, :]) ≈ ξ2x1
+        @test (@view vgeo[:, :, :, VGEO3D.ξ2x2, :]) ≈ ξ2x2
+        @test (@view vgeo[:, :, :, VGEO3D.ξ2x3, :]) ≈ ξ2x3
+        @test (@view vgeo[:, :, :, VGEO3D.ξ3x1, :]) ≈ ξ3x1
+        @test (@view vgeo[:, :, :, VGEO3D.ξ3x2, :]) ≈ ξ3x2
+        @test (@view vgeo[:, :, :, VGEO3D.ξ3x3, :]) ≈ ξ3x3
+        n1 = @view sgeo[:, :, SGEO3D.n1, :]
+        n2 = @view sgeo[:, :, SGEO3D.n2, :]
+        n3 = @view sgeo[:, :, SGEO3D.n3, :]
+        sJ = @view sgeo[:, :, SGEO3D.sJ, :]
+        for d in 1:dim
+            for f in (2d - 1):(2d)
+                @test all(
+                    hypot.(
+                        n1[1:Nfp[d], f, :],
+                        n2[1:Nfp[d], f, :],
+                        n3[1:Nfp[d], f, :],
+                    ) .≈ 1,
+                )
+            end
         end
+        d, f = 1, 1
+        @test [
+            (sJ[1:Nfp[d], f, :] .* n1[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n2[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n3[1:Nfp[d], f, :])[:],
+        ] ≈ [
+            (-J[1, :, :, :] .* ξ1x1[1, :, :, :])[:],
+            (-J[1, :, :, :] .* ξ1x2[1, :, :, :])[:],
+            (-J[1, :, :, :] .* ξ1x3[1, :, :, :])[:],
+        ]
+        d, f = 1, 2
+        @test [
+            (sJ[1:Nfp[d], f, :] .* n1[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n2[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n3[1:Nfp[d], f, :])[:],
+        ] ≈ [
+            (J[Nq[d], :, :, :] .* ξ1x1[Nq[d], :, :, :])[:],
+            (J[Nq[d], :, :, :] .* ξ1x2[Nq[d], :, :, :])[:],
+            (J[Nq[d], :, :, :] .* ξ1x3[Nq[d], :, :, :])[:],
+        ]
+        d, f = 2, 3
+        @test [
+            (sJ[1:Nfp[d], f, :] .* n1[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n2[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n3[1:Nfp[d], f, :])[:],
+        ] ≈ [
+            (-J[:, 1, :, :] .* ξ2x1[:, 1, :, :])[:],
+            (-J[:, 1, :, :] .* ξ2x2[:, 1, :, :])[:],
+            (-J[:, 1, :, :] .* ξ2x3[:, 1, :, :])[:],
+        ]
+        d, f = 2, 4
+        @test [
+            (sJ[1:Nfp[d], f, :] .* n1[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n2[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n3[1:Nfp[d], f, :])[:],
+        ] ≈ [
+            (J[:, Nq[d], :, :] .* ξ2x1[:, Nq[d], :, :])[:],
+            (J[:, Nq[d], :, :] .* ξ2x2[:, Nq[d], :, :])[:],
+            (J[:, Nq[d], :, :] .* ξ2x3[:, Nq[d], :, :])[:],
+        ]
+        d, f = 3, 5
+        @test [
+            (sJ[1:Nfp[d], f, :] .* n1[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n2[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n3[1:Nfp[d], f, :])[:],
+        ] ≈ [
+            (-J[:, :, 1, :] .* ξ3x1[:, :, 1, :])[:],
+            (-J[:, :, 1, :] .* ξ3x2[:, :, 1, :])[:],
+            (-J[:, :, 1, :] .* ξ3x3[:, :, 1, :])[:],
+        ]
+        d, f = 3, 6
+        @test [
+            (sJ[1:Nfp[d], f, :] .* n1[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n2[1:Nfp[d], f, :])[:],
+            (sJ[1:Nfp[d], f, :] .* n3[1:Nfp[d], f, :])[:],
+        ] ≈ [
+            (J[:, :, Nq[d], :] .* ξ3x1[:, :, Nq[d], :])[:],
+            (J[:, :, Nq[d], :] .* ξ3x2[:, :, Nq[d], :])[:],
+            (J[:, :, Nq[d], :] .* ξ3x3[:, :, Nq[d], :])[:],
+        ]
     end
     #}}}
-
-    #{{{
-    for FT in (Float32, Float64)
-        f(ξ1, ξ2, ξ3) = @.( (
-            ξ2 + ξ1 * ξ3 - (ξ1^2 * ξ2^2 * ξ3^2) / 4,
-            ξ3 - ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^3 + 1,
-            ξ1 + (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^6,
-        ))
-
-        fx1ξ1(ξ1, ξ2, ξ3) = @.(ξ3 - (ξ1 * ξ2^2 * ξ3^2) / 2)
-        fx1ξ2(ξ1, ξ2, ξ3) = @.(1 - (ξ1^2 * ξ2 * ξ3^2) / 2)
-        fx1ξ3(ξ1, ξ2, ξ3) = @.(ξ1 - (ξ1^2 * ξ2^2 * ξ3) / 2)
-        fx2ξ1(ξ1, ξ2, ξ3) =
-            @.(-(3 * ξ2 * ξ3 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
-        fx2ξ2(ξ1, ξ2, ξ3) =
-            @.(-(3 * ξ1 * ξ3 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
-        fx2ξ3(ξ1, ξ2, ξ3) =
-            @.(1 - (3 * ξ1 * ξ2 * ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^2) / 2)
-        fx3ξ1(ξ1, ξ2, ξ3) = @.(
-            3 * (ξ1 / 2 + 1 / 2)^5 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^6 + 1
-        )
-        fx3ξ2(ξ1, ξ2, ξ3) =
-            @.(3 * (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^5 * (ξ3 / 2 + 1 / 2)^6)
-        fx3ξ3(ξ1, ξ2, ξ3) =
-            @.(3 * (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^5)
-
-        let
-            N = 9
-
-            ξ1, w = Elements.lglpoints(FT, N)
-            D = Elements.spectralderivative(ξ1)
-            Nq = N + 1
-
-            dim = 3
-            e2c = Array{FT, 3}(undef, dim, 8, 1)
-            e2c[:, :, 1] = [
-                -1 1 -1 1 -1 1 -1 1
-                -1 -1 1 1 -1 -1 1 1
-                -1 -1 -1 -1 1 1 1 1
-            ]
-
-            nelem = size(e2c, 3)
-
-            (x1, x2, x3) = Metrics.creategrid3d(e2c, ξ1)
-
-            (x1ξ1, x1ξ2, x1ξ3, x2ξ1, x2ξ2, x2ξ3, x3ξ1, x3ξ2, x3ξ3) = (
-                fx1ξ1(x1, x2, x3),
-                fx1ξ2(x1, x2, x3),
-                fx1ξ3(x1, x2, x3),
-                fx2ξ1(x1, x2, x3),
-                fx2ξ2(x1, x2, x3),
-                fx2ξ3(x1, x2, x3),
-                fx3ξ1(x1, x2, x3),
-                fx3ξ2(x1, x2, x3),
-                fx3ξ3(x1, x2, x3),
-            )
-            J = (
-                x1ξ1 .* (x2ξ2 .* x3ξ3 - x2ξ3 .* x3ξ2) +
-                x2ξ1 .* (x3ξ2 .* x1ξ3 - x3ξ3 .* x1ξ2) +
-                x3ξ1 .* (x1ξ2 .* x2ξ3 - x1ξ3 .* x2ξ2)
-            )
-
-            ξ1x1 = (x2ξ2 .* x3ξ3 - x2ξ3 .* x3ξ2) ./ J
-            ξ1x2 = (x3ξ2 .* x1ξ3 - x3ξ3 .* x1ξ2) ./ J
-            ξ1x3 = (x1ξ2 .* x2ξ3 - x1ξ3 .* x2ξ2) ./ J
-            ξ2x1 = (x2ξ3 .* x3ξ1 - x2ξ1 .* x3ξ3) ./ J
-            ξ2x2 = (x3ξ3 .* x1ξ1 - x3ξ1 .* x1ξ3) ./ J
-            ξ2x3 = (x1ξ3 .* x2ξ1 - x1ξ1 .* x2ξ3) ./ J
-            ξ3x1 = (x2ξ1 .* x3ξ2 - x2ξ2 .* x3ξ1) ./ J
-            ξ3x2 = (x3ξ1 .* x1ξ2 - x3ξ2 .* x1ξ1) ./ J
-            ξ3x3 = (x1ξ1 .* x2ξ2 - x1ξ2 .* x2ξ1) ./ J
-
-            foreach(
-                j -> (x1[j], x2[j], x3[j]) = f(x1[j], x2[j], x3[j]),
-                1:length(x1),
-            )
-
-            metric = Metrics.computemetric(x1, x2, x3, D)
-
-            @test metric.J ≈ J
-            @test metric.ξ1x1 ≈ ξ1x1
-            @test metric.ξ1x2 ≈ ξ1x2
-            @test metric.ξ1x3 ≈ ξ1x3
-            @test metric.ξ2x1 ≈ ξ2x1
-            @test metric.ξ2x2 ≈ ξ2x2
-            @test metric.ξ2x3 ≈ ξ2x3
-            @test metric.ξ3x1 ≈ ξ3x1
-            @test metric.ξ3x2 ≈ ξ3x2
-            @test metric.ξ3x3 ≈ ξ3x3
-            ind = LinearIndices((1:Nq, 1:Nq))
-            n1 = metric.n1
-            n2 = metric.n2
-            n3 = metric.n3
-            sJ = metric.sJ
-            @test hypot.(n1, n2, n3) ≈ ones(FT, size(n1))
-            @test (
-                [
-                    sJ[ind, 1, :] .* n1[ind, 1, :],
-                    sJ[ind, 1, :] .* n2[ind, 1, :],
-                    sJ[ind, 1, :] .* n3[ind, 1, :],
-                ] ≈ [
-                    -J[1, :, :, :] .* ξ1x1[1, :, :, :],
-                    -J[1, :, :, :] .* ξ1x2[1, :, :, :],
-                    -J[1, :, :, :] .* ξ1x3[1, :, :, :],
-                ]
-            )
-            @test (
-                [
-                    sJ[ind, 2, :] .* n1[ind, 2, :],
-                    sJ[ind, 2, :] .* n2[ind, 2, :],
-                    sJ[ind, 2, :] .* n3[ind, 2, :],
-                ] ≈ [
-                    J[Nq, :, :, :] .* ξ1x1[Nq, :, :, :],
-                    J[Nq, :, :, :] .* ξ1x2[Nq, :, :, :],
-                    J[Nq, :, :, :] .* ξ1x3[Nq, :, :, :],
-                ]
-            )
-            @test sJ[ind, 3, :] .* n1[ind, 3, :] ≈
-                  -J[:, 1, :, :] .* ξ2x1[:, 1, :, :]
-            @test sJ[ind, 3, :] .* n2[ind, 3, :] ≈
-                  -J[:, 1, :, :] .* ξ2x2[:, 1, :, :]
-            @test sJ[ind, 3, :] .* n3[ind, 3, :] ≈
-                  -J[:, 1, :, :] .* ξ2x3[:, 1, :, :]
-            @test sJ[ind, 4, :] .* n1[ind, 4, :] ≈
-                  J[:, Nq, :, :] .* ξ2x1[:, Nq, :, :]
-            @test sJ[ind, 4, :] .* n2[ind, 4, :] ≈
-                  J[:, Nq, :, :] .* ξ2x2[:, Nq, :, :]
-            @test sJ[ind, 4, :] .* n3[ind, 4, :] ≈
-                  J[:, Nq, :, :] .* ξ2x3[:, Nq, :, :]
-            @test sJ[ind, 5, :] .* n1[ind, 5, :] ≈
-                  -J[:, :, 1, :] .* ξ3x1[:, :, 1, :]
-            @test sJ[ind, 5, :] .* n2[ind, 5, :] ≈
-                  -J[:, :, 1, :] .* ξ3x2[:, :, 1, :]
-            @test sJ[ind, 5, :] .* n3[ind, 5, :] ≈
-                  -J[:, :, 1, :] .* ξ3x3[:, :, 1, :]
-            @test sJ[ind, 6, :] .* n1[ind, 6, :] ≈
-                  J[:, :, Nq, :] .* ξ3x1[:, :, Nq, :]
-            @test sJ[ind, 6, :] .* n2[ind, 6, :] ≈
-                  J[:, :, Nq, :] .* ξ3x2[:, :, Nq, :]
-            @test sJ[ind, 6, :] .* n3[ind, 6, :] ≈
-                  J[:, :, Nq, :] .* ξ3x3[:, :, Nq, :]
-        end
-    end
-    #}}}
-
 
     # Constant preserving test
     #{{{
-    for FT in (Float32, Float64)
+    for FT in (Float32, Float64), N in ((5, 5, 5), (3, 4, 5), (4, 4, 5))
+        Nq = N .+ 1
+        Np = prod(Nq)
+        Nfp = div.(Np, Nq)
+
+        dim = length(N)
+        nface = 2dim
+
+        # Create element operators for each polynomial order
+        ξω = ntuple(j -> Elements.lglpoints(FT, N[j]), dim)
+        ξ, ω = ntuple(j -> map(x -> x[j], ξω), 2)
+        D = ntuple(j -> Elements.spectralderivative(ξ[j]), dim)
+
         f(ξ1, ξ2, ξ3) = @.( (
             ξ2 + ξ1 * ξ3 - (ξ1^2 * ξ2^2 * ξ3^2) / 4,
-            ξ3 - ((ξ1 * ξ2 * ξ3) / 2 + 1 / 2)^3 + 1,
-            ξ1 + (ξ1 / 2 + 1 / 2)^6 * (ξ2 / 2 + 1 / 2)^6 * (ξ3 / 2 + 1 / 2)^6,
+            ξ3 - ((ξ1 * ξ2 * ξ3 + 1) / 2)^3 + 1,
+            ξ1 + ((ξ1 + 1) / 2)^6 * ((ξ2 + 1) / 2)^6 * ((ξ3 + 1) / 2)^6,
         ))
-        let
-            N = 5
 
-            ξ1, w = Elements.lglpoints(FT, N)
-            D = Elements.spectralderivative(ξ1)
-            Nq = N + 1
+        e2c = Array{FT, 3}(undef, dim, 8, 1)
+        e2c[:, :, 1] = [
+            -1 1 -1 1 -1 1 -1 1
+            -1 -1 1 1 -1 -1 1 1
+            -1 -1 -1 -1 1 1 1 1
+        ]
 
-            dim = 3
-            nface = 2dim
-            e2c = Array{FT, 3}(undef, dim, 8, 1)
-            e2c[:, :, 1] = [
-                -1 1 -1 1 -1 1 -1 1
-                -1 -1 1 1 -1 -1 1 1
-                -1 -1 -1 -1 1 1 1 1
-            ]
+        nelem = size(e2c, 3)
 
-            nelem = size(e2c, 3)
+        vgeo = Array{FT, 5}(undef, Nq..., length(VGEO3D), nelem)
+        sgeo = Array{FT, 4}(undef, maximum(Nfp), nface, length(SGEO3D), nelem)
+        Metrics.creategrid!(
+            ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
+            e2c,
+            ξ...,
+        )
+        x1 = @view vgeo[:, :, :, VGEO3D.x1, :]
+        x2 = @view vgeo[:, :, :, VGEO3D.x2, :]
+        x3 = @view vgeo[:, :, :, VGEO3D.x3, :]
 
-            vgeo = Array{FT, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
-            sgeo = Array{FT, 4}(undef, Nq^2, nface, length(SGEO3D), nelem)
-            Metrics.creategrid!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), dim)...,
-                e2c,
-                ξ1,
-            )
-            x1 = @view vgeo[:, :, :, VGEO3D.x1, :]
-            x2 = @view vgeo[:, :, :, VGEO3D.x2, :]
-            x3 = @view vgeo[:, :, :, VGEO3D.x3, :]
+        foreach(
+            j -> (x1[j], x2[j], x3[j]) = f(x1[j], x2[j], x3[j]),
+            1:length(x1),
+        )
 
-            foreach(
-                j -> (x1[j], x2[j], x3[j]) = f(x1[j], x2[j], x3[j]),
-                1:length(x1),
-            )
+        Metrics.computemetric!(
+            ntuple(j -> (@view vgeo[:, :, :, j, :]), length(VGEO3D))...,
+            ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
+            D...,
+        )
 
-            Metrics.computemetric!(
-                ntuple(j -> (@view vgeo[:, :, :, j, :]), length(VGEO3D))...,
-                ntuple(j -> (@view sgeo[:, :, j, :]), length(SGEO3D))...,
-                D,
-            )
-            sgeo = reshape(sgeo, Nq, Nq, nface, length(SGEO3D), nelem)
+        (Cx1, Cx2, Cx3) = (zeros(FT, Nq...), zeros(FT, Nq...), zeros(FT, Nq...))
 
-            (Cx1, Cx2, Cx3) = (
-                zeros(FT, Nq, Nq, Nq),
-                zeros(FT, Nq, Nq, Nq),
-                zeros(FT, Nq, Nq, Nq),
-            )
+        J = @view vgeo[:, :, :, VGEO3D.J, :]
+        ξ1x1 = @view vgeo[:, :, :, VGEO3D.ξ1x1, :]
+        ξ1x2 = @view vgeo[:, :, :, VGEO3D.ξ1x2, :]
+        ξ1x3 = @view vgeo[:, :, :, VGEO3D.ξ1x3, :]
+        ξ2x1 = @view vgeo[:, :, :, VGEO3D.ξ2x1, :]
+        ξ2x2 = @view vgeo[:, :, :, VGEO3D.ξ2x2, :]
+        ξ2x3 = @view vgeo[:, :, :, VGEO3D.ξ2x3, :]
+        ξ3x1 = @view vgeo[:, :, :, VGEO3D.ξ3x1, :]
+        ξ3x2 = @view vgeo[:, :, :, VGEO3D.ξ3x2, :]
+        ξ3x3 = @view vgeo[:, :, :, VGEO3D.ξ3x3, :]
 
-            J = @view vgeo[:, :, :, VGEO3D.J, :]
-            ξ1x1 = @view vgeo[:, :, :, VGEO3D.ξ1x1, :]
-            ξ1x2 = @view vgeo[:, :, :, VGEO3D.ξ1x2, :]
-            ξ1x3 = @view vgeo[:, :, :, VGEO3D.ξ1x3, :]
-            ξ2x1 = @view vgeo[:, :, :, VGEO3D.ξ2x1, :]
-            ξ2x2 = @view vgeo[:, :, :, VGEO3D.ξ2x2, :]
-            ξ2x3 = @view vgeo[:, :, :, VGEO3D.ξ2x3, :]
-            ξ3x1 = @view vgeo[:, :, :, VGEO3D.ξ3x1, :]
-            ξ3x2 = @view vgeo[:, :, :, VGEO3D.ξ3x2, :]
-            ξ3x3 = @view vgeo[:, :, :, VGEO3D.ξ3x3, :]
-
-            e = 1
-            for m in 1:Nq
-                for n in 1:Nq
-                    Cx1[:, n, m] += D * (J[:, n, m, e] .* ξ1x1[:, n, m, e])
-                    Cx1[n, :, m] += D * (J[n, :, m, e] .* ξ2x1[n, :, m, e])
-                    Cx1[n, m, :] += D * (J[n, m, :, e] .* ξ3x1[n, m, :, e])
-
-                    Cx2[:, n, m] += D * (J[:, n, m, e] .* ξ1x2[:, n, m, e])
-                    Cx2[n, :, m] += D * (J[n, :, m, e] .* ξ2x2[n, :, m, e])
-                    Cx2[n, m, :] += D * (J[n, m, :, e] .* ξ3x2[n, m, :, e])
-
-                    Cx3[:, n, m] += D * (J[:, n, m, e] .* ξ1x3[:, n, m, e])
-                    Cx3[n, :, m] += D * (J[n, :, m, e] .* ξ2x3[n, :, m, e])
-                    Cx3[n, m, :] += D * (J[n, m, :, e] .* ξ3x3[n, m, :, e])
-                end
+        e = 1
+        for k in 1:Nq[3]
+            for j in 1:Nq[2]
+                Cx1[:, j, k] += D[1] * (J[:, j, k, e] .* ξ1x1[:, j, k, e])
+                Cx2[:, j, k] += D[1] * (J[:, j, k, e] .* ξ1x2[:, j, k, e])
+                Cx3[:, j, k] += D[1] * (J[:, j, k, e] .* ξ1x3[:, j, k, e])
             end
-            @test maximum(abs.(Cx1)) ≤ 1000 * eps(FT)
-            @test maximum(abs.(Cx2)) ≤ 1000 * eps(FT)
-            @test maximum(abs.(Cx3)) ≤ 1000 * eps(FT)
         end
+
+        for k in 1:Nq[3]
+            for i in 1:Nq[1]
+                Cx1[i, :, k] += D[2] * (J[i, :, k, e] .* ξ2x1[i, :, k, e])
+                Cx2[i, :, k] += D[2] * (J[i, :, k, e] .* ξ2x2[i, :, k, e])
+                Cx3[i, :, k] += D[2] * (J[i, :, k, e] .* ξ2x3[i, :, k, e])
+            end
+        end
+
+
+        for j in 1:Nq[2]
+            for i in 1:Nq[1]
+                Cx1[i, j, :] += D[3] * (J[i, j, :, e] .* ξ3x1[i, j, :, e])
+                Cx2[i, j, :] += D[3] * (J[i, j, :, e] .* ξ3x2[i, j, :, e])
+                Cx3[i, j, :] += D[3] * (J[i, j, :, e] .* ξ3x3[i, j, :, e])
+            end
+        end
+        @test maximum(abs.(Cx1)) ≤ 300 * eps(FT)
+        @test maximum(abs.(Cx2)) ≤ 300 * eps(FT)
+        @test maximum(abs.(Cx3)) ≤ 300 * eps(FT)
     end
     #}}}
 end

--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -87,7 +87,8 @@ ClimateMachine.init()
             DeviceArray = Array,
         )
 
-        ξ = ClimateMachine.Mesh.Grids.referencepoints(grid)
+        # XXX: Needs updating for multiple polynomial orders
+        ξ = ClimateMachine.Mesh.Grids.referencepoints(grid)[1]
         a, b = GaussQuadrature.legendre_coefs(T, N)
         V = GaussQuadrature.orthonormal_poly(ξ, a, b)
 

--- a/test/Numerics/Mesh/min_node_distance.jl
+++ b/test/Numerics/Mesh/min_node_distance.jl
@@ -70,7 +70,8 @@ let
                 #   writepvtu(testname, filename.(0:MPI.Comm_size(mpicomm)-1), (), FT)
                 # end
 
-                ξ = referencepoints(grid)
+                # XXX: Needs updating for multiple polynomial orders
+                ξ = referencepoints(grid)[1]
                 hmnd = (ξ[2] - ξ[1]) / (2Neh)
                 vmnd = (ξ[2] - ξ[1]) / (2Nev)
 

--- a/test/Numerics/SystemSolvers/bandedsystem.jl
+++ b/test/Numerics/SystemSolvers/bandedsystem.jl
@@ -99,10 +99,10 @@ let
                         # compute metrics causes problems for the single column approach
                         # (possibly need to not use curl-invariant computation)
                         if !single_column
-                            ξ1 = ξ1 + sin(2π * ξ1 * ξ2) / 10
-                            ξ2 = ξ2 + sin(2π * ξ1) / 5
+                            ξ1 = ξ1 + sin(2 * FT(π) * ξ1 * ξ2) / 10
+                            ξ2 = ξ2 + sin(2 * FT(π) * ξ1) / 5
                             if dim == 3
-                                ξ3 = ξ3 + sin(8π * ξ1 * ξ2) / 10
+                                ξ3 = ξ3 + sin(8 * FT(π) * ξ1 * ξ2) / 10
                             end
                         end
                         (ξ1, ξ2, ξ3)

--- a/test/Ocean/HydrostaticBoussinesq/test_3D_spindown.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_3D_spindown.jl
@@ -7,7 +7,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.VariableTemplates
-using ClimateMachine.Mesh.Grids: polynomialorder
+using ClimateMachine.Mesh.Grids: polynomialorders
 using ClimateMachine.Ocean.HydrostaticBoussinesq
 using ClimateMachine.Ocean.OceanProblems
 
@@ -83,7 +83,12 @@ function run_hydrostatic_test(; imex::Bool = false, BC = nothing, refDat = ())
     driver = config_simple_box(FT, N, resolution, dimensions; BC = BC)
 
     grid = driver.grid
-    vert_filter = CutoffFilter(grid, polynomialorder(grid) - 1)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
+    vert_filter = CutoffFilter(grid, N - 1)
     exp_filter = ExponentialFilter(grid, 1, 8)
     modeldata = (vert_filter = vert_filter, exp_filter = exp_filter)
 

--- a/test/Ocean/ShallowWater/test_2D_spindown.jl
+++ b/test/Ocean/ShallowWater/test_2D_spindown.jl
@@ -6,7 +6,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.VariableTemplates
-using ClimateMachine.Mesh.Grids: polynomialorder
+using ClimateMachine.Mesh.Grids: polynomialorders
 using ClimateMachine.Ocean.ShallowWater
 using ClimateMachine.Ocean.OceanProblems
 

--- a/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
+++ b/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
@@ -99,7 +99,12 @@ function setup_models(
         c = FT(1),
     )
 
-    vert_filter = CutoffFilter(grid_3D, polynomialorder(grid_3D) - 1)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid_3D)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
+    vert_filter = CutoffFilter(grid_3D, N - 1)
     exp_filter = ExponentialFilter(grid_3D, 1, 8)
 
     integral_model = DGModel(

--- a/test/Ocean/SplitExplicit/split_explicit.jl
+++ b/test/Ocean/SplitExplicit/split_explicit.jl
@@ -5,7 +5,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.VariableTemplates
-using ClimateMachine.Mesh.Grids: polynomialorder
+using ClimateMachine.Mesh.Grids: polynomialorders
 using ClimateMachine.Ocean
 using ClimateMachine.Ocean.HydrostaticBoussinesq
 using ClimateMachine.Ocean.ShallowWater

--- a/test/Ocean/SplitExplicit/test_vertical_integral_model.jl
+++ b/test/Ocean/SplitExplicit/test_vertical_integral_model.jl
@@ -6,7 +6,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.VariableTemplates
-using ClimateMachine.Mesh.Grids: polynomialorder
+using ClimateMachine.Mesh.Grids: polynomialorders
 using ClimateMachine.Ocean.HydrostaticBoussinesq
 using ClimateMachine.Ocean.ShallowWater
 using ClimateMachine.Ocean.SplitExplicit: VerticalIntegralModel

--- a/test/Utilities/SingleStackUtils/ssu_tests.jl
+++ b/test/Utilities/SingleStackUtils/ssu_tests.jl
@@ -59,30 +59,42 @@ function init_state_prognostic!(
 end
 
 function test_hmean(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     vars,
-) where {T, dim, N}
+) where {T, dim, Ns}
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
     state_vars_avg = get_horizontal_mean(grid, Q, vars)
     target = target_meanprof(grid)
     @test state_vars_avg["ρ"] ≈ target
 end
 
 function test_hvar(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     vars,
-) where {T, dim, N}
+) where {T, dim, Ns}
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
     state_vars_var = get_horizontal_variance(grid, Q, vars)
     target = target_varprof(grid)
     @test state_vars_var["ρ"] ≈ target
 end
 
 function test_horizontally_ave(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
     Q_in::MPIStateArray,
     vars,
-) where {T, dim, N}
+) where {T, dim, Ns}
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
     Q = deepcopy(Q_in)
     state_vars_var = get_horizontal_variance(grid, Q, vars)
     i_vars = varsindex(vars, :ρ)
@@ -93,8 +105,12 @@ function test_horizontally_ave(
 end
 
 function target_meanprof(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
-) where {T, dim, N}
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
+) where {T, dim, Ns}
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
     Nq = N + 1
     Ntot = Nq * grid.topology.stacksize
     z = Array(get_z(grid))
@@ -104,8 +120,12 @@ function target_meanprof(
 end
 
 function target_varprof(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
-) where {T, dim, N}
+    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
+) where {T, dim, Ns}
+    # XXX: Needs updating for multiple polynomial orders
+    # Currently only support single polynomial order
+    @assert all(Ns[1] .== Ns)
+    N = Ns[1]
     Nq = N + 1
     nvertelem = grid.topology.stacksize
     Ntot = Nq * nvertelem


### PR DESCRIPTION
Update the mesh interface to support multiple polynomial orders in the mesh
construction (derivative matrices, quadrature rules, metrics terms,
connectivities between grid degrees of freedom)

The main user facing changes are that the `DiscontinuousSpectralElementGrid`
type now contains tuples of arrays for the

  - derivative matrix `D`
  - quadrature weights `ω`
  - indefinite integral operator `Imat`

(one element of for the operator for each the reference element directions)

The keyword argument `polynomialorder` of the `DiscontinuousSpectralElementGrid`
constructor can now either be an

  - `Int` in which case all dimension have the same polynomial order
  - `Ntuple{dim, Int}` corresponding to the polynomial order for each reference
    dimension
  - `Ntuple{2, Int}` if the mesh dimensionality is `3`, in which case the first
    argument is taken to the two horizontal polynomial orders (`ξ1` and `ξ2`)
    and the second is taken to be the vertical polynomial order (`ξ3`)

When the connectivity is constructed if the given polynomial orders will not
result in a conformal mesh then an error is thrown; note this implies that for
the cubed sphere mesh the polynomial orders must be the same in both horizontal
directions.

The `sgeo` data structure uses suboptimal storage in that it is of size
`(_nsgeo, maximum(Nfp), nface, nelem)` where 

  - `_nsgeo` is the number of surface metric terms
  - `Nfp` is the number of face points on each face
    (`Nfp = prod(Nq) ./ Nq` where `Nq = N .+ 1`)
  - `nface` is the number of reference element faces
  - `nelem` is the number of elements

This storage is suboptimal since `Nfp` is not constant for all the faces. A more
optimal storage pattern might be `(_nsgeo, 2prod(Nfp), nelem)` but this will
make the indexing into the array more complicated; possible future optimization.
Elements of `sgeo` that are not valid are set to `NaN`

Note that the no where in the actual compute kernels use the multiple polynomial
orders, this PR only updates the mesh data structure itself. Places where the
same polynomial order in all dimension needed to be assumed due to changes from
this PR are marked with the comment
```
# XXX: Needs updating for multiple polynomial orders
```
