### PR TITLE
Compute operators and metrics with high float type

### DIFF
--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -6,6 +6,7 @@ import ..BrickMesh
 using MPI
 using LinearAlgebra
 using KernelAbstractions
+using DoubleFloats: DoubleFloat
 
 export DiscontinuousSpectralElementGrid, AbstractGrid
 export dofs_per_element, arraytype, dimensionality, polynomialorder
@@ -182,10 +183,12 @@ struct DiscontinuousSpectralElementGrid{
         DeviceArray,
         polynomialorder,
         meshwarp::Function = (x...) -> identity(x),
+        compute_type = FloatType == Float32 ? Float64 : DoubleFloat{FloatType},
     ) where {dim}
 
         N = polynomialorder
-        (ξ, ω) = Elements.lglpoints(FloatType, N)
+        (ξ, ω) = Elements.lglpoints(BigFloat, N)
+        ξ, ω = compute_type.(ξ), compute_type.(ω)
         Imat = indefinite_integral_interpolation_matrix(ξ, ω)
         D = Elements.spectralderivative(ξ)
 
@@ -218,17 +221,17 @@ struct DiscontinuousSpectralElementGrid{
         activedofs[vmaprecv] .= true
 
         # Create arrays on the device
-        vgeo = DeviceArray(vgeo)
-        sgeo = DeviceArray(sgeo)
+        vgeo = DeviceArray(FloatType.(vgeo))
+        sgeo = DeviceArray(FloatType.(sgeo))
         elemtobndy = DeviceArray(topology.elemtobndy)
         vmap⁻ = DeviceArray(vmap⁻)
         vmap⁺ = DeviceArray(vmap⁺)
         vmapsend = DeviceArray(vmapsend)
         vmaprecv = DeviceArray(vmaprecv)
         activedofs = DeviceArray(activedofs)
-        ω = DeviceArray(ω)
-        D = DeviceArray(D)
-        Imat = DeviceArray(Imat)
+        ω = DeviceArray(FloatType.(ω))
+        D = DeviceArray(FloatType.(D))
+        Imat = DeviceArray(FloatType.(Imat))
 
         # FIXME: There has got to be a better way!
         DAT1 = typeof(ω)


### PR DESCRIPTION
Compute geometry with higher float type.

Seems to cause some problems on mac with banded matrices. Not sure why.

(Effectively reopens #1569 )

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
