### PR TITLE
Update installation guide: use CLIMATEMACHINE_SETTINGS_DISABLE_GPU

### DIFF
--- a/docs/src/GettingStarted/Installation.md
+++ b/docs/src/GettingStarted/Installation.md
@@ -78,4 +78,15 @@ $ julia --project tutorials/Atmos/dry_rayleigh_benard.jl
 ```
 
 The `ClimateMachine` is CUDA-enabled and will use GPU(s) if available. To run
-on the CPU, set the environment variable `CLIMATEMACHINE_GPU` to `false`.
+on the CPU, set the environment variable `CLIMATEMACHINE_SETTINGS_DISABLE_GPU` to `true`.
+This can either be done inline with the Julia launch command using
+
+```
+CLIMATEMACHINE_SETTINGS_DISABLE_GPU=true julia --project
+```
+
+or for the whole shell session, for example with `bash` this would be
+
+```
+export CLIMATEMACHINE_SETTINGS_DISABLE_GPU=true
+```


### PR DESCRIPTION
This is to avoid the following warning:
```
Warning: CLIMATEMACHINE_GPU will be deprecated; use CLIMATEMACHINE_SETTINGS_DISABLE_GPU
```

### Description

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
