### PR TITLE
change from fractional to rates

### DIFF
--- a/test/Atmos/EDMF/closures/entr_detr.jl
+++ b/test/Atmos/EDMF/closures/entr_detr.jl
@@ -44,78 +44,76 @@ function entr_detr(
     N_up = n_updrafts(m.turbconv)
     ρ_inv = 1 / gm.ρ
     a_up_i = up[i].ρa * ρ_inv
+    if a_up_i<FT(0)#m.turbconv.subdomains.a_min
+        E_dyn = FT(0)
+        Δ_dyn = FT(0)
+        E_trb = FT(0)
+    else
+        lim_E = entr.lim_ϵ
+        lim_amp = entr.lim_amp
+        w_min = entr.w_min
+        # precompute vars
+        w_up_i = up[i].ρaw / up[i].ρa
+        sqrt_tke = sqrt(max(en.ρatke, 0) * ρ_inv / env.a)
+        # ensure far from zero
+        Δw = filter_w(w_up_i - env.w, w_min)
+        w_up_i = filter_w(w_up_i, w_min)
+        Δb = up_aux[i].buoyancy - en_aux.buoyancy
+        D_E, D_δ, M_δ, M_E =
+            nondimensional_exchange_functions(m, entr, state, aux, t, ts, env, i)
 
-    lim_ϵ = entr.lim_ϵ
-    lim_amp = entr.lim_amp
-    w_min = entr.w_min
-    # precompute vars
-    w_up_i = up[i].ρaw / up[i].ρa
-    sqrt_tke = sqrt(max(en.ρatke, 0) * ρ_inv / env.a)
-    # ensure far from zero
-    Δw = filter_w(w_up_i - env.w, w_min)
-    w_up_i = filter_w(w_up_i, w_min)
+        # I am commenting this out for now, to make sure there is no slowdown here
+        Λ_w = abs(Δb / Δw)
+        Λ_tke = entr.c_λ * abs(Δb / (max(en.ρatke * ρ_inv, 0) + w_min))
+        λ = lamb_smooth_minimum(
+            SVector(Λ_w, Λ_tke),
+            m.turbconv.mix_len.smin_ub,
+            m.turbconv.mix_len.smin_rm,
+        )
 
-    Δb = up_aux[i].buoyancy - en_aux.buoyancy
+        # compute entrainment/detrainment components
+        E_trb =
+            2 * up[i].ρa * entr.c_t * sqrt_tke /
+            max(m.turbconv.pressure.H_up, entr.εt_min)
+        E_dyn = up[i].ρa*λ*(D_E + M_E)
+        Δ_dyn = up[i].ρa*λ*(D_δ + M_δ)
 
-    D_ε, D_δ, M_δ, M_ε =
-        nondimensional_exchange_functions(m, entr, state, aux, t, ts, env, i)
-
-    # I am commenting this out for now, to make sure there is no slowdown here
-    Λ_w = abs(Δb / Δw)
-    Λ_tke = entr.c_λ * abs(Δb / (max(en.ρatke * ρ_inv, 0) + w_min))
-    λ = lamb_smooth_minimum(
-        SVector(Λ_w, Λ_tke),
-        m.turbconv.mix_len.smin_ub,
-        m.turbconv.mix_len.smin_rm,
-    )
-
-    # compute limiters
-    εt_lim = εt_limiter(w_up_i, lim_ϵ, lim_amp)
-    ε_lim = ε_limiter(a_up_i, lim_ϵ, lim_amp)
-    δ_lim = δ_limiter(a_up_i, lim_ϵ, lim_amp)
-    # compute entrainment/detrainment components
-    ε_trb =
-        2 * a_up_i * entr.c_t * sqrt_tke /
-        max((w_up_i * a_up_i * m.turbconv.pressure.H_up), entr.εt_min)
-    ε_dyn = λ / w_up_i * (D_ε + M_ε) * ε_lim
-    δ_dyn = λ / w_up_i * (D_δ + M_δ) * δ_lim
-
-    ε_dyn = min(max(ε_dyn, FT(0)), FT(1))
-    δ_dyn = min(max(δ_dyn, FT(0)), FT(1))
-    ε_trb = min(max(ε_trb, FT(0)), FT(1))
-
-    return ε_dyn, δ_dyn, ε_trb
+        E_dyn = min(max(E_dyn, FT(0)), FT(1))
+        Δ_dyn = min(max(Δ_dyn, FT(0)), FT(1))
+        E_trb = min(max(E_trb, FT(0)), FT(1))
+    end
+    return E_dyn, Δ_dyn, E_trb
 end;
 
-"""
-    ε_limiter(a_up::FT, ϵ::FT) where {FT}
-Returns the asymptotic value of entrainment
-needed to ensure boundedness of the updraft
-area fraction between 0 and 1, given
- - `a_up`, the updraft area fraction
- - `ϵ`, a minimum threshold value
-"""
-ε_limiter(a_up::FT, ϵ::FT, lim_amp::FT) where {FT} =
-    FT(1) + lim_amp * exp(-a_up^2 / (2 * ϵ)) - exp(-(FT(1) - a_up)^2 / (2 * ϵ))
+# """
+#     ε_limiter(a_up::FT, ϵ::FT) where {FT}
+# Returns the asymptotic value of entrainment
+# needed to ensure boundedness of the updraft
+# area fraction between 0 and 1, given
+#  - `a_up`, the updraft area fraction
+#  - `ϵ`, a minimum threshold value
+# """
+# ε_limiter(a_up::FT, ϵ::FT, lim_amp::FT) where {FT} =
+#     FT(1) + lim_amp * exp(-a_up^2 / (2 * ϵ)) - exp(-(FT(1) - a_up)^2 / (2 * ϵ))
 
-"""
-    δ_limiter(a_up::FT, ϵ::FT) where {FT}
-Returns the asymptotic value of detrainment
-needed to ensure boundedness of the updraft
-area fraction between 0 and 1, given
- - `a_up`, the updraft area fraction
- - `ϵ`, a minimum threshold value
-"""
-δ_limiter(a_up::FT, ϵ::FT, lim_amp::FT) where {FT} =
-    FT(1) - exp(-a_up^2 / (2 * ϵ)) + lim_amp * exp(-(FT(1) - a_up)^2 / (2 * ϵ))
+# """
+#     δ_limiter(a_up::FT, ϵ::FT) where {FT}
+# Returns the asymptotic value of detrainment
+# needed to ensure boundedness of the updraft
+# area fraction between 0 and 1, given
+#  - `a_up`, the updraft area fraction
+#  - `ϵ`, a minimum threshold value
+# """
+# δ_limiter(a_up::FT, ϵ::FT, lim_amp::FT) where {FT} =
+#     FT(1) - exp(-a_up^2 / (2 * ϵ)) + lim_amp * exp(-(FT(1) - a_up)^2 / (2 * ϵ))
 
-"""
-    εt_limiter(w_up_i::FT, ϵ::FT) where {FT}
-Returns the asymptotic value of turbulent
-entrainment needed to ensure positiveness
-of the updraft vertical velocity, given
- - `w_up_i`, the updraft vertical velocity
- - `ϵ`, a minimum threshold value
-"""
-εt_limiter(w_up_i::FT, ϵ::FT, lim_amp::FT) where {FT} =
-    FT(1) + lim_amp * exp(-w_up_i^2 / (2 * ϵ))
+# """
+#     εt_limiter(w_up_i::FT, ϵ::FT) where {FT}
+# Returns the asymptotic value of turbulent
+# entrainment needed to ensure positiveness
+# of the updraft vertical velocity, given
+#  - `w_up_i`, the updraft vertical velocity
+#  - `ϵ`, a minimum threshold value
+# """
+# εt_limiter(w_up_i::FT, ϵ::FT, lim_amp::FT) where {FT} =
+#     FT(1) + lim_amp * exp(-w_up_i^2 / (2 * ϵ))

--- a/test/Atmos/EDMF/closures/mixing_length.jl
+++ b/test/Atmos/EDMF/closures/mixing_length.jl
@@ -8,8 +8,8 @@
         diffusive::Vars,
         aux::Vars,
         t::Real,
-        δ::Tuple,
-        εt::Tuple,
+        Δ::Tuple,
+        Et::Tuple,
         ts,
         env,
     ) where {FT}
