### PR TITLE
Decompose discretization kernels into horizontal and vertical calls

### DIFF
--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -59,8 +59,6 @@ include("remainder.jl")
 
 function basic_grid_info(dg::DGModel)
     grid = dg.grid
-    topology = grid.topology
-
     dim = dimensionality(grid)
     # XXX: Needs updating for multiple polynomial orders
     N = polynomialorders(grid)
@@ -73,22 +71,29 @@ function basic_grid_info(dg::DGModel)
     Nfp = Nq * Nqk
     Np = dofs_per_element(grid)
 
-    nelem = length(topology.elems)
-    nvertelem = topology.stacksize
-    nhorzelem = div(nelem, nvertelem)
-    nrealelem = length(topology.realelems)
-    nhorzrealelem = div(nrealelem, nvertelem)
+    topology_info = basic_topology_info(grid.topology)
 
-    return (
+    ninteriorelem = length(dg.grid.interiorelems)
+    nexteriorelem = length(dg.grid.exteriorelems)
+
+    grid_info = (
+        dim = dim,
+        N = N,
         Nq = Nq,
         Nqk = Nqk,
         Nfp = Nfp,
         Np = Np,
-        nvertelem = nvertelem,
-        nhorzelem = nhorzelem,
-        nhorzrealelem = nhorzrealelem,
-        nrealelem = nrealelem,
+        ninteriorelem = ninteriorelem,
+        nexteriorelem = nexteriorelem,
     )
+
+    return merge(grid_info, topology_info)
+end
+
+function basic_launch_info(dg::DGModel)
+    device = array_device(dg.state_auxiliary)
+    grid_info = basic_grid_info(dg)
+    return merge(grid_info, (device = device,))
 end
 
 """
@@ -110,43 +115,16 @@ end
 
 function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
 
-    balance_law = dg.balance_law
     device = array_device(state_prognostic)
-
-    grid = dg.grid
-    topology = grid.topology
-
-    dim = dimensionality(grid)
-    # XXX: Needs updating for multiple polynomial orders
-    N = polynomialorders(grid)
-    # Currently only support single polynomial order
-    @assert all(N[1] .== N)
-    N = N[1]
-
-    Nq = N + 1
-    Nqk = dim == 2 ? 1 : Nq
-    Nfp = Nq * Nqk
-    nrealelem = length(topology.realelems)
-
-    state_gradient_flux = dg.state_gradient_flux
     Qhypervisc_grad, Qhypervisc_div = dg.states_higher_order
-    state_auxiliary = dg.state_auxiliary
 
     FT = eltype(state_prognostic)
-    num_state_prognostic = number_states(balance_law, Prognostic())
-    num_state_gradient_flux = number_states(balance_law, GradientFlux())
-    nhyperviscstate = number_states(balance_law, Hyperdiffusive())
+    num_state_prognostic = number_states(dg.balance_law, Prognostic())
+    num_state_gradient_flux = number_states(dg.balance_law, GradientFlux())
+    nhyperviscstate = number_states(dg.balance_law, Hyperdiffusive())
     num_state_tendency = size(tendency, 2)
 
     @assert num_state_prognostic ≤ num_state_tendency
-
-    Np = dofs_per_element(grid)
-
-    workgroups_volume = (Nq, Nq, Nqk)
-    ndrange_volume = (nrealelem * Nq, Nq, Nqk)
-    workgroups_surface = Nfp
-    ndrange_interior_surface = Nfp * length(grid.interiorelems)
-    ndrange_exterior_surface = Nfp * length(grid.exteriorelems)
 
     if num_state_prognostic < num_state_tendency && β != 1
         # if we don't operate on the full state, then we need to scale here instead of volume_tendency!
@@ -155,24 +133,18 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
     end
 
     communicate =
-        !(isstacked(topology) && typeof(dg.direction) <: VerticalDirection)
+        !(
+            isstacked(dg.grid.topology) &&
+            typeof(dg.direction) <: VerticalDirection
+        )
 
     update_auxiliary_state!(
         dg,
-        balance_law,
+        dg.balance_law,
         state_prognostic,
         t,
         dg.grid.topology.realelems,
     )
-
-    if nhyperviscstate > 0
-        hypervisc_indexmap = varsindices(
-            vars_state(balance_law, Gradient(), FT),
-            fieldnames(vars_state(balance_law, GradientLaplacian(), FT)),
-        )
-    else
-        hypervisc_indexmap = nothing
-    end
 
     exchange_state_prognostic = NoneEvent()
     exchange_state_gradient_flux = NoneEvent()
@@ -181,9 +153,6 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
 
     comp_stream = Event(device)
 
-    ########################
-    # Gradient Computation #
-    ########################
     if communicate
         exchange_state_prognostic = MPIStateArrays.begin_ghost_exchange!(
             state_prognostic;
@@ -192,46 +161,23 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
     end
 
     if num_state_gradient_flux > 0 || nhyperviscstate > 0
+        ########################
+        # Gradient Computation #
+        ########################
 
-        comp_stream = volume_gradients!(device, (Nq, Nq))(
-            balance_law,
-            Val(dim),
-            Val(N),
-            dg.diffusion_direction,
-            state_prognostic.data,
-            state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            state_auxiliary.data,
-            grid.vgeo,
-            t,
-            # XXX: Needs updating for multiple polynomial orders
-            grid.D[1],
-            Val(hypervisc_indexmap),
-            topology.realelems,
-            ndrange = (Nq * nrealelem, Nq),
-            dependencies = (comp_stream,),
+        comp_stream = launch_volume_gradients!(
+            dg,
+            state_prognostic,
+            t;
+            dependencies = comp_stream,
         )
 
-        comp_stream = interface_gradients!(device, workgroups_surface)(
-            balance_law,
-            Val(dim),
-            Val(N),
-            dg.diffusion_direction,
-            dg.numerical_flux_gradient,
-            state_prognostic.data,
-            state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            state_auxiliary.data,
-            grid.vgeo,
-            grid.sgeo,
-            t,
-            grid.vmap⁻,
-            grid.vmap⁺,
-            grid.elemtobndy,
-            Val(hypervisc_indexmap),
-            grid.interiorelems;
-            ndrange = ndrange_interior_surface,
-            dependencies = (comp_stream,),
+        comp_stream = launch_interface_gradients!(
+            dg,
+            state_prognostic,
+            t;
+            surface = :interior,
+            dependencies = comp_stream,
         )
 
         if communicate
@@ -245,7 +191,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             wait(device, exchange_state_prognostic)
             update_auxiliary_state!(
                 dg,
-                balance_law,
+                dg.balance_law,
                 state_prognostic,
                 t,
                 dg.grid.topology.ghostelems,
@@ -253,25 +199,11 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             exchange_state_prognostic = Event(device)
         end
 
-        comp_stream = interface_gradients!(device, workgroups_surface)(
-            balance_law,
-            Val(dim),
-            Val(N),
-            dg.diffusion_direction,
-            dg.numerical_flux_gradient,
-            state_prognostic.data,
-            state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            state_auxiliary.data,
-            grid.vgeo,
-            grid.sgeo,
-            t,
-            grid.vmap⁻,
-            grid.vmap⁺,
-            grid.elemtobndy,
-            Val(hypervisc_indexmap),
-            grid.exteriorelems;
-            ndrange = ndrange_exterior_surface,
+        comp_stream = launch_interface_gradients!(
+            dg,
+            state_prognostic,
+            t;
+            surface = :exterior,
             dependencies = (comp_stream, exchange_state_prognostic),
         )
 
@@ -279,7 +211,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             if num_state_gradient_flux > 0
                 exchange_state_gradient_flux =
                     MPIStateArrays.begin_ghost_exchange!(
-                        state_gradient_flux,
+                        dg.state_gradient_flux,
                         dependencies = comp_stream,
                     )
             end
@@ -297,7 +229,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             wait(device, comp_stream)
             update_auxiliary_state_gradient!(
                 dg,
-                balance_law,
+                dg.balance_law,
                 state_prognostic,
                 t,
                 dg.grid.topology.realelems,
@@ -311,40 +243,20 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
         # Laplacian Computation #
         #########################
 
-        comp_stream =
-            volume_divergence_of_gradients!(device, workgroups_volume)(
-                balance_law,
-                Val(dim),
-                Val(N),
-                dg.diffusion_direction,
-                Qhypervisc_grad.data,
-                Qhypervisc_div.data,
-                grid.vgeo,
-                # XXX: Needs updating for multiple polynomial orders
-                grid.D[1],
-                topology.realelems;
-                ndrange = ndrange_volume,
-                dependencies = (comp_stream,),
-            )
+        comp_stream = launch_volume_divergence_of_gradients!(
+            dg,
+            state_prognostic,
+            t;
+            dependencies = comp_stream,
+        )
 
-        comp_stream =
-            interface_divergence_of_gradients!(device, workgroups_surface)(
-                balance_law,
-                Val(dim),
-                Val(N),
-                dg.diffusion_direction,
-                CentralNumericalFluxDivergence(),
-                Qhypervisc_grad.data,
-                Qhypervisc_div.data,
-                grid.vgeo,
-                grid.sgeo,
-                grid.vmap⁻,
-                grid.vmap⁺,
-                grid.elemtobndy,
-                grid.interiorelems;
-                ndrange = ndrange_interior_surface,
-                dependencies = (comp_stream,),
-            )
+        comp_stream = launch_interface_divergence_of_gradients!(
+            dg,
+            state_prognostic,
+            t;
+            surface = :interior,
+            dependencies = comp_stream,
+        )
 
         if communicate
             exchange_Qhypervisc_grad = MPIStateArrays.end_ghost_exchange!(
@@ -353,24 +265,13 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             )
         end
 
-        comp_stream =
-            interface_divergence_of_gradients!(device, workgroups_surface)(
-                balance_law,
-                Val(dim),
-                Val(N),
-                dg.diffusion_direction,
-                CentralNumericalFluxDivergence(),
-                Qhypervisc_grad.data,
-                Qhypervisc_div.data,
-                grid.vgeo,
-                grid.sgeo,
-                grid.vmap⁻,
-                grid.vmap⁺,
-                grid.elemtobndy,
-                grid.exteriorelems;
-                ndrange = ndrange_exterior_surface,
-                dependencies = (comp_stream, exchange_Qhypervisc_grad),
-            )
+        comp_stream = launch_interface_divergence_of_gradients!(
+            dg,
+            state_prognostic,
+            t;
+            surface = :exterior,
+            dependencies = (comp_stream, exchange_Qhypervisc_grad),
+        )
 
         if communicate
             exchange_Qhypervisc_div = MPIStateArrays.begin_ghost_exchange!(
@@ -383,47 +284,20 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
         # Hyperdiffusive terms computation #
         ####################################
 
-        comp_stream =
-            volume_gradients_of_laplacians!(device, workgroups_volume)(
-                balance_law,
-                Val(dim),
-                Val(N),
-                dg.diffusion_direction,
-                Qhypervisc_grad.data,
-                Qhypervisc_div.data,
-                state_prognostic.data,
-                state_auxiliary.data,
-                grid.vgeo,
-                # XXX: Needs updating for multiple polynomial orders
-                grid.ω[1],
-                grid.D[1],
-                topology.realelems,
-                t;
-                ndrange = ndrange_volume,
-                dependencies = (comp_stream,),
-            )
+        comp_stream = launch_volume_gradients_of_laplacians!(
+            dg,
+            state_prognostic,
+            t,
+            dependencies = (comp_stream,),
+        )
 
-        comp_stream =
-            interface_gradients_of_laplacians!(device, workgroups_surface)(
-                balance_law,
-                Val(dim),
-                Val(N),
-                dg.diffusion_direction,
-                CentralNumericalFluxHigherOrder(),
-                Qhypervisc_grad.data,
-                Qhypervisc_div.data,
-                state_prognostic.data,
-                state_auxiliary.data,
-                grid.vgeo,
-                grid.sgeo,
-                grid.vmap⁻,
-                grid.vmap⁺,
-                grid.elemtobndy,
-                grid.interiorelems,
-                t;
-                ndrange = ndrange_interior_surface,
-                dependencies = (comp_stream,),
-            )
+        comp_stream = launch_interface_gradients_of_laplacians!(
+            dg,
+            state_prognostic,
+            t;
+            surface = :interior,
+            dependencies = (comp_stream,),
+        )
 
         if communicate
             exchange_Qhypervisc_div = MPIStateArrays.end_ghost_exchange!(
@@ -432,27 +306,13 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             )
         end
 
-        comp_stream =
-            interface_gradients_of_laplacians!(device, workgroups_surface)(
-                balance_law,
-                Val(dim),
-                Val(N),
-                dg.diffusion_direction,
-                CentralNumericalFluxHigherOrder(),
-                Qhypervisc_grad.data,
-                Qhypervisc_div.data,
-                state_prognostic.data,
-                state_auxiliary.data,
-                grid.vgeo,
-                grid.sgeo,
-                grid.vmap⁻,
-                grid.vmap⁺,
-                grid.elemtobndy,
-                grid.exteriorelems,
-                t;
-                ndrange = ndrange_exterior_surface,
-                dependencies = (comp_stream, exchange_Qhypervisc_div),
-            )
+        comp_stream = launch_interface_gradients_of_laplacians!(
+            dg,
+            state_prognostic,
+            t;
+            surface = :exterior,
+            dependencies = (comp_stream, exchange_Qhypervisc_div),
+        )
 
         if communicate
             exchange_Qhypervisc_grad = MPIStateArrays.begin_ghost_exchange!(
@@ -466,49 +326,24 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
     ###################
     # RHS Computation #
     ###################
-    comp_stream = volume_tendency!(device, (Nq, Nq))(
-        balance_law,
-        Val(dim),
-        Val(N),
-        dg.direction,
-        tendency.data,
-        state_prognostic.data,
-        state_gradient_flux.data,
-        Qhypervisc_grad.data,
-        state_auxiliary.data,
-        grid.vgeo,
+    comp_stream = launch_volume_tendency!(
+        dg,
+        tendency,
+        state_prognostic,
         t,
-        # XXX: Needs updating for multiple polynomial orders
-        grid.ω[1],
-        grid.D[1],
-        topology.realelems,
         α,
         β;
-        ndrange = (nrealelem * Nq, Nq),
         dependencies = (comp_stream,),
     )
 
-    comp_stream = interface_tendency!(device, workgroups_surface)(
-        balance_law,
-        Val(dim),
-        Val(N),
-        dg.direction,
-        dg.numerical_flux_first_order,
-        dg.numerical_flux_second_order,
-        tendency.data,
-        state_prognostic.data,
-        state_gradient_flux.data,
-        Qhypervisc_grad.data,
-        state_auxiliary.data,
-        grid.vgeo,
-        grid.sgeo,
+    comp_stream = launch_interface_tendency!(
+        dg,
+        tendency,
+        state_prognostic,
         t,
-        grid.vmap⁻,
-        grid.vmap⁺,
-        grid.elemtobndy,
-        grid.interiorelems,
-        α;
-        ndrange = ndrange_interior_surface,
+        α,
+        β;
+        surface = :interior,
         dependencies = (comp_stream,),
     )
 
@@ -517,7 +352,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             if num_state_gradient_flux > 0
                 exchange_state_gradient_flux =
                     MPIStateArrays.end_ghost_exchange!(
-                        state_gradient_flux;
+                        dg.state_gradient_flux;
                         dependencies = exchange_state_gradient_flux,
                     )
 
@@ -527,7 +362,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
                 wait(device, exchange_state_gradient_flux)
                 update_auxiliary_state_gradient!(
                     dg,
-                    balance_law,
+                    dg.balance_law,
                     state_prognostic,
                     t,
                     dg.grid.topology.ghostelems,
@@ -551,7 +386,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             wait(device, exchange_state_prognostic)
             update_auxiliary_state!(
                 dg,
-                balance_law,
+                dg.balance_law,
                 state_prognostic,
                 t,
                 dg.grid.topology.ghostelems,
@@ -560,27 +395,14 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
         end
     end
 
-    comp_stream = interface_tendency!(device, workgroups_surface)(
-        balance_law,
-        Val(dim),
-        Val(N),
-        dg.direction,
-        dg.numerical_flux_first_order,
-        dg.numerical_flux_second_order,
-        tendency.data,
-        state_prognostic.data,
-        state_gradient_flux.data,
-        Qhypervisc_grad.data,
-        state_auxiliary.data,
-        grid.vgeo,
-        grid.sgeo,
+    comp_stream = launch_interface_tendency!(
+        dg,
+        tendency,
+        state_prognostic,
         t,
-        grid.vmap⁻,
-        grid.vmap⁺,
-        grid.elemtobndy,
-        grid.exteriorelems,
-        α;
-        ndrange = ndrange_exterior_surface,
+        α,
+        β;
+        surface = :exterior,
         dependencies = (
             comp_stream,
             exchange_state_prognostic,
@@ -1085,4 +907,655 @@ function continuous_field_gradient!(
         dependencies = (event,),
     )
     wait(device, event)
+end
+
+function hyperdiff_indexmap(balance_law, ::Type{FT}) where {FT}
+    ns_hyperdiff = number_states(balance_law, Hyperdiffusive())
+    if ns_hyperdiff > 0
+        return varsindices(
+            vars_state(balance_law, Gradient(), FT),
+            fieldnames(vars_state(balance_law, GradientLaplacian(), FT)),
+        )
+    else
+        return nothing
+    end
+end
+
+"""
+    launch_volume_gradients!(dg, state_prognostic, t; dependencies)
+
+Launches horizontal and vertical kernels for computing the volume gradients.
+"""
+function launch_volume_gradients!(dg, state_prognostic, t; dependencies)
+    FT = eltype(state_prognostic)
+    Qhypervisc_grad, _ = dg.states_higher_order
+
+    info = basic_launch_info(dg)
+    workgroup = (info.Nq, info.Nq)
+    ndrange = (info.Nq * info.nrealelem, info.Nq)
+    comp_stream = dependencies
+
+    # If the model direction is EveryDirection, we need to perform
+    # both horizontal AND vertical kernel calls; otherwise, we only
+    # call the kernel corresponding to the model direction `dg.diffusion_direction`
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa HorizontalDirection
+        comp_stream = volume_gradients!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            HorizontalDirection(),
+            state_prognostic.data,
+            dg.state_gradient_flux.data,
+            Qhypervisc_grad.data,
+            dg.state_auxiliary.data,
+            dg.grid.vgeo,
+            t,
+            # XXX: Needs updating for multiple polynomial orders
+            dg.grid.D[1],
+            Val(hyperdiff_indexmap(dg.balance_law, FT)),
+            dg.grid.topology.realelems,
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+
+    # Now we call the kernel corresponding to the vertical direction
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa VerticalDirection
+        comp_stream = volume_gradients!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            VerticalDirection(),
+            state_prognostic.data,
+            dg.state_gradient_flux.data,
+            Qhypervisc_grad.data,
+            dg.state_auxiliary.data,
+            dg.grid.vgeo,
+            t,
+            # XXX: Needs updating for multiple polynomial orders
+            dg.grid.D[1],
+            Val(hyperdiff_indexmap(dg.balance_law, FT)),
+            dg.grid.topology.realelems,
+            # If we are computing the volume gradient in every direction, we
+            # need to increment into the appropriate fields _after_ the
+            # horizontal computation.
+            !(dg.diffusion_direction isa VerticalDirection),
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+    return comp_stream
+end
+
+"""
+    launch_interface_gradients!(dg, state_prognostic, t; surface::Symbol, dependencies)
+
+Launches horizontal and vertical kernels for computing the interface gradients.
+The argument `surface` is either `:interior` or `:exterior`, which denotes whether
+we are computing interface gradients on boundaries which are interior (exterior resp.)
+to the _parallel_ boundary.
+"""
+function launch_interface_gradients!(
+    dg,
+    state_prognostic,
+    t;
+    surface::Symbol,
+    dependencies,
+)
+    @assert surface === :interior || surface === :exterior
+
+    FT = eltype(state_prognostic)
+    Qhypervisc_grad, _ = dg.states_higher_order
+
+    info = basic_launch_info(dg)
+    workgroup = info.Nfp
+    if surface === :interior
+        elems = dg.grid.interiorelems
+        ndrange = info.Nfp * info.ninteriorelem
+    else
+        elems = dg.grid.exteriorelems
+        ndrange = info.Nfp * info.nexteriorelem
+    end
+
+    comp_stream = dependencies
+
+    # If the model direction is EveryDirection, we need to perform
+    # both horizontal AND vertical kernel calls; otherwise, we only
+    # call the kernel corresponding to the model direction `dg.diffusion_direction`
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa HorizontalDirection
+        comp_stream = interface_gradients!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            HorizontalDirection(),
+            dg.numerical_flux_gradient,
+            state_prognostic.data,
+            dg.state_gradient_flux.data,
+            Qhypervisc_grad.data,
+            dg.state_auxiliary.data,
+            dg.grid.vgeo,
+            dg.grid.sgeo,
+            t,
+            dg.grid.vmap⁻,
+            dg.grid.vmap⁺,
+            dg.grid.elemtobndy,
+            Val(hyperdiff_indexmap(dg.balance_law, FT)),
+            elems;
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+
+    # Vertical interface kernel call
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa VerticalDirection
+        comp_stream = interface_gradients!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            VerticalDirection(),
+            dg.numerical_flux_gradient,
+            state_prognostic.data,
+            dg.state_gradient_flux.data,
+            Qhypervisc_grad.data,
+            dg.state_auxiliary.data,
+            dg.grid.vgeo,
+            dg.grid.sgeo,
+            t,
+            dg.grid.vmap⁻,
+            dg.grid.vmap⁺,
+            dg.grid.elemtobndy,
+            Val(hyperdiff_indexmap(dg.balance_law, FT)),
+            elems;
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+    return comp_stream
+end
+
+"""
+    launch_volume_divergence_of_gradients!(dg, state_prognostic, t; dependencies)
+
+Launches horizontal and vertical volume kernels for computing the divergence of gradients.
+"""
+function launch_volume_divergence_of_gradients!(
+    dg,
+    state_prognostic,
+    t;
+    dependencies,
+)
+    Qhypervisc_grad, Qhypervisc_div = dg.states_higher_order
+
+    info = basic_launch_info(dg)
+    workgroup = (info.Nq, info.Nq, info.Nqk)
+    ndrange = (info.nrealelem * info.Nq, info.Nq, info.Nqk)
+    comp_stream = dependencies
+
+    # If the model direction is EveryDirection, we need to perform
+    # both horizontal AND vertical kernel calls; otherwise, we only
+    # call the kernel corresponding to the model direction `dg.diffusion_direction`
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa HorizontalDirection
+        comp_stream = volume_divergence_of_gradients!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            HorizontalDirection(),
+            Qhypervisc_grad.data,
+            Qhypervisc_div.data,
+            dg.grid.vgeo,
+            # XXX: Needs updating for multiple polynomial orders
+            dg.grid.D[1],
+            dg.grid.topology.realelems;
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+
+    # And now the vertical kernel call
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa VerticalDirection
+        comp_stream = volume_divergence_of_gradients!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            VerticalDirection(),
+            Qhypervisc_grad.data,
+            Qhypervisc_div.data,
+            dg.grid.vgeo,
+            # XXX: Needs updating for multiple polynomial orders
+            dg.grid.D[1],
+            dg.grid.topology.realelems,
+            # If we are computing the volume gradient in every direction, we
+            # need to increment into the appropriate fields _after_ the
+            # horizontal computation.
+            !(dg.diffusion_direction isa VerticalDirection);
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+    return comp_stream
+end
+
+"""
+    launch_interface_divergence_of_gradients!(dg, state_prognostic, t; surface::Symbol, dependencies)
+
+Launches horizontal and vertical interface kernels for computing the divergence of gradients.
+The argument `surface` is either `:interior` or `:exterior`, which denotes whether
+we are computing values on boundaries which are interior (exterior resp.)
+to the _parallel_ boundary.
+"""
+function launch_interface_divergence_of_gradients!(
+    dg,
+    state_prognostic,
+    t;
+    surface::Symbol,
+    dependencies,
+)
+    @assert surface === :interior || surface === :exterior
+    Qhypervisc_grad, Qhypervisc_div = dg.states_higher_order
+
+    info = basic_launch_info(dg)
+    workgroup = info.Nfp
+    if surface === :interior
+        elems = dg.grid.interiorelems
+        ndrange = info.Nfp * info.ninteriorelem
+    else
+        elems = dg.grid.exteriorelems
+        ndrange = info.Nfp * info.nexteriorelem
+    end
+    comp_stream = dependencies
+
+    # If the model direction is EveryDirection, we need to perform
+    # both horizontal AND vertical kernel calls; otherwise, we only
+    # call the kernel corresponding to the model direction `dg.diffusion_direction`
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa HorizontalDirection
+        comp_stream =
+            interface_divergence_of_gradients!(info.device, workgroup)(
+                dg.balance_law,
+                Val(info.dim),
+                Val(info.N),
+                HorizontalDirection(),
+                CentralNumericalFluxDivergence(),
+                Qhypervisc_grad.data,
+                Qhypervisc_div.data,
+                dg.grid.vgeo,
+                dg.grid.sgeo,
+                dg.grid.vmap⁻,
+                dg.grid.vmap⁺,
+                dg.grid.elemtobndy,
+                elems;
+                ndrange = ndrange,
+                dependencies = comp_stream,
+            )
+    end
+
+    # Vertical kernel call
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa VerticalDirection
+        comp_stream =
+            interface_divergence_of_gradients!(info.device, workgroup)(
+                dg.balance_law,
+                Val(info.dim),
+                Val(info.N),
+                VerticalDirection(),
+                CentralNumericalFluxDivergence(),
+                Qhypervisc_grad.data,
+                Qhypervisc_div.data,
+                dg.grid.vgeo,
+                dg.grid.sgeo,
+                dg.grid.vmap⁻,
+                dg.grid.vmap⁺,
+                dg.grid.elemtobndy,
+                elems;
+                ndrange = ndrange,
+                dependencies = comp_stream,
+            )
+    end
+
+    return comp_stream
+end
+
+"""
+    launch_volume_gradients_of_laplacians!(dg, state_prognostic, t; dependencies)
+
+Launches horizontal and vertical volume kernels for computing the DG gradient of
+a second-order DG gradient (Laplacian).
+"""
+function launch_volume_gradients_of_laplacians!(
+    dg,
+    state_prognostic,
+    t;
+    dependencies,
+)
+    Qhypervisc_grad, Qhypervisc_div = dg.states_higher_order
+
+    info = basic_launch_info(dg)
+    workgroup = (info.Nq, info.Nq, info.Nqk)
+    ndrange = (info.nrealelem * info.Nq, info.Nq, info.Nqk)
+    comp_stream = dependencies
+
+    # If the model direction is EveryDirection, we need to perform
+    # both horizontal AND vertical kernel calls; otherwise, we only
+    # call the kernel corresponding to the model direction `dg.diffusion_direction`
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa HorizontalDirection
+        comp_stream = volume_gradients_of_laplacians!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            HorizontalDirection(),
+            Qhypervisc_grad.data,
+            Qhypervisc_div.data,
+            state_prognostic.data,
+            dg.state_auxiliary.data,
+            dg.grid.vgeo,
+            # XXX: Needs updating for multiple polynomial orders
+            dg.grid.ω[1],
+            dg.grid.D[1],
+            dg.grid.topology.realelems,
+            t;
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+
+    # Vertical kernel call
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa VerticalDirection
+        comp_stream = volume_gradients_of_laplacians!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            VerticalDirection(),
+            Qhypervisc_grad.data,
+            Qhypervisc_div.data,
+            state_prognostic.data,
+            dg.state_auxiliary.data,
+            dg.grid.vgeo,
+            # XXX: Needs updating for multiple polynomial orders
+            dg.grid.ω[1],
+            dg.grid.D[1],
+            dg.grid.topology.realelems,
+            t,
+            # If we are computing the volume gradient in every direction, we
+            # need to increment into the appropriate fields _after_ the
+            # horizontal computation.
+            !(dg.diffusion_direction isa VerticalDirection);
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+
+    return comp_stream
+end
+
+"""
+    launch_interface_gradients_of_laplacians!(dg, state_prognostic, t; surface::Symbol, dependencies)
+
+Launches horizontal and vertical interface kernels for computing the gradients of Laplacians
+(second-order gradients). The argument `surface` is either `:interior` or `:exterior`,
+which denotes whether we are computing values on boundaries which are interior (exterior resp.)
+to the _parallel_ boundary.
+"""
+function launch_interface_gradients_of_laplacians!(
+    dg,
+    state_prognostic,
+    t;
+    surface::Symbol,
+    dependencies,
+)
+    @assert surface === :interior || surface === :exterior
+    Qhypervisc_grad, Qhypervisc_div = dg.states_higher_order
+
+    info = basic_launch_info(dg)
+    workgroup = info.Nfp
+    if surface === :interior
+        elems = dg.grid.interiorelems
+        ndrange = info.Nfp * info.ninteriorelem
+    else
+        elems = dg.grid.exteriorelems
+        ndrange = info.Nfp * info.nexteriorelem
+    end
+
+    comp_stream = dependencies
+
+    # If the model direction is EveryDirection, we need to perform
+    # both horizontal AND vertical kernel calls; otherwise, we only
+    # call the kernel corresponding to the model direction `dg.diffusion_direction`
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa HorizontalDirection
+        comp_stream =
+            interface_gradients_of_laplacians!(info.device, workgroup)(
+                dg.balance_law,
+                Val(info.dim),
+                Val(info.N),
+                HorizontalDirection(),
+                CentralNumericalFluxHigherOrder(),
+                Qhypervisc_grad.data,
+                Qhypervisc_div.data,
+                state_prognostic.data,
+                dg.state_auxiliary.data,
+                dg.grid.vgeo,
+                dg.grid.sgeo,
+                dg.grid.vmap⁻,
+                dg.grid.vmap⁺,
+                dg.grid.elemtobndy,
+                elems,
+                t;
+                ndrange = ndrange,
+                dependencies = comp_stream,
+            )
+    end
+
+    # Vertical kernel call
+    if dg.diffusion_direction isa EveryDirection ||
+       dg.diffusion_direction isa VerticalDirection
+        comp_stream =
+            interface_gradients_of_laplacians!(info.device, workgroup)(
+                dg.balance_law,
+                Val(info.dim),
+                Val(info.N),
+                VerticalDirection(),
+                CentralNumericalFluxHigherOrder(),
+                Qhypervisc_grad.data,
+                Qhypervisc_div.data,
+                state_prognostic.data,
+                dg.state_auxiliary.data,
+                dg.grid.vgeo,
+                dg.grid.sgeo,
+                dg.grid.vmap⁻,
+                dg.grid.vmap⁺,
+                dg.grid.elemtobndy,
+                elems,
+                t;
+                ndrange = ndrange,
+                dependencies = comp_stream,
+            )
+    end
+
+    return comp_stream
+end
+
+"""
+    launch_volume_tendency!(dg, state_prognostic, t; dependencies)
+
+Launches horizontal and vertical volume kernels for computing tendencies (sources, sinks, etc).
+"""
+function launch_volume_tendency!(
+    dg,
+    tendency,
+    state_prognostic,
+    t,
+    α,
+    β;
+    dependencies,
+)
+    Qhypervisc_grad, _ = dg.states_higher_order
+
+    info = basic_launch_info(dg)
+    workgroup = (info.Nq, info.Nq)
+    ndrange = (info.Nq * info.nrealelem, info.Nq)
+    comp_stream = dependencies
+
+    # If the model direction is EveryDirection, we need to perform
+    # both horizontal AND vertical kernel calls; otherwise, we only
+    # call the kernel corresponding to the model direction `dg.diffusion_direction`
+    if dg.direction isa EveryDirection || dg.direction isa HorizontalDirection
+        comp_stream = volume_tendency!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            dg.direction,
+            HorizontalDirection(),
+            tendency.data,
+            state_prognostic.data,
+            dg.state_gradient_flux.data,
+            Qhypervisc_grad.data,
+            dg.state_auxiliary.data,
+            dg.grid.vgeo,
+            t,
+            # XXX: Needs updating for multiple polynomial orders
+            dg.grid.ω[1],
+            dg.grid.D[1],
+            dg.grid.topology.realelems,
+            α,
+            β,
+            # If the model direction is horizontal, we want to be sure to add sources
+            dg.direction isa HorizontalDirection,
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+
+    # Vertical kernel
+    if dg.direction isa EveryDirection || dg.direction isa VerticalDirection
+        comp_stream = volume_tendency!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            dg.direction,
+            VerticalDirection(),
+            tendency.data,
+            state_prognostic.data,
+            dg.state_gradient_flux.data,
+            Qhypervisc_grad.data,
+            dg.state_auxiliary.data,
+            dg.grid.vgeo,
+            t,
+            # XXX: Needs updating for multiple polynomial orders
+            dg.grid.ω[1],
+            dg.grid.D[1],
+            dg.grid.topology.realelems,
+            α,
+            # If we are computing the volume gradient in every direction, we
+            # need to increment into the appropriate fields _after_ the
+            # horizontal computation.
+            dg.direction isa EveryDirection ? true : β,
+            # Boolean to add source. In the case of EveryDirection, we always add the sources
+            # in the vertical kernel. Here, we make the assumption that we're either computing
+            # in every direction, or _just_ the vertical direction.
+            true;
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+
+    return comp_stream
+end
+
+"""
+    launch_interface_tendency!(dg, state_prognostic, t; surface::Symbol, dependencies)
+
+Launches horizontal and vertical interface kernels for computing tendencies (sources, sinks, etc).
+The argument `surface` is either `:interior` or `:exterior`, which denotes whether we are computing
+values on boundaries which are interior (exterior resp.) to the _parallel_ boundary.
+"""
+function launch_interface_tendency!(
+    dg,
+    tendency,
+    state_prognostic,
+    t,
+    α,
+    β;
+    surface::Symbol,
+    dependencies,
+)
+    @assert surface === :interior || surface === :exterior
+    Qhypervisc_grad, _ = dg.states_higher_order
+
+    info = basic_launch_info(dg)
+    workgroup = info.Nfp
+    if surface === :interior
+        elems = dg.grid.interiorelems
+        ndrange = info.Nfp * info.ninteriorelem
+    else
+        elems = dg.grid.exteriorelems
+        ndrange = info.Nfp * info.nexteriorelem
+    end
+
+    comp_stream = dependencies
+
+    # If the model direction is EveryDirection, we need to perform
+    # both horizontal AND vertical kernel calls; otherwise, we only
+    # call the kernel corresponding to the model direction `dg.diffusion_direction`
+    if dg.direction isa EveryDirection || dg.direction isa HorizontalDirection
+        comp_stream = interface_tendency!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            HorizontalDirection(),
+            dg.numerical_flux_first_order,
+            dg.numerical_flux_second_order,
+            tendency.data,
+            state_prognostic.data,
+            dg.state_gradient_flux.data,
+            Qhypervisc_grad.data,
+            dg.state_auxiliary.data,
+            dg.grid.vgeo,
+            dg.grid.sgeo,
+            t,
+            dg.grid.vmap⁻,
+            dg.grid.vmap⁺,
+            dg.grid.elemtobndy,
+            elems,
+            α;
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+
+    # Vertical kernel call
+    if dg.direction isa EveryDirection || dg.direction isa VerticalDirection
+        comp_stream = interface_tendency!(info.device, workgroup)(
+            dg.balance_law,
+            Val(info.dim),
+            Val(info.N),
+            VerticalDirection(),
+            dg.numerical_flux_first_order,
+            dg.numerical_flux_second_order,
+            tendency.data,
+            state_prognostic.data,
+            dg.state_gradient_flux.data,
+            Qhypervisc_grad.data,
+            dg.state_auxiliary.data,
+            dg.grid.vgeo,
+            dg.grid.sgeo,
+            t,
+            dg.grid.vmap⁻,
+            dg.grid.vmap⁺,
+            dg.grid.elemtobndy,
+            elems,
+            α;
+            ndrange = ndrange,
+            dependencies = comp_stream,
+        )
+    end
+
+    return comp_stream
 end

--- a/src/Numerics/Mesh/Topologies.jl
+++ b/src/Numerics/Mesh/Topologies.jl
@@ -14,6 +14,8 @@ export AbstractTopology,
 
 export grid1d, SingleExponentialStretching, InteriorStretching
 
+export basic_topology_info
+
 """
     AbstractTopology{dim}
 
@@ -235,15 +237,17 @@ end
 Base.getproperty(a::CubedShellTopology, p::Symbol) =
     getproperty(getfield(a, :topology), p)
 
+abstract type AbstractStackedTopology{dim} <: AbstractTopology{dim} end
+
 
 """
-    StackedBrickTopology{dim, T} <: AbstractTopology{dim}
+    StackedBrickTopology{dim, T} <: AbstractStackedTopology{dim}
 
 A simple grid-based topology, where all elements on the trailing dimension are
 stacked to be contiguous. This is a convenience wrapper around
 [`BoxElementTopology`](@ref).
 """
-struct StackedBrickTopology{dim, T} <: AbstractTopology{dim}
+struct StackedBrickTopology{dim, T} <: AbstractStackedTopology{dim}
     topology::BoxElementTopology{dim, T}
     stacksize::Int64
 end
@@ -253,13 +257,13 @@ function Base.getproperty(a::StackedBrickTopology, p::Symbol)
 end
 
 """
-    StackedCubedSphereTopology{3, T} <: AbstractTopology{3}
+    StackedCubedSphereTopology{3, T} <: AbstractStackedTopology{3}
 
 A cube-sphere topology. All elements on the same "vertical" dimension are
 stacked to be contiguous. This is a convenience wrapper around
 [`BoxElementTopology`](@ref).
 """
-struct StackedCubedSphereTopology{T} <: AbstractTopology{3}
+struct StackedCubedSphereTopology{T} <: AbstractStackedTopology{3}
     topology::BoxElementTopology{3, T}
     stacksize::Int64
 end
@@ -1293,6 +1297,29 @@ function grid1d(a::A, b::B, stretch::InteriorStretching, nelem) where {A, B}
     s = range(zero(F), stop = one(F), length = nelem + 1)
     range(a, stop = b, length = nelem + 1) .+
     coe .* (stretch.attractor .- (b - a) .* s) .* (1 .- s) .* s
+end
+
+function basic_topology_info(topology::AbstractStackedTopology)
+    nelem = length(topology.elems)
+    nvertelem = topology.stacksize
+    nhorzelem = div(nelem, nvertelem)
+    nrealelem = length(topology.realelems)
+    nhorzrealelem = div(nrealelem, nvertelem)
+
+    return (
+        nelem = nelem,
+        nvertelem = nvertelem,
+        nhorzelem = nhorzelem,
+        nrealelem = nrealelem,
+        nhorzrealelem = nhorzrealelem,
+    )
+end
+
+function basic_topology_info(topology::AbstractTopology)
+    return (
+        nelem = length(topology.elems),
+        nrealelem = length(topology.realelems),
+    )
 end
 
 end

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -709,12 +709,15 @@ function update_auxiliary_state_gradient!(
     # has a limited recursion depth for the types allowed.
     number_aux = number_states(m, Auxiliary())
     index_wz0 = varsindex(vars_state(m, Auxiliary(), FT), :wz0)
-    Nq, Nqk, _, _, nelemv, nelemh, nhorzrealelem, _ = basic_grid_info(dg)
+    info = basic_grid_info(dg)
+    Nq, Nqk = info.Nq, info.Nqk
+    nelemv, nelemh = info.nvertelem, info.nhorzelem
+    nrealelemh = info.nhorzrealelem
 
     # project w(z=0) down the stack
     data = reshape(A.data, Nq^2, Nqk, number_aux, nelemv, nelemh)
-    flat_wz0 = @view data[:, end:end, index_w, end:end, 1:nhorzrealelem]
-    boxy_wz0 = @view data[:, :, index_wz0, :, 1:nhorzrealelem]
+    flat_wz0 = @view data[:, end:end, index_w, end:end, 1:nrealelemh]
+    boxy_wz0 = @view data[:, :, index_wz0, :, 1:nrealelemh]
     boxy_wz0 .= flat_wz0
 
     return true

--- a/src/Ocean/SplitExplicit/Communication.jl
+++ b/src/Ocean/SplitExplicit/Communication.jl
@@ -21,7 +21,10 @@ end
     forcing_tendency,
 ) where {C <: Coupled}
     FT = eltype(state_bc)
-    Nq, Nqk, _, _, nelemv, nelemh, nrealelemh, _ = basic_grid_info(model_bc)
+    info = basic_grid_info(model_bc)
+    Nq, Nqk = info.Nq, info.Nqk
+    nelemv, nelemh = info.nvertelem, info.nhorzelem
+    nrealelemh = info.nhorzrealelem
 
     #### integrate the tendency
     model_int = model_bc.modeldata.integral_model
@@ -85,7 +88,10 @@ end
     state_bt,
 ) where {C <: Coupled}
     FT = eltype(state_bc)
