### PR TITLE
Add internal energies of dry air, vapor, liquid and ice

### DIFF
--- a/docs/src/APIs/Common/Thermodynamics.md
+++ b/docs/src/APIs/Common/Thermodynamics.md
@@ -46,6 +46,10 @@ has_condensate
 Ice
 ice_specific_humidity
 internal_energy
+internal_energy_dry
+internal_energy_vapor
+internal_energy_liquid
+internal_energy_ice
 internal_energy_sat
 latent_heat_fusion
 latent_heat_liq_ice

--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -13,6 +13,10 @@ export vapor_specific_humidity
 export total_energy
 export internal_energy
 export internal_energy_sat
+export internal_energy_dry
+export internal_energy_vapor
+export internal_energy_liquid
+export internal_energy_ice
 
 # Specific heats and gas constants of moist air
 export cp_m, cv_m, gas_constant_air, gas_constants
@@ -413,6 +417,99 @@ The internal energy per unit mass, given
     e_int = ρinv * ρe_int
     return e_int
 end
+
+"""
+    internal_energy_dry(param_set, T)
+
+The dry air internal energy
+
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `T` temperature
+"""
+function internal_energy_dry(param_set::APS, T::FT) where {FT <: Real}
+    _T_0::FT = T_0(param_set)
+    _cv_d::FT = cv_d(param_set)
+
+    return _cv_d * (T - _T_0)
+end
+"""
+    internal_energy_dry(ts::ThermodynamicState)
+
+The the dry air internal energy, given a thermodynamic state `ts`.
+"""
+internal_energy_dry(ts::ThermodynamicState) =
+    internal_energy_dry(ts.param_set, air_temperature(ts))
+
+"""
+    internal_energy_vapor(param_set, T)
+
+The water vapor internal energy
+
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `T` temperature
+"""
+function internal_energy_vapor(param_set::APS, T::FT) where {FT <: Real}
+    _T_0::FT = T_0(param_set)
+    _cv_v::FT = cv_v(param_set)
+    _e_int_v0::FT = e_int_v0(param_set)
+
+    return _cv_v * (T - _T_0) + _e_int_v0
+end
+
+"""
+    internal_energy_vapor(ts::ThermodynamicState)
+
+The the water vapor internal energy, given a thermodynamic state `ts`.
+"""
+internal_energy_vapor(ts::ThermodynamicState) =
+    internal_energy_vapor(ts.param_set, air_temperature(ts))
+
+"""
+    internal_energy_liquid(param_set, T)
+
+The liquid water internal energy
+
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `T` temperature
+"""
+function internal_energy_liquid(param_set::APS, T::FT) where {FT <: Real}
+    _T_0::FT = T_0(param_set)
+    _cv_l::FT = cv_l(param_set)
+
+    return _cv_l * (T - _T_0)
+end
+
+"""
+    internal_energy_liquid(ts::ThermodynamicState)
+
+The the liquid water internal energy, given a thermodynamic state `ts`.
+"""
+internal_energy_liquid(ts::ThermodynamicState) =
+    internal_energy_liquid(ts.param_set, air_temperature(ts))
+
+"""
+    internal_energy_ice(param_set, T)
+
+The ice internal energy
+
+ - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
+ - `T` temperature
+"""
+function internal_energy_ice(param_set::APS, T::FT) where {FT <: Real}
+    _T_0::FT = T_0(param_set)
+    _cv_i::FT = cv_i(param_set)
+    _e_int_i0::FT = e_int_i0(param_set)
+
+    return _cv_i * (T - _T_0) - _e_int_i0
+end
+
+"""
+    internal_energy_ice(ts::ThermodynamicState)
+
+The the ice internal energy, given a thermodynamic state `ts`.
+"""
+internal_energy_ice(ts::ThermodynamicState) =
+    internal_energy_ice(ts.param_set, air_temperature(ts))
 
 """
     internal_energy_sat(param_set, T, ρ, q_tot, phase_type)

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -365,6 +365,18 @@ end
     e_pot = FT(93)
     @test internal_energy(ρ, ρe, ρu, e_pot) ≈ 1000.0
 
+    # internal energies for dry, vapor, liquid and ice
+    T = FT(300)
+    q = PhasePartition(FT(20 * 1e-3), FT(5 * 1e-3), FT(2 * 1e-3))
+    q_vap = vapor_specific_humidity(q)
+    Id = internal_energy_dry(param_set, T)
+    Iv = internal_energy_vapor(param_set, T)
+    Il = internal_energy_liquid(param_set, T)
+    Ii = internal_energy_ice(param_set, T)
+    @test internal_energy(param_set, T, q) ≈
+          (1 - q.tot) * Id + q_vap * Iv + q.liq * Il + q.ice * Ii
+    @test internal_energy(param_set, T) ≈ Id
+
     # potential temperatures
     T = FT(300)
     @test TD.liquid_ice_pottemp_given_pressure(param_set, T, _MSLP) === T
@@ -1024,6 +1036,10 @@ end
         @test typeof.(air_temperature.(ts)) == typeof.(e_int)
         @test typeof.(internal_energy_sat.(ts)) == typeof.(e_int)
         @test typeof.(internal_energy.(ts)) == typeof.(e_int)
+        @test typeof.(internal_energy_dry.(ts)) == typeof.(e_int)
+        @test typeof.(internal_energy_vapor.(ts)) == typeof.(e_int)
+        @test typeof.(internal_energy_liquid.(ts)) == typeof.(e_int)
+        @test typeof.(internal_energy_ice.(ts)) == typeof.(e_int)
         @test typeof.(latent_heat_vapor.(ts)) == typeof.(e_int)
         @test typeof.(latent_heat_sublim.(ts)) == typeof.(e_int)
         @test typeof.(latent_heat_fusion.(ts)) == typeof.(e_int)
@@ -1083,6 +1099,10 @@ end
     @test all(air_temperature.(ts_eq) .≈ air_temperature.(ts_dry))
     @test all(internal_energy.(ts_eq) .≈ internal_energy.(ts_dry))
     @test all(internal_energy_sat.(ts_eq) .≈ internal_energy_sat.(ts_dry))
+    @test all(internal_energy_dry.(ts_eq) .≈ internal_energy_dry.(ts_dry))
+    @test all(internal_energy_vapor.(ts_eq) .≈ internal_energy_vapor.(ts_dry))
+    @test all(internal_energy_liquid.(ts_eq) .≈ internal_energy_liquid.(ts_dry))
+    @test all(internal_energy_ice.(ts_eq) .≈ internal_energy_ice.(ts_dry))
     @test all(soundspeed_air.(ts_eq) .≈ soundspeed_air.(ts_dry))
     @test all(supersaturation.(ts_eq, Ice()) .≈ supersaturation.(ts_dry, Ice()))
     @test all(


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->

This adds definitions for internal energies of dry air, water vapor, liquid water and ice. I will need it for microphysics source terms to total energy in precipitation interface PR.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
