### PR TITLE
Add EDMF driver for stable_bl_model.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1048,6 +1048,16 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "gpu_sbl_edmf"
+    key: "gpu_sbl_edmf"
+    command:
+      - "mpiexec julia --color=yes --project test/Atmos/EDMF/stable_bl_edmf.jl --diagnostics=default --fix-rng-seed"
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
   - label: "gpu_bomex_bulk_sfc_flux"
     key: "gpu_bomex_bulk_sfc_flux"
     command:

--- a/experiments/AtmosLES/stable_bl_les.jl
+++ b/experiments/AtmosLES/stable_bl_les.jl
@@ -68,16 +68,6 @@ function main()
     )
     dgn_config = config_diagnostics(driver_config)
 
-    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
-        Filters.apply!(
-            solver_config.Q,
-            ("moisture.ρq_tot",),
-            solver_config.dg.grid,
-            TMARFilter(),
-        )
-        nothing
-    end
-
     check_cons = (
         ClimateMachine.ConservationCheck("ρ", "1mins", FT(0.0001)),
         ClimateMachine.ConservationCheck("ρe", "1mins", FT(0.0025)),
@@ -86,7 +76,6 @@ function main()
     result = ClimateMachine.invoke!(
         solver_config;
         diagnostics_config = dgn_config,
-        user_callbacks = (cbtmarfilter,),
         check_cons = check_cons,
         check_euclidean_distance = true,
     )

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -47,6 +47,8 @@ using ClimateMachine.Thermodynamics
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.TurbulenceConvection
 using ClimateMachine.VariableTemplates
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Auxiliary, Gradient, GradientFlux, Prognostic
 
 using CLIMAParameters
 using CLIMAParameters.Planet: R_d, cp_d, cv_d, MSLP, grav, day
@@ -176,8 +178,11 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     π_exner = FT(1) - _grav / (c_p * θ) * z # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
     # Establish thermodynamic state and moist phase partitioning
-    TS = PhaseEquil_ρθq(bl.param_set, ρ, θ_liq, q_tot)
-
+    if bl.moisture isa DryModel
+        TS = PhaseDry_ρθ(bl.param_set, ρ, θ_liq)
+    else
+        TS = PhaseEquil_ρθq(bl.param_set, ρ, θ_liq, q_tot)
+    end
     # Compute momentum contributions
     ρu = ρ * u
     ρv = ρ * v
@@ -192,11 +197,13 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     state.ρ = ρ
     state.ρu = SVector(ρu, ρv, ρw)
     state.ρe = ρe_tot
-    state.moisture.ρq_tot = ρ * q_tot
-
+    if !(bl.moisture isa DryModel)
+        state.moisture.ρq_tot = ρ * q_tot
+    end
     if z <= FT(50) # Add random perturbations to bottom 50m of model
         state.ρe += rand() * ρe_tot / 100
     end
+    init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
 end
 
 function surface_temperature_variation(bl, state, t)
@@ -218,6 +225,7 @@ function stable_bl_model(
     zmax,
     surface_flux;
     turbconv = NoTurbConv(),
+    moisture_model = "dry",
 ) where {FT}
 
     ics = init_problem!     # Initial conditions
@@ -256,7 +264,22 @@ function stable_bl_model(
             v_geostrophic,
         ),
     )
-
+    if moisture_model == "dry"
+        moisture = DryModel()
+    elseif moisture_model == "equilibrium"
+        source = source_default
+        moisture = EquilMoist{FT}(; maxiter = 5, tolerance = FT(0.1))
+    elseif moisture_model == "nonequilibrium"
+        source = (source_default..., CreateClouds())
+        moisture = NonEquilMoist()
+    else
+        @warn @sprintf(
+            """
+%s: unrecognized moisture_model in source terms, using the defaults""",
+            moisture_model,
+        )
+        source = source_default
+    end
     # Set up problem initial and boundary conditions
     if surface_flux == "prescribed"
         energy_bc = PrescribedEnergyFlux((state, aux, t) -> LHF + SHF)
@@ -279,10 +302,20 @@ function stable_bl_model(
         )
     end
 