-    Nq, Nqk, _, _, nelemv, nelemh, nrealelemh, _ = basic_grid_info(model_bc)
+    info = basic_grid_info(model_bc)
+    Nq, Nqk = info.Nq, info.Nqk
+    nelemv, nelemh = info.nvertelem, info.nhorzelem
+    nrealelemh = info.nhorzrealelem
 
     ### integrate the horizontal velocity
     model_int = model_bc.modeldata.integral_model

--- a/src/Ocean/SplitExplicit/HydrostaticBoussinesqCoupling.jl
+++ b/src/Ocean/SplitExplicit/HydrostaticBoussinesqCoupling.jl
@@ -44,7 +44,10 @@ end
 # Compute Horizontal Flow deviation from vertical mean
 @inline function compute_flow_deviation!(dg, m::HBModel, ::Coupled, Q, t)
     FT = eltype(Q)
-    Nq, Nqk, _, _, nelemv, nelemh, nrealelemh, _ = basic_grid_info(dg)
+    info = basic_grid_info(dg)
+    Nq, Nqk = info.Nq, info.Nqk
+    nelemv, nelemh = info.nvertelem, info.nhorzelem
+    nrealelemh = info.nhorzrealelem
 
     #### integrate the tendency
     model_int = dg.modeldata.integral_model

