### PR TITLE
Missing @inbounds in LocalGeometry getproperty

### DIFF
--- a/src/Numerics/Mesh/Geometry.jl
+++ b/src/Numerics/Mesh/Geometry.jl
@@ -66,7 +66,7 @@ end
     geo::LocalGeometry{Np, N},
     sym::Symbol,
 ) where {Np, N}
-    if sym === :polyorder
+    @inbounds if sym === :polyorder
         return N
     elseif sym === :coord
         vgeo, n, e = getfield(geo, :vgeo), getfield(geo, :n), getfield(geo, :e)


### PR DESCRIPTION
There was a missing `@inbounds` in #1629 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
