### PR TITLE
Add custom filter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -518,6 +518,16 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "gpu_custom_filter"
+    key: "gpu_custom_filter"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/custom_filter.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
   - label: "gpu_remainder_model"
     key: "gpu_remainder_model"
     command:

--- a/docs/src/APIs/Numerics/DGMethods/DGMethods.md
+++ b/docs/src/APIs/Numerics/DGMethods/DGMethods.md
@@ -23,3 +23,9 @@ to be filled
 
 to be filled
 
+## Custom filter
+
+```@docs
+AbstractCustomFilter
+custom_filter!
+```

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -56,6 +56,7 @@ export DGModel,
     continuous_field_gradient!,
     courant
 
+include("custom_filter.jl")
 include("NumericalFluxes.jl")
 include("DGModel.jl")
 include("DGModel_kernels.jl")

--- a/src/Numerics/DGMethods/custom_filter.jl
+++ b/src/Numerics/DGMethods/custom_filter.jl
@@ -1,0 +1,117 @@
+#### Custom Filter
+using ..Mesh.Filters: AbstractFilter
+import ..Mesh.Filters: apply!
+export AbstractCustomFilter
+
+"""
+    AbstractCustomFilter <: AbstractFilter
+
+Dispatch type for a pointwise custom filter; see [`custom_filter!`](@ref)
+
+!!! warning
+    Modifying the prognostic state with this filter
+    does not guarantee conservation of the modified
+    state.
+"""
+abstract type AbstractCustomFilter <: AbstractFilter end
+
+"""
+    custom_filter!(
+        ::AbstractCustomFilter,
+        balance_law,
+        state,
+        aux,
+    )
+
+Apply the custom filter `AbstractCustomFilter`,
+to the prognostic state for a given balance law.
+"""
+function custom_filter!(::AbstractCustomFilter, balance_law, state, aux) end
+
+function apply!(
+    custom_filter::AbstractCustomFilter,
+    grid::DiscontinuousSpectralElementGrid,
+    m::BalanceLaw,
+    state_prognostic::MPIStateArray,
+    state_auxiliary::MPIStateArray,
+) where {F!}
+    elems = grid.topology.realelems
+    device = array_device(state_prognostic)
+    Np = dofs_per_element(grid)
+    # XXX: Needs updating for multiple polynomial orders
+    N = polynomialorders(grid)
+    # Currently only support single polynomial order
+    @assert all(N[1] .== N)
+    N = N[1]
+    knl_custom_filter! = kernel_custom_filter!(device, min(Np, 1024))
+    event = Event(device)
+    event = knl_custom_filter!(
+        m,
+        Val(dimensionality(grid)),
+        Val(N),
+        custom_filter,
+        state_prognostic.data,
+        state_auxiliary.data,
+        elems,
+        grid.activedofs;
+        ndrange = Np * length(elems),
+        dependencies = (event,),
+    )
+    wait(device, event)
+end
+
+@kernel function kernel_custom_filter!(
+    bl::BalanceLaw,
+    ::Val{dim},
+    ::Val{N},
+    custom_filter,
+    state_prognostic,
+    state_auxiliary,
+    elems,
+    activedofs,
+) where {dim, N}
+    @uniform begin
+        FT = eltype(state_prognostic)
+        num_state_prognostic = number_states(bl, Prognostic())
+        num_state_auxiliary = number_states(bl, Auxiliary())
+        vs_p = Vars{vars_state(bl, Prognostic(), FT)}
+        vs_a = Vars{vars_state(bl, Auxiliary(), FT)}
+        Nq = N + 1
+        Nqk = dim == 2 ? 1 : Nq
+        Np = Nq * Nq * Nqk
+
+        local_state_prognostic = MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+    end
+
+    I = @index(Global, Linear)
+    eI = (I - 1) ÷ Np + 1
+    n = (I - 1) % Np + 1
+
+    @inbounds begin
+        e = elems[eI]
+
+        active = activedofs[n + (e - 1) * Np]
+
+        if active
+            @unroll for s in 1:num_state_prognostic
+                local_state_prognostic[s] = state_prognostic[n, s, e]
+            end
+
+            @unroll for s in 1:num_state_auxiliary
+                local_state_auxiliary[s] = state_auxiliary[n, s, e]
+            end
+
+            custom_filter!(
+                custom_filter,
+                bl,
+                vs_p(local_state_prognostic),
+                vs_a(local_state_auxiliary),
+            )
+
+            @unroll for s in 1:num_state_prognostic
+                state_prognostic[n, s, e] = local_state_prognostic[s]
+            end
+        end
+    end
+end

