### PR TITLE
Move Coriolis and GeoForcing to new tendency specification

### DIFF
--- a/docs/src/GettingStarted/Atmos.md
+++ b/docs/src/GettingStarted/Atmos.md
@@ -21,7 +21,7 @@ possible options for each subcomponent.
     moisture::M = EquilMoist{FT}(),
     precipitation::P = NoPrecipitation(),
     radiation::R = NoRadiation(),
-    source::S = (Gravity(), Coriolis(), GeostrophicForcing{FT}(7.62e-5, 0, 0)),
+    source::S = (Gravity(), Coriolis(), GeostrophicForcing(FT, 7.62e-5, 0, 0)),
     tracers::TR = NoTracers(),
     boundarycondition::BC = AtmosBC(),
     init_state_prognostic::IS = nothing,

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -284,7 +284,7 @@ function config_dycoms(FT, N, resolution, xmax, ymax, zmax)
         RayleighSponge{FT}(zmax, zsponge, c_sponge, u_relaxation, 2)
     # Geostrophic forcing
     geostrophic_forcing =
-        GeostrophicForcing{FT}(f_coriolis, u_geostrophic, v_geostrophic)
+        GeostrophicForcing(FT, f_coriolis, u_geostrophic, v_geostrophic)
 
     # Boundary conditions
     # SGS Filter constants

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -162,7 +162,7 @@ function AtmosModel{FT}(
     source::S = (
         Gravity(),
         Coriolis(),
-        GeostrophicForcing{FT}(7.62e-5, 0, 0),
+        GeostrophicForcing(FT, 7.62e-5, 0, 0),
         turbconv_sources(turbconv)...,
     ),
     tracers::TR = NoTracers(),

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -10,6 +10,8 @@ filter_source(pv::PrognosticVariable, s) = nothing
 # Sources that have been added to new specification:
 filter_source(pv::PV, s::Subsidence{PV}) where {PV <: PrognosticVariable} = s
 filter_source(pv::PV, s::Gravity{PV}) where {PV <: Momentum} = s
+filter_source(pv::PV, s::GeostrophicForcing{PV}) where {PV <: Momentum} = s
+filter_source(pv::PV, s::Coriolis{PV}) where {PV <: Momentum} = s
 
 # Filter sources / empty elements
 filter_sources(t::Tuple) = filter(x -> !(x == nothing), t)

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -2,11 +2,7 @@ using ..Microphysics_0M
 using CLIMAParameters.Planet: Omega, e_int_i0, cv_l, cv_i, T_0
 
 export AbstractSource,
-    RayleighSponge,
-    GeostrophicForcing,
-    Coriolis,
-    RemovePrecipitation,
-    CreateClouds
+    RayleighSponge, GeostrophicForcing, RemovePrecipitation, CreateClouds
 
 # sources are applied additively
 @generated function atmos_source!(
@@ -50,7 +46,6 @@ function atmos_source!(
     # Migrated to Σsources
 end
 
-struct Coriolis <: AbstractSource end
 function atmos_source!(
     ::Coriolis,
     atmos::AtmosModel,
@@ -61,10 +56,7 @@ function atmos_source!(
     t::Real,
     direction,
 )
-    FT = eltype(state)
-    _Omega::FT = Omega(atmos.param_set)
-    # note: this assumes a SphericalOrientation
-    source.ρu -= SVector(0, 0, 2 * _Omega) × state.ρu
+    # Migrated to Σsources
 end
 
 function atmos_source!(
@@ -80,11 +72,6 @@ function atmos_source!(
     # Migrated to Σsources
 end
 
-struct GeostrophicForcing{FT} <: AbstractSource
-    f_coriolis::FT
-    u_geostrophic::FT
-    v_geostrophic::FT
-end
 function atmos_source!(
     s::GeostrophicForcing,
     atmos::AtmosModel,
@@ -95,10 +82,7 @@ function atmos_source!(
     t::Real,
     direction,
 )
-    u_geo = SVector(s.u_geostrophic, s.v_geostrophic, 0)
-    ẑ = vertical_unit_vector(atmos, aux)
-    fkvector = s.f_coriolis * ẑ
-    source.ρu -= fkvector × (state.ρu .- state.ρ * u_geo)
+    # Migrated to Σsources
 end
 
 """

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -39,3 +39,56 @@ function source(
         return -state.ρ * aux.orientation.∇Φ
     end
 end
+
+export Coriolis
+struct Coriolis{PV <: Momentum} <: TendencyDef{Source, PV} end
+Coriolis() = Coriolis{Momentum}()
+function source(
+    s::Coriolis{Momentum},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+    diffusive,
+)
+    FT = eltype(state)
+    _Omega::FT = Omega(m.param_set)
+    # note: this assumes a SphericalOrientation
+    return -SVector(0, 0, 2 * _Omega) × state.ρu
+end
+
+export GeostrophicForcing
+struct GeostrophicForcing{PV <: Momentum, FT} <: TendencyDef{Source, PV}
+    f_coriolis::FT
+    u_geostrophic::FT
+    v_geostrophic::FT
+end
+function GeostrophicForcing(
+    ::Type{FT},
+    f_coriolis,
+    u_geostrophic,
+    v_geostrophic,
+) where {FT}
+    return GeostrophicForcing{Momentum, FT}(
+        FT(f_coriolis),
+        FT(u_geostrophic),
+        FT(v_geostrophic),
+    )
+end
+function source(
+    s::GeostrophicForcing{Momentum},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+    diffusive,
+)
+    u_geo = SVector(s.u_geostrophic, s.v_geostrophic, 0)
+    ẑ = vertical_unit_vector(m, aux)
+    fkvector = s.f_coriolis * ẑ
+    return -fkvector × (state.ρu .- state.ρ * u_geo)
+end


### PR DESCRIPTION
### Description

This PR moves the Coriolis and Geostrophic forcing terms to the new tendency specification.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
