### PR TITLE
Make `recover_thermo_state` call `new_thermo_state` in turbconv

### DIFF
--- a/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
@@ -64,16 +64,16 @@ new_thermo_state_en(
 Recover NamedTuple of all thermo states
 """
 function recover_thermo_state_all(bl, state, aux)
-    ts = recover_thermo_state(bl, state, aux)
+    ts = new_thermo_state(bl, state, aux)
     return (
         gm = ts,
-        en = recover_thermo_state_en(bl, bl.moisture, state, aux, ts),
-        up = recover_thermo_state_up(bl, bl.moisture, state, aux, ts),
+        en = new_thermo_state_en(bl, bl.moisture, state, aux, ts),
+        up = new_thermo_state_up(bl, bl.moisture, state, aux, ts),
     )
 end
 
 """
-    recover_thermo_state_up(bl, state, aux)
+    recover_thermo_state_up(bl, state, aux, ts = new_thermo_state(bl, state, aux))
 
 Recover the updraft thermodynamic states given:
  - `bl`, parent `BalanceLaw`
@@ -87,12 +87,24 @@ Recover the updraft thermodynamic states given:
     This method assumes that the temperature has been
     previously computed from a new thermodynamic state
     and stored in `aux`.
+
+!!! warn
+    While recover_thermo_state_up is an ideal long-term solution,
+    right now we are directly calling new_thermo_state_up to avoid
+    inconsistent aux states in kernels where the aux states are
+    out of sync with the boundary state.
 """
-recover_thermo_state_up(bl, state, aux) =
-    recover_thermo_state_up(bl, bl.moisture, state, aux)
+function recover_thermo_state_up(
+    bl,
+    state,
+    aux,
+    ts = new_thermo_state(bl, state, aux),
+)
+    return new_thermo_state_up(bl, bl.moisture, state, aux, ts)
+end
 
 """
-    recover_thermo_state_en(bl, state, aux)
+    recover_thermo_state_en(bl, state, aux, ts = recover_thermo_state(bl, state, aux))
 
 Recover the environment thermodynamic state given:
  - `bl`, parent `BalanceLaw`
@@ -106,9 +118,21 @@ Recover the environment thermodynamic state given:
     This method assumes that the temperature has been
     previously computed from a new thermodynamic state
     and stored in `aux`.
+
+!!! warn
+    While recover_thermo_state_up is an ideal long-term solution,
+    right now we are directly calling new_thermo_state_up to avoid
+    inconsistent aux states in kernels where the aux states are
+    out of sync with the boundary state.
 """
-recover_thermo_state_en(bl, state, aux) =
-    recover_thermo_state_en(bl, bl.moisture, state, aux)
+function recover_thermo_state_en(
+    bl,
+    state,
+    aux,
+    ts = new_thermo_state(bl, state, aux),
+)
+    return new_thermo_state_en(bl, bl.moisture, state, aux, ts)
+end
 
 ####
 #### Implementation


### PR DESCRIPTION
### Description

This PR makes `recover_thermo_state` call `new_thermo_state` in the turbconv model (which was not done in #1647). It looks like this is PR passes the regression test 🎉

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
