### PR TITLE
Add stable_bl_edmf_implicit.jl example, which uses fully implicit solver to solve EDMF

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1188,6 +1188,16 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "gpu_stable_bl_edmf_implicit_test"
+    key: "gpu_stable_bl_edmf_implicit_test"
+    command:
+      - "mpiexec julia --color=yes --project test/Atmos/EDMF/stable_bl_edmf_implicit.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
   - label: "gpu_heat_analytic_unit_test"
     key: "gpu_heat_analytic_unit_test"
     command:

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -237,16 +237,23 @@ end
     vars_state(m::AtmosModel, ::Prognostic, FT)
 
 Conserved state variables (prognostic variables).
+
+!!! warning
+
+    The order of the fields for `AtmosModel` needs to match the one for
+    `AtmosLinearModel` since a shared state is used
 """
 function vars_state(m::AtmosModel, st::Prognostic, FT)
     @vars begin
+        # start of inclusion in `AtmosLinearModel`
         ρ::FT
         ρu::SVector{3, FT}
         ρe::FT
         turbulence::vars_state(m.turbulence, st, FT)
-        turbconv::vars_state(m.turbconv, st, FT)
         hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
         moisture::vars_state(m.moisture, st, FT)
+        # end of inclusion in `AtmosLinearModel`
+        turbconv::vars_state(m.turbconv, st, FT)
         radiation::vars_state(m.radiation, st, FT)
         tracers::vars_state(m.tracers, st, FT)
     end

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -82,6 +82,16 @@ end
 
 abstract type AtmosLinearModel <: BalanceLaw end
 
+"""
+    vars_state(m::AtmosLinearModel, ::Prognostic, FT)
+
+Conserved state variables (prognostic variables).
+
+!!! warning
+
+    `AtmosLinearModel` state ordering must be a contiguous subset of the initial
+    state of `AtmosModel` since a shared state is used.
+"""
 function vars_state(lm::AtmosLinearModel, st::Prognostic, FT)
     @vars begin
         ρ::FT

--- a/src/Numerics/ODESolvers/BackwardEulerSolvers.jl
+++ b/src/Numerics/ODESolvers/BackwardEulerSolvers.jl
@@ -181,13 +181,7 @@ function (lin::LinBESolver)(Q, Qhat, α, p, t)
 
     if typeof(lin.solver) <: AbstractIterativeSystemSolver
         FT = eltype(α)
-        preconditioner_update!(
-            rhs!,
-            rhs!.f!,
-            lin.preconditioner,
-            nothing,
-            FT(NaN),
-        )
+        preconditioner_update!(rhs!, rhs!.f!, lin.preconditioner, p, t)
         linearsolve!(rhs!, lin.preconditioner, lin.solver, Q, Qhat, p, t)
         preconditioner_counter_update!(lin.preconditioner)
     else

--- a/src/Numerics/SystemSolvers/SystemSolvers.jl
+++ b/src/Numerics/SystemSolvers/SystemSolvers.jl
@@ -124,7 +124,7 @@ function nonlinearsolve!(
         update_Q!(jvp!, Q, args...)
 
         # update preconditioner based on finite difference, with jvp!
-        preconditioner_update!(jvp!, rhs!.f!, preconditioner, nothing, FT(NaN))
+        preconditioner_update!(jvp!, rhs!.f!, preconditioner, args...)
 
         # do newton iteration with Q^{n+1} = Q^{n} - dF/dQ(Q^n)⁻¹ (rhs!(Q) - Qrhs)
         residual_norm, linear_iterations = donewtoniteration!(
@@ -136,7 +136,7 @@ function nonlinearsolve!(
             solver,
             args...,
         )
-        @info "Linear solver converged in $linear_iterations iterations"
+        # @info "Linear solver converged in $linear_iterations iterations"
         iters += 1
 
         preconditioner_counter_update!(preconditioner)
@@ -151,7 +151,7 @@ function nonlinearsolve!(
         # ||Delta Q|| / ||Q|| ?
         relresidual = residual_norm / initial_residual_norm
         if relresidual < tol || residual_norm < tol
-            @info "Newton converged in $iters iterations!"
+            # @info "Newton converged in $iters iterations!"
             converged = true
         end
     end

--- a/test/Atmos/EDMF/stable_bl_edmf_implicit.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf_implicit.jl
@@ -1,0 +1,310 @@
+using ClimateMachine
+using ClimateMachine.SystemSolvers
+using ClimateMachine.ODESolvers
+using ClimateMachine.MPIStateArrays
+
+ClimateMachine.init(;
+    parse_clargs = true,
+    output_dir = get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", "output"),
+    fix_rng_seed = true,
+)
+using ClimateMachine.SingleStackUtils
+using ClimateMachine.Checkpoint
+using ClimateMachine.BalanceLaws: vars_state
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+
+include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))
+include("edmf_model.jl")
+include("edmf_kernels.jl")
+
+"""
+    init_state_prognostic!(
+            turbconv::EDMF{FT},
+            m::AtmosModel{FT},
+            state::Vars,
+            aux::Vars,
+            localgeo,
+            t::Real,
+        ) where {FT}
+
+Initialize EDMF state variables.
+This method is only called at `t=0`.
+"""
+function init_state_prognostic!(
+    turbconv::EDMF{FT},
+    m::AtmosModel{FT},
+    state::Vars,
+    aux::Vars,
+    localgeo,
+    t::Real,
+) where {FT}
+    # Aliases:
+    gm = state
+    en = state.turbconv.environment
+    up = state.turbconv.updraft
+    N_up = n_updrafts(turbconv)
+    # GCM setting - Initialize the grid mean profiles of prognostic variables (ρ,e_int,q_tot,u,v,w)
+    z = altitude(m, aux)
+
+    # SCM setting - need to have separate cases coded and called from a folder - see what LES does
+    # a thermo state is used here to convert the input θ to e_int profile
+    e_int = internal_energy(m, state, aux)
+
+    ts = PhaseDry(m.param_set, e_int, state.ρ)
+    T = air_temperature(ts)
+    p = air_pressure(ts)
+    q = PhasePartition(ts)
+    θ_liq = liquid_ice_pottemp(ts)
+
+    a_min = turbconv.subdomains.a_min
+    @unroll_map(N_up) do i
+        up[i].ρa = gm.ρ * a_min
+        up[i].ρaw = gm.ρu[3] * a_min
+        up[i].ρaθ_liq = gm.ρ * a_min * θ_liq
+        up[i].ρaq_tot = FT(0)
+    end
+
+    # initialize environment covariance with zero for now
+    if z <= FT(250)
+        coeff =
+            gm.ρ *
+            FT(0.4) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0)
+        en.ρatke = coeff
+        en.ρaθ_liq_cv = coeff
+    else
+        en.ρatke = FT(0)
+        en.ρaθ_liq_cv = FT(0)
+    end
+    en.ρaq_tot_cv = FT(0)
+    en.ρaθ_liq_q_tot_cv = FT(0)
+    return nothing
+end;
+
+function main(::Type{FT}) where {FT}
+    # add a command line argument to specify the kind of surface flux
+    # TODO: this will move to the future namelist functionality
+    sbl_args = ArgParseSettings(autofix_names = true)
+    add_arg_group!(sbl_args, "StableBoundaryLayer")
+    @add_arg_table! sbl_args begin
+        "--surface-flux"
+        help = "specify surface flux for energy and moisture"
+        metavar = "prescribed|bulk"
+        arg_type = String
+        default = "bulk"
+    end
+
+    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
+
+    surface_flux = cl_args["surface_flux"]
+
+    # DG polynomial order
+    N = 1
+    nelem_vert = 50
+
+    # Prescribe domain parameters
+    zmax = FT(400)
+
+    t0 = FT(0)
+
+    # Simulation time
+    timeend = FT(3600 * 6)
+    CFLmax = FT(40.0)
+
+    config_type = SingleStackConfigType
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
+    N_updrafts = 1
+    N_quad = 3 # Using N_quad = 1 leads to norm(Q) = NaN at init.
+    turbconv = EDMF(FT, N_updrafts, N_quad)
+
+    model = stable_bl_model(
+        FT,
+        config_type,
+        zmax,
+        surface_flux;
+        turbconv = turbconv,
+    )
+
+    # Assemble configuration
+    driver_config = ClimateMachine.SingleStackConfiguration(
+        "SBL_EDMF",
+        N,
+        nelem_vert,
+        zmax,
+        param_set,
+        model;
+        hmax = FT(40),
+        solver_type = ode_solver_type,
+    )
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+    )
+
+    #################### Change the ode_solver to implicit solver
+
+    dg = solver_config.dg
+    Q = solver_config.Q
+
+
+    vdg = DGModel(
+        driver_config;
+        state_auxiliary = dg.state_auxiliary,
+        direction = VerticalDirection(),
+    )
+
+
+    # linear solver relative tolerance rtol which should be slightly smaller than the nonlinear solver tol
+    linearsolver = BatchedGeneralizedMinimalResidual(
+        dg,
+        Q;
+        max_subspace_size = 30,
+        atol = -1.0,
+        rtol = 5e-5,
+    )
+
+    """
+    N(q)(Q) = Qhat  => F(Q) = N(q)(Q) - Qhat
+
+    F(Q) == 0
+    ||F(Q^i) || / ||F(Q^0) || < tol
+
+    """
+    # ϵ is a sensity parameter for this problem, it determines the finite difference Jacobian dF = (F(Q + ϵdQ) - F(Q))/ϵ
+    # I have also try larger tol, but tol = 1e-3 does not work
+    nonlinearsolver =
+        JacobianFreeNewtonKrylovSolver(Q, linearsolver; tol = 1e-4, ϵ = 1.e-10)
+
+    # this is a second order time integrator, to change it to a first order time integrator
+    # change it ARK1ForwardBackwardEuler, which can reduce the cost by half at the cost of accuracy 
+    # and stability
+    # preconditioner_update_freq = 50 means updating the preconditioner every 50 Newton solves, 
+    # update it more freqent will accelerate the convergence of linear solves, but updating it 
+    # is very expensive
+    ode_solver = ARK2ImplicitExplicitMidpoint(
+        dg,
+        vdg,
+        NonLinearBackwardEulerSolver(
+            nonlinearsolver;
+            isadjustable = true,
+            preconditioner_update_freq = 50,
+        ),
+        Q;
+        dt = solver_config.dt,
+        t0 = 0,
+        split_explicit_implicit = false,
+        variant = NaiveVariant(),
+    )
+
+    solver_config.solver = ode_solver
+
+    #######################################
+
+    # --- Zero-out horizontal variations:
+    vsp = vars_state(model, Prognostic(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :turbconv),
+    )
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :ρe),
+    )
+    vsa = vars_state(model, Auxiliary(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.dg.state_auxiliary,
+        varsindex(vsa, :turbconv),
+    )
+    # ---
+
+    dgn_config = config_diagnostics(driver_config)
+
+    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            (turbconv_filters(turbconv)...,),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
+        nothing
+    end
+
+    # State variable
+    Q = solver_config.Q
+    # Compute total mass and total energy
+    ρ_idx = varsindices(vars_state(dg.balance_law, Prognostic(), FT), "ρ")
+    ρe_idx = varsindices(vars_state(dg.balance_law, Prognostic(), FT), "ρe")
+    Σρ₀ = weightedsum(Q, ρ_idx)
+    Σρe₀ = weightedsum(Q, ρe_idx)
+
+    grid = driver_config.grid
+
+    # state_types = (Prognostic(), Auxiliary(), GradientFlux())
+    state_types = (Prognostic(), Auxiliary())
+    all_data = [dict_of_nodal_states(solver_config, state_types; interp = true)]
+    time_data = FT[0]
+
+    # Define the number of outputs from `t0` to `timeend`
+    n_outputs = 5
+    # This equates to exports every ceil(Int, timeend/n_outputs) time-step:
+    every_x_simulation_time = ceil(Int, timeend / n_outputs)
+
+    cb_data_vs_time =
+        GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
+            push!(
+                all_data,
+                dict_of_nodal_states(solver_config, state_types; interp = true),
+            )
+            push!(time_data, gettime(solver_config.solver))
+            nothing
+        end
+
+    cb_check_cons = GenericCallbacks.EveryXSimulationSteps(3000) do
+        Q = solver_config.Q
+        δρ = (weightedsum(Q, ρ_idx) - Σρ₀) / Σρ₀
+        δρe = (weightedsum(Q, ρe_idx) .- Σρe₀) ./ Σρe₀
+        @show (abs(δρ))
+        @show (abs(δρe))
+        @test (abs(δρ) <= 1.0e-10)
+        @test (abs(δρe) <= 0.025)
+        nothing
+    end
+
+    cb_print_step = GenericCallbacks.EveryXSimulationSteps(100) do
+        @show getsteps(solver_config.solver)
+        nothing
+    end
+
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (
+            cbtmarfilter,
+            cb_check_cons,
+            cb_data_vs_time,
+            cb_print_step,
+        ),
+        check_euclidean_distance = true,
+    )
+
+    dons = dict_of_nodal_states(solver_config, state_types; interp = true)
+    push!(all_data, dons)
+    push!(time_data, gettime(solver_config.solver))
+
+    return solver_config, all_data, time_data, state_types
+end
+
+solver_config, all_data, time_data, state_types = main(Float64)


### PR DESCRIPTION
This is an example which uses fully implicit solver to solve EDMF(stable boundary layer) for 6h within 15 mins.
This example only demonstrates that we can use fully implicit solver here, but I have not visualized/compared the results

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
