### PR TITLE
Rename Atmos.Source to Atmos.AbstractSource

### DIFF
--- a/experiments/AtmosGCM/GCMDriver/gcm_sources.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_sources.jl
@@ -5,12 +5,12 @@
 import ClimateMachine.Atmos: atmos_source!
 
 """
-    HeldSuarezForcing <: Source
+    HeldSuarezForcing <: AbstractSource
 
 Defines a forcing that parametrises radiative and frictional effects using
 Newtonian relaxation and Rayleigh friction, following Held and Suarez (1994)
 """
-struct HeldSuarezForcing <: Source end
+struct HeldSuarezForcing <: AbstractSource end
 
 function atmos_source!(
     ::HeldSuarezForcing,

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -99,12 +99,12 @@ function init_heldsuarez!(problem, bl, state, aux, localgeo, t)
 end
 
 """
-    HeldSuarezForcing <: Source
+    HeldSuarezForcing <: AbstractSource
 
 Defines a forcing that parametrises radiative and frictional effects using
 Newtonian relaxation and Rayleigh friction, following Held and Suarez (1994)
 """
-struct HeldSuarezForcing <: Source end
+struct HeldSuarezForcing <: AbstractSource end
 
 function atmos_source!(
     ::HeldSuarezForcing,

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -99,7 +99,7 @@ using ClimateMachine.Atmos: altitude, recover_thermo_state
 """
   Bomex Geostrophic Forcing (Source)
 """
-struct BomexGeostrophic{FT} <: Source
+struct BomexGeostrophic{FT} <: AbstractSource
     "Coriolis parameter [s⁻¹]"
     f_coriolis::FT
     "Eastward geostrophic velocity `[m/s]` (Base)"
@@ -138,7 +138,7 @@ end
 """
   Bomex Sponge (Source)
 """
-struct BomexSponge{FT} <: Source
+struct BomexSponge{FT} <: AbstractSource
     "Maximum domain altitude (m)"
     z_max::FT
     "Altitude at with sponge starts (m)"
@@ -189,7 +189,7 @@ end
   BomexTendencies (Source)
 Moisture, Temperature and Subsidence tendencies
 """
-struct BomexTendencies{FT} <: Source
+struct BomexTendencies{FT} <: AbstractSource
     "Advection tendency in total moisture `[s⁻¹]`"
     ∂qt∂t_peak::FT
     "Lower extent of piecewise profile (moisture term) `[m]`"

--- a/experiments/AtmosLES/convective_bl_model.jl
+++ b/experiments/AtmosLES/convective_bl_model.jl
@@ -59,7 +59,7 @@ using ClimateMachine.Atmos: altitude, recover_thermo_state
 """
   ConvectiveBL Geostrophic Forcing (Source)
 """
-struct ConvectiveBLGeostrophic{FT} <: Source
+struct ConvectiveBLGeostrophic{FT} <: AbstractSource
     "Coriolis parameter [s⁻¹]"
     f_coriolis::FT
     "Eastward geostrophic velocity `[m/s]` (Base)"
@@ -98,7 +98,7 @@ end
 """
   ConvectiveBL Sponge (Source)
 """
-struct ConvectiveBLSponge{FT} <: Source
+struct ConvectiveBLSponge{FT} <: AbstractSource
     "Maximum domain altitude (m)"
     z_max::FT
     "Altitude at with sponge starts (m)"

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -59,7 +59,7 @@ using ClimateMachine.Atmos: altitude, recover_thermo_state
 """
   StableBL Geostrophic Forcing (Source)
 """
-struct StableBLGeostrophic{FT} <: Source
+struct StableBLGeostrophic{FT} <: AbstractSource
     "Coriolis parameter [s⁻¹]"
     f_coriolis::FT
     "Eastward geostrophic velocity `[m/s]` (Base)"
@@ -98,7 +98,7 @@ end
 """
   StableBL Sponge (Source)
 """
-struct StableBLSponge{FT} <: Source
+struct StableBLSponge{FT} <: AbstractSource
     "Maximum domain altitude (m)"
     z_max::FT
     "Altitude at with sponge starts (m)"

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -1,7 +1,7 @@
 using ..Microphysics_0M
 using CLIMAParameters.Planet: Omega, e_int_i0, cv_l, cv_i, T_0
 
-export Source,
+export AbstractSource,
     Gravity,
     RayleighSponge,
     Subsidence,
@@ -37,9 +37,9 @@ export Source,
     end
 end
 
-abstract type Source end
+abstract type AbstractSource end
 
-struct Gravity <: Source end
+struct Gravity <: AbstractSource end
 function atmos_source!(
     ::Gravity,
     atmos::AtmosModel,
@@ -57,7 +57,7 @@ function atmos_source!(
     end
 end
 
-struct Coriolis <: Source end
+struct Coriolis <: AbstractSource end
 function atmos_source!(
     ::Coriolis,
     atmos::AtmosModel,
@@ -74,7 +74,7 @@ function atmos_source!(
     source.ρu -= SVector(0, 0, 2 * _Omega) × state.ρu
 end
 
-struct Subsidence{FT} <: Source
+struct Subsidence{FT} <: AbstractSource
     D::FT
 end
 
@@ -102,7 +102,7 @@ subsidence_velocity(subsidence::Subsidence{FT}, z::FT) where {FT} =
     -subsidence.D * z
 
 
-struct GeostrophicForcing{FT} <: Source
+struct GeostrophicForcing{FT} <: AbstractSource
     f_coriolis::FT
     u_geostrophic::FT
     v_geostrophic::FT
@@ -124,13 +124,13 @@ function atmos_source!(
 end
 
 """
-    RayleighSponge{FT} <: Source
+    RayleighSponge{FT} <: AbstractSource
 
 Rayleigh Damping (Linear Relaxation) for top wall momentum components
 Assumes laterally periodic boundary conditions for LES flows. Momentum components
 are relaxed to reference values (zero velocities) at the top boundary.
 """
-struct RayleighSponge{FT} <: Source
+struct RayleighSponge{FT} <: AbstractSource
     "Maximum domain altitude (m)"
     z_max::FT
     "Altitude at with sponge starts (m)"
@@ -161,13 +161,13 @@ function atmos_source!(
 end
 
 """
-    CreateClouds{FT} <: Source
+    CreateClouds{FT} <: AbstractSource
 
 A source/sink to `q_liq` and `q_ice` implemented as a relaxation towards
 equilibrium in the Microphysics module.
 The default relaxation timescales are defined in CLIMAParameters.jl.
 """
-struct CreateClouds <: Source end
+struct CreateClouds <: AbstractSource end
 function atmos_source!(
     ::CreateClouds,
     atmos::AtmosModel,
@@ -198,7 +198,7 @@ function atmos_source!(
 end
 
 """
-    RemovePrecipitation{FT} <: Source
+    RemovePrecipitation{FT} <: AbstractSource
 
 A sink to `q_tot` when cloud condensate is exceeding a threshold.
 The threshold is defined either in terms of condensate or supersaturation.
@@ -206,7 +206,7 @@ The removal rate is implemented as a relaxation term
 in the Microphysics_0M module.
 The default thresholds and timescale are defined in CLIMAParameters.jl.
 """
-struct RemovePrecipitation <: Source
+struct RemovePrecipitation <: AbstractSource
     " Set to true if using qc based threshold"
     use_qc_thr::Bool
 end

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -334,7 +334,7 @@ function compute_gradient_flux!(
     tc_dif.S² = ∇transform.u[3, 1]^2 + ∇transform.u[3, 2]^2 + en_dif.∇w[3]^2
 end;
 
-struct TurbconvSource <: Source end
+struct TurbconvSource <: AbstractSource end
 
 function atmos_source!(
     ::TurbconvSource,

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -53,7 +53,7 @@ function mms3_init_state!(problem, bl, state::Vars, aux::Vars, localgeo, t)
     state.ρe = E_g(t, x1, x2, x3, Val(3))
 end
 
-struct MMS3Source <: Source end
+struct MMS3Source <: AbstractSource end
 function atmos_source!(
     ::MMS3Source,
     ::AtmosModel,

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -56,7 +56,7 @@ function mms2_init_state!(problem, bl, state::Vars, aux::Vars, localgeo, t)
     state.ρe = E_g(t, x1, x2, x3, Val(2))
 end
 
-struct MMS2Source <: Source end
+struct MMS2Source <: AbstractSource end
 function atmos_source!(
     ::MMS2Source,
     ::AtmosModel,
@@ -88,7 +88,7 @@ function mms3_init_state!(problem, bl, state::Vars, aux::Vars, localgeo, t)
     state.ρe = E_g(t, x1, x2, x3, Val(3))
 end
 
-struct MMS3Source <: Source end
+struct MMS3Source <: AbstractSource end
 function atmos_source!(
     ::MMS3Source,
     ::AtmosModel,

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -42,7 +42,7 @@ using CLIMAParameters.Planet: MSLP, R_d, day, grav, cp_d, cv_d, planet_radius
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet();
 
-struct HeldSuarezForcingTutorial <: Source end
+struct HeldSuarezForcingTutorial <: AbstractSource end
 
 # Construct the Held-Suarez forcing function. We can view this as part the
 # right-hand-side of our governing equations. It forces the total energy field


### PR DESCRIPTION
### Description

This PR renames `Source` to `AbstractSource`, as it's an abstract type. These changes were peeled off from #1634 because they touch a bunch more files than #1634 needs to.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
