### PR TITLE
Added modularized stable BL LES case (model+driver).

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -998,6 +998,16 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "gpu_sbl_les"
+    key: "gpu_sbl_les"
+    command:
+      - "mpiexec julia --color=yes --project experiments/AtmosLES/stable_bl_les.jl --diagnostics=default --fix-rng-seed"
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
   - label: "gpu_bomex_single_stack"
     key: "gpu_bomex_single_stack"
     command:

--- a/experiments/AtmosLES/stable_bl_les.jl
+++ b/experiments/AtmosLES/stable_bl_les.jl
@@ -1,0 +1,95 @@
+include("stable_bl_model.jl")
+
+function main()
+
+    # TODO: this will move to the future namelist functionality
+    sbl_args = ArgParseSettings(autofix_names = true)
+    add_arg_group!(sbl_args, "StableBoundaryLayer")
+    @add_arg_table! sbl_args begin
+        "--surface-flux"
+        help = "specify surface flux for energy and moisture"
+        metavar = "prescribed|bulk"
+        arg_type = String
+        default = "bulk"
+    end
+
+    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
+
+    surface_flux = cl_args["surface_flux"]
+
+    FT = Float64
+    config_type = AtmosLESConfigType
+
+    # DG polynomial order
+    N = 4
+    # Domain resolution and size
+    Δh = FT(20)
+    Δv = FT(20)
+
+    resolution = (Δh, Δh, Δv)
+
+    # Prescribe domain parameters
+    xmax = FT(100)
+    ymax = FT(100)
+    zmax = FT(400)
+
+    t0 = FT(0)
+
+    # Required simulation time == 9hours
+    timeend = FT(3600 * 0.1)
+    CFLmax = FT(0.4)
+
+    # Choose default IMEX solver
+    ode_solver_type = ClimateMachine.ExplicitSolverType()
+
+    model = stable_bl_model(FT, config_type, zmax, surface_flux)
+    ics = model.problem.init_state_prognostic
+
+    # Assemble configuration
+    driver_config = ClimateMachine.AtmosLESConfiguration(
+        "StableBoundaryLayer",
+        N,
+        resolution,
+        xmax,
+        ymax,
+        zmax,
+        param_set,
+        init_problem!,
+        solver_type = ode_solver_type,
+        model = model,
+    )
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+    )
+    dgn_config = config_diagnostics(driver_config)
+
+    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            ("moisture.ρq_tot",),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
+        nothing
+    end
+
+    check_cons = (
+        ClimateMachine.ConservationCheck("ρ", "1mins", FT(0.0001)),
+        ClimateMachine.ConservationCheck("ρe", "1mins", FT(0.0025)),
+    )
+
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (cbtmarfilter,),
+        check_cons = check_cons,
+        check_euclidean_distance = true,
+    )
+end
+
+main()

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -1,5 +1,9 @@
 #!/usr/bin/env julia --project
-
+#=
+# This experiment file establishes the initial conditions, boundary conditions,
+# source terms and simulation parameters (domain size + resolution) for the
+# GABLS LES case (Beare et al, 2006; Kosovic and Curry, 2000). 
+#
 ## @article{10.1175/1520-0469(2000)057<1052:ALESSO>2.0.CO;2,
 ##     author = {Kosović, Branko and Curry, Judith A.},
 ##     title = "{A Large Eddy Simulation Study of a Quasi-Steady, 
@@ -14,22 +18,22 @@
 ##     doi = {10.1175/1520-0469(2000)057<1052:ALESSO>2.0.CO;2},
 ##     url = {https://doi.org/10.1175/1520-0469(2000)057<1052:ALESSO>2.0.CO;2},
 ## }
+#
+# To simulate the experiment, type in
+#
+# julia --project experiments/AtmosLES/stable_bl_les.jl
+=#
 