-    moisture_flux = FT(0)
-    problem = AtmosProblem(
-        init_state_prognostic = ics,
-        boundarycondition = (
+    if moisture_model == "dry"
+        boundary_conditions = (
+            AtmosBC(
+                momentum = Impenetrable(DragLaw(
+                    # normPu_int is the internal horizontal speed
+                    # P represents the projection onto the horizontal
+                    (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
+                )),
+                energy = energy_bc,
+            ),
+            AtmosBC(),
+        )
+    else
+        boundary_conditions = (
             AtmosBC(
                 momentum = Impenetrable(DragLaw(
                     # normPu_int is the internal horizontal speed
@@ -293,7 +326,13 @@ function stable_bl_model(
                 moisture = moisture_bc,
             ),
             AtmosBC(),
-        ),
+        )
+    end
+
+    moisture_flux = FT(0)
+    problem = AtmosProblem(
+        init_state_prognostic = ics,
+        boundarycondition = boundary_conditions,
     )
 
     # Assemble model components
@@ -302,7 +341,7 @@ function stable_bl_model(
         param_set;
         problem = problem,
         turbulence = SmagorinskyLilly{FT}(C_smag),
-        moisture = EquilMoist{FT}(; maxiter = 5, tolerance = FT(0.1)),
+        moisture = moisture,
         source = source_default,
         turbconv = turbconv,
     )

--- a/test/Atmos/EDMF/helper_funcs/save_subdomain_temperature.jl
+++ b/test/Atmos/EDMF/helper_funcs/save_subdomain_temperature.jl
@@ -35,3 +35,11 @@ function save_subdomain_temperature!(
     aux.turbconv.environment.T = air_temperature(ts_en)
     return nothing
 end
+
+# No need to save temperature for DryModel.
+function save_subdomain_temperature!(
+    m::AtmosModel,
+    moist::DryModel,
+    state::Vars,
+    aux::Vars,
+) end

--- a/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
@@ -140,6 +140,28 @@ end
 
 function new_thermo_state_up(
     m::AtmosModel,
+    moist::DryModel,
+    state::Vars,
+    aux::Vars,
+    ts::ThermodynamicState,
+)
+    N_up = n_updrafts(m.turbconv)
+    up = state.turbconv.updraft
+    p = air_pressure(ts)
+
+    # compute thermo state for updrafts
+    ts_up = vuntuple(N_up) do i
+        ρa_up = up[i].ρa
+        ρaθ_liq_up = up[i].ρaθ_liq
+        θ_liq_up = ρaθ_liq_up / ρa_up
+
+        PhaseDry_pθ(m.param_set, p, θ_liq_up)
+    end
+    return ts_up
+end
+
+function new_thermo_state_up(
+    m::AtmosModel,
     moist::EquilMoist,
     state::Vars,
     aux::Vars,
@@ -160,6 +182,32 @@ function new_thermo_state_up(
         PhaseEquil_pθq(m.param_set, p, θ_liq_up, q_tot_up)
     end
     return ts_up
+end
+
+function new_thermo_state_en(
+    m::AtmosModel,
+    moist::DryModel,
+    state::Vars,
+    aux::Vars,
+    ts::ThermodynamicState,
+)
+    N_up = n_updrafts(m.turbconv)
+    up = state.turbconv.updraft
+
+    # diagnose environment thermo state
+    ρ_inv = 1 / state.ρ
+    p = air_pressure(ts)
+    θ_liq = liquid_ice_pottemp(ts)
+    a_en = environment_area(state, aux, N_up)
+    θ_liq_en = (θ_liq - sum(vuntuple(j -> up[j].ρaθ_liq * ρ_inv, N_up))) / a_en
+    a_min = m.turbconv.subdomains.a_min
+    a_max = m.turbconv.subdomains.a_max
+    if !(0 <= θ_liq_en)
+        @print("θ_liq_en = ", θ_liq_en, "\n")
+        error("Environment θ_liq_en out-of-bounds in new_thermo_state_en")
+    end
+    ts_en = PhaseDry_pθ(m.param_set, p, θ_liq_en)
+    return ts_en
 end
 
 function new_thermo_state_en(
@@ -196,7 +244,7 @@ end
 
 function recover_thermo_state_up(
     m::AtmosModel,
-    moist::EquilMoist,
+    moist::Union{DryModel, EquilMoist},
     state::Vars,
     aux::Vars,
     ts::ThermodynamicState = recover_thermo_state(m, state, aux),
@@ -210,6 +258,7 @@ end
 
 recover_thermo_state_up_i(m, state, aux, i_up, ts) =
     recover_thermo_state_up_i(m, m.moisture, state, aux, i_up, ts)
+
 function recover_thermo_state_up_i(
     m::AtmosModel,
     moist::EquilMoist,
@@ -237,7 +286,6 @@ function recover_thermo_state_up_i(
         T_up_i,
     )
 end
-
 
 function recover_thermo_state_en(
     m::AtmosModel,

--- a/test/Atmos/EDMF/stable_bl_edmf.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf.jl
@@ -1,0 +1,255 @@
+using ClimateMachine
+ClimateMachine.init(;
+    parse_clargs = true,
+    output_dir = get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", "output"),
+    fix_rng_seed = true,
+)
+using ClimateMachine.SingleStackUtils
+using ClimateMachine.Checkpoint
+using ClimateMachine.BalanceLaws: vars_state
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+
+include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))
+include("edmf_model.jl")
+include("edmf_kernels.jl")
+
+"""
+    init_state_prognostic!(
+            turbconv::EDMF{FT},
+            m::AtmosModel{FT},
+            state::Vars,
+            aux::Vars,
+            localgeo,
+            t::Real,
+        ) where {FT}
+
+Initialize EDMF state variables.
+This method is only called at `t=0`.
+"""
+function init_state_prognostic!(
+    turbconv::EDMF{FT},
+    m::AtmosModel{FT},
+    state::Vars,
+    aux::Vars,
+    localgeo,
+    t::Real,
+) where {FT}
+    # Aliases:
+    gm = state
+    en = state.turbconv.environment
+    up = state.turbconv.updraft
+    N_up = n_updrafts(turbconv)
+    # GCM setting - Initialize the grid mean profiles of prognostic variables (ρ,e_int,q_tot,u,v,w)
+    z = altitude(m, aux)
+
+    # SCM setting - need to have separate cases coded and called from a folder - see what LES does
+    # a thermo state is used here to convert the input θ to e_int profile
+    e_int = internal_energy(m, state, aux)
+
+    ts = PhaseDry(m.param_set, e_int, state.ρ)
+    T = air_temperature(ts)
+    p = air_pressure(ts)
+    q = PhasePartition(ts)
+    θ_liq = liquid_ice_pottemp(ts)
+
+    a_min = turbconv.subdomains.a_min
+    @unroll_map(N_up) do i
+        up[i].ρa = gm.ρ * a_min
+        up[i].ρaw = gm.ρu[3] * a_min
+        up[i].ρaθ_liq = gm.ρ * a_min * θ_liq
+        up[i].ρaq_tot = FT(0)
+    end
+
+    # initialize environment covariance with zero for now
+    if z <= FT(250)
+        en.ρatke =
+            gm.ρ *
+            FT(0.4) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0)
+        en.ρaθ_liq_cv =
+            gm.ρ *
+            FT(0.4) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0)
+    else
+        en.ρatke = FT(0)
+        en.ρaθ_liq_cv = FT(0)
+    end
+    en.ρaq_tot_cv = FT(0)
+    en.ρaθ_liq_q_tot_cv = FT(0)
+    return nothing
+end;
+
+function main(::Type{FT}) where {FT}
+    # add a command line argument to specify the kind of surface flux
+    # TODO: this will move to the future namelist functionality
+    sbl_args = ArgParseSettings(autofix_names = true)
+    add_arg_group!(sbl_args, "StableBoundaryLayer")
+    @add_arg_table! sbl_args begin
+        "--surface-flux"
+        help = "specify surface flux for energy and moisture"
+        metavar = "prescribed|bulk"
+        arg_type = String
+        default = "bulk"
+    end
+
+    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
+
+    surface_flux = cl_args["surface_flux"]
+
+    # DG polynomial order
+    N = 1
+    nelem_vert = 50
+
+    # Prescribe domain parameters
+    zmax = FT(400)
+
+    t0 = FT(0)
+
+    # Simulation time
+    timeend = FT(360)
+    CFLmax = FT(0.50)
+
+    config_type = SingleStackConfigType
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
+    N_updrafts = 1
+    N_quad = 3 # Using N_quad = 1 leads to norm(Q) = NaN at init.
+    turbconv = EDMF(FT, N_updrafts, N_quad)
+
+    model = stable_bl_model(
+        FT,
+        config_type,
+        zmax,
+        surface_flux;
+        turbconv = turbconv,
+    )
+
+    # Assemble configuration
+    driver_config = ClimateMachine.SingleStackConfiguration(
+        "SBL_EDMF",
+        N,
+        nelem_vert,
+        zmax,
+        param_set,
+        model;
+        hmax = FT(40),
+        solver_type = ode_solver_type,
+    )
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+    )
+
+    # --- Zero-out horizontal variations:
+    vsp = vars_state(model, Prognostic(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :turbconv),
+    )
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :ρe),
+    )
+    vsa = vars_state(model, Auxiliary(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.dg.state_auxiliary,
+        varsindex(vsa, :turbconv),
+    )
+    # ---
+
+    dgn_config = config_diagnostics(driver_config)
+
+    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            (turbconv_filters(turbconv)...,),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
+        nothing
+    end
+
+    # State variable
+    Q = solver_config.Q
+    # Volume geometry information
+    vgeo = driver_config.grid.vgeo
+    M = vgeo[:, Grids._M, :]
+    # Unpack prognostic vars
+    ρ₀ = Q.ρ
+    ρe₀ = Q.ρe
+    # DG variable sums
+    Σρ₀ = sum(ρ₀ .* M)
+    Σρe₀ = sum(ρe₀ .* M)
+
+    grid = driver_config.grid
+
+    # state_types = (Prognostic(), Auxiliary(), GradientFlux())
+    state_types = (Prognostic(), Auxiliary())
+    all_data = [dict_of_nodal_states(solver_config, state_types; interp = true)]
+    time_data = FT[0]
+
+    # Define the number of outputs from `t0` to `timeend`
+    n_outputs = 5
+    # This equates to exports every ceil(Int, timeend/n_outputs) time-step:
+    every_x_simulation_time = ceil(Int, timeend / n_outputs)
+
+    cb_data_vs_time =
+        GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
+            push!(
+                all_data,
+                dict_of_nodal_states(solver_config, state_types; interp = true),
+            )
+            push!(time_data, gettime(solver_config.solver))
+            nothing
+        end
+
+    cb_check_cons = GenericCallbacks.EveryXSimulationSteps(3000) do
+        Q = solver_config.Q
+        δρ = (sum(Q.ρ .* M) - Σρ₀) / Σρ₀
+        δρe = (sum(Q.ρe .* M) .- Σρe₀) ./ Σρe₀
+        @show (abs(δρ))
+        @show (abs(δρe))
+        @test (abs(δρ) <= 0.001)
+        @test (abs(δρe) <= 0.0025)
+        nothing
+    end
+
+    cb_print_step = GenericCallbacks.EveryXSimulationSteps(100) do
+        @show getsteps(solver_config.solver)
+        nothing
+    end
+
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (
+            cbtmarfilter,
+            cb_check_cons,
+            cb_data_vs_time,
+            cb_print_step,
+        ),
+        check_euclidean_distance = true,
+    )
+
+    dons = dict_of_nodal_states(solver_config, state_types; interp = true)
+    push!(all_data, dons)
+    push!(time_data, gettime(solver_config.solver))
+
+    return solver_config, all_data, time_data, state_types
+end
+
+solver_config, all_data, time_data, state_types = main(Float64)


### PR DESCRIPTION
### Description

This PR adds an EDMF driver for the simulation of the stable boundary layer. This is a dry simulation with zero/negligible area fraction. The PR also includes improvements of the EDMF helper functions to allow for simulations using a `DryModel`.

Co-authored by @charleskawczynski.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
