### PR TITLE
Fix race condition with Haverkamp artifact file

### DIFF
--- a/test/Land/Model/haverkamp_implicit_test.jl
+++ b/test/Land/Model/haverkamp_implicit_test.jl
@@ -32,7 +32,7 @@ using ClimateMachine.BalanceLaws:
 using ClimateMachine.ArtifactWrappers
 
 haverkamp_dataset = ArtifactWrapper(
-    joinpath("test", "Land", "Model", "Artifacts.toml"),
+    joinpath("test", "Land", "Model", "Artifacts_implicit.toml"),
     "richards",
     ArtifactFile[ArtifactFile(
         url = "https://caltech.box.com/shared/static/dfijf07io7h5dk1k87saaewgsg9apq8d.csv",


### PR DESCRIPTION
### Description

Rename `Artifacts.toml` to `Artifacts_implicit.toml` in `test/Land/Model/haverkamp_implicit_test.jl`, since the same exact Artifact is also generated in `test/Land/Model/haverkamp_test.jl`.

Closes #1678.

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
