### PR TITLE
Remove support for `nothing` source

### DIFF
--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -24,16 +24,7 @@ function atmos_source!(
 )
     f(atmos, source, state, diffusive, aux, t, direction)
 end
-function atmos_source!(
-    ::Nothing,
-    atmos::AtmosModel,
-    source::Vars,
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
-    direction,
-) end
+
 # sources are applied additively
 @generated function atmos_source!(
     stuple::Tuple,

--- a/src/Land/Model/source.jl
+++ b/src/Land/Model/source.jl
@@ -13,18 +13,6 @@ function land_source!(
     f(land, source, state, diffusive, aux, t, direction)
 end
 
-function land_source!(
-    ::Nothing,
-    land::LandModel,
-    source::Vars,
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
-    direction,
-) end
-
-
 # sources are applied additively
 
 @generated function land_source!(

--- a/test/Atmos/Model/discrete_hydrostatic_balance.jl
+++ b/test/Atmos/Model/discrete_hydrostatic_balance.jl
@@ -76,7 +76,7 @@ function config_balanced(
         turbulence = ConstantDynamicViscosity(FT(0)),
         hyperdiffusion = NoHyperDiffusion(),
         moisture = DryModel(),
-        source = Gravity(),
+        source = (Gravity(),),
         init_state_prognostic = init_to_ref_state!,
     )
 

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -89,7 +89,7 @@ function main()
         ref_state = ref_state,
         turbulence = turbulence,
         moisture = DryModel(),
-        source = Gravity(),
+        source = (Gravity(),),
     )
 
     driver_config = ClimateMachine.AtmosGCMConfiguration(

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -80,7 +80,7 @@ function main()
         ref_state = ref_state,
         turbulence = turbulence,
         moisture = DryModel(),
-        source = Gravity(),
+        source = (Gravity(),),
     )
 
     ode_solver = ClimateMachine.MultirateSolverType(

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -121,7 +121,7 @@ function test_run(
         ref_state = HydrostaticState(T_profile),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = Gravity(),
+        source = (Gravity(),),
         tracers = NTracers{length(δ_χ), FT}(δ_χ),
     )
     linearmodel = AtmosAcousticGravityLinearModel(model)

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -130,7 +130,7 @@ function test_run(
         ref_state = HydrostaticState(T_profile),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = Gravity(),
+        source = (Gravity(),),
         tracers = NTracers{length(δ_χ), FT}(δ_χ),
     )
     dg = DGModel(

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -231,7 +231,7 @@ function test_run(
         ref_state = NoReferenceState(),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = nothing,
+        source = (),
     )
 
     dg = DGModel(

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -153,7 +153,7 @@ function test_run(
         ref_state = IsentropicVortexReferenceState{FT}(setup),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = nothing,
+        source = (),
     )
 
     linear_model = AtmosAcousticLinearModel(model)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -147,7 +147,7 @@ function test_run(
         ref_state = IsentropicVortexReferenceState{FT}(setup),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = nothing,
+        source = (),
     )
     # The linear model has the fast time scales
     fast_model = AtmosAcousticLinearModel(model)

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -148,7 +148,7 @@ function test_run(
         ref_state = IsentropicVortexReferenceState{FT}(setup),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = nothing,
+        source = (),
     )
     # This is a bad idea; this test is just testing how
     # implicit GARK composes with explicit methods

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -151,7 +151,7 @@ function test_run(
         ref_state = IsentropicVortexReferenceState{FT}(setup),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = nothing,
+        source = (),
     )
     # The linear model has the fast time scales
     fast_model = AtmosAcousticLinearModel(model)

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -132,7 +132,6 @@ function test_run(
         polynomialorder = polynomialorder,
     )
     # -------------- Define model ---------------------------------- #
-    source = Gravity()
     T_profile = DryAdiabaticProfile{FT}(param_set)
     model = AtmosModel{FT}(
         AtmosLESConfigType,
@@ -140,7 +139,7 @@ function test_run(
         init_state_prognostic = Initialise_Density_Current!,
         ref_state = HydrostaticState(T_profile),
         turbulence = AnisoMinDiss{FT}(1),
-        source = source,
+        source = (Gravity(),),
     )
     # -------------- Define DGModel --------------------------- #
     dg = DGModel(

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -109,7 +109,7 @@ let
                     ref_state = NoReferenceState(),
                     turbulence = ConstantDynamicViscosity(μ, WithDivergence()),
                     moisture = DryModel(),
-                    source = Gravity(),
+                    source = (Gravity(),),
                 )
 
                 dg = DGModel(

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -91,7 +91,7 @@ function test_run(
         ref_state = HydrostaticState(T_profile),
         turbulence = Vreman(FT(0.23)),
         moisture = DryModel(),
-        source = Gravity(),
+        source = (Gravity(),),
     )
     dg = DGModel(
         fullmodel,

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -283,7 +283,7 @@ function run_cubed_sphere_interpolation_test(DA, FT)
         ref_state = NoReferenceState(),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = nothing,
+        source = (),
     )
 
     dg = DGModel(


### PR DESCRIPTION
### Description

#1634 requires sources to be specified via Tuples, and supporting mixed tuple types seems a bit more complicated than what it is worth. This PR removes the use of and reliance on `source = nothing` and `source = (nothing,....)`.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