--- a/src/Ocean/SplitExplicit01/Communication.jl
+++ b/src/Ocean/SplitExplicit01/Communication.jl
@@ -82,7 +82,10 @@ end
     elems = grid.topology.elems
     update_auxiliary_state!(tendency_dg, tend, dQslow2fast, 0, elems)
 
-    Nq, Nqk, _, _, nelemv, nelemh, nrealelemh, _ = basic_grid_info(dgSlow)
+    info = basic_grid_info(dgSlow)
+    Nq, Nqk = info.Nq, info.Nqk
+    nelemv, nelemh = info.nvertelem, info.nhorzelem
+    nrealelemh = info.nhorzrealelem
 
     ## get top value (=integral over full depth) of ∫du
     nb_aux_tnd = number_states(tend, Auxiliary())
@@ -163,7 +166,10 @@ end
     fast_time_rec,
 )
     FT = eltype(Qslow)
-    Nq, Nqk, _, _, nelemv, nelemh, nrealelemh, _ = basic_grid_info(dgSlow)
+    info = basic_grid_info(dgSlow)
+    Nq, Nqk = info.Nq, info.Nqk
+    nelemv, nelemh = info.nvertelem, info.nhorzelem
+    nrealelemh = info.nhorzrealelem
     grid = dgSlow.grid
     elems = grid.topology.elems
 

--- a/src/Ocean/SplitExplicit01/OceanModel.jl
+++ b/src/Ocean/SplitExplicit01/OceanModel.jl
@@ -521,7 +521,10 @@ function update_auxiliary_state!(
     update_auxiliary_state!(f!, dg, m, ct3d_dQ, t, elems)
     #----------
 
-    Nq, Nqk, _, _, nelemv, nelemh, nrealelemh, _ = basic_grid_info(dg)
+    info = basic_grid_info(dg)
+    Nq, Nqk = info.Nq, info.Nqk
+    nelemv, nelemh = info.nvertelem, info.nhorzelem
+    nrealelemh = info.nhorzrealelem
 
     # compute integrals for w and pkin
     indefinite_stack_integral!(dg, m, Q, A, t, elems) # bottom -> top


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
This PR documents the core DG kernels used in the numerics (volume/interface kernels for the prognostic and auxiliary equations in the LDG formulation). Hyperdiffusion kernels will be documented in a later PR. All DG kernels have been split in the main tendency evaluation function into separate horizontal and vertical calls.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