-## @article{doi:10.1029/2018MS001534,
-## author = {Nishizawa, S. and Kitamura, Y.},
-## title = {A Surface Flux Scheme Based on the Monin-Obukhov Similarity for Finite Volume Models},
-## journal = {Journal of Advances in Modeling Earth Systems},
-## volume = {10},
-## number = {12},
-## pages = {3159-3175},
-## year = {2018}
-## doi = {10.1029/2018MS001534},
-## url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2018MS001534},
-## }
+using ArgParse
+using Distributions
+using Random
+using StaticArrays
+using Test
+using DocStringExtensions
+using LinearAlgebra
+using Printf
 
 using ClimateMachine
-ClimateMachine.init(parse_clargs = true)
-
 using ClimateMachine.Atmos
 using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
@@ -41,14 +45,8 @@ using ClimateMachine.Mesh.Grids
 using ClimateMachine.ODESolvers
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TurbulenceClosures
+using ClimateMachine.TurbulenceConvection
 using ClimateMachine.VariableTemplates
-
-using Distributions
-using Random
-using StaticArrays
-using Test
-using DocStringExtensions
-using LinearAlgebra
 
 using CLIMAParameters
 using CLIMAParameters.Planet: R_d, cp_d, cv_d, MSLP, grav, day
@@ -201,7 +199,7 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     end
 end
 
-function surface_temperature_variation(state, aux, t)
+function surface_temperature_variation(state, t)
     FT = eltype(state)
     ρ = state.ρ
     q_tot = state.moisture.ρq_tot / ρ
@@ -210,24 +208,33 @@ function surface_temperature_variation(state, aux, t)
     return air_temperature(TS)
 end
 
-function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
+function stable_bl_model(
+    ::Type{FT},
+    config_type,
+    zmax,
+    surface_flux;
+    turbconv = NoTurbConv(),
+) where {FT}
 
     ics = init_problem!     # Initial conditions
 
     C_smag = FT(0.23)     # Smagorinsky coefficient
     C_drag = FT(0.001)    # Momentum exchange coefficient
+    u_star = FT(0.30)
+
     z_sponge = FT(300)     # Start of sponge layer
     α_max = FT(0.75)       # Strength of sponge layer (timescale)
     γ = 2                  # Strength of sponge layer (exponent)
+
     u_geostrophic = FT(8)        # Eastward relaxation speed
     u_slope = FT(0)              # Slope of altitude-dependent relaxation speed
     v_geostrophic = FT(0)        # Northward relaxation speed
-    f_coriolis = FT(1.39e-4) # Coriolis parameter
+    f_coriolis = FT(1.39e-4) # Coriolis parameter at 73N
+
     q_sfc = FT(0)
-    u_star = FT(0.30)
 
     # Assemble source components
-    source = (
+    source_default = (
         Gravity(),
         StableBLSponge{FT}(
             zmax,
@@ -246,10 +253,27 @@ function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
         ),
     )
 
-    # Choose default IMEX solver
-    ode_solver_type = ClimateMachine.ExplicitSolverType()
-
     # Set up problem initial and boundary conditions
+    if surface_flux == "prescribed"
+        energy_bc = PrescribedEnergyFlux((state, aux, t) -> LHF + SHF)
+        moisture_bc = PrescribedMoistureFlux((state, aux, t) -> moisture_flux)
+    elseif surface_flux == "bulk"
+        energy_bc = BulkFormulaEnergy(
+            (state, aux, t, normPu_int) -> C_drag,
+            (state, aux, t) -> (surface_temperature_variation(state, t), q_sfc),
+        )
+        moisture_bc = BulkFormulaMoisture(
+            (state, aux, t, normPu_int) -> C_drag,
+            (state, aux, t) -> q_sfc,
+        )
+    else
+        @warn @sprintf(
+            """
+%s: unrecognized surface flux; using 'prescribed'""",
+            surface_flux,
+        )
+    end
+
     moisture_flux = FT(0)
     problem = AtmosProblem(
         init_state_prognostic = ics,
@@ -260,17 +284,8 @@ function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
                     # P represents the projection onto the horizontal
                     (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
                 )),
-                energy = BulkFormulaEnergy(
-                    (state, aux, t, normPu_int) -> C_drag,
-                    (state, aux, t) -> (
-                        surface_temperature_variation(state, aux, t),
-                        q_sfc,
-                    ),
-                ),
-                moisture = BulkFormulaMoisture(
-                    (state, aux, t, normPu_int) -> C_drag,
-                    (state, aux, t) -> q_sfc,
-                ),
+                energy = energy_bc,
+                moisture = moisture_bc,
             ),
             AtmosBC(),
         ),
