### PR TITLE
Add contour plot to plothelpers

### DIFF
--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -481,6 +481,16 @@ export_plot(
 );
 # ![](solution_vs_time.png)
 
+export_contour(
+    z,
+    time_data,
+    all_data,
+    "ρcT",
+    joinpath(output_dir, "solution_contour.png");
+    ylabel = "z [cm]",
+)
+# ![](solution_contour.png)
+
 # The results look as we would expect: a fixed temperature at the bottom is
 # resulting in heat flux that propagates up the domain. To run this file, and
 # inspect the solution in `all_data`, include this tutorial in the Julia REPL


### PR DESCRIPTION
### Description

It's currently difficult to interpret EDMF results with line plots. This PR adds contour plots to `docs/plothelpers.jl`, which should help with interpreting/debugging. cc @yairchn 

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
