### PR TITLE
add a test assert making sure the solid-body-rotation do not generate flow

### DIFF
--- a/experiments/TestCase/solid_body_rotation.jl
+++ b/experiments/TestCase/solid_body_rotation.jl
@@ -82,9 +82,8 @@ function main()
     poly_order = 3                           # discontinuous Galerkin polynomial order
     n_horz = 12                              # horizontal element number
     n_vert = 6                               # vertical element number
-    n_days::FT = 0.5
     timestart::FT = 0                        # start time (s)
-    timeend::FT = n_days * day(param_set)    # end time (s)
+    timeend::FT = 7200
 
     # Set up a reference state for linearization of equations
     temp_profile_ref =
@@ -171,6 +170,7 @@ function main()
         norm(solver_config.Q .- init_solver_config.Q) /
         norm(init_solver_config.Q)
     @info "Relative error = $relative_error"
+    @test relative_error < 1e-9
 end
 
 function config_diagnostics(FT, driver_config)


### PR DESCRIPTION
This PR makes the following changes in the solid body rotation test in `TestCase`:
- adding a test assert to make sure state variables stays identical to the initial condition;
- reducing simulation time to 2 hours (it was 12 hours before).

### Description

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
