### PR TITLE
Fix thermo print statements

### DIFF
--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -1573,9 +1573,9 @@ function saturation_adjustment_given_ρθq(
                 @print("-----------------------------------------\n")
                 @print("maxiter reached in saturation_adjustment_given_ρθq:\n")
                 @print(
-                    ", ρ=",
+                    "    ρ=",
                     ρ,
-                    "    θ_liq_ice=",
+                    ", θ_liq_ice=",
                     θ_liq_ice,
                     ", q_tot=",
                     q_tot,
@@ -1682,9 +1682,9 @@ function saturation_adjustment_given_pθq(
                 @print("-----------------------------------------\n")
                 @print("maxiter reached in saturation_adjustment_given_pθq:\n")
                 @print(
-                    ", p=",
+                    "    p=",
                     p,
-                    "    θ_liq_ice=",
+                    ", θ_liq_ice=",
                     θ_liq_ice,
                     ", q_tot=",
                     q_tot,
@@ -1996,9 +1996,9 @@ function air_temperature_given_θρq_nonlinear(
                 ρ,
                 ", q.tot=",
                 q.tot,
-                "q.liq = ",
+                ", q.liq = ",
                 q.liq,
-                "q.ice = ",
+                ", q.ice = ",
                 q.ice,
                 ", T = ",
                 sol.root,


### PR DESCRIPTION
### Description

This PR fixes some of the thermo print statements, which are missing commas and are improperly formatted.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
