### PR TITLE
Pass BalanceLaw to BulkFormulaEnergy

### DIFF
--- a/experiments/AtmosGCM/GCMDriver/gcm_bcs.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_bcs.jl
@@ -21,8 +21,8 @@ function parse_surface_flux_arg(
         boundarycondition = (
             AtmosBC(
                 energy = BulkFormulaEnergy(
-                    (state, aux, t, normPu_int) -> _C_drag,
-                    (state, aux, t) -> bulk_flux(state, aux, t),
+                    (bl, state, aux, t, normPu_int) -> _C_drag,
+                    (bl, state, aux, t) -> bulk_flux(state, aux, t),
                 ),
                 moisture = BulkFormulaMoisture(
                     (state, aux, t, normPu_int) -> _C_drag,

--- a/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
+++ b/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
@@ -242,8 +242,8 @@ function config_baroclinic_wave(
         boundarycondition = (
             AtmosBC(
                 energy = BulkFormulaEnergy(
-                    (state, aux, t, normPu_int) -> _C_drag,
-                    (state, aux, t) -> bulk_flux(state, aux, t),
+                    (bl, state, aux, t, normPu_int) -> _C_drag,
+                    (bl, state, aux, t) -> bulk_flux(state, aux, t),
                 ),
                 moisture = BulkFormulaMoisture(
                     (state, aux, t, normPu_int) -> _C_drag,

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -473,8 +473,8 @@ function bomex_model(
         moisture_bc = PrescribedMoistureFlux((state, aux, t) -> moisture_flux)
     elseif surface_flux == "bulk"
         energy_bc = BulkFormulaEnergy(
-            (state, aux, t, normPu_int) -> C_drag,
-            (state, aux, t) -> (T_sfc, q_sfc),
+            (bl, state, aux, t, normPu_int) -> C_drag,
+            (bl, state, aux, t) -> (T_sfc, q_sfc),
         )
         moisture_bc = BulkFormulaMoisture(
             (state, aux, t, normPu_int) -> C_drag,

--- a/experiments/AtmosLES/convective_bl_model.jl
+++ b/experiments/AtmosLES/convective_bl_model.jl
@@ -14,7 +14,7 @@
 ## number={12},
 ## pages={3159-3175},
 ## doi={10.1029/2018MS001534},
-## url={https://doi.org/10.1029/2018MS001534}
+## url={https://doi.org/10.1029/2018MS001534},
 ## }
 #
 # To simulate the experiment, type in
@@ -197,12 +197,16 @@ function init_convective_bl!(problem, bl, state, aux, localgeo, t)
     init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
 end
 
-function surface_temperature_variation(state, t)
+function surface_temperature_variation(bl, state, t)
     FT = eltype(state)
     ρ = state.ρ
-    q_tot = state.moisture.ρq_tot / ρ
     θ_liq_sfc = FT(291.15) + FT(20) * sinpi(FT(t / 12 / 3600))
-    TS = PhaseEquil_ρθq(param_set, ρ, θ_liq_sfc, q_tot)
+    if bl.moisture isa DryModel
+        TS = PhaseDry_ρθ(bl.param_set, ρ, θ_liq_sfc)
+    else
+        q_tot = state.moisture.ρq_tot / ρ
+        TS = PhaseEquil_ρθq(bl.param_set, ρ, θ_liq_sfc, q_tot)
+    end
     return air_temperature(TS)
 end
 
@@ -254,8 +258,9 @@ function convective_bl_model(
         moisture_bc = PrescribedMoistureFlux((state, aux, t) -> moisture_flux)
     elseif surface_flux == "bulk"
         energy_bc = BulkFormulaEnergy(
-            (state, aux, t, normPu_int) -> C_drag,
-            (state, aux, t) -> (surface_temperature_variation(state, t), q_sfc),
+            (bl, state, aux, t, normPu_int) -> C_drag,
+            (bl, state, aux, t) ->
+                (surface_temperature_variation(bl, state, t), q_sfc),
         )
         moisture_bc = BulkFormulaMoisture(
             (state, aux, t, normPu_int) -> C_drag,

--- a/src/Atmos/Model/bc_energy.jl
+++ b/src/Atmos/Model/bc_energy.jl
@@ -119,8 +119,8 @@ end
     BulkFormulaEnergy(fn) :: EnergyBC
 
 Calculate the net inward energy flux across the boundary. The drag
-coefficient is `C_h = fn_C_h(state, aux, t, normu_int_tan)`. The surface
-temperature and q_tot are `T, q_tot = fn_T_and_q_tot(state, aux, t)`.
+coefficient is `C_h = fn_C_h(atmos, state, aux, t, normu_int_tan)`. The surface
+temperature and q_tot are `T, q_tot = fn_T_and_q_tot(atmos, state, aux, t)`.
 
 Return the flux (in W m^-2).
 """
@@ -158,8 +158,8 @@ function atmos_energy_normal_boundary_flux_second_order!(
     u_int⁻ = state_int⁻.ρu / state_int⁻.ρ
     u_int⁻_tan = projection_tangential(atmos, aux_int⁻, u_int⁻)
     normu_int⁻_tan = norm(u_int⁻_tan)
-    C_h = bc_energy.fn_C_h(state⁻, aux⁻, t, normu_int⁻_tan)
-    T, q_tot = bc_energy.fn_T_and_q_tot(state⁻, aux⁻, t)
+    C_h = bc_energy.fn_C_h(atmos, state⁻, aux⁻, t, normu_int⁻_tan)
+    T, q_tot = bc_energy.fn_T_and_q_tot(atmos, state⁻, aux⁻, t)
 
     # calculate MSE from the states at the boundary and at the interior point
     ts = PhaseEquil_ρTq(atmos.param_set, state⁻.ρ, T, q_tot)


### PR DESCRIPTION
### Description

This PR adds a BalanceLaw as an argument to the closures used for the energy fluxes in BulkFormulaEnergy. This argument is necessary for simulation that may have different energy closures depending on whether they are dry or moist.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
