### PR TITLE
Add cd in the instructions - just for quick copy/paste

### DIFF
--- a/docs/src/GettingStarted/Installation.md
+++ b/docs/src/GettingStarted/Installation.md
@@ -44,8 +44,13 @@ Download the `ClimateMachine`
 $ git clone https://github.com/CliMA/ClimateMachine.jl
 ```
 
-Now change into the `ClimateMachine.jl` directory and install all the packages
-required with:
+Now change into the `ClimateMachine.jl` directory with 
+
+```
+$ cd ClimateMachine.jl
+```
+
+and install all the required packages with:
 
 ```
 $ julia --project -e 'using Pkg; pkg"instantiate"; pkg"build MPI"'


### PR DESCRIPTION
My very first and very quick PR! 

### Description

This just adds the code snippet for the "change directory" instruction, that was previously expressed in words. I found myself doing just quick copy&paste of the code parts, and if someone doesn't note the written part, this wouldn't work. So it's just to allow easy reproducibility of the instructions.

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
