### PR TITLE
modify the isothermal zonal flow test case and move it to TestCase folder

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -992,7 +992,7 @@ steps:
   - label: "gpu_isothermal_zonal_flow"
     key: "gpu_isothermal_zonal_flow"
     command:
-      - "mpiexec julia --color=yes --project experiments/AtmosGCM/isothermal_zonal_flow.jl "
+      - "mpiexec julia --color=yes --project experiments/TestCase/isothermal_zonal_flow.jl "
     agents:
       config: gpu
       queue: central


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
This PR updates the isothermal zonal flow in:
1. replacing the default Rusanov flux by Roe flux;
2. adding a test assert to ensure the flow stay identical to its initial state;
3. moving the test driver into `TestCase`

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
