### PR TITLE
Move Gravity to new tendency specification

### DIFF
--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -9,6 +9,7 @@ import ..BalanceLaws: eq_tends
 filter_source(pv::PrognosticVariable, s) = nothing
 # Sources that have been added to new specification:
 filter_source(pv::PV, s::Subsidence{PV}) where {PV <: PrognosticVariable} = s
+filter_source(pv::PV, s::Gravity{PV}) where {PV <: Momentum} = s
 
 # Filter sources / empty elements
 filter_sources(t::Tuple) = filter(x -> !(x == nothing), t)

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -2,7 +2,6 @@ using ..Microphysics_0M
 using CLIMAParameters.Planet: Omega, e_int_i0, cv_l, cv_i, T_0
 
 export AbstractSource,
-    Gravity,
     RayleighSponge,
     GeostrophicForcing,
     Coriolis,
@@ -38,7 +37,6 @@ end
 
 abstract type AbstractSource end
 
-struct Gravity <: AbstractSource end
 function atmos_source!(
     ::Gravity,
     atmos::AtmosModel,
@@ -49,11 +47,7 @@ function atmos_source!(
     t::Real,
     direction,
 )
-    if atmos.ref_state isa HydrostaticState
-        source.ρu -= (state.ρ - aux.ref_state.ρ) * aux.orientation.∇Φ
-    else
-        source.ρu -= state.ρ * aux.orientation.∇Φ
-    end
+    # Migrated to Σsources
 end
 
 struct Coriolis <: AbstractSource end

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -1,5 +1,9 @@
 ##### Momentum tendencies
 
+#####
+##### First order fluxes
+#####
+
 function flux(::Advect{Momentum}, m, state, aux, t, ts, direction)
     return state.ρu .* (state.ρu / state.ρ)'
 end
@@ -9,5 +13,29 @@ function flux(::PressureGradient{Momentum}, m, state, aux, t, ts, direction)
         return (air_pressure(ts) - aux.ref_state.p) * I
     else
         return air_pressure(ts) * I
+    end
+end
+
+#####
+##### Sources
+#####
+
+export Gravity
+struct Gravity{PV <: Momentum} <: TendencyDef{Source, PV} end
+Gravity() = Gravity{Momentum}()
+function source(
+    s::Gravity{Momentum},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+    diffusive,
+)
+    if m.ref_state isa HydrostaticState
+        return -(state.ρ - aux.ref_state.ρ) * aux.orientation.∇Φ
+    else
+        return -state.ρ * aux.orientation.∇Φ
     end
 end


### PR DESCRIPTION
### Description

This PR moves `Gravity` to the new tendency specification. I can confirm that, in `experiments/AtmosGCM/heldsuarez.jl`, the tendency table is properly updated:
<img width="1057" alt="Screen Shot 2020-11-09 at 6 09 37 AM" src="https://user-images.githubusercontent.com/1880641/98551884-b1c3e480-2252-11eb-8d3d-e231e5ffcf64.png">


<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
