### PR TITLE
build docs on a slurm cluster node with buildkite

### DIFF
--- a/.buildkite/docs-pipeline.yml
+++ b/.buildkite/docs-pipeline.yml
@@ -1,0 +1,37 @@
+env:
+  JULIA_VERSION: "1.5.2"
+  GKSwstype: nul
+  OPENBLAS_NUM_THREADS: 1
+  CLIMATEMACHINE_SETTINGS_DISABLE_GPU: "true"
+  CLIMATEMACHINE_SETTINGS_FIX_RNG_SEED: "true"
+  CLIMATEMACHINE_SETTINGS_DISABLE_CUSTOM_LOGGER: "true"
+
+steps:
+  - label: "Build project"
+    command:
+      - "julia --project --color=yes -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --project=docs/ --color=yes -e 'using Pkg; Pkg.instantiate()'"
+      - "julia --project=docs/ --color=yes -e 'using Pkg; Pkg.precompile()'"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1 
+      slurm_cpus_per_task: 1
+      slurm_mem_per_cpu: 6000
+
+  - wait
+
+  - label: "Build docs"
+    command:
+      - "julia --project=docs/ --color=yes --procs=8 docs/make.jl"
+    env:
+      JULIA_PROJECT: "docs/"
+    agents:
+      config: cpu
+      queue: central
+      slurm_time: 120
+      slurm_nodes: 1
+      slurm_ntasks: 8
+      slurm_cpus_per_task: 1
+      slurm_mem_per_cpu: 6000
+

--- a/.github/workflows/Documenter.yaml
+++ b/.github/workflows/Documenter.yaml
@@ -1,12 +1,6 @@
 name: Documentation
 
 on:
-  push:
-    branches:
-      - master
-      - trying
-      - staging
-    tags: '*'
   pull_request:
     paths:
       - 'docs/**'
@@ -61,11 +55,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XDG_RUNTIME_DIR: "/home/runner"
           JULIA_PROJECT: "docs/"
-          CLIMATEMACHINE_DOCS_GENERATE_TUTORIALS: "true"
+          CLIMATEMACHINE_DOCS_GENERATE_TUTORIALS: "false"
           ClIMATEMACHINE_SETTINGS_DISABLE_GPU: "true"
           CLIMATEMACHINE_SETTINGS_DISABLE_CUSTOM_LOGGER: "true"
           CLIMATEMACHINE_SETTINGS_FIX_RNG_SEED: "true"
-        run: xvfb-run -- julia --procs=auto docs/make.jl
+        run: xvfb-run -- julia --project=docs/ --color=yes docs/make.jl
       - name: Help! Documenter Failed
         run: |
           cat .github/workflows/doc_build_common_error_messages.md

--- a/bors.toml
+++ b/bors.toml
@@ -3,7 +3,7 @@ status = [
   "test-os (windows-latest)",
   "test-os (macos-latest)",
   "buildkite/climatemachine-ci",
-  "docs-build",
+  "buildkite/climatemachine-docs",
   "format"
 ]
 delete_merged_branches = true

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,5 @@
-
 # https://github.com/jheinen/GR.jl/issues/278#issuecomment-587090846
-ENV["GKSwstype"] = "100"
+ENV["GKSwstype"] = "nul"
 # some of the tutorials cannot be run on the GPU
 ENV["CLIMATEMACHINE_SETTINGS_DISABLE_GPU"] = true
 # avoid problems with Documenter/Literate when using `global_logger()`


### PR DESCRIPTION
* update github workflow to not build tutorials only on pull request
* update bors to use status of buildkite docs pipeline

This reduces the overall time to roughly 45-50 minutes, with each tutorial is running in parallel with 8 workers (can be increased given overall memory budget).

Pipeline: https://buildkite.com/clima/climatemachine-docs

### Description

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
