### PR TITLE
Add density-pressure thermo constructors

### DIFF
--- a/docs/src/APIs/Common/Thermodynamics.md
+++ b/docs/src/APIs/Common/Thermodynamics.md
@@ -18,15 +18,18 @@ PhaseDry_pT
 PhaseDry_pθ
 PhaseDry_ρθ
 PhaseDry_ρT
+PhaseDry_ρp
 PhaseEquil
 PhaseEquil_ρTq
 PhaseEquil_pTq
 PhaseEquil_pθq
 PhaseEquil_ρθq
+PhaseEquil_ρpq
 PhaseNonEquil
 PhaseNonEquil_ρTq
 PhaseNonEquil_ρθq
 PhaseNonEquil_pθq
+PhaseNonEquil_ρpq
 ```
 
 ## Thermodynamic state methods

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -709,6 +709,16 @@ end
         ResidualTolerance(FT(1e-10)),
     )
 
+    @test_throws ErrorException TD.saturation_adjustment_ρpq.(
+        param_set,
+        ρ,
+        p,
+        q_tot,
+        Ref(phase_type),
+        2,
+        FT(1e-10),
+    )
+
 end
 
 @testset "Thermodynamics - constructor consistency" begin
@@ -745,6 +755,15 @@ end
         @test all(air_density.(ts_ρT) .≈ air_density.(ts))
         @test all(internal_energy.(ts_ρT) .≈ internal_energy.(ts))
 
+
+        ts = PhaseDry_ρp.(param_set, ρ, p)
+        @test all(air_density.(ts) .≈ ρ)
+        @test all(air_pressure.(ts) .≈ p)
+        e_tot_proposed =
+            TD.total_energy_given_ρp.(param_set, ρ, p, e_kin, e_pot)
+        @test all(total_energy.(e_kin, e_pot, ts) .≈ e_tot_proposed)
+
+
         profiles = PhaseEquilProfiles(param_set, ArrayType)
         @unpack T, p, RS, e_int, ρ, θ_liq_ice, phase_type = profiles
         @unpack q_tot, q_liq, q_ice, q_pt, RH, e_kin, e_pot = profiles
@@ -768,6 +787,24 @@ end
         @test all(internal_energy.(ts) .≈ e_int)
         @test all(getproperty.(PhasePartition.(ts), :tot) .≈ q_tot)
         @test all(air_density.(ts) .≈ ρ)
+
+        ts = PhaseEquil_ρpq.(param_set, ρ, p, q_tot, true)
+        @test all(air_density.(ts) .≈ ρ)
+        @test all(air_pressure.(ts) .≈ p)
+        @test all(getproperty.(PhasePartition.(ts), :tot) .≈ q_tot)
+
+        # Test against total_energy_given_ρp when not iterating
+        ts = PhaseEquil_ρpq.(param_set, ρ, p, q_tot, false)
+        e_tot_proposed =
+            TD.total_energy_given_ρp.(
+                param_set,
+                ρ,
+                p,
+                e_kin,
+                e_pot,
+                PhasePartition.(q_tot),
+            )
+        @test all(total_energy.(e_kin, e_pot, ts) .≈ e_tot_proposed)
 
         # PhaseNonEquil
         ts = PhaseNonEquil.(param_set, e_int, ρ, q_pt)
@@ -841,6 +878,22 @@ end
         @test all(liquid_ice_pottemp.(ts) .≈ θ_liq_ice)
         @test all(air_pressure.(ts) .≈ p)
         @test all(compare_moisture.(ts, q_pt))
+
+        ts = PhaseNonEquil_ρpq.(param_set, ρ, p, q_pt)
+        @test all(air_density.(ts) .≈ ρ)
+        @test all(air_pressure.(ts) .≈ p)
+        @test all(
+            getproperty.(PhasePartition.(ts), :tot) .≈ getproperty.(q_pt, :tot),
+        )
+        @test all(
+            getproperty.(PhasePartition.(ts), :liq) .≈ getproperty.(q_pt, :liq),
+        )
+        @test all(
+            getproperty.(PhasePartition.(ts), :ice) .≈ getproperty.(q_pt, :ice),
+        )
+        e_tot_proposed =
+            TD.total_energy_given_ρp.(param_set, ρ, p, e_kin, e_pot, q_pt)
+        @test all(total_energy.(e_kin, e_pot, ts) .≈ e_tot_proposed)
 
         # PhaseNonEquil_ρθq
         ts = PhaseNonEquil_ρθq.(param_set, ρ, θ_liq_ice, q_pt, 5, FT(1e-3))
@@ -941,6 +994,7 @@ end
 
     θ_dry = dry_pottemp.(param_set, T, ρ)
     ts_dry = PhaseDry.(param_set, e_int, ρ)
+    ts_dry_ρp = PhaseDry_ρp.(param_set, ρ, p)
     ts_dry_pT = PhaseDry_pT.(param_set, p, T)
     ts_dry_ρθ = PhaseDry_ρθ.(param_set, ρ, θ_dry)
     ts_dry_pθ = PhaseDry_pθ.(param_set, p, θ_dry)
@@ -962,6 +1016,14 @@ end
             q_tot,
         )
 
+    ts_ρp =
+        PhaseEquil_ρpq.(
+            param_set,
+            air_density.(ts_dry),
+            air_pressure.(ts_dry),
+            q_tot,
+        )
+
     @test all(air_temperature.(ts_T) .≈ air_temperature.(ts_Tp))
     # @test all(isapprox.(air_pressure.(ts_T), air_pressure.(ts_Tp), atol = _MSLP * 2e-2)) # TODO: Fails, needs fixing / better test
     @test all(total_specific_humidity.(ts_T) .≈ total_specific_humidity.(ts_Tp))
@@ -978,12 +1040,14 @@ end
 
     for ts in (
         ts_dry,
+        ts_dry_ρp,
         ts_dry_pT,
         ts_dry_ρθ,
         ts_dry_pθ,
         ts_eq,
         ts_T,
         ts_Tp,
+        ts_ρp,
         ts_neq,
         ts_T_neq,
         ts_θ_liq_ice_eq,


### PR DESCRIPTION
### Description

This PR adds density-pressure thermo constructors

 - `PhaseDry_ρp`
 - `PhaseEquil_ρpq`
 - `PhaseNonEquil_ρpq`

These constructors are tested along with all of the others, and they're also tested against a newly added method `total_energy_given_ρp`, which is used in the constructors to compute total energy by first computing temperature from the ideal gas law. I believe that this is needed so that we can translate between conservative and primitive variables. This allows users to, instead of calling `total_energy_given_ρp` directly:

```julia
ts = PhaseDry_ρp.(param_set, ρ, p)
ts = PhaseEquil_ρpq.(param_set, ρ, p, q_tot)
ts = PhaseNonEquil_ρpq.(param_set, ρ, p, q_pt)

e_tot = total_energy.(e_kin, e_pot, ts)
```

At the moment, these constructors are failing the consistency tests (for pressure) in the moist constructors (the dry passes the consistency tests, however), but passing the `total_energy_given_ρp` test. I'd like to get to the bottom of this so that we can properly document what's going on.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
