### PR TITLE
Fix the ordering of the state in the AtmosModel

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -237,16 +237,23 @@ end
     vars_state(m::AtmosModel, ::Prognostic, FT)
 
 Conserved state variables (prognostic variables).
+
+!!! warning
+
+    The order of the fields for `AtmosModel` needs to match the one for
+    `AtmosLinearModel` since a shared state is used
 """
 function vars_state(m::AtmosModel, st::Prognostic, FT)
     @vars begin
+        # start of inclusion in `AtmosLinearModel`
         ρ::FT
         ρu::SVector{3, FT}
         ρe::FT
         turbulence::vars_state(m.turbulence, st, FT)
-        turbconv::vars_state(m.turbconv, st, FT)
         hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
         moisture::vars_state(m.moisture, st, FT)
+        # end of inclusion in `AtmosLinearModel`
+        turbconv::vars_state(m.turbconv, st, FT)
         radiation::vars_state(m.radiation, st, FT)
         tracers::vars_state(m.tracers, st, FT)
     end

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -82,6 +82,16 @@ end
 
 abstract type AtmosLinearModel <: BalanceLaw end
 
+"""
+    vars_state(m::AtmosLinearModel, ::Prognostic, FT)
+
+Conserved state variables (prognostic variables).
+
+!!! warning
+
+    `AtmosLinearModel` state ordering must be a contiguous subset of the initial
+    state of `AtmosModel` since a shared state is used.
+"""
 function vars_state(lm::AtmosLinearModel, st::Prognostic, FT)
     @vars begin
         ρ::FT


### PR DESCRIPTION
The AtmosLinearModel must use a contiguous subset of the AtmosModel,
since `turbconv` was not in the `AtmosLinearModel` it needs to be
moved later in the state list.

closes #1494 

co-authored-by: Charles Kawczynski <kawczynski.charles@gmail.com>