--- a/test/Numerics/DGMethods/custom_filter.jl
+++ b/test/Numerics/DGMethods/custom_filter.jl
@@ -1,0 +1,80 @@
+using Test
+using ClimateMachine
+using ClimateMachine.VariableTemplates: @vars, Vars
+using ClimateMachine.BalanceLaws
+using ClimateMachine.DGMethods: AbstractCustomFilter, apply!
+import ClimateMachine
+import ClimateMachine.BalanceLaws:
+    vars_state, init_state_auxiliary!, init_state_prognostic!
+using MPI
+using LinearAlgebra
+
+struct CustomFilterTestModel <: BalanceLaw end
+struct CustomTestFilter <: AbstractCustomFilter end
+
+vars_state(::CustomFilterTestModel, ::Auxiliary, FT) = @vars()
+vars_state(::CustomFilterTestModel, ::Prognostic, FT) where {N} = @vars(q::FT)
+
+init_state_auxiliary!(::CustomFilterTestModel, _...) = nothing
+
+function init_state_prognostic!(
+    ::CustomFilterTestModel,
+    state::Vars,
+    aux::Vars,
+    localgeo,
+)
+    coord = localgeo.coord
+    state.q = hypot(coord[1], coord[2])
+end
+
+@testset "Test custom filter" begin
+    let
+        ClimateMachine.init()
+        N = 4
+        Ne = (2, 2, 2)
+
+        function ClimateMachine.DGMethods.custom_filter!(
+            ::CustomTestFilter,
+            bl::CustomFilterTestModel,
+            state::Vars,
+            aux::Vars,
+        )
+            state.q = state.q^2
+        end
+
+        @testset for FT in (Float64, Float32)
+            dim = 2
+            brickrange =
+                ntuple(j -> range(FT(-1); length = Ne[j] + 1, stop = 1), dim)
+            topl = ClimateMachine.Mesh.Topologies.BrickTopology(
+                MPI.COMM_WORLD,
+                brickrange,
+                periodicity = ntuple(j -> true, dim),
+            )
+
+            grid = ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+                topl,
+                FloatType = FT,
+                DeviceArray = ClimateMachine.array_type(),
+                polynomialorder = N,
+            )
+
+            model = CustomFilterTestModel()
+            dg = ClimateMachine.DGMethods.DGModel(
+                model,
+                grid,
+                nothing,
+                nothing,
+                nothing;
+                state_gradient_flux = nothing,
+            )
+
+            Q = ClimateMachine.DGMethods.init_ode_state(dg)
+            data = Array(Q.realdata)
+
+            apply!(CustomTestFilter(), grid, model, Q, dg.state_auxiliary)
+
+            @test all(Array(Q.realdata) .== data .^ 2)
+        end
+    end
+end

--- a/test/Numerics/DGMethods/runtests.jl
+++ b/test/Numerics/DGMethods/runtests.jl
@@ -9,4 +9,5 @@ include(joinpath("..", "..", "testhelpers.jl"))
     runmpi(joinpath(@__DIR__, "integral_test.jl"))
     runmpi(joinpath(@__DIR__, "integral_test_sphere.jl"))
     runmpi(joinpath(@__DIR__, "vars_test.jl"))
+    runmpi(joinpath(@__DIR__, "custom_filter.jl"))
 end


### PR DESCRIPTION
### Description

The EDMF team has demonstrated significantly more stable simulations using custom filters. cc: @yairchn @ilopezgp 

