### PR TITLE
Fix ordering of mass matrix elements for multiple polynomial orders

### DIFF
--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -659,7 +659,7 @@ function computegeometry(
         )
     end
 
-    M = kron(1, ntuple(j -> ω[j], dim)...)
+    M = kron(1, reverse(ω)...)
     MJ .= M .* J
     MJI .= 1 ./ MJ
     for d in 1:dim
@@ -667,14 +667,16 @@ function computegeometry(
             MJI[vmap⁻[1:Nfp[d], (2d - 1):(2d), :]]
     end
 
-    MH = kron(ones(FT, Nq[dim]), ntuple(j -> ω[j], dim - 1)...)
+    MH = kron(ones(FT, Nq[dim]), reverse(ω[1:(dim - 1)])...)
 
     sM = fill!(similar(sJ, maximum(Nfp), nface), NaN)
     for d in 1:dim
         for f in (2d - 1):(2d)
-            sM[1:Nfp[d], f] =
-                dim > 1 ?
-                kron(1, ntuple(j -> ω[mod1(d + j, dim)], dim - 1)...) : one(FT)
+            ωf = ntuple(j -> ω[mod1(d + j, dim)], dim - 1)
+            if !(dim == 3 && d == 2)
+                ωf = reverse(ωf)
+            end
+            sM[1:Nfp[d], f] = dim > 1 ? kron(1, ωf...) : one(FT)
         end
     end
     sMJ .= sM .* sJ

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -659,6 +659,7 @@ function computegeometry(
         )
     end
 
+    # since `ξ1` is the fastest dimension and `ξdim` the slowest the tensor product order is reversed
     M = kron(1, reverse(ω)...)
     MJ .= M .* J
     MJI .= 1 ./ MJ
@@ -673,6 +674,7 @@ function computegeometry(
     for d in 1:dim
         for f in (2d - 1):(2d)
             ωf = ntuple(j -> ω[mod1(d + j, dim)], dim - 1)
+            # Because of the `mod1` this face is already flipped
             if !(dim == 3 && d == 2)
                 ωf = reverse(ωf)
             end

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -662,7 +662,10 @@ function computegeometry(
     M = kron(1, ntuple(j -> ω[j], dim)...)
     MJ .= M .* J
     MJI .= 1 ./ MJ
-    vMJI .= MJI[vmap⁻]
+    for d in 1:dim
+        vMJI[1:Nfp[d], (2d - 1):(2d), :] .=
+            MJI[vmap⁻[1:Nfp[d], (2d - 1):(2d), :]]
+    end
 
     MH = kron(ones(FT, Nq[dim]), ntuple(j -> ω[j], dim - 1)...)
 

--- a/test/Numerics/Mesh/Grids.jl
+++ b/test/Numerics/Mesh/Grids.jl
@@ -1,0 +1,97 @@
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.Mesh.Topologies: BrickTopology
+using Test
+using MPI
+
+MPI.Initialized() || MPI.Init()
+
+@testset "2-D Mass matrix" begin
+    topology = BrickTopology(MPI.COMM_WORLD, ntuple(_ -> (-1, 1), 2);)
+
+    @testset for N in ((2, 2), (2, 3), (3, 2))
+        Nq = N .+ 1
+        Np = prod(Nq)
+        Nfp = div.(Np, Nq)
+
+        grid = DiscontinuousSpectralElementGrid(
+            topology,
+            FloatType = Float64,
+            DeviceArray = Array,
+            polynomialorder = N,
+        )
+
+        @views begin
+            ω = grid.ω
+            M = grid.vgeo[:, Grids._M, 1]
+            MH = grid.vgeo[:, Grids._MH, 1]
+            sM = grid.sgeo[Grids._sM, :, :, 1]
+
+            M = reshape(M, Nq[1], Nq[2])
+            @test M ≈ [ω[1][i] * ω[2][j] for i in 1:Nq[1], j in 1:Nq[2]]
+
+            MH = reshape(MH, Nq[1], Nq[2])
+            @test MH ≈ [ω[1][i] for i in 1:Nq[1], j in 1:Nq[2]]
+
+            sM12 = sM[1:Nfp[1], 1:2]
+            @test sM12[:, 1] ≈ [ω[2][j] for j in 1:Nq[2]]
+            @test sM12[:, 2] ≈ [ω[2][j] for j in 1:Nq[2]]
+
+            sM34 = sM[1:Nfp[2], 3:4]
+            @test sM34[:, 1] ≈ [ω[1][j] for j in 1:Nq[1]]
+            @test sM34[:, 2] ≈ [ω[1][j] for j in 1:Nq[1]]
+        end
+    end
+end
+
+@testset "3-D Mass matrix" begin
+    topology = BrickTopology(MPI.COMM_WORLD, ntuple(_ -> (-1, 1), 3);)
+
+    @testset for N in ((2, 2, 2), (2, 3, 4), (4, 3, 2), (2, 4, 3))
+        Nq = N .+ 1
+        Np = prod(Nq)
+        Nfp = div.(Np, Nq)
+
+        grid = DiscontinuousSpectralElementGrid(
+            topology,
+            FloatType = Float64,
+            DeviceArray = Array,
+            polynomialorder = N,
+        )
+
+        @views begin
+            ω = grid.ω
+            M = grid.vgeo[:, Grids._M, 1]
+            MH = grid.vgeo[:, Grids._MH, 1]
+            sM = grid.sgeo[Grids._sM, :, :, 1]
+
+            M = reshape(M, Nq[1], Nq[2], Nq[3])
+            @test M ≈ [
+                ω[1][i] * ω[2][j] * ω[3][k]
+                for i in 1:Nq[1], j in 1:Nq[2], k in 1:Nq[3]
+            ]
+
+            MH = reshape(MH, Nq[1], Nq[2], Nq[3])
+            @test MH ≈ [
+                ω[1][i] * ω[2][j] for i in 1:Nq[1], j in 1:Nq[2], k in 1:Nq[3]
+            ]
+
+            sM12 = reshape(sM[1:Nfp[1], 1:2], Nq[2], Nq[3], 2)
+            @test sM12[:, :, 1] ≈
+                  [ω[2][j] * ω[3][k] for j in 1:Nq[2], k in 1:Nq[3]]
+            @test sM12[:, :, 2] ≈
+                  [ω[2][j] * ω[3][k] for j in 1:Nq[2], k in 1:Nq[3]]
+
+            sM34 = reshape(sM[1:Nfp[2], 3:4], Nq[1], Nq[3], 2)
+            @test sM34[:, :, 1] ≈
+                  [ω[1][i] * ω[3][k] for i in 1:Nq[1], k in 1:Nq[3]]
+            @test sM34[:, :, 2] ≈
+                  [ω[1][i] * ω[3][k] for i in 1:Nq[1], k in 1:Nq[3]]
+
+            sM56 = reshape(sM[1:Nfp[3], 5:6], Nq[1], Nq[2], 2)
+            @test sM56[:, :, 1] ≈
+                  [ω[1][i] * ω[2][j] for i in 1:Nq[1], j in 1:Nq[2]]
+            @test sM56[:, :, 2] ≈
+                  [ω[1][i] * ω[2][j] for i in 1:Nq[1], j in 1:Nq[2]]
+        end
+    end
+end

--- a/test/Numerics/Mesh/runtests.jl
+++ b/test/Numerics/Mesh/runtests.jl
@@ -14,6 +14,10 @@ end
     runmpi(joinpath(@__DIR__, "Metrics.jl"))
 end
 
+@testset "Mesh Grids" begin
+    runmpi(joinpath(@__DIR__, "Grids.jl"))
+end
+
 @testset "Mesh Topology" begin
     runmpi(joinpath(@__DIR__, "topology.jl"))
 end


### PR DESCRIPTION
Fixes ordering of mass matrix elements for multiple polynomial orders and adds a test.

CC: @thomasgibson 

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
