### PR TITLE
Add `--sim-time` command line argument

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -75,6 +75,7 @@ Base.@kwdef mutable struct ClimateMachine_Settings
     debug_init::Bool = false
     integration_testing::Bool = false
     array_type::Type = Array
+    sim_time::Float64 = NaN
     fixed_number_of_steps::Int = -1
 end
 
@@ -276,6 +277,11 @@ function parse_commandline(
         action = :store_const
         constant = true
         default = get_setting(:integration_testing, defaults, global_defaults)
+        "--sim-time"
+        help = "run for the specified time (in simulation seconds)"
+        metavar = "<number>"
+        arg_type = Float64
+        default = get_setting(:sim_time, defaults, global_defaults)
         "--fixed-number-of-steps"
         help = "if `≥0` perform specified number of steps"
         metavar = "<number>"
@@ -351,6 +357,10 @@ Recognized keyword arguments are:
         fill state arrays with NaNs and dump them post-initialization
 - `integration_testing::Bool = false`:
         enable integration_testing
+- `sim_time::Float64 = NaN`:
+        run for the specified time (in simulation seconds)
+- `fixed_number_of_steps::Int = -1`:
+        if `≥0` perform specified number of steps
 
 Returns `nothing`, or if `parse_clargs = true`, returns parsed command line
 arguments.

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -94,6 +94,7 @@ function SolverConfiguration(
     direction = get_direction(driver_config.config_type),
     timeend_dt_adjust = true,
     CFL_direction = get_direction(driver_config.config_type),
+    sim_time = Settings.sim_time,
     fixed_number_of_steps = Settings.fixed_number_of_steps,
     skip_update_aux = false,
 ) where {FT <: AbstractFloat}
@@ -213,6 +214,9 @@ function SolverConfiguration(
             t0,
             CFL_direction,
         )
+    end
+    if !isnan(sim_time)
+        timeend = sim_time
     end
     if fixed_number_of_steps < 0
         numberofsteps = convert(Int, cld(timeend - t0, ode_dt))


### PR DESCRIPTION
### Description

This PR adds a `--sim-time` command line argument which allows overriding the experiment-specified `timeend`. The `--fixed-number-of-steps` command line argument overrides this one.

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
