### PR TITLE
Use Float64 in BOMEX LES

### DIFF
--- a/experiments/AtmosLES/bomex_les.jl
+++ b/experiments/AtmosLES/bomex_les.jl
@@ -24,7 +24,7 @@ function main()
     surface_flux = cl_args["surface_flux"]
     moisture_model = cl_args["moisture_model"]
 
-    FT = Float32
+    FT = Float64
     config_type = AtmosLESConfigType
 
     # DG polynomial order

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -9,8 +9,6 @@
 # `src/Driver/solver_configs.jl` while the `AtmosModel` defaults can be found in
 # `src/Atmos/Model/AtmosModel.jl` and `src/Driver/driver_configs.jl`
 #
-# This setup works in both Float32 and Float64 precision. `FT`
-#
 # To simulate the full 6 hour experiment, change `timeend` to (3600*6) and type in
 #
 # julia --project experiments/AtmosLES/bomex.jl


### PR DESCRIPTION
### Description

To avoid uncertainties with `Float32` precision, this PR changes the BOMEX LES experiment to use `Float64`.

Partially addresses #1589.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
