### PR TITLE
Added modularized convective BL LES case (model+driver)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1008,6 +1008,16 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "gpu_cbl_les"
+    key: "gpu_cbl_les"
+    command:
+      - "mpiexec julia --color=yes --project experiments/AtmosLES/convective_bl_les.jl --diagnostics=default --fix-rng-seed"
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
   - label: "gpu_bomex_single_stack"
     key: "gpu_bomex_single_stack"
     command:

--- a/experiments/AtmosLES/convective_bl_les.jl
+++ b/experiments/AtmosLES/convective_bl_les.jl
@@ -1,0 +1,94 @@
+include("convective_bl_model.jl")
+function main()
+
+    # TODO: this will move to the future namelist functionality
+    cbl_args = ArgParseSettings(autofix_names = true)
+    add_arg_group!(cbl_args, "ConvectiveBoundaryLayer")
+    @add_arg_table! cbl_args begin
+        "--surface-flux"
+        help = "specify surface flux for energy and moisture"
+        metavar = "prescribed|bulk"
+        arg_type = String
+        default = "bulk"
+    end
+
+    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = cbl_args)
+
+    surface_flux = cl_args["surface_flux"]
+
+    FT = Float64
+    config_type = AtmosLESConfigType
+
+    # DG polynomial order
+    N = 4
+    # Domain resolution and size
+    Δh = FT(80)
+    Δv = FT(80)
+
+    resolution = (Δh, Δh, Δv)
+
+    # Prescribe domain parameters
+    xmax = FT(4800)
+    ymax = FT(4800)
+    zmax = FT(3200)
+
+    t0 = FT(0)
+
+    # Full simulation requires 16+ hours of simulated time
+    timeend = FT(3600 * 0.1)
+    CFLmax = FT(0.4)
+
+    # Choose default Explicit solver
+    ode_solver_type = ClimateMachine.ExplicitSolverType()
+
+    model = convective_bl_model(FT, config_type, zmax, surface_flux)
+    ics = model.problem.init_state_prognostic
+
+    # Assemble configuration
+    driver_config = ClimateMachine.AtmosLESConfiguration(
+        "ConvectiveBoundaryLayer",
+        N,
+        resolution,
+        xmax,
+        ymax,
+        zmax,
+        param_set,
+        ics,
+        solver_type = ode_solver_type,
+        model = model,
+    )
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+        CFL_direction = HorizontalDirection(),
+    )
+    dgn_config = config_diagnostics(driver_config)
+
+    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            ("moisture.ρq_tot",),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
+        nothing
+    end
+
+    check_cons = (
+        ClimateMachine.ConservationCheck("ρ", "1mins", FT(0.0001)),
+        ClimateMachine.ConservationCheck("ρe", "1mins", FT(0.0025)),
+    )
+
+    result = ClimateMachine.invoke!(
+        solver_config;
+        user_callbacks = (cbtmarfilter,),
+        diagnostics_config = dgn_config,
+        check_cons = check_cons,
+        check_euclidean_distance = true,
+    )
+end
+
+main()


### PR DESCRIPTION
### Description

This PR modularize the Convective Boundary Layer experiment, separating the previous unstable_bl_kitamura.jl into a model file and an LES configuration script. This follows the convention of the change that was made for the Bomex LES and stable BL cases, and it is a necessary step towards creating a Single Column Model configuration for the stable boundary layer experiment.

I have checked that it yields the same results as unstable_bl_kitamura.jl, and I have added an additional conservation check.
<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