@@ -21,8 +21,8 @@ Returns the mixing length used in the diffusive turbulence closure, given:
  - `diffusive`, additional variables
  - `aux`, auxiliary variables
  - `t`, the time
- - `δ`, the detrainment rate
- - `εt`, the turbulent entrainment rate
+ - `Δ`, the detrainment rate
+ - `Et`, the turbulent entrainment rate
  - `ts`, NamedTuple of thermodynamic states
  - `env`, NamedTuple of environment variables
 """
@@ -33,8 +33,8 @@ function mixing_length(
     diffusive::Vars,
     aux::Vars,
     t::Real,
-    δ::Tuple,
-    εt::Tuple,
+    Δ::Tuple,
+    Et::Tuple,
     ts,
     env,
 ) where {FT}
@@ -91,9 +91,9 @@ function mixing_length(
     w_up = vuntuple(i -> up[i].ρaw / up[i].ρa, N_up)
     b = sum(
         ntuple(N_up) do i
-            a_up[i] * w_up[i] * δ[i] / env.a *
+            a_up[i] * w_up[i] * Δ[i]/max(up[i].ρaw,eps(FT)) / env.a *
             ((w_up[i] - env.w) * (w_up[i] - env.w) / 2 - tke_en) -
-            a_up[i] * w_up[i] * (w_up[i] - env.w) * εt[i] * env.w / env.a
+            a_up[i] * w_up[i] * (w_up[i] - env.w) * Et[i]/max(up[i].ρaw,eps(FT)) * env.w / env.a
         end,
     )
 

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -51,9 +51,9 @@ function vars_state(::Updraft, ::Auxiliary, FT)
     @vars(
         buoyancy::FT,
         a::FT,
-        ε_dyn::FT,
-        δ_dyn::FT,
-        ε_trb::FT,
+        E_dyn::FT,
+        Δ_dyn::FT,
+        E_trb::FT,
         T::FT,
         θ_liq::FT,
         q_tot::FT,
@@ -235,12 +235,12 @@ function turbconv_nodal_update_auxiliary_state!(
         entr_detr(m, m.turbconv.entr_detr, state, aux, t, ts, env, i)
     end
 
-    ε_dyn, δ_dyn, ε_trb = ntuple(i -> map(x -> x[i], εδ_up), 3)
+    E_dyn, Δ_dyn, E_trb = ntuple(i -> map(x -> x[i], εδ_up), 3)
 
     @unroll_map(N_up) do i
-        up_aux[i].ε_dyn = ε_dyn[i]
-        up_aux[i].δ_dyn = δ_dyn[i]
-        up_aux[i].ε_trb = ε_trb[i]
+        up_aux[i].E_dyn = E_dyn[i]
+        up_aux[i].Δ_dyn = Δ_dyn[i]
+        up_aux[i].E_trb = E_trb[i]
     end
 
 end;
@@ -364,10 +364,10 @@ function atmos_source!(
     # Get environment variables
     env = environment_vars(state, aux, N_up)
 
-    εδ_up = ntuple(N_up) do i
+    EΔ_up = ntuple(N_up) do i
         entr_detr(m, m.turbconv.entr_detr, state, aux, t, ts, env, i)
     end
-    ε_dyn, δ_dyn, ε_trb = ntuple(i -> map(x -> x[i], εδ_up), 3)
+    E_dyn, Δ_dyn, E_trb = ntuple(i -> map(x -> x[i], EΔ_up), 3)
 
     # get environment values
     _grav::FT = grav(m.param_set)
@@ -403,84 +403,71 @@ function atmos_source!(
         )
 
         # entrainment and detrainment
-        up_src[i].ρa += up[i].ρaw * (ε_dyn[i] - δ_dyn[i])
+        up_src[i].ρa += (E_dyn[i] - Δ_dyn[i])
         up_src[i].ρaw +=
-            up[i].ρaw *
-            ((ε_dyn[i] + ε_trb[i]) * env.w - (δ_dyn[i] + ε_trb[i]) * w_up_i)
+            ((E_dyn[i] + E_trb[i]) * env.w - (Δ_dyn[i] + E_trb[i]) * w_up_i)
         up_src[i].ρaθ_liq +=
-            up[i].ρaw * (
-                (ε_dyn[i] + ε_trb[i]) * θ_liq_en -
-                (δ_dyn[i] + ε_trb[i]) * up[i].ρaθ_liq * ρa_up_i_inv
-            )
+                ((E_dyn[i] + E_trb[i]) * θ_liq_en -
+                 (Δ_dyn[i] + E_trb[i]) * up[i].ρaθ_liq * ρa_up_i_inv
+                )
         up_src[i].ρaq_tot +=
-            up[i].ρaw * (
-                (ε_dyn[i] + ε_trb[i]) * q_tot_en -
-                (δ_dyn[i] + ε_trb[i]) * up[i].ρaq_tot * ρa_up_i_inv
-            )
+                ((E_dyn[i] + E_trb[i]) * q_tot_en -
+                 (Δ_dyn[i] + E_trb[i]) * up[i].ρaq_tot * ρa_up_i_inv
+                )
 
         # add buoyancy and perturbation pressure in subdomain w equation
         up_src[i].ρaw += up[i].ρa * (up_aux[i].buoyancy - dpdz)
         # microphysics sources should be applied here
 
         # environment second moments:
+        # environment second moments:
         en_src.ρatke += (
-            up[i].ρaw *
-            δ_dyn[i] *
+            Δ_dyn[i] *
             (w_up_i - env.w) *
             (w_up_i - env.w) *
             FT(0.5) +
-            up[i].ρaw *
-            ε_trb[i] *
+            E_trb[i] *
             (env.w - gm.ρu[3] * ρ_inv) *
-            (env.w - w_up_i) - up[i].ρaw * (ε_dyn[i] + ε_trb[i]) * tke_en
+            (env.w - w_up_i) - (E_dyn[i] + E_trb[i]) * tke_en
         )
 
         en_src.ρaθ_liq_cv += (
-            up[i].ρaw *
-            δ_dyn[i] *
+            Δ_dyn[i] *
             (up[i].ρaθ_liq * ρa_up_i_inv - θ_liq_en) *
             (up[i].ρaθ_liq * ρa_up_i_inv - θ_liq_en) +
-            up[i].ρaw *
-            ε_trb[i] *
+            E_trb[i] *
             (θ_liq_en - θ_liq) *
             (θ_liq_en - up[i].ρaθ_liq * ρa_up_i_inv) +
-            up[i].ρaw *
-            ε_trb[i] *
+            E_trb[i] *
             (θ_liq_en - θ_liq) *
             (θ_liq_en - up[i].ρaθ_liq * ρa_up_i_inv) -
-            up[i].ρaw * (ε_dyn[i] + ε_trb[i]) * en.ρaθ_liq_cv
+            (E_dyn[i] + E_trb[i]) * en.ρaθ_liq_cv
         )
 
         en_src.ρaq_tot_cv += (
-            up[i].ρaw *
-            δ_dyn[i] *
+            Δ_dyn[i] *
             (up[i].ρaq_tot * ρa_up_i_inv - q_tot_en) *
             (up[i].ρaq_tot * ρa_up_i_inv - q_tot_en) +
-            up[i].ρaw *
-            ε_trb[i] *
-            (q_tot_en - ρq_tot * ρ_inv) *
+            E_trb[i] *
+            (q_tot_en - gm.moisture.ρq_tot * ρ_inv) *
             (q_tot_en - up[i].ρaq_tot * ρa_up_i_inv) +
-            up[i].ρaw *
-            ε_trb[i] *
-            (q_tot_en - ρq_tot * ρ_inv) *
+            E_trb[i] *
+            (q_tot_en - gm.moisture.ρq_tot * ρ_inv) *
             (q_tot_en - up[i].ρaq_tot * ρa_up_i_inv) -
-            up[i].ρaw * (ε_dyn[i] + ε_trb[i]) * en.ρaq_tot_cv
+            (E_dyn[i] + E_trb[i]) * en.ρaq_tot_cv
         )
 
         en_src.ρaθ_liq_q_tot_cv += (
-            up[i].ρaw *
-            δ_dyn[i] *
+            Δ_dyn[i] *
             (up[i].ρaθ_liq * ρa_up_i_inv - θ_liq_en) *
             (up[i].ρaq_tot * ρa_up_i_inv - q_tot_en) +
-            up[i].ρaw *
-            ε_trb[i] *
+            E_trb[i] *
             (θ_liq_en - θ_liq) *
             (q_tot_en - up[i].ρaq_tot * ρa_up_i_inv) +
-            up[i].ρaw *
-            ε_trb[i] *
-            (q_tot_en - ρq_tot * ρ_inv) *
+            E_trb[i] *
+            (q_tot_en - gm.moisture.ρq_tot * ρ_inv) *
             (θ_liq_en - up[i].ρaθ_liq * ρa_up_i_inv) -
-            up[i].ρaw * (ε_dyn[i] + ε_trb[i]) * en.ρaθ_liq_q_tot_cv
+            (E_dyn[i] + E_trb[i]) * en.ρaθ_liq_q_tot_cv
         )
 
         # pressure tke source from the i'th updraft
@@ -493,8 +480,8 @@ function atmos_source!(
         diffusive,
         aux,
         t,
-        δ_dyn,
-        ε_trb,
+        Δ_dyn,
+        E_trb,
         ts,
         env,
     )
@@ -587,11 +574,11 @@ function flux_second_order!(
     a_min = turbconv.subdomains.a_min
     a_max = turbconv.subdomains.a_max
 
-    εδ_up = ntuple(N_up) do i
+    EΔ_up = ntuple(N_up) do i
         entr_detr(m, m.turbconv.entr_detr, state, aux, t, ts, env, i)
     end
 
-    ε_dyn, δ_dyn, ε_trb = ntuple(i -> map(x -> x[i], εδ_up), 3)
+    E_dyn, Δ_dyn, E_trb = ntuple(i -> map(x -> x[i], EΔ_up), 3)
 
     l_mix = mixing_length(
         m,
@@ -600,8 +587,8 @@ function flux_second_order!(
         diffusive,
         aux,
         t,
-        δ_dyn,
-        ε_trb,
+        Δ_dyn,
+        E_trb,
         ts,
         env,
     )


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
This draft PR changes the fractional entrainment and detrainment (ε, δ) to be written as entrainment and detrainment rates (E=ρawε , Δ=ρawδ) which should be positive definite regardless of updraft vertical velocity (w) to maintain physical sources.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