The current implementation of the custom filter is a Q&D hack that takes many passes over the entire MPIStateArray:
```julia
cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
    bl = solver_config.dg.balance_law
    st = vars_state(bl, Prognostic(), eltype(Q))
    aux = vars_state(bl, Auxiliary(), eltype(Q))
    a_min = bl.turbconv.subdomains.a_min
    a_max = bl.turbconv.subdomains.a_max
    i_ρ = varsindex(st, :ρ)
    i_ρq_tot_gm = varsindex(st, :moisture, :ρq_tot)
    ρ_gm = solver_config.Q[:,i_ρ,:]
    i_ρaθ_liq_en = varsindex(aux, :turbconv, :environment,:ρaθ_liq)
    ρaθ_liq_en  = solver_config.dg.state_auxiliary[:,i_ρaθ_liq_en,:]
    ρaθ_liq_ups = FT(0)
    ρaq_tot_ups = FT(0)
    ρa_ups      = FT(0)
    ρaw_ups     = FT(0)
    for i in 1:n_updrafts(bl.turbconv)
        i_ρaθ_liq_up = varsindex(st, :turbconv, :updraft, Val(i), :ρaθ_liq)
        i_ρaq_tot_up = varsindex(st, :turbconv, :updraft, Val(i), :ρaq_tot)
        i_ρa_up      = varsindex(st, :turbconv, :updraft, Val(i), :ρa)
        i_ρaw_up     = varsindex(st, :turbconv, :updraft, Val(i), :ρaw)
        ρaθ_liq_ups  = ρaθ_liq_ups .+ solver_config.Q[:,i_ρaθ_liq_up,:]
        ρaq_tot_ups  = ρaq_tot_ups .+ solver_config.Q[:,i_ρaq_tot_up,:]
        ρa_ups       = ρa_ups .+ solver_config.Q[:,i_ρa_up,:]
        ρaw_ups      = ρaw_ups .+ solver_config.Q[:,i_ρaw_up,:]
    end
    ρq_tot_gm   = solver_config.Q[:,i_ρq_tot_gm,:]
    ρaw_en      = - ρaw_ups
    ρaq_tot_en  = (ρq_tot_gm - ρaq_tot_ups) ./ (ρ_gm .- ρa_ups)
    θ_liq_en    = ρaθ_liq_en ./ (ρ_gm .- ρa_ups)
    q_tot_en    = ρaq_tot_en ./ (ρ_gm .- ρa_ups)
    w_en        = ρaw_en./ (ρ_gm .- ρa_ups)
    for i in 1:n_updrafts(bl.turbconv)
        i_ρa_up      = varsindex(st, :turbconv, :updraft, Val(i), :ρa)
        i_ρaθ_liq_up = varsindex(st, :turbconv, :updraft, Val(i), :ρaθ_liq)
        i_ρaq_tot_up = varsindex(st, :turbconv, :updraft, Val(i), :ρaq_tot)
        i_ρaw_up     = varsindex(st, :turbconv, :updraft, Val(i), :ρaw)
        a_up_mask   = solver_config.Q[:,i_ρa_up,:] .< ρ_gm*a_min
        ρ_area_change = max.(a_up_mask.*(ρ_gm*a_min .- solver_config.Q[:,i_ρa_up,:]),FT(0))
        solver_config.Q[:,i_ρa_up,:]      .+= a_up_mask .*ρ_area_change
        solver_config.Q[:,i_ρaθ_liq_up,:] .+= a_up_mask .*θ_liq_en.*ρ_area_change
        solver_config.Q[:,i_ρaq_tot_up,:] .+= a_up_mask .*q_tot_en.*ρ_area_change
        solver_config.Q[:,i_ρaw_up,:]     .+= a_up_mask .*w_en.*ρ_area_change
    end
    nothing
end
```

With this PR, we can simplify this to a single pass:

```julia
import ClimateMachine.DGMethods: custom_filter!
struct EDMFFilter <: AbstractCustomFilter end
function custom_filter!(::EDMFFilter, atmos, state, aux)
    FT = eltype(state)
    bl = atmos
    a_min = bl.turbconv.subdomains.a_min
    a_max = bl.turbconv.subdomains.a_max
    en = state.turbconv.environment
    up = state.turbconv.updraft
    N_up = n_updrafts(bl.turbconv)
    ρ_gm = state.ρ
    ρaθ_liq_ups = sum(ntuple(up[i].ρaθ_liq, N_up))
    ρaq_tot_ups = sum(ntuple(up[i].ρaq_tot, N_up))
    ρa_ups      = sum(ntuple(up[i].ρa, N_up))
    ρaw_ups     = sum(ntuple(up[i].ρaw, N_up))
    ρq_tot_gm   = state.ρq_tot
    ρaw_en      = - ρaw_ups
    ρaq_tot_en  = (ρq_tot_gm - ρaq_tot_ups) / (ρ_gm - ρa_ups)
    θ_liq_en    = en.ρaθ_liq / (ρ_gm - ρa_ups)
    q_tot_en    = ρaq_tot_en / (ρ_gm - ρa_ups)
    w_en        = ρaw_en / (ρ_gm - ρa_ups)
    @unroll_map(N_up) do i
        a_up_mask   = up[i].ρa < ρ_gm*a_min
        ρ_area_change = max(a_up_mask * (ρ_gm * a_min - up[i].ρa), FT(0))
        up[i].ρa      += a_up_mask * ρ_area_change
        up[i].ρaθ_liq += a_up_mask * θ_liq_en * ρ_area_change
        up[i].ρaq_tot += a_up_mask * q_tot_en * ρ_area_change
        up[i].ρaw     += a_up_mask * w_en * ρ_area_change
    end
end

cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
    apply!(
        EDMFFilter(),
        solver_config.dg.grid,
        solver_config.dg.balance_law,
        solver_config.Q,
        solver_config.dg.state_auxiliary,
    )
    nothing
end
```

I'm aware that this filter will not preserve mass, however, I think that either 1) we may be able to orthogonally improve that or 2) it may not matter based on the assumptions made in the EDMF model.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
