### PR TITLE
Updates section in Contributing docs about using the formatter

### DIFF
--- a/docs/src/Contributing.md
+++ b/docs/src/Contributing.md
@@ -78,14 +78,15 @@ by the formatter implemented in the script `.dev/climaformat.jl`.
 To use the script `.dev/climaformat.jl` to reformat every file in
 `ClimateMachine.jl/` run
 
-```
-julia --project .dev/climaformat.jl
+```bash
+.dev/climaformat.jl
 ```
 
-from `ClimateMachine.jl`'s root directory. To format individual files, type
+in a terminal from `ClimateMachine.jl`'s root directory. To format individual files,
+type
 
-```
-julia --project .dev/climaformat.jl src/individual_file.jl
+```bash
+.dev/climaformat.jl src/individual_file.jl
 ```
 
 instead.
@@ -95,8 +96,8 @@ instead.
     1. `git add` your unformatted contributions to the git index with
        commands like `git add unformatted_contribution.jl` before running
        the formatter.
-    2. Reformat your code by running `julia --project .dev/climaformat.jl`.
-    3. Use `git diff --cached` to view changes made by the formatter, and
+    2. Reformat your code by running `.dev/climaformat.jl`.
+    3. Use `git diff` to view changes made by the formatter, and
        `git checkout :/` to throw them away if you don't like the way they
        look.
 

--- a/docs/src/Contributing.md
+++ b/docs/src/Contributing.md
@@ -70,7 +70,37 @@ in `docs/`.
 When your PR is ready for review, clean up your commit history by squashing
 and make sure your code is current with `ClimateMachine` master by rebasing.
 
-### Squash and rebase
+## Reformatting your code with `.dev/climaformat.jl`
+
+Your PR cannot be merged unless it conforms to the format style specified
+by the formatter implemented in the script `.dev/climaformat.jl`.
+
+To use the script `.dev/climaformat.jl` to reformat every file in
+`ClimateMachine.jl/` run
+
+```
+julia --project .dev/climaformat.jl
+```
+
+from `ClimateMachine.jl`'s root directory. To format individual files, type
+
+```
+julia --project .dev/climaformat.jl src/individual_file.jl
+```
+
+instead.
+
+!!! warn "Reformatting edits your code"
+    If you would like to be able to revert changes made by the formatter,
+    1. `git add` your unformatted contributions to the git index with
+       commands like `git add unformatted_contribution.jl` before running
+       the formatter.
+    2. Reformat your code by running `julia --project .dev/climaformat.jl`.
+    3. Use `git diff --cached` to view changes made by the formatter, and
+       `git checkout :/` to throw them away if you don't like the way they
+       look.
+
+## Squash and rebase
 
 Use `git rebase` (not `git merge`) to sync your work:
 


### PR DESCRIPTION
The new section looks like

![image](https://user-images.githubusercontent.com/15271942/98445898-4eb63e80-20e8-11eb-938d-a1f8f9efdcb9.png)

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
