### PR TITLE
Make `get_z` and `get_vars_from_nodal_stack` interp work with cu-arrays

### DIFF
--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -343,12 +343,14 @@ function get_z(
 ) where {T, dim, N}
     if rm_dupes
         ijk_range = (1:((N + 1)^2):(((N + 1)^3) - (N + 1)^2))
-        z = reshape(grid.vgeo[ijk_range, _x3, :], :)
-        z = [z..., grid.vgeo[(N + 1)^3, _x3, end]]
+        vgeo = Array(grid.vgeo)
+        z = reshape(vgeo[ijk_range, _x3, :], :)
+        z = [z..., vgeo[(N + 1)^3, _x3, end]]
         return z * z_scale
     else
         ijk_range = (1:((N + 1)^2):((N + 1)^3))
-        return reshape(grid.vgeo[ijk_range, _x3, :], :) * z_scale
+        z = Array(reshape(grid.vgeo[ijk_range, _x3, :], :))
+        return z * z_scale
     end
 end
 

--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -69,9 +69,9 @@ function get_vars_from_nodal_stack(
             push!(vars_wanted, vi)
         end
     end
-    vmap⁻ = grid.vmap⁻
-    vmap⁺ = grid.vmap⁺
-    vgeo = grid.vgeo
+    vmap⁻ = array_device(Q) isa CPU ? grid.vmap⁻ : Array(grid.vmap⁻)
+    vmap⁺ = array_device(Q) isa CPU ? grid.vmap⁺ : Array(grid.vmap⁺)
+    vgeo = array_device(Q) isa CPU ? grid.vgeo : Array(grid.vgeo)
     # extract values from `state_data`
     @inbounds for ev in vrange, k in 1:Nqk, v in vars_wanted
         if interp && k == 1


### PR DESCRIPTION
### Description

`get_z` with `rm_dupes = true` is breaking when the grid uses device data. Same with `get_vars_from_nodal_stack` with `interp=true`. This PR just converts these incoming CuArrays to ordinary arrays, since these pieces are mostly relevant to the single stack utils and aren't performant critical at the moment.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
