### PR TITLE
Add const to `FT` and enforce to be in type domain

### DIFF
--- a/test/Land/Model/heat_analytic_unit_test.jl
+++ b/test/Land/Model/heat_analytic_unit_test.jl
@@ -27,29 +27,29 @@ using ClimateMachine.SingleStackUtils
 using ClimateMachine.BalanceLaws:
     BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, vars_state
 
+function init_soil!(land, state, aux, localgeo, time)
+    FT = eltype(state)
+    ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, time)
+    θ_l = volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
+    ρc_s = volumetric_heat_capacity(
+        θ_l,
+        θ_i,
+        land.soil.param_functions.ρc_ds,
+        land.param_set,
+    )
+
+    state.soil.heat.ρe_int = FT(volumetric_internal_energy(
+        θ_i,
+        ρc_s,
+        land.soil.heat.initialT(aux),
+        land.param_set,
+    ))
+end
+
+const FT = Float32
+
 @testset "Heat analytic unit test" begin
     ClimateMachine.init()
-    FT = Float32
-
-    function init_soil!(land, state, aux, localgeo, time)
-        myFT = eltype(state)
-        ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, time)
-        θ_l =
-            volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
-        ρc_s = volumetric_heat_capacity(
-            θ_l,
-            θ_i,
-            land.soil.param_functions.ρc_ds,
-            land.param_set,
-        )
-
-        state.soil.heat.ρe_int = myFT(volumetric_internal_energy(
-            θ_i,
-            ρc_s,
-            land.soil.heat.initialT(aux),
-            land.param_set,
-        ))
-    end
 
     soil_param_functions = SoilParamFunctions{FT}(
         porosity = 0.495,

--- a/test/Numerics/SystemSolvers/poisson.jl
+++ b/test/Numerics/SystemSolvers/poisson.jl
@@ -163,13 +163,13 @@ end
 function test_run(
     mpicomm,
     ArrayType,
-    FT,
+    ::Type{FT},
     dim,
     polynomialorder,
     brickrange,
     periodicity,
     linmethod,
-)
+) where {FT}
 
     topology = BrickTopology(mpicomm, brickrange, periodicity = periodicity)
     grid = DiscontinuousSpectralElementGrid(

--- a/test/Ocean/HydrostaticBoussinesq/test_3D_spindown.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_3D_spindown.jl
@@ -18,7 +18,13 @@ using CLIMAParameters.Planet: grav
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function config_simple_box(FT, N, resolution, dimensions; BC = nothing)
+function config_simple_box(
+    ::Type{FT},
+    N,
+    resolution,
+    dimensions;
+    BC = nothing,
+) where {FT}
     if BC == nothing
         problem = SimpleBox{FT}(dimensions...)
     else

--- a/test/Ocean/ShallowWater/GyreDriver.jl
+++ b/test/Ocean/ShallowWater/GyreDriver.jl
@@ -67,7 +67,19 @@ end
 
 outname = "vtk_new_dt_" * gyre * "_" * advec
 
-function setup_model(FT, stommel, linear, τₒ, fₒ, β, γ, ν, Lˣ, Lʸ, H)
+function setup_model(
+    ::Type{FT},
+    stommel,
+    linear,
+    τₒ,
+    fₒ,
+    β,
+    γ,
+    ν,
+    Lˣ,
+    Lʸ,
+    H,
+) where {FT}
     problem = HomogeneousBox{FT}(
         Lˣ,
         Lʸ,
@@ -104,7 +116,16 @@ end
 # Timestepping function #
 #########################
 
-function test_run(mpicomm, topl, ArrayType, N, dt, FT, model, test)
+function test_run(
+    mpicomm,
+    topl,
+    ArrayType,
+    N,
+    dt,
+    ::Type{FT},
+    model,
+    test,
+) where {FT}
     grid = DiscontinuousSpectralElementGrid(
         topl,
         FloatType = FT,

--- a/test/Ocean/SplitExplicit/simple_box_2dt.jl
+++ b/test/Ocean/SplitExplicit/simple_box_2dt.jl
@@ -130,7 +130,7 @@ function ocean_init_aux!(m::BarotropicModel, P::SimpleBox, A, geom)
     return nothing
 end
 
-function main()
+function main(::Type{FT}) where {FT}
     mpicomm = MPI.COMM_WORLD
 
     ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
@@ -456,4 +456,4 @@ const τₒ = 1e-1
 const λʳ = 10 // 86400 # m/s
 const θᴱ = 10    # deg.C
 
-main()
+main(FT)

--- a/test/Ocean/SplitExplicit/simple_box_ivd.jl
+++ b/test/Ocean/SplitExplicit/simple_box_ivd.jl
@@ -29,7 +29,7 @@ const param_set = EarthParameterSet()
 
 const ArrayType = ClimateMachine.array_type()
 
-function main(BC)
+function main(::Type{FT}, BC) where {FT}
     mpicomm = MPI.COMM_WORLD
 
     brickrange_2D = (xrange, yrange)
@@ -308,7 +308,7 @@ end
 #################
 # RUN THE TESTS #
 #################
-FT = Float64
+const FT = Float64
 vtkpath = abspath(joinpath(ClimateMachine.Settings.output_dir, "vtk_split"))
 
 const timeend = 5 * 24 * 3600 # s
@@ -352,5 +352,5 @@ BC = (
 )
 
 @testset "$(@__FILE__)" begin
-    main(BC)
+    main(FT, BC)
 end

--- a/test/Ocean/SplitExplicit/test_vertical_integral_model.jl
+++ b/test/Ocean/SplitExplicit/test_vertical_integral_model.jl
@@ -30,7 +30,7 @@ using CLIMAParameters.Planet: grav
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function test_vertical_integral_model(time; refDat = ())
+function test_vertical_integral_model(::Type{FT}, time; refDat = ()) where {FT}
     mpicomm = MPI.COMM_WORLD
     ArrayType = ClimateMachine.array_type()
 
@@ -139,7 +139,7 @@ end
 #################
 # RUN THE TESTS #
 #################
-FT = Float64
+const FT = Float64
 
 const N = 4
 const Nˣ = 5
@@ -163,7 +163,7 @@ const cᶻ = 0
         [0, 86400, 30 * 86400, 365 * 86400, 10 * 365 * 86400, 100 * 365 * 86400]
     for (index, time) in enumerate(times)
         @testset "$(time)" begin
-            test_vertical_integral_model(time, refDat = refVals[index])
+            test_vertical_integral_model(FT, time, refDat = refVals[index])
         end
     end
 end

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -186,7 +186,14 @@ end
 # model. The purpose of this is to populate the
 # `AtmosLESConfiguration` with arguments
 # appropriate to the problem being considered.
-function config_agnesi_hs_lin(FT, N, resolution, xmax, ymax, zmax)
+function config_agnesi_hs_lin(
+    ::Type{FT},
+    N,
+    resolution,
+    xmax,
+    ymax,
+    zmax,
+) where {FT}
     ##
     ## Explicit Rayleigh damping:
     ##

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -182,7 +182,14 @@ end
 # model. The purpose of this is to populate the
 # `AtmosLESConfiguration` with arguments
 # appropriate to the problem being considered.
-function config_agnesi_hs_lin(FT, N, resolution, xmax, ymax, zmax)
+function config_agnesi_hs_lin(
+    ::Type{FT},
+    N,
+    resolution,
+    xmax,
+    ymax,
+    zmax,
+) where {FT}
     ##
     ## Explicit Rayleigh damping:
     ##

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -115,7 +115,7 @@ import ClimateMachine.BalanceLaws:
 # ## Initialization
 
 # Define the float type (`Float64` or `Float32`)
-FT = Float64;
+const FT = Float64;
 # Initialize ClimateMachine for CPU.
 ClimateMachine.init(; disable_gpu = true);
 

--- a/tutorials/Atmos/burgers_single_stack_bjfnk.jl
+++ b/tutorials/Atmos/burgers_single_stack_bjfnk.jl
@@ -116,7 +116,7 @@ import ClimateMachine.BalanceLaws:
 # ## Initialization
 
 # Define the float type (`Float64` or `Float32`)
-FT = Float64;
+const FT = Float64;
 # Initialize ClimateMachine for CPU.
 ClimateMachine.init(; disable_gpu = true);
 

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -87,7 +87,7 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.Mesh.Filters
 # - Required so functions for computation of temperature profiles.
 using ClimateMachine.TemperatureProfiles
-# - Required so functions for computation of moist thermodynamic quantities and turbulence closures 
+# - Required so functions for computation of moist thermodynamic quantities and turbulence closures
 # are available.
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TurbulenceClosures
@@ -182,7 +182,14 @@ end
 # ## [Model Configuration](@id config-helper)
 # We define a configuration function to assist in prescribing the physical
 # model.
-function config_densitycurrent(FT, N, resolution, xmax, ymax, zmax)
+function config_densitycurrent(
+    ::Type{FT},
+    N,
+    resolution,
+    xmax,
+    ymax,
+    zmax,
+) where {FT}
 
     ## Choose an Explicit Single-rate Solver LSRK144 from the existing [ODESolvers](@ref
     ## ODESolvers-docs) options Apply the outer constructor to define the

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -107,7 +107,7 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
 end
 
 # Define problem configuration kernel
-function config_problem(FT, N, resolution, xmax, ymax, zmax)
+function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
 
     ## Boundary conditions
     T_bot = FT(299)

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -136,7 +136,7 @@ ClimateMachine.init();
 # precisions, with lower precision we get our results faster, and with higher
 # precision, we may get more accurate results, depending on the questions we
 # are after.
-FT = Float32;
+const FT = Float32;
 
 
 # ## Setup model configuration

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -3,7 +3,7 @@
 # In this example, we demonstrate the usage of the `ClimateMachine`
 # [AtmosModel](@ref AtmosModel-docs) machinery to solve the fluid
 # dynamics of a thermal perturbation in a neutrally stratified background state
-# defined by its uniform potential temperature. We solve a flow in a box configuration - 
+# defined by its uniform potential temperature. We solve a flow in a box configuration -
 # this is representative of a large-eddy simulation. Several versions of the problem
 # setup may be found in literature, but the general idea is to examine the
 # vertical ascent of a thermal bubble (we can interpret these as simple
@@ -177,9 +177,16 @@ end
 # model. The purpose of this is to populate the
 # `ClimateMachine.AtmosLESConfiguration` with arguments
 # appropriate to the problem being considered.
-function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
+function config_risingbubble(
+    ::Type{FT},
+    N,
+    resolution,
+    xmax,
+    ymax,
+    zmax,
+) where {FT}
 
-    ## Choose an Explicit Single-rate Solver from the existing [`ODESolvers`](@ref ClimateMachine.ODESolvers) options. 
+    ## Choose an Explicit Single-rate Solver from the existing [`ODESolvers`](@ref ClimateMachine.ODESolvers) options.
     ## Apply the outer constructor to define the `ode_solver`.
     ## The 1D-IMEX method is less appropriate for the problem given the current
     ## mesh aspect ratio (1:1).
@@ -318,19 +325,19 @@ end
 # `julia --project tutorials/Atmos/risingbubble.jl` will run the
 # experiment from the main ClimateMachine.jl directory, with diagnostics output
 # at the intervals specified in [`config_diagnostics`](@ref
-# config_diagnostics).  You can also prescribe command line arguments for 
+# config_diagnostics).  You can also prescribe command line arguments for
 # simulation update and output specifications.  For
 # rapid turnaround, we recommend that you run this experiment on a GPU.
 
-# VTK output can be controlled via command line by 
+# VTK output can be controlled via command line by
 # setting `parse_clargs=true` in the `ClimateMachine.init`
-# arguments, and then using `--vtk=<interval>`. 
+# arguments, and then using `--vtk=<interval>`.
 
 # ## [Output Visualisation](@id output-viz)
 # See the `ClimateMachine` API interface documentation
 # for generating output.
-# 
-# 
+#
+#
 # - [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit/)
 # - [Paraview](https://wci.llnl.gov/simulation/computer-codes/visit/)
 # are two commonly used programs for `.vtu` files.

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -92,7 +92,7 @@ import ClimateMachine.DGMethods: calculate_dt
 # ## Initialization
 
 # Define the float type (`Float64` or `Float32`)
-FT = Float64;
+const FT = Float64;
 # Initialize ClimateMachine for CPU.
 ClimateMachine.init(; disable_gpu = true);
 

--- a/tutorials/Land/Soil/Coupled/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Coupled/equilibrium_test.jl
@@ -121,7 +121,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet();
 # Initialize and pick a floating point precision:
 ClimateMachine.init()
-FT = Float64;
+const FT = Float64;
 
 # Load plot helpers:
 const clima_dir = dirname(dirname(pathof(ClimateMachine)));

--- a/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
+++ b/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
@@ -114,7 +114,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet();
 # Initialize and pick a floating point precision.
 ClimateMachine.init()
-FT = Float32;
+const FT = Float32;
 # Load functions that will help with plotting
 const clima_dir = dirname(dirname(pathof(ClimateMachine)));
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));

--- a/tutorials/Land/Soil/Water/hydraulic_functions.jl
+++ b/tutorials/Land/Soil/Water/hydraulic_functions.jl
@@ -23,7 +23,7 @@ using ClimateMachine
 using ClimateMachine.Land
 using ClimateMachine.Land.SoilWaterParameterizations
 
-FT = Float32;
+const FT = Float32;
 # # Specifying a  `hydraulics` model
 # The van Genuchten model requires two free parameters, `α` and `n`.
 # A third parameter, `m`, is computed from `n`. Of these, only `α` carries

--- a/tutorials/Numerics/DGMethods/Box1D.jl
+++ b/tutorials/Numerics/DGMethods/Box1D.jl
@@ -141,8 +141,6 @@ function boundary_state!(
     _...,
 ) end;
 
-FT = Float64;
-
 function run_box1D(
     N_poly::Int,
     init_q::FT,
@@ -159,7 +157,7 @@ function run_box1D(
     boyd_param_1::Int = 0,
     boyd_param_2::Int = 32,
     numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
-)
+) where {FT}
     N_poly = N_poly
     nelem = 128
     zmax = FT(350)

--- a/tutorials/Numerics/DGMethods/showcase_filters.jl
+++ b/tutorials/Numerics/DGMethods/showcase_filters.jl
@@ -7,21 +7,29 @@ using ClimateMachine
 const clima_dir = dirname(dirname(pathof(ClimateMachine)));
 include(joinpath(clima_dir, "tutorials", "Numerics", "DGMethods", "Box1D.jl"))
 
+const FT = Float64
+
 output_dir = @__DIR__;
 mkpath(output_dir);
 
 # The unfiltered result of the box advection test for order 4 polynomial with
 # central flux is
-run_box1D(4, 0.0, 1.0, 1.0, joinpath(output_dir, "box_1D_4_no_filter.svg"))
+run_box1D(
+    4,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
+    joinpath(output_dir, "box_1D_4_no_filter.svg"),
+)
 # ![](box_1D_4_no_filter.svg)
 
 # The unfiltered result of the box advection test for order 4 polynomial with
 # Rusanov flux (aka upwinding for advection) is
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_no_filter_upwind.svg"),
     numerical_flux_first_order = RusanovNumericalFlux(),
 )
