### PR TITLE
Remove plot helpers hack

### DIFF
--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -494,30 +494,30 @@ time_data = FT[0]                                      # store time data
 # Generate plots of initial conditions for the southwest nodal stack
 export_plot(
     z,
+    time_data,
     state_data,
     ("ρcT",),
-    joinpath(output_dir, "initial_condition_T_nodal.png"),
+    joinpath(output_dir, "initial_condition_T_nodal.png");
     xlabel = "ρcT at southwest node",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     state_data,
     ("ρu[1]",),
-    joinpath(output_dir, "initial_condition_u_nodal.png"),
+    joinpath(output_dir, "initial_condition_u_nodal.png");
     xlabel = "ρu at southwest node",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     state_data,
     ("ρu[2]",),
-    joinpath(output_dir, "initial_condition_v_nodal.png"),
+    joinpath(output_dir, "initial_condition_v_nodal.png");
     xlabel = "ρv at southwest node",
     ylabel = z_label,
-    time_data = time_data,
 );
 
 # ![](initial_condition_T_nodal.png)
@@ -544,21 +544,21 @@ data_var = Dict[state_vars_var]
 
 export_plot(
     z,
+    time_data,
     data_avg,
     ("ρu[1]",),
     joinpath(output_dir, "initial_condition_avg_u.png");
     xlabel = "Horizontal mean of ρu",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     data_var,
     ("ρu[1]",),
-    joinpath(output_dir, "initial_condition_variance_u.png"),
+    joinpath(output_dir, "initial_condition_variance_u.png");
     xlabel = "Horizontal variance of ρu",
     ylabel = z_label,
-    time_data = time_data,
 );
 
 # ![](initial_condition_avg_u.png)
@@ -628,48 +628,48 @@ ClimateMachine.invoke!(solver_config; user_callbacks = (callback,))
 # `ρu` for the southwest nodal stack:
 export_plot(
     z,
+    time_data,
     data_avg,
     ("ρu[1]"),
-    joinpath(output_dir, "solution_vs_time_u_avg.png"),
+    joinpath(output_dir, "solution_vs_time_u_avg.png");
     xlabel = "Horizontal mean of ρu",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     data_var,
     ("ρu[1]"),
-    joinpath(output_dir, "variance_vs_time_u.png"),
+    joinpath(output_dir, "variance_vs_time_u.png");
     xlabel = "Horizontal variance of ρu",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     data_avg,
     ("ρcT"),
-    joinpath(output_dir, "solution_vs_time_T_avg.png"),
+    joinpath(output_dir, "solution_vs_time_T_avg.png");
     xlabel = "Horizontal mean of ρcT",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     data_var,
     ("ρcT"),
-    joinpath(output_dir, "variance_vs_time_T.png"),
+    joinpath(output_dir, "variance_vs_time_T.png");
     xlabel = "Horizontal variance of ρcT",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     data_nodal,
     ("ρu[1]"),
-    joinpath(output_dir, "solution_vs_time_u_nodal.png"),
+    joinpath(output_dir, "solution_vs_time_u_nodal.png");
     xlabel = "ρu at southwest node",
     ylabel = z_label,
-    time_data = time_data,
 );
 # ![](solution_vs_time_u_avg.png)
 # ![](variance_vs_time_u.png)

--- a/tutorials/Atmos/burgers_single_stack_bjfnk.jl
+++ b/tutorials/Atmos/burgers_single_stack_bjfnk.jl
@@ -538,30 +538,30 @@ time_data = FT[0]                                      # store time data
 # Generate plots of initial conditions for the southwest nodal stack
 export_plot(
     z,
+    time_data,
     state_data,
     ("ρcT",),
-    joinpath(output_dir, "initial_condition_T_nodal.png"),
+    joinpath(output_dir, "initial_condition_T_nodal.png");
     xlabel = "ρcT at southwest node",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     state_data,
     ("ρu[1]",),
-    joinpath(output_dir, "initial_condition_u_nodal.png"),
+    joinpath(output_dir, "initial_condition_u_nodal.png");
     xlabel = "ρu at southwest node",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     state_data,
     ("ρu[2]",),
-    joinpath(output_dir, "initial_condition_v_nodal.png"),
+    joinpath(output_dir, "initial_condition_v_nodal.png");
     xlabel = "ρv at southwest node",
     ylabel = z_label,
-    time_data = time_data,
 );
 
 # ![](initial_condition_T_nodal.png)
