### PR TITLE
Fix bugs in the preconditioner construction step in the fully implicit solver

### DIFF
--- a/src/Numerics/ODESolvers/BackwardEulerSolvers.jl
+++ b/src/Numerics/ODESolvers/BackwardEulerSolvers.jl
@@ -181,13 +181,7 @@ function (lin::LinBESolver)(Q, Qhat, α, p, t)
 
     if typeof(lin.solver) <: AbstractIterativeSystemSolver
         FT = eltype(α)
-        preconditioner_update!(
-            rhs!,
-            rhs!.f!,
-            lin.preconditioner,
-            nothing,
-            FT(NaN),
-        )
+        preconditioner_update!(rhs!, rhs!.f!, lin.preconditioner, p, t)
         linearsolve!(rhs!, lin.preconditioner, lin.solver, Q, Qhat, p, t)
         preconditioner_counter_update!(lin.preconditioner)
     else

--- a/src/Numerics/SystemSolvers/SystemSolvers.jl
+++ b/src/Numerics/SystemSolvers/SystemSolvers.jl
@@ -124,7 +124,7 @@ function nonlinearsolve!(
         update_Q!(jvp!, Q, args...)
 
         # update preconditioner based on finite difference, with jvp!
-        preconditioner_update!(jvp!, rhs!.f!, preconditioner, nothing, FT(NaN))
+        preconditioner_update!(jvp!, rhs!.f!, preconditioner, args...)
 
         # do newton iteration with Q^{n+1} = Q^{n} - dF/dQ(Q^n)⁻¹ (rhs!(Q) - Qrhs)
         residual_norm, linear_iterations = donewtoniteration!(


### PR DESCRIPTION
### Description

The vertical discretization might depend on the time and parameters(which is the case for EDMF test), but the parameter and time are set to be nothing and NaN when we construct the preconditioner

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
