### PR TITLE
Remove source function support

### DIFF
--- a/experiments/AtmosGCM/GCMDriver/gcm_sources.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_sources.jl
@@ -2,16 +2,23 @@
 # This file contains helpers and lists currently available options
 
 # Current options for GCM-specific sources:
+import ClimateMachine.Atmos: atmos_source!
+
 """
+    HeldSuarezForcing <: Source
+
 Defines a forcing that parametrises radiative and frictional effects using
 Newtonian relaxation and Rayleigh friction, following Held and Suarez (1994)
 """
-function held_suarez_forcing!(
-    bl,
-    source,
-    state,
-    diffusive,
-    aux,
+struct HeldSuarezForcing <: Source end
+
+function atmos_source!(
+    ::HeldSuarezForcing,
+    bl::AtmosModel,
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
     t::Real,
     direction,
 )

--- a/experiments/AtmosGCM/GCMDriver/heldsuarez_problem.jl
+++ b/experiments/AtmosGCM/GCMDriver/heldsuarez_problem.jl
@@ -52,5 +52,4 @@ end
 
 problem_name(::HeldSuarezProblem) = "HeldSuarez"
 
-setup_source(::HeldSuarezProblem) =
-    (Gravity(), Coriolis(), held_suarez_forcing!)
+setup_source(::HeldSuarezProblem) = (Gravity(), Coriolis(), HeldSuarezForcing())

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -10,21 +10,6 @@ export Source,
     RemovePrecipitation,
     CreateClouds
 
-# kept for compatibility
-# can be removed if no functions are using this
-function atmos_source!(
-    f::Function,
-    atmos::AtmosModel,
-    source::Vars,
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
-    direction,
-)
-    f(atmos, source, state, diffusive, aux, t, direction)
-end
-
 # sources are applied additively
 @generated function atmos_source!(
     stuple::Tuple,

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -9,6 +9,8 @@ using ClimateMachine.BalanceLaws: number_states
 using ClimateMachine.MPIStateArrays: MPIStateArray
 using ClimateMachine.DGMethods: LocalGeometry, DGModel
 
+import ClimateMachine.Atmos: atmos_source!
+
 import ClimateMachine.BalanceLaws:
     vars_state,
     update_auxiliary_state!,
@@ -332,8 +334,10 @@ function compute_gradient_flux!(
     tc_dif.S² = ∇transform.u[3, 1]^2 + ∇transform.u[3, 2]^2 + en_dif.∇w[3]^2
 end;
 
+struct TurbconvSource <: Source end
 
-function turbconv_source!(
+function atmos_source!(
+    ::TurbconvSource,
     m::AtmosModel{FT},
     source::Vars,
     state::Vars,

--- a/test/Atmos/EDMF/edmf_model.jl
+++ b/test/Atmos/EDMF/edmf_model.jl
@@ -340,5 +340,5 @@ turbconv_filters(m::EDMF) = (
     "turbconv.updraft",
 )
 n_quad_points(m::Environment{FT, N_quad}) where {FT, N_quad} = N_quad
-turbconv_sources(m::EDMF) = (turbconv_source!,)
+turbconv_sources(m::EDMF) = (TurbconvSource(),)
 turbconv_bcs(::EDMF) = EDMFBCs()

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -14,6 +14,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.VariableTemplates
 
 import ClimateMachine.Thermodynamics: total_specific_enthalpy
+import ClimateMachine.Atmos: atmos_source!
 
 using CLIMAParameters
 struct EarthParameterSet <: AbstractEarthParameterSet end
@@ -52,8 +53,10 @@ function mms3_init_state!(problem, bl, state::Vars, aux::Vars, localgeo, t)
     state.ρe = E_g(t, x1, x2, x3, Val(3))
 end
 
-function mms3_source!(
-    bl,
+struct MMS3Source <: Source end
+function atmos_source!(
+    ::MMS3Source,
+    ::AtmosModel,
     source::Vars,
     state::Vars,
     diffusive::Vars,
@@ -103,7 +106,7 @@ function main()
         ref_state = NoReferenceState(),
         turbulence = ConstantDynamicViscosity(FT(μ_exact), WithDivergence()),
         moisture = DryModel(),
-        source = mms3_source!,
+        source = (MMS3Source(),),
     )
 
     brickrange = (

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -40,6 +40,7 @@ include("mms_solution_generated.jl")
 
 import ClimateMachine.Thermodynamics: total_specific_enthalpy
 using ClimateMachine.Atmos
+import ClimateMachine.Atmos: atmos_source!
 
 total_specific_enthalpy(ts::PhaseDry{FT}, e_tot::FT) where {FT <: Real} =
     zero(FT)
@@ -55,8 +56,10 @@ function mms2_init_state!(problem, bl, state::Vars, aux::Vars, localgeo, t)
     state.ρe = E_g(t, x1, x2, x3, Val(2))
 end
 
-function mms2_source!(
-    bl,
+struct MMS2Source <: Source end
+function atmos_source!(
+    ::MMS2Source,
+    ::AtmosModel,
     source::Vars,
     state::Vars,
     diffusive::Vars,
@@ -85,8 +88,10 @@ function mms3_init_state!(problem, bl, state::Vars, aux::Vars, localgeo, t)
     state.ρe = E_g(t, x1, x2, x3, Val(3))
 end
 
-function mms3_source!(
-    bl,
+struct MMS3Source <: Source end
+function atmos_source!(
+    ::MMS3Source,
+    ::AtmosModel,
     source::Vars,
     state::Vars,
     diffusive::Vars,
@@ -132,7 +137,7 @@ function test_run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
                 WithDivergence(),
             ),
             moisture = DryModel(),
-            source = mms2_source!,
+            source = (MMS2Source(),),
         )
     else
         problem = AtmosProblem(
@@ -150,7 +155,7 @@ function test_run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
                 WithDivergence(),
             ),
             moisture = DryModel(),
-            source = mms3_source!,
+            source = (MMS3Source(),),
         )
     end
 

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -31,28 +31,31 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.VariableTemplates
+import ClimateMachine.Atmos: atmos_source!
 
 # [ClimateMachine parameters](https://github.com/CliMA/CLIMAParameters.jl) are
 # needed to have access to Earth's physical parameters.
 using CLIMAParameters
-using CLIMAParameters.Planet: R_d, day, grav, cp_d, cv_d, planet_radius
+using CLIMAParameters.Planet: MSLP, R_d, day, grav, cp_d, cv_d, planet_radius
 
 # We need to load the physical parameters for Earth to have an Earth-like simulation :).
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet();
 
+struct HeldSuarezForcingTutorial <: Source end
 
 # Construct the Held-Suarez forcing function. We can view this as part the
 # right-hand-side of our governing equations. It forces the total energy field
 # in a way that the resulting steady-state velocity and temperature fields of
 # the simulation resemble those of an idealized dry planet.
-function held_suarez_forcing!(
-    balance_law,
-    source,
-    state,
-    diffusive,
-    aux,
-    time::Real,
+function atmos_source!(
+    ::HeldSuarezForcingTutorial,
+    balance_law::AtmosModel,
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
     direction,
 )
     FT = eltype(state)
@@ -65,14 +68,15 @@ function held_suarez_forcing!(
     ρu = state.ρu
     ρe = state.ρe
 
-    coord = aux.coord
-    e_int = internal_energy(balance_law, state, aux)
-    T = air_temperature(balance_law.param_set, e_int)
+    ts = recover_thermo_state(balance_law, state, aux)
+    e_int = internal_energy(ts)
+    T = air_temperature(ts)
     _R_d = FT(R_d(balance_law.param_set))
     _day = FT(day(balance_law.param_set))
     _grav = FT(grav(balance_law.param_set))
     _cp_d = FT(cp_d(balance_law.param_set))
     _cv_d = FT(cv_d(balance_law.param_set))
+    _p0 = FT(MSLP(balance_law.param_set))
 
     ## Held-Suarez parameters
     k_a = FT(1 / (40 * _day))
@@ -86,12 +90,10 @@ function held_suarez_forcing!(
 
     ## Held-Suarez forcing
     φ = latitude(balance_law, aux)
-    p = air_pressure(balance_law.param_set, T, ρ)
+    p = air_pressure(ts)
 
-    ##TODO: replace _p0 with dynamic surface pressure in Δσ calculations to
-    #account for topography, but leave unchanged for calculations of σ involved
-    #in T_equil
-    _p0 = FT(1.01325e5)
+    #TODO: replace _p0 with dynamic surface pressure in Δσ calculations to account
+    #for topography, but leave unchanged for calculations of σ involved in T_equil
     σ = p / _p0
     exner_p = σ^(_R_d / _cp_d)
     Δσ = (σ - σ_b) / (1 - σ_b)
@@ -186,7 +188,7 @@ model = AtmosModel{FT}(
     turbulence = turbulence_model,
     hyperdiffusion = hyperdiffusion_model,
     moisture = DryModel(),
-    source = (Gravity(), Coriolis(), held_suarez_forcing!, sponge),
+    source = (Gravity(), Coriolis(), HeldSuarezForcingTutorial(), sponge),
 );
 
 # This concludes the setup of the physical model!


### PR DESCRIPTION
### Description

Similar to #1666, #1634 requires sources to be specified via Tuples. This PR removes the use of and reliance on supporting functions inside the `atmos.source` tuple, for example, `source = held_suarez_forcing!` and `source = (held_suarez_forcing!,....)`. Instead a new subtype of `Source` is made and we overload `atmos_source!` for the given subtype. Will wait for #1666 to avoid merge conflicts.

This PR also reuses what was `held_suarez_forcing!`, which seemed to be defined in multiple places. I left the `held_suarez_forcing!` defined in the tutorial to keep it stand-alone.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