@@ -588,21 +588,21 @@ data_var = Dict[state_vars_var]
 
 export_plot(
     z,
+    time_data,
     data_avg,
     ("ρu[1]",),
     joinpath(output_dir, "initial_condition_avg_u.png");
     xlabel = "Horizontal mean of ρu",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     data_var,
     ("ρu[1]",),
-    joinpath(output_dir, "initial_condition_variance_u.png"),
+    joinpath(output_dir, "initial_condition_variance_u.png");
     xlabel = "Horizontal variance of ρu",
     ylabel = z_label,
-    time_data = time_data,
 );
 
 # ![](initial_condition_avg_u.png)
@@ -674,48 +674,48 @@ ClimateMachine.invoke!(solver_config; user_callbacks = (callback,))
 # `ρu` for the southwest nodal stack:
 export_plot(
     z,
+    time_data,
     data_avg,
     ("ρu[1]"),
-    joinpath(output_dir, "solution_vs_time_u_avg.png"),
+    joinpath(output_dir, "solution_vs_time_u_avg.png");
     xlabel = "Horizontal mean of ρu",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     data_var,
     ("ρu[1]"),
-    joinpath(output_dir, "variance_vs_time_u.png"),
+    joinpath(output_dir, "variance_vs_time_u.png");
     xlabel = "Horizontal variance of ρu",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     data_avg,
     ("ρcT"),
-    joinpath(output_dir, "solution_vs_time_T_avg.png"),
+    joinpath(output_dir, "solution_vs_time_T_avg.png");
     xlabel = "Horizontal mean of ρcT",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     data_var,
     ("ρcT"),
-    joinpath(output_dir, "variance_vs_time_T.png"),
+    joinpath(output_dir, "variance_vs_time_T.png");
     xlabel = "Horizontal variance of ρcT",
     ylabel = z_label,
-    time_data = time_data,
 );
 export_plot(
     z,
+    time_data,
     data_nodal,
     ("ρu[1]"),
-    joinpath(output_dir, "solution_vs_time_u_nodal.png"),
+    joinpath(output_dir, "solution_vs_time_u_nodal.png");
     xlabel = "ρu at southwest node",
     ylabel = z_label,
-    time_data = time_data,
 );
 # ![](solution_vs_time_u_avg.png)
 # ![](variance_vs_time_u.png)

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -417,12 +417,13 @@ time_data = FT[0]                                      # store time data
 
 export_plot(
     z,
+    time_data,
     all_data,
     ("ρcT",),
     joinpath(output_dir, "initial_condition.png");
     xlabel = "ρcT",
     ylabel = z_label,
-    time_data = time_data,
+    xlims = (m.initialT - 1, m.T_bottom + 1),
 );
 # ![](initial_condition.png)
 
@@ -472,12 +473,12 @@ push!(time_data, gettime(solver_config.solver));
 
 export_plot(
     z,
+    time_data,
     all_data,
     ("ρcT",),
     joinpath(output_dir, "solution_vs_time.png");
     xlabel = "ρcT",
     ylabel = z_label,
-    time_data = time_data,
 );
 # ![](solution_vs_time.png)
 

--- a/tutorials/Numerics/DGMethods/Box1D.jl
+++ b/tutorials/Numerics/DGMethods/Box1D.jl
@@ -304,12 +304,12 @@ Mass Conservation:
 
     export_plot(
         z,
+        time_data,
         all_data,
         ("q",),
         joinpath(output_dir, plot_name);
         xlabel = "x",
         ylabel = "q",
-        time_data = time_data,
         horiz_layout = true,
     )
 


### PR DESCRIPTION
### Description

The recently added `plothelpers.jl` hack is already causing issues with some upstream branches 🙄.

This PR
 - Removes the plothelpers hack and just add `xlims` as a kwarg, which should default to Plots.jl default (`:auto`). 
 - Makes `time_data` a positional arg, to unify the interface with the other plotting functions.
 - Fix condition for when `single_var` should sometimes be `true`.
 - Adds a kwarg for `time_units`
 - Propagates `ylabel` in `export_state_plots`

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
