### PR TITLE
Remove unpack_fields, use UnPack package

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -517,10 +517,10 @@ uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
 version = "1.0.2"
 
 [[MbedTLS_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "c0b1286883cac4e2b617539de41111e0776d02e8"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "0eef589dd1c26a3ac9d753fe1a8bcad63f956fa6"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.8+0"
+version = "2.16.8+1"
 
 [[MicrosoftMPI_jll]]
 deps = ["Libdl", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -44,6 +44,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticNumbers = "c5e4b96a-f99f-5557-8ed2-dc63ef9b5131"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]

--- a/docs/src/HowToGuides/Common/Thermodynamics.md
+++ b/docs/src/HowToGuides/Common/Thermodynamics.md
@@ -148,6 +148,7 @@ Thermodynamics.jl is tested using a set of profiles specified in `test/Common/Th
 ```@example
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TemperatureProfiles
+using UnPack
 using CLIMAParameters
 using CLIMAParameters.Planet
 using Plots
@@ -155,7 +156,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end;
 const param_set = EarthParameterSet();
 include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "Thermodynamics", "profiles.jl"))
 profiles = PhaseDryProfiles(param_set, Array{Float32});
-@unpack_fields profiles T ρ z
+@unpack T, ρ, z = profiles
 p1 = scatter(ρ, z./10^3, xlabel="Density [kg/m^3]", ylabel="z [km]", title="Density");
 p2 = scatter(T, z./10^3, xlabel="Temperature [K]", ylabel="z [km]", title="Temperature");
 plot(p1, p2, layout=(1,2))
@@ -168,6 +169,7 @@ savefig("tested_profiles_dry.svg");
 ```@example
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TemperatureProfiles
+using UnPack
 using CLIMAParameters
 using CLIMAParameters.Planet
 using Plots
@@ -175,7 +177,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end;
 const param_set = EarthParameterSet();
 include(joinpath(@__DIR__, repeat([".."], 4)...,"test", "Common", "Thermodynamics", "profiles.jl"))
 profiles = PhaseEquilProfiles(param_set, Array{Float32});
-@unpack_fields profiles T ρ q_tot z
+@unpack T, ρ, q_tot, z = profiles
 p1 = scatter(ρ, z./10^3, xlabel="Density [kg/m^3]", ylabel="z [km]", title="Density");
 p2 = scatter(T, z./10^3, xlabel="Temperature [K]", ylabel="z [km]", title="Temperature");
 p3 = scatter(q_tot*1000, z./10^3, xlabel="Total specific\nhumidity [g/kg]", ylabel="z [km]", title="Total specific\nhumidity");
@@ -200,6 +202,7 @@ tested profiles and the nearest space where convergence fails.
 ```@example
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TemperatureProfiles
+using UnPack
 using CLIMAParameters
 using CLIMAParameters.Planet
 using Plots
@@ -213,7 +216,7 @@ clima_root = joinpath(@__DIR__, repeat([".."], 4)...);
 include(joinpath(clima_root, "test", "Common", "Thermodynamics", "profiles.jl"))
 include(joinpath(clima_root, "docs", "plothelpers.jl"));
 profiles = PhaseEquilProfiles(param_set, Array{FT});
-@unpack_fields profiles ρ e_int q_tot
+@unpack ρ, e_int, q_tot = profiles
 
 dims = (10, 10, 10);
 ρ = range(min(ρ...), stop=max(ρ...), length=dims[1]);

--- a/test/Common/Thermodynamics/profiles.jl
+++ b/test/Common/Thermodynamics/profiles.jl
@@ -9,36 +9,6 @@ tested with in runtests.jl
 using Random
 
 """
-    unpack_fields(_struct, syms...)
-
-Unpack struct properties `syms`
-from struct `_struct`
-
-# Example
-```julia
-julia> struct Foo;a;b;c;end
-
-julia> f = Foo(1,2,3)
-Foo(1, 2, 3)
-
-julia> @unpack_fields f a c; @show a c
-a = 1
-c = 3
-```
-"""
-macro unpack_fields(_struct, syms...)
-    thunk = Expr(:block)
-    for sym in syms
-        push!(
-            thunk.args,
-            :($(esc(sym)) = getproperty($(esc(_struct)), $(QuoteNode(sym)))),
-        )
-    end
-    push!(thunk.args, nothing)
-    return thunk
-end
-
-"""
     ProfileSet
 
 A set of profiles used to test Thermodynamics.

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TemperatureProfiles
+using UnPack
 using NCDatasets
 using Random
 using RootSolvers
@@ -57,7 +58,8 @@ include("data_tests.jl")
         _kappa_d = FT(kappa_d(param_set))
 
         profiles = PhaseEquilProfiles(param_set, ArrayType)
-        @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
+        @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
+        @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
         # Test state for thermodynamic consistency (with ideal gas law)
         T_idgl = TD.air_temperature_from_ideal_gas_law.(param_set, p, ρ, q_pt)
@@ -422,7 +424,8 @@ end
     for ArrayType in array_types
         FT = eltype(ArrayType)
         profiles = PhaseEquilProfiles(param_set, ArrayType)
-        @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type e_kin e_pot
+        @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
+        @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
         RH_sat_mask = or.(RH .> 1, RH .≈ 1)
         RH_unsat_mask = .!or.(RH .> 1, RH .≈ 1)
@@ -654,7 +657,8 @@ end
     ArrayType = Array{Float64}
     FT = eltype(ArrayType)
     profiles = PhaseEquilProfiles(param_set, ArrayType)
-    @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
+    @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
+    @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
     @test_throws ErrorException TD.saturation_adjustment.(
         param_set,
@@ -727,7 +731,8 @@ end
         _MSLP = FT(MSLP(param_set))
 
         profiles = PhaseDryProfiles(param_set, ArrayType)
-        @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
+        @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
+        @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
         # PhaseDry
         ts = PhaseDry.(param_set, e_int, ρ)
@@ -752,7 +757,8 @@ end
         @test all(internal_energy.(ts_ρT) .≈ internal_energy.(ts))
 
         profiles = PhaseEquilProfiles(param_set, ArrayType)
-        @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
+        @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
+        @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
         # PhaseEquil
         ts =
@@ -885,7 +891,8 @@ end
 
 
         profiles = PhaseEquilProfiles(param_set, ArrayType)
-        @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
+        @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
+        @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
         # Test that relative humidity is 1 for saturated conditions
         q_sat = q_vap_saturation.(param_set, T, ρ, Ref(phase_type))
@@ -963,7 +970,8 @@ end
     ArrayType = Array{Float32}
     FT = eltype(ArrayType)
     profiles = PhaseEquilProfiles(param_set, ArrayType)
-    @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type e_pot e_kin
+    @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
+    @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
     ρu = FT[1.0, 2.0, 3.0]
     @test typeof.(internal_energy.(ρ, ρ .* e_int, Ref(ρu), e_pot)) ==
@@ -1070,7 +1078,8 @@ end
     ArrayType = Array{Float64}
     FT = eltype(ArrayType)
     profiles = PhaseEquilProfiles(param_set, ArrayType)
-    @unpack_fields profiles T p RS e_int ρ θ_liq_ice q_tot q_liq q_ice q_pt RH phase_type
+    @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
+    @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
 
     # PhasePartition test is noisy, so do this only once:
     ts_dry = PhaseDry(param_set, first(e_int), first(ρ))


### PR DESCRIPTION
### Description

This PR removes `@unpack_fields` and replaces it with `@unpack` from [UnPack.jl](https://github.com/mauro3/UnPack.jl) (which has been added).

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
