### PR TITLE
Move first order moisture flux to new tendency specification

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1079,6 +1079,16 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "gpu_bomex_single_stack_nonequil"
+    key: "gpu_bomex_single_stack_nonequil"
+    command:
+      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex_single_stack.jl --moisture-model nonequilibrium --diagnostics=default --fix-rng-seed"
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
   - label: "gpu_bomex_edmf"
     key: "gpu_bomex_edmf"
     command:

--- a/experiments/AtmosLES/bomex_single_stack.jl
+++ b/experiments/AtmosLES/bomex_single_stack.jl
@@ -6,6 +6,11 @@ function main()
     bomex_args = ArgParseSettings(autofix_names = true)
     add_arg_group!(bomex_args, "BOMEX")
     @add_arg_table! bomex_args begin
+        "--moisture-model"
+        help = "specify cloud condensate model"
+        metavar = "equilibrium|nonequilibrium"
+        arg_type = String
+        default = "equilibrium"
         "--surface-flux"
         help = "specify surface flux for energy and moisture"
         metavar = "prescribed|bulk"
@@ -17,6 +22,7 @@ function main()
         ClimateMachine.init(parse_clargs = true, custom_clargs = bomex_args)
 
     surface_flux = cl_args["surface_flux"]
+    moisture_model = cl_args["moisture_model"]
 
     FT = Float64
     config_type = SingleStackConfigType
@@ -39,7 +45,13 @@ function main()
     # Choose default IMEX solver
     ode_solver_type = ClimateMachine.IMEXSolverType()
 
-    model = bomex_model(FT, config_type, zmax, surface_flux)
+    model = bomex_model(
+        FT,
+        config_type,
+        zmax,
+        surface_flux;
+        moisture_model = moisture_model,
+    )
     ics = model.problem.init_state_prognostic
     # Assemble configuration
     driver_config = ClimateMachine.SingleStackConfiguration(

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -434,7 +434,7 @@ equations.
 
     # pressure terms
     flux_radiation!(m.radiation, m, flux, state, aux, t)
-    flux_moisture!(m.moisture, m, flux, state, aux, t)
+    flux_first_order!(m.moisture, m, flux, state, aux, t, direction)
     flux_precipitation!(m.precipitation, m, flux, state, aux, t)
     flux_tracers!(m.tracers, m, flux, state, aux, t)
     flux_first_order!(m.turbconv, m, flux, state, aux, t)

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -37,4 +37,5 @@ eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Energy} =
     (Advect{PV}(), Pressure{PV}())
 
 # Moisture
-eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Moisture} = ()
+eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Moisture} =
+    (Advect{PV}(),)

--- a/src/Atmos/Model/tendencies_moisture.jl
+++ b/src/Atmos/Model/tendencies_moisture.jl
@@ -1,6 +1,25 @@
 ##### Moisture tendencies
 
 #####
+##### First order fluxes
+#####
+
+function flux(::Advect{TotalMoisture}, m, state, aux, t, ts, direction)
+    u = state.ρu / state.ρ
+    return u * state.moisture.ρq_tot
+end
+
+function flux(::Advect{LiquidMoisture}, m, state, aux, t, ts, direction)
+    u = state.ρu / state.ρ
+    return u * state.moisture.ρq_liq
+end
+
+function flux(::Advect{IceMoisture}, m, state, aux, t, ts, direction)
+    u = state.ρu / state.ρ
+    return u * state.moisture.ρq_ice
+end
+
+#####
 ##### Sources
 #####
 


### PR DESCRIPTION
### Description

This PR

 - moves the first order moisture flux to the new tendency specification. I can confirm that the tendency table is updated, for `experiments/AtmosLES/bomex_model.jl` with `moisture_model == "nonequilibrium"`, but I haven't checked the results.
 - Renames `flux_moisture!` to `flux_first_order!` in efforts to standardize some of the AtmosModel method calls
 - Adds `Moisture <: PrognosticVariable` to combine specification for the moisture variables.


<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
