### PR TITLE
Add some second order fluxes to new tend spec

### DIFF
--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -4,6 +4,10 @@
 
 import ..BalanceLaws: eq_tends
 
+#####
+##### Sources
+#####
+
 # --------- Some of these methods are generic or
 #           temporary during transition to new specification:
 filter_source(pv::PrognosticVariable, s) = nothing
@@ -24,6 +28,10 @@ eq_tends(pv::PrognosticVariable, m::AtmosModel, ::Source) =
     filter_sources(pv, m.source)
 # ---------
 
+#####
+##### First order fluxes
+#####
+
 # Mass
 eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Mass} =
     (Advect{PV}(),)
@@ -39,3 +47,25 @@ eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Energy} =
 # Moisture
 eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Moisture} =
     (Advect{PV}(),)
+
+#####
+##### Second order fluxes
+#####
+
+# Mass
+moist_diffusion(pv::PV, ::DryModel) where {PV <: Mass} = ()
+moist_diffusion(pv::PV, ::MoistureModel) where {PV <: Mass} =
+    (MoistureDiffusion{PV}(),)
+eq_tends(pv::PV, m::AtmosModel, ::Flux{SecondOrder}) where {PV <: Mass} =
+    (moist_diffusion(pv, m.moisture)...,)
+
+# Momentum
+eq_tends(pv::PV, ::AtmosModel, ::Flux{SecondOrder}) where {PV <: Momentum} =
+    (ViscousStress{PV}(),)
+
+# Energy
+eq_tends(pv::PV, ::AtmosModel, ::Flux{SecondOrder}) where {PV <: Energy} =
+    (ViscousProduction{PV}(), EnthalpyProduction{PV}())
+
+# Moisture
+eq_tends(pv::PV, ::AtmosModel, ::Flux{SecondOrder}) where {PV <: Moisture} = ()

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -174,7 +174,6 @@ function flux_second_order!(
 end
 #TODO: Consider whether to not pass ρ and ρu (not state), foc BCs reasons
 function flux_second_order!(moist::EquilMoist, flux::Grad, state::Vars, d_q_tot)
-    flux.ρ += d_q_tot * state.ρ
     flux.ρu += d_q_tot .* state.ρu'
     flux.moisture.ρq_tot += d_q_tot * state.ρ
 end
@@ -281,7 +280,6 @@ function flux_second_order!(
     d_q_liq,
     d_q_ice,
 )
-    flux.ρ += d_q_tot * state.ρ
     flux.ρu += d_q_tot .* state.ρu'
     flux.moisture.ρq_tot += d_q_tot * state.ρ
     flux.moisture.ρq_liq += d_q_liq * state.ρ

--- a/src/Atmos/Model/tendencies_energy.jl
+++ b/src/Atmos/Model/tendencies_energy.jl
@@ -13,6 +13,43 @@ function flux(::Pressure{Energy}, m, state, aux, t, ts, direction)
 end
 
 #####
+##### First order fluxes
+#####
+
+struct ViscousProduction{PV <: Energy} <: TendencyDef{Flux{SecondOrder}, PV} end
+function flux(
+    ::ViscousProduction{Energy},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    diffusive,
+    hyperdiff,
+)
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    ν, D_t, τ = sponge_viscosity_modifier(m, m.viscoussponge, ν, D_t, τ, aux)
+    return τ * state.ρu
+end
+
+struct EnthalpyProduction{PV <: Energy} <: TendencyDef{Flux{SecondOrder}, PV} end
+function flux(
+    ::EnthalpyProduction{Energy},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    diffusive,
+    hyperdiff,
+)
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    ν, D_t, τ = sponge_viscosity_modifier(m, m.viscoussponge, ν, D_t, τ, aux)
+    d_h_tot = -D_t .* diffusive.∇h_tot
+    return d_h_tot * state.ρ
+end
+
+#####
 ##### Sources
 #####
 

--- a/src/Atmos/Model/tendencies_mass.jl
+++ b/src/Atmos/Model/tendencies_mass.jl
@@ -1,7 +1,32 @@
 ##### Mass tendencies
 
+#####
+##### First order fluxes
+#####
+
 function flux(::Advect{Mass}, m, state, aux, t, ts, direction)
     return state.ρu
+end
+
+#####
+##### Second order fluxes
+#####
+
+struct MoistureDiffusion{PV <: Mass} <: TendencyDef{Flux{SecondOrder}, PV} end
+function flux(
+    ::MoistureDiffusion{Mass},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    diffusive,
+    hyperdiff,
+)
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    ν, D_t, τ = sponge_viscosity_modifier(m, m.viscoussponge, ν, D_t, τ, aux)
+    d_q_tot = (-D_t) .* diffusive.moisture.∇q_tot
+    return d_q_tot * state.ρ
 end
 
 #####

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -18,6 +18,26 @@ function flux(::PressureGradient{Momentum}, m, state, aux, t, ts, direction)
 end
 
 #####
+##### Second order fluxes
+#####
+
+struct ViscousStress{PV <: Momentum} <: TendencyDef{Flux{SecondOrder}, PV} end
+function flux(
+    ::ViscousStress{Momentum},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    diffusive,
+    hyperdiff,
+)
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    ν, D_t, τ = sponge_viscosity_modifier(m, m.viscoussponge, ν, D_t, τ, aux)
+    return τ * state.ρ
+end
+
+#####
 ##### Sources
 #####
 

--- a/src/BalanceLaws/show_tendencies.jl
+++ b/src/BalanceLaws/show_tendencies.jl
@@ -33,18 +33,18 @@ function show_tendencies(bl; include_params = false)
     ip = include_params
     prog_vars = prognostic_vars(bl)
     if !isempty(prog_vars)
-        # TODO: add Flux{SecondOrder}
         header = [
-            "Equation" "Flux{FirstOrder}" "Source"
-            "(Y_i)" "(F_1)" "(S)"
+            "Equation" "Flux{FirstOrder}" "Flux{SecondOrder}" "Source"
+            "(Y_i)" "(F_1)" "(F_2)" "(S)"
         ]
         eqs = collect(string.(nameof.(typeof.(prog_vars))))
         fmt_tends(tt) = map(prog_vars) do pv
             format_tends(eq_tends(pv, bl, tt), ip)
         end |> collect
         F1 = fmt_tends(Flux{FirstOrder}())
+        F2 = fmt_tends(Flux{SecondOrder}())
         S = fmt_tends(Source())
-        data = hcat(eqs, F1, S)
+        data = hcat(eqs, F1, F2, S)
         @warn "This table is temporarily incomplete"
         println("\nPDE: ∂_t Y_i + (∇•F_1(Y))_i + (∇•F_2(Y,G)))_i = (S(Y,G))_i")
         pretty_table(


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->

This PR adds some of the second-order fluxes to the new tendency specification.

@simonbyrne one thing I had thought about was, rather than splatting in `args = (atmos, state, aux, t, ts, diffusive, hyperdiffusive)` to the `flux` and `source` functions, we could pass in a `NamedTuple`:
```julia
    nt = (atmos=atmos, state=state, aux=aux, t=t, ts=ts, diffusive=diffusive, hyperdiff=hyperdiffusive)
```
and then have:
```julia
function flux(::ViscousProduction{Energy}, nt)
    @unpack diffusive, aux, atmos, t = nt
    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
    ν, D_t, τ = sponge_viscosity_modifier(m, m.viscoussponge, ν, D_t, τ, aux)
    return τ * state.ρu
end
```

Pros of using `NamedTuple`s:
 - Compactify signature
 - Makes changing the effective arg list much easier

Cons of using `NamedTuple`s:
 - Need to look where `nt` was constructed to know what's available / what name is used

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