@@ -37,9 +45,9 @@ run_box1D(
 # `TMARFilter()` with central numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_tmar.svg");
     tmar_filter = true,
 )
@@ -50,9 +58,9 @@ run_box1D(
 # `TMARFilter()` with Rusanov numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_tmar_upwind.svg");
     tmar_filter = true,
     numerical_flux_first_order = RusanovNumericalFlux(),
@@ -62,9 +70,9 @@ run_box1D(
 # `CutoffFilter(grid, Nc=1)` with central numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_cutoff_1.svg");
     cutoff_filter = true,
     cutoff_param = 1,
@@ -74,9 +82,9 @@ run_box1D(
 # `CutoffFilter(grid, Nc=3)` with central numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_cutoff_3.svg");
     cutoff_filter = true,
     cutoff_param = 3,
@@ -86,9 +94,9 @@ run_box1D(
 # `ExponentialFilter(grid, Nc=1, s=4)` with central numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_exp_1_4.svg");
     exp_filter = true,
     exp_param_1 = 1,
@@ -99,9 +107,9 @@ run_box1D(
 # `ExponentialFilter(grid, Nc=1, s=8)` with central numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_exp_1_8.svg");
     exp_filter = true,
     exp_param_1 = 1,
@@ -112,9 +120,9 @@ run_box1D(
 # `ExponentialFilter(grid, Nc=1, s=32)` with central numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_exp_1_32.svg");
     exp_filter = true,
     exp_param_1 = 1,
@@ -125,9 +133,9 @@ run_box1D(
 # `BoydVandevenFilter(grid, Nc=1, s=4)` with central numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_boyd_1_4.svg");
     boyd_filter = true,
     boyd_param_1 = 1,
@@ -138,9 +146,9 @@ run_box1D(
 # `BoydVandevenFilter(grid, Nc=1, s=8)` with central numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_boyd_1_8.svg");
     boyd_filter = true,
     boyd_param_1 = 1,
@@ -151,9 +159,9 @@ run_box1D(
 # `BoydVandevenFilter(grid, Nc=1, s=32)` with central numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_boyd_1_32.svg");
     boyd_filter = true,
     boyd_param_1 = 1,
@@ -165,9 +173,9 @@ run_box1D(
 # flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_tmar_exp_1_8.svg");
     exp_filter = true,
     tmar_filter = true,
@@ -180,9 +188,9 @@ run_box1D(
 # numerical flux:
 run_box1D(
     4,
-    0.0,
-    1.0,
-    1.0,
+    FT(0.0),
+    FT(1.0),
+    FT(1.0),
     joinpath(output_dir, "box_1D_4_tmar_boyd_1_8.svg");
     boyd_filter = true,
     tmar_filter = true,


### PR DESCRIPTION
### Description

The docs build recently started timing out, cc @thomasgibson. This PR is an attempted quick-fix by enforcing that `FT` is in the type domain for the tutorials. I accidentally started doing this in some of the tests, too. Perhaps this will speed some things up.


<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
