### PR TITLE
Add `relative_humidity` for `PhaseDry`

### DIFF
--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -2166,6 +2166,8 @@ relative_humidity(ts::ThermodynamicState{FT}) where {FT <: Real} =
         PhasePartition(ts),
     )
 
+relative_humidity(ts::PhaseDry{FT}) where {FT <: Real} = FT(0)
+
 """
     total_specific_enthalpy(e_tot, R_m, T)
 


### PR DESCRIPTION
### Description

This PR adds `relative_humidity` for `PhaseDry` thermo states. Docs are already there for the generic `::ThermodynamicState`, and this will automatically be picked up in the test suite in the "Thermodynamics - dry limit" tests.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
