### PR TITLE
Prep support for dry turbconv

### DIFF
--- a/test/Atmos/EDMF/closures/surface_functions.jl
+++ b/test/Atmos/EDMF/closures/surface_functions.jl
@@ -70,9 +70,9 @@ function subdomain_surface_values(
         θ_liq + surface_scalar_coeff[i] * sqrt(max(θ_liq_cv, 0))
     end
 
+    ρq_tot = atmos.moisture isa DryModel ? FT(0) : gm.moisture.ρq_tot
     q_tot_up_surf = ntuple(N_up) do i
-        gm.moisture.ρq_tot * ρ_inv +
-        surface_scalar_coeff[i] * sqrt(max(q_tot_cv, 0))
+        ρq_tot * ρ_inv + surface_scalar_coeff[i] * sqrt(max(q_tot_cv, 0))
     end
 
     return (

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -382,6 +382,7 @@ function atmos_source!(
     ρa_up = vuntuple(N_up) do i
         gm.ρ * enforce_unit_bounds(up[i].ρa * ρ_inv, a_min, a_max)
     end
+    ρq_tot = m.moisture isa DryModel ? FT(0) : gm.moisture.ρq_tot
 
     @unroll_map(N_up) do i
 
@@ -457,11 +458,11 @@ function atmos_source!(
             (up[i].ρaq_tot * ρa_up_i_inv - q_tot_en) +
             up[i].ρaw *
             ε_trb[i] *
-            (q_tot_en - gm.moisture.ρq_tot * ρ_inv) *
+            (q_tot_en - ρq_tot * ρ_inv) *
             (q_tot_en - up[i].ρaq_tot * ρa_up_i_inv) +
             up[i].ρaw *
             ε_trb[i] *
-            (q_tot_en - gm.moisture.ρq_tot * ρ_inv) *
+            (q_tot_en - ρq_tot * ρ_inv) *
             (q_tot_en - up[i].ρaq_tot * ρa_up_i_inv) -
             up[i].ρaw * (ε_dyn[i] + ε_trb[i]) * en.ρaq_tot_cv
         )
@@ -477,7 +478,7 @@ function atmos_source!(
             (q_tot_en - up[i].ρaq_tot * ρa_up_i_inv) +
             up[i].ρaw *
             ε_trb[i] *
-            (q_tot_en - gm.moisture.ρq_tot * ρ_inv) *
+            (q_tot_en - ρq_tot * ρ_inv) *
             (θ_liq_en - up[i].ρaθ_liq * ρa_up_i_inv) -
             up[i].ρaw * (ε_dyn[i] + ε_trb[i]) * en.ρaθ_liq_q_tot_cv
         )
@@ -630,12 +631,12 @@ function flux_second_order!(
             (gm.ρu[3] * ρ_inv - up[i].ρaw / ρa_up[i])
         end,
     )
-
+    ρq_tot = m.moisture isa DryModel ? FT(0) : gm.moisture.ρq_tot
     massflux_q_tot = sum(
         vuntuple(N_up) do i
             up[i].ρa *
             ρ_inv *
-            (gm.moisture.ρq_tot * ρ_inv - up[i].ρaq_tot / up[i].ρa) *
+            (ρq_tot * ρ_inv - up[i].ρaq_tot / up[i].ρa) *
             (gm.ρu[3] * ρ_inv - up[i].ρaw / ρa_up[i])
         end,
     )


### PR DESCRIPTION
### Description

This PR preps support for running with a dry `turbconv` model. More is coming, but we don't want to add too much untested code at a time (the DryModel branches, in this case).

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