@@ -278,28 +293,16 @@ function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
 
     # Assemble model components
     model = AtmosModel{FT}(
-        AtmosLESConfigType,
+        config_type,
         param_set;
         problem = problem,
         turbulence = SmagorinskyLilly{FT}(C_smag),
         moisture = EquilMoist{FT}(; maxiter = 5, tolerance = FT(0.1)),
-        source = source,
+        source = source_default,
+        turbconv = turbconv,
     )
 
-    # Assemble configuration
-    config = ClimateMachine.AtmosLESConfiguration(
-        "StableBoundaryLayer",
-        N,
-        resolution,
-        xmax,
-        ymax,
-        zmax,
-        param_set,
-        init_problem!,
-        solver_type = ode_solver_type,
-        model = model,
-    )
-    return config
+    return model
 end
 
 function config_diagnostics(driver_config)
@@ -318,75 +321,3 @@ function config_diagnostics(driver_config)
         core_dgngrp,
     ])
 end
-
-function main()
-    FT = Float64
-
-    # DG polynomial order
-    N = 4
-    # Domain resolution and size
-    Δh = FT(20)
-    Δv = FT(20)
-
-    resolution = (Δh, Δh, Δv)
-
-    # Prescribe domain parameters
-    xmax = FT(100)
-    ymax = FT(100)
-    zmax = FT(400)
-
-    t0 = FT(0)
-
-    # Required simulation time == 9hours
-    timeend = FT(3600 * 0.1)
-    CFLmax = FT(0.4)
-
-    driver_config = config_problem(FT, N, resolution, xmax, ymax, zmax)
-    solver_config = ClimateMachine.SolverConfiguration(
-        t0,
-        timeend,
-        driver_config,
-        init_on_cpu = true,
-        Courant_number = CFLmax,
-    )
-    dgn_config = config_diagnostics(driver_config)
-
-    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
-        Filters.apply!(
-            solver_config.Q,
-            ("moisture.ρq_tot",),
-            solver_config.dg.grid,
-            TMARFilter(),
-        )
-        nothing
-    end
-
-    # State variable
-    Q = solver_config.Q
-    # Volume geometry information
-    vgeo = driver_config.grid.vgeo
-    M = vgeo[:, Grids._M, :]
-    # Unpack prognostic vars
-    ρ₀ = Q.ρ
-    ρe₀ = Q.ρe
-    # DG variable sums
-    Σρ₀ = sum(ρ₀ .* M)
-    Σρe₀ = sum(ρe₀ .* M)
-    cb_check_cons = GenericCallbacks.EveryXSimulationSteps(3000) do
-        Q = solver_config.Q
-        δρ = (sum(Q.ρ .* M) - Σρ₀) / Σρ₀
-        δρe = (sum(Q.ρe .* M) .- Σρe₀) ./ Σρe₀
-        @show (abs(δρ))
-        @show (abs(δρe))
-        nothing
-    end
-
-    result = ClimateMachine.invoke!(
-        solver_config;
-        diagnostics_config = dgn_config,
-        user_callbacks = (cbtmarfilter, cb_check_cons),
-        check_euclidean_distance = true,
-    )
-end
-
-main()


### PR DESCRIPTION
This PR adds a modularized Stable Boundary Layer experiment, separating the existing `stable_bl_kosovic.jl` into a model file and an LES configuration script. This follows the convention of the change that was made for the Bomex LES case, and it is a necessary step towards creating a Single Column Model configuration for the stable boundary layer experiment.

I have checked that it yields the same results as `stable_bl_kosovic.jl`, and I have added an additional conservation check.

### Description

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
