### PR TITLE
Interpolate duplicate lgl points in `get_vars_from_nodal_stack`

### DIFF
--- a/docs/src/HowToGuides/Atmos/AtmosReferenceState.md
+++ b/docs/src/HowToGuides/Atmos/AtmosReferenceState.md
@@ -12,7 +12,7 @@ include(joinpath(clima_dir, "test", "Atmos", "Model", "get_atmos_ref_states.jl")
 function export_ref_state_plot(nelem_vert, N_poly)
     solver_config = get_atmos_ref_states(nelem_vert, N_poly, 0.5)
     z = get_z(solver_config.dg.grid)
-    all_data = dict_of_nodal_states(solver_config, ["z"])
+    all_data = dict_of_nodal_states(solver_config)
     T = all_data["ref_state.T"]
     ρ = all_data["ref_state.ρ"]
     p = all_data["ref_state.p"]

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -328,18 +328,28 @@ function min_node_distance(
 end
 
 """
-    get_z(grid, z_scale = 1)
+    get_z(grid; z_scale = 1, rm_dupes = false)
 
 Get the Gauss-Lobatto points along the Z-coordinate.
 
  - `grid`: DG grid
  - `z_scale`: multiplies `z-coordinate`
+ - `rm_dupes`: removes duplicate Gauss-Lobatto points
 """
 function get_z(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::DiscontinuousSpectralElementGrid{T, dim, N};
     z_scale = 1,
+    rm_dupes = false,
 ) where {T, dim, N}
-    return reshape(grid.vgeo[(1:((N + 1)^2):((N + 1)^3)), _x3, :], :) * z_scale
+    if rm_dupes
+        ijk_range = (1:((N + 1)^2):(((N + 1)^3) - (N + 1)^2))
+        z = reshape(grid.vgeo[ijk_range, _x3, :], :)
+        z = [z..., grid.vgeo[(N + 1)^3, _x3, end]]
+        return z * z_scale
+    else
+        ijk_range = (1:((N + 1)^2):((N + 1)^3))
+        return reshape(grid.vgeo[ijk_range, _x3, :], :) * z_scale
+    end
 end
 
 function Base.getproperty(G::DiscontinuousSpectralElementGrid, s::Symbol)

--- a/test/Atmos/EDMF/bomex_edmf.jl
+++ b/test/Atmos/EDMF/bomex_edmf.jl
@@ -193,7 +193,7 @@ function main(::Type{FT}) where {FT}
 
     # state_types = (Prognostic(), Auxiliary(), GradientFlux())
     state_types = (Prognostic(), Auxiliary())
-    all_data = [dict_of_nodal_states(solver_config, ["z"], state_types)]
+    all_data = [dict_of_nodal_states(solver_config, state_types)]
     time_data = FT[0]
 
     # Define the number of outputs from `t0` to `timeend`
@@ -203,10 +203,7 @@ function main(::Type{FT}) where {FT}
 
     cb_data_vs_time =
         GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
-            push!(
-                all_data,
-                dict_of_nodal_states(solver_config, ["z"], state_types),
-            )
+            push!(all_data, dict_of_nodal_states(solver_config, state_types))
             push!(time_data, gettime(solver_config.solver))
             nothing
         end
@@ -239,7 +236,8 @@ function main(::Type{FT}) where {FT}
         check_euclidean_distance = true,
     )
 
-    push!(all_data, dict_of_nodal_states(solver_config, ["z"], state_types))
+    dons = dict_of_nodal_states(solver_config, state_types)
+    push!(all_data, dons)
     push!(time_data, gettime(solver_config.solver))
 
     return solver_config, all_data, time_data, state_types

--- a/test/Atmos/EDMF/bomex_edmf_regression_test.jl
+++ b/test/Atmos/EDMF/bomex_edmf_regression_test.jl
@@ -41,8 +41,7 @@ vars_to_compare(N_up) = Dict(
 compare = Dict()
 @testset "Regression Test" begin
     N_up = n_updrafts(solver_config.dg.balance_law.turbconv)
-    numerical_data =
-        dict_of_nodal_states(solver_config, ["z"], (Prognostic(), Auxiliary()))
+    numerical_data = dict_of_nodal_states(solver_config)
     data_to_compare = Dict()
     for (ftc, v) in vars_to_compare(N_up)
         data_to_compare[ftc] = numerical_data[ftc]

--- a/test/Atmos/Model/ref_state.jl
+++ b/test/Atmos/Model/ref_state.jl
@@ -20,7 +20,7 @@ const TD = Thermodynamics
     RH = 0.5
     (nelem_vert, N_poly) = (20, 4)
     solver_config = get_atmos_ref_states(nelem_vert, N_poly, RH)
-    all_data = dict_of_nodal_states(solver_config, ["z"], (Auxiliary(),))
+    all_data = dict_of_nodal_states(solver_config, (Auxiliary(),))
     T = all_data["ref_state.T"]
     p = all_data["ref_state.p"]
     ρ = all_data["ref_state.ρ"]
@@ -37,7 +37,7 @@ end
     # Fails on (80, 1)
     for (nelem_vert, N_poly) in [(40, 2), (20, 4)]
         solver_config = get_atmos_ref_states(nelem_vert, N_poly, RH)
-        all_data = dict_of_nodal_states(solver_config, ["z"])
+        all_data = dict_of_nodal_states(solver_config)
         phase_type = PhaseEquil
         T = all_data["ref_state.T"]
         p = all_data["ref_state.p"]

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -480,7 +480,7 @@ mkpath(output_dir);
 z_scale = 100 # convert from meters to cm
 z_key = "z"
 z_label = "z [cm]"
-z = get_z(driver_config.grid, z_scale)
+z = get_z(driver_config.grid; z_scale = z_scale)
 state_vars = get_vars_from_nodal_stack(
     driver_config.grid,
     solver_config.Q,

--- a/tutorials/Atmos/burgers_single_stack_bjfnk.jl
+++ b/tutorials/Atmos/burgers_single_stack_bjfnk.jl
@@ -524,7 +524,7 @@ mkpath(output_dir);
 z_scale = 100 # convert from meters to cm
 z_key = "z"
 z_label = "z [cm]"
-z = get_z(driver_config.grid, z_scale)
+z = get_z(driver_config.grid; z_scale = z_scale)
 state_vars = get_vars_from_nodal_stack(
     driver_config.grid,
     solver_config.Q,

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -409,10 +409,10 @@ mkpath(output_dir);
 z_scale = 100; # convert from meters to cm
 z_key = "z";
 z_label = "z [cm]";
-z = get_z(grid, z_scale);
+z = get_z(grid; z_scale = z_scale, rm_dupes = true);
 
 # Create an array to store the solution:
-all_data = Dict[dict_of_nodal_states(solver_config, [z_key])]  # store initial condition at ``t=0``
+all_data = Dict[dict_of_nodal_states(solver_config; interp = true)]  # store initial condition at ``t=0``
 time_data = FT[0]                                      # store time data
 
 export_plot(
@@ -443,7 +443,7 @@ const every_x_simulation_time = ceil(Int, timeend / n_outputs);
 # `all_data` for time the callback is executed. In addition, time is collected
 # and appended to `time_data`.
 callback = GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
-    push!(all_data, dict_of_nodal_states(solver_config, [z_key]))
+    push!(all_data, dict_of_nodal_states(solver_config; interp = true))
     push!(time_data, gettime(solver_config.solver))
     nothing
 end;
@@ -456,7 +456,7 @@ end;
 ClimateMachine.invoke!(solver_config; user_callbacks = (callback,));
 
 # Append result at the end of the last time step:
-push!(all_data, dict_of_nodal_states(solver_config, [z_key]));
+push!(all_data, dict_of_nodal_states(solver_config; interp = true));
 push!(time_data, gettime(solver_config.solver));
 
 # # Post-processing

--- a/tutorials/Numerics/DGMethods/Box1D.jl
+++ b/tutorials/Numerics/DGMethods/Box1D.jl
@@ -198,18 +198,18 @@ function run_box1D(
     output_dir = @__DIR__
     mkpath(output_dir)
 
-    z_key = "z"
     z_label = "z"
     z = get_z(grid)
 
-    all_data = Dict[dict_of_nodal_states(solver_config, [z_key])]  # store initial condition at ``t=0``
+    # store initial condition at ``t=0``
+    all_data = Dict[dict_of_nodal_states(solver_config)]
     time_data = FT[0]                                      # store time data
 
     # output
     output_freq = floor(Int, timeend / dt) + 10
 
     cb_output = GenericCallbacks.EveryXSimulationSteps(output_freq) do
-        push!(all_data, dict_of_nodal_states(solver_config, [z_key]))
+        push!(all_data, dict_of_nodal_states(solver_config))
         push!(time_data, gettime(solver_config.solver))
         nothing
     end
@@ -299,7 +299,7 @@ Mass Conservation:
         (final_mass - initial_mass) / initial_mass
     )
 
-    push!(all_data, dict_of_nodal_states(solver_config, [z_key]))
+    push!(all_data, dict_of_nodal_states(solver_config))
     push!(time_data, gettime(solver_config.solver))
 
     export_plot(


### PR DESCRIPTION
### Description

This PR
 - Adds a kwarg `rm_dupes` to `get_z`, to remove duplicate lgl points at the element faces.
 - Adds a kwarg `interp` to `get_vars_from_nodal_stack` to vertically average variables at the duplicate lgl points at the element faces.
 - Swaps some positional args and kwargs in `dict_of_nodal_states`
 - Adds `@inbounds` to `get_vars_from_nodal_stack` loops

This PR will help with two issues at the moment
 - Exported plots currently included duplicate points at the element faces, which visually appear as jagged oscillations.
 - We cannot create contour plots with duplicate points in space

This new feature is exercised in the heat tutorial.

Closes #1556

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
