### PR TITLE
Improve Implicit Solver

### DIFF
--- a/docs/list_of_how_to_guides.jl
+++ b/docs/list_of_how_to_guides.jl
@@ -12,6 +12,7 @@ how_to_guides = Any[
         "Reference profiles" => "HowToGuides/Atmos/AtmosReferenceState.md",
         "Moisture model" => "HowToGuides/Atmos/MoistureModelChoices.md",
         "Precipitation model" => "HowToGuides/Atmos/PrecipitationModelChoices.md",
+        "How to create an experiment with moisture and precipitation" => "HowToGuides/Atmos/MoistureAndPrecip.md",
     ],
     "Ocean" => Any[
     # "Home" => "HowToGuides/Ocean/index.md"

--- a/docs/src/HowToGuides/Atmos/MoistureAndPrecip.md
+++ b/docs/src/HowToGuides/Atmos/MoistureAndPrecip.md
@@ -1,0 +1,305 @@
+## Representing moisture and precipitation
+
+This tutorial shows how to setup an Atmos experiment with moisture
+(i.e. water vapor, cloud liquid water, and cloud ice)
+and precipitation (i.e. rain and/or snow).
+It expands on the LES and GCM tutorials already available in the
+[Atmos tutorials section](https://clima.github.io/ClimateMachine.jl/latest/generated/TutorialList/#Atmos).
+Therefore, this tutorial only discusses additional steps that are needed
+in order to define an experiment with moisture and precipitation.
+For a tutorial on how to setup basic Atmos experiment see the
+[Held-Suarez](https://clima.github.io/ClimateMachine.jl/latest/generated/Atmos/heldsuarez/)
+or the [Rising thermal bubble](https://clima.github.io/ClimateMachine.jl/latest/generated/Atmos/risingbubble/)
+tutorials.
+For a full experiment setup with moisture and precipitation
+see the [DyCOMS](https://github.com/CliMA/ClimateMachine.jl/blob/master/experiments/AtmosLES/dycoms.jl)
+or the [Squall line](https://github.com/CliMA/ClimateMachine.jl/blob/master/experiments/AtmosLES/squall_line.jl)
+setups that are part of the Atmos model CI.
+
+When setting up a moist and precipitating Atmos experiment,
+the user has to decide between two moisture and three precipitation models.
+The differences between the two moisture models are described in the
+[Moisture model](https://clima.github.io/ClimateMachine.jl/latest/HowToGuides/Atmos/MoistureModelChoices/) section.
+In general, the `EquilMoist` model solves for only one additional state variable
+and diagnoses the cloud condensate partitioning between liquid and ice
+based on equilibrium assumptions and an iterative search algorithm.
+The `NonEquilMoist` model solves equations for all three cloud condensate state variables
+Because the condensation and deposition timescales are fast,
+in many cases, the `EquilMoist` model is a good approximation.
+However, it is obviously not sufficient when modeling nonequilibrium
+processes, such as supercooled clouds.
+Because of the lack of need for iterative search to perform partitioning
+of cloud condensate, the `NonEquilMoist` model might be more robust,
+if a little slower than the `EquilMoist` model.
+The differences between the three precipitation models are described in the
+[Precipitation model](https://clima.github.io/ClimateMachine.jl/latest/HowToGuides/Atmos/PrecipitationModelChoices/) section.
+In general, the `NoPrecipitation` option can be used in simulations without
+precipitation or in simulations when the effect of precipitation
+is modeled by instantly removing cloud condensate.
+This option, coupled with either of the moisture models, is a good start
+when running in moist `AtmosGCM` configuration.
+The parameterization of instantaneous precipitation removal is described by the
+[0-moment microphysics](https://clima.github.io/ClimateMachine.jl/latest/Theory/Atmos/Microphysics_0M/)
+scheme.
+The `RainModel` encapsulates the "warm rain" processes, i.e.
+the formation of precipitation in temperatures above freezing.
+The `RainSnowModel` describes the full set of microphysical processes
+leading to the formation of precipitation.
+Both models are based on
+[1-moment microphysics](https://clima.github.io/ClimateMachine.jl/latest/Theory/Atmos/Microphysics/)
+scheme, which is a simple representation of cloud microphysics.
+It is a good starting point for the moist `AtmosLES` configurations,
+coupling to the subgrid scale parameterizations, and testing the machine learning pipelines.
+In the future, a more sophisticated 2-moment microphysics scheme will most likely be needed.
+
+
+## Using CLIMAParameters.jl
+
+The microphysics parameterizations used to compute the sources and sinks for
+moisture and precipitation variables assume certain structure
+in the physical parameters used.
+This is done in order to leverage the dynamic dispatch mechanism and re-use
+the internal microphysics functions on different microphysics species
+based on their type.
+This structure has to be created when using different parameters from
+[CLIMAParameters.jl](https://github.com/CliMA/CLIMAParameters.jl).
+
+```julia
+using CLIMAParameters
+using CLIMAParameters.Planet
+using CLIMAParameters.Atmos.Microphysics
+
+struct LiquidParameterSet <: AbstractLiquidParameterSet end
+struct IceParameterSet <: AbstractIceParameterSet end
+struct RainParameterSet <: AbstractRainParameterSet end
+struct SnowParameterSet <: AbstractSnowParameterSet end
+struct MicropysicsParameterSet{L, I, R, S} <: AbstractMicrophysicsParameterSet
+    liq::L
+    ice::I
+    rai::R
+    sno::S
+end
+struct EarthParameterSet{M} <: AbstractEarthParameterSet
+    microphys::M
+end
+
+const microphys = MicropysicsParameterSet(
+    LiquidParameterSet(),
+    IceParameterSet(),
+    RainParameterSet(),
+    SnowParameterSet(),
+)
+const param_set = EarthParameterSet(microphys)
+```
+
+After this is done, the created `param_set` should be passed
+in the same way as in the "dry" tutorials.
+
+
+## Initial condition
+
+As discussed in the documentation on the
+[moisture](https://clima.github.io/ClimateMachine.jl/latest/HowToGuides/Atmos/MoistureModelChoices/)
+and
+[precipitation](https://clima.github.io/ClimateMachine.jl/latest/HowToGuides/Atmos/PrecipitationModelChoices/)
+choices, different model configurations result in different state variables.
+When using the `EquilMoist` model, the initial condition on total water
+is the only thing that is needed:
+
+```julia
+state.moisture.ρq_tot = ρ * 0.0042
+```
+
+When using the `NonEquilMoist` model, the initial condition on total water,
+cloud liquid water and cloud ice is needed:
+
+```julia
+state.moisture.ρq_tot = ρ * 0.0042
+state.moisture.ρq_liq = FT(0)
+state.moisture.ρq_ice = FT(0)
+```
+
+Similarly for the `RainModel` we need to define the initial condition for
+rain:
+
+```julia
+state.precipitation.ρq_rai = FT(0)
+```
+
+And for the `RainSnowModel` the initial condition for both rain and snow is needed:
+
+```julia
+state.precipitation.ρq_rai = FT(0)
+state.precipitation.ρq_sno = FT(0)
+```
+
+As in the previous tutorials `FT()` is the float type chosen for the simulation.
+
+The moisture and precipitation state variables are grouped together
+into `state.moisture` and `state.precipitation` fields.
+As shown when specifying the initial condition,
+this hierarchy has to be observed when accessing the members
+of moisture or precipitation state variables.
+
+
+## Choosing the moisture and precipitation models and sources
+
+When opting to use the `EquilMoist` moisture model, we need to specify
+the maximum number of iterations and the tolerance allowed
+in the iterative search performed to diagnose cloud condensate
+phase partitioning.
+The cloud liquid water and cloud ice are stored in the auxiliary
+state variables.
+Because the partitioning is diagnosed, no additional source terms
+have to be specified:
+
+```julia
+moisture = EquilMoist{FT}(; maxiter = 8, tolerance = FT(1e-1))
+```
+
+Alternatively, when using the `NonEquilMoist` model, an additional source term
+`CreateClouds` is needed.
+It is assumed here that `source` lists all the previously
+defined source terms.
+We are splatting to it the additional
+cloud condensate sources for cloud liquid water and cloud ice.
+
+```julia
+moisture = NonEquilMoist()
+source = (source..., CreateClouds()...)
+```
+
+If choosing the `NoPrecipitation` model we can either define no additional
+source terms (a true simulation without any representation of precipitation),
+or use the instant precipitation removal source term `RemovePrecipitation`.
+The boolean flag passed to it as argument chooses between two definitions
+of the threshold above which cloud condensate is removed,
+see [here](https://clima.github.io/ClimateMachine.jl/latest/Theory/Atmos/Microphysics_0M/#Moisture-sink-due-to-precipitation).
+The flag set to `true` results in cloud condensate based threshold.
+The flag set to `false` results in saturation excess threshold.
+
+```julia
+precipitation = NoPrecipitation()
+source = (source..., RemovePrecipitation(true)...)
+```
+
+If using the `RainModel`, the `WarmRain_1M` source terms have to be chosen:
+
+```julia
+precipitation = RainModel()
+source = (source..., WarmRain_1M()...)
+```
+
+Alternatively, if using the `RainSnowModel`, the `RainSnow_1M` source terms
+have to be chosen:
+
+```julia
+precipitation = RainSnowModel()
+source = (source..., RainSnow_1M()...)
+```
+
+As in the previous tutorials, all of the `source`, `moisture`, `precipitation`
+choices, along with the `param_set` `struct` have to be passed to
+the Atmos model configuration:
+
+```julia
+model = AtmosModel{FT}(
+    AtmosLESConfigType,
+    param_set;
+    problem = problem,
+    ref_state = ref_state,
+    moisture = moisture,
+    precipitation = precipitation,
+    turbulence = SmagorinskyLilly{FT}(C_smag),
+    source = source,
+)
+```
+
+
+## Boundary conditions
+
+Boundary condition specification is currently undergoing a re-write.
+More details on boundary conditions will follow soon.
+By default no additional moisture or precipitation fluxes are applied.
+
+
+## Using filters
+
+All moisture and precipitation variables are positive definite.
+However, due to numerical errors, they can turn negative during the simulation.
+To mitigate that behavior it is advisable to use the `TMAR filter`.
+The filter adjust the nodal points inside the DG element.
+It truncates the negative nodal points to zero
+and adjusts the values of the remaining points
+to preserve the element average.
+To conserve mass of the advected tracers the `TMAR filter` should be combined
+with a flux-correction to those DG elements whose average value is negative.
+The flux-corrected option is currently being implemented.
+If mass conservation is deemed more important than positive sign of advected tracers,
+one can run the simulation without the `TMAR filter`.
+The microphysics functions are implemented such that `f(negative_argument) = f(0)`.
+
+The list of state variables to be filtered
+depends on the moisture and precipitation model choices.
+For example:
+
+```julia
+filter_vars = ("moisture.ρq_tot",)
+filter_vars = (filter_vars..., "moisture.ρq_liq", "moisture.ρq_ice")
+filter_vars = (filter_vars..., "precipitation.ρq_rai")
+filter_vars = (filter_vars..., "precipitation.ρq_rai", "precipitation.ρq_sno")
+```
+
+The list of variables to be filtered should then be passed to the `TMAR filter` `callback`:
+
+```julia
+cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+    Filters.apply!(
+        solver_config.Q,
+        filter_vars,
+        solver_config.dg.grid,
+        TMARFilter(),
+    )
+    nothing
+end
+```
+
+And the filter `callback` should be passed to the final `invoke` method:
+
+```julia
+result = ClimateMachine.invoke!(
+    solver_config;
+    diagnostics_config = dgn_config,
+    user_callbacks = (cbtmarfilter,),
+    check_euclidean_distance = true,
+)
+```
+
+## Accessing moisture and precipitation variables
+
+To access moisture and precipitation variables at the end of the simulation
+(for example for some debugging or assert checking in the CI)
+we need to use the `varsindex` and `vars_state` functions:
+
+```julia
+m = driver_config.bl
+Q = solver_config.Q
+ρ_ind = varsindex(vars_state(m, Prognostic(), FT), :ρ)
+
+ρq_tot_ind = varsindex(vars_state(m, Prognostic(), FT), :moisture, :ρq_tot)
+ρq_sno_ind = varsindex(vars_state(m, Prognostic(), FT), :precipitation, :ρq_sno)
+
+min_q_tot = minimum(abs.(Array(Q[:, ρq_tot_ind, :]) ./ Array(Q[:, ρ_ind, :]),))
+max_q_sno = maximum(abs.(Array(Q[:, ρq_sno_ind, :]) ./ Array(Q[:, ρ_ind, :]),))
+
+@info(min_q_tot, max_q_sno)
+```
+
+The vertical profiles (horizontal averages) of moisture and precipitation
+variables, their variances and covariances,
+as well as the liquid, ice rain and snow water paths
+are available in the output netcdf file when using the
+`setup_atmos_default_diagnostics` group.
+Additionally one can choose to save into the netcdf output all of the state
+variables and auxiliary variables using the `setup_dump_state_diagnostics`
+and `setup_dump_aux_diagnostics` groups.

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -506,18 +506,17 @@ equations.
 )
 
     flux_pad = SVector(1, 1, 1)
+    ts = recover_thermo_state(m, state, aux)
     tend = Flux{FirstOrder}()
-    _args = (state = state, aux = aux, t = t, direction = direction)
-    args = merge(_args, (precomputed = precompute(atmos, _args, tend),))
-    flux.ρ = Σfluxes(eq_tends(Mass(), atmos, tend), atmos, args) .* flux_pad
-    flux.ρu =
-        Σfluxes(eq_tends(Momentum(), atmos, tend), atmos, args) .* flux_pad
-    flux.ρe = Σfluxes(eq_tends(Energy(), atmos, tend), atmos, args) .* flux_pad
+    args = (m, state, aux, t, ts, direction)
+    flux.ρ = Σfluxes(eq_tends(Mass(), m, tend), args...) .* flux_pad
+    flux.ρu = Σfluxes(eq_tends(Momentum(), m, tend), args...) .* flux_pad
+    flux.ρe = Σfluxes(eq_tends(Energy(), m, tend), args...) .* flux_pad
 
-    flux_first_order!(atmos.moisture, atmos, flux, args)
-    flux_first_order!(atmos.precipitation, atmos, flux, args)
-    flux_first_order!(atmos.tracers, atmos, flux, args)
-    flux_first_order!(atmos.turbconv, atmos, flux, args)
+    flux_first_order!(m.moisture, m, flux, state, aux, t, ts, direction)
+    flux_first_order!(m.precipitation, m, flux, state, aux, t, ts, direction)
+    flux_first_order!(m.tracers, m, flux, state, aux, t, ts, direction)
+    flux_first_order!(m.turbconv, m, flux, state, aux, t, ts, direction)
 
 end
 

--- a/src/Driver/SolverTypes/HEVISolverType.jl
+++ b/src/Driver/SolverTypes/HEVISolverType.jl
@@ -1,0 +1,198 @@
+
+export HEVISolverType
+
+"""
+# Description
+    HEVISolverType(FT;
+        solver_method = ARK2ImplicitExplicitMidpoint,
+
+        linear_max_subspace_size = Int(30)
+        linear_atol = FT(-1.0)
+        linear_rtol = FT(5e-5)
+
+        nonlinear_max_iterations = Int(10)
+        nonlinear_rtol = FT(1e-4)
+        nonlinear_ϵ = FT(1.e-10)
+        preconditioner_update_freq = Int(50)
+    )
+
+This solver type constructs a solver for ODEs with the
+additively horizontal explicit vertical explicit~(HEVI) partitioned form. 
+the equation is assumed to be decomposed as
+
+```math
+  \\dot{Q} = [l(Q, t)] + [f(Q, t) - l(Q, t)]
+```
+
+where `Q` is the state, `f` is the full tendency and `l` is the vertical implicit
+operator. The splitting is done automatically.
+
+# Arguments
+- `solver_method` (Function): Function defining the particular additive
+    Runge-Kutta method to be used for the HEVI method.
+    Default: `ARK2ImplicitExplicitMidpoint`
+- `linear_max_subspace_size` (Int): maximal dimension of each (batched)
+    Krylov subspace. GEMRES, a iterative linear solver is applied 
+    Default: `30`
+- `linear_atol` (FT): absolute tolerance for linear solver convergence.
+    Default: `-1.0`
+- `linear_rtol` (FT): relative tolerance for linear solver convergence.
+    Default: `5.0e-5`
+- `nonlinear_max_iterations` (Int): max number of Newton iterations
+    Default: `10`
+- `nonlinear_rtol` (FT): relative tolerance for nonlinear solver convergence.
+    Default: `1e-4`
+- `nonlinear_ϵ` (FT): parameter denoting finite different step size for the 
+   Jacobian approximation.
+   Default: `1e-10`
+- `preconditioner_update_freq` (Int): Int denoting how frequent you need 
+    to update the preconditioner 
+    -1: no preconditioner;
+    positive number, update every freq times.
+    Default: `50`
+"""
+struct HEVISolverType{FT} <: AbstractSolverType
+    # Function for the HEVI method
+    solver_method::Function
+
+    linear_max_subspace_size::Int
+    linear_atol::FT
+    linear_rtol::FT
+
+    nonlinear_max_iterations::Int
+    nonlinear_rtol::FT
+    nonlinear_ϵ::FT
+    
+    preconditioner_update_freq::Int
+
+    function HEVISolverType(
+        FT;
+        solver_method = ARK2ImplicitExplicitMidpoint,
+
+        linear_max_subspace_size = Int(30),
+        linear_atol = FT(-1.0),
+        linear_rtol = FT(5e-5),
+
+        nonlinear_max_iterations = Int(10),
+        nonlinear_rtol = FT(1e-4),
+        nonlinear_ϵ = FT(1.e-10),
+        preconditioner_update_freq = Int(50),
+    )
+
+        return new{FT}(
+            solver_method,
+            linear_max_subspace_size,
+            linear_atol,
+            linear_rtol,
+            nonlinear_max_iterations,
+            nonlinear_rtol,
+            nonlinear_ϵ,
+            preconditioner_update_freq,
+        )
+    end
+end
+
+"""
+    getdtmodel(ode_solver::HEVISolverType, bl)
+
+A function which returns a model representing the dynamics
+with the most restrictive time-stepping requirements.
+"""
+function getdtmodel(ode_solver::HEVISolverType, bl)
+    # Most restrictive dynamics are treated implicitly
+    return bl
+end
+
+"""
+# Description
+    solversetup(
+        ode_solver::HEVISolverType{FT},
+        dg,
+        Q,
+        dt,
+        t0,
+        diffusion_direction,
+    )
+
+Creates an ODE solver using a HEVI-type time-integration
+scheme. All horizontal acoustic waves are treated explicitly,
+while the 1-D vertical problem is treated implicitly. All
+other dynamics (advection, diffusion) is treated explicitly
+in the additive Runge-Kutta method.
+
+# Comments:
+Currently, the only HEVI-type splitting ClimateMachine can currently
+do only involves splitting the acoustic processes; it is not currently
+possible to perform more fine-grained separation of tendencies
+(for example, including vertical advection or diffusion in the 1-D implicit problem)
+"""
+function solversetup(
+    ode_solver::HEVISolverType,
+    dg,
+    Q,
+    dt,
+    t0,
+    diffusion_direction,
+)
+
+
+# All we need to do is create a DGModel for the
+    # vertical acoustic waves (determined from the `implicit_model`)
+    vdg = DGModel(
+        dg.balance_law,
+        dg.grid,
+        dg.numerical_flux_first_order,
+        dg.numerical_flux_second_order,
+        dg.numerical_flux_gradient;
+        state_auxiliary = dg.state_auxiliary,
+        direction = VerticalDirection(),
+        diffusion_direction = VerticalDirection(),
+    )
+
+    # linear solver relative tolerance rtol which should be slightly smaller than the nonlinear solver tol
+    linearsolver = BatchedGeneralizedMinimalResidual(
+        dg,
+        Q;
+        max_subspace_size = ode_solver.linear_max_subspace_size,
+        atol = ode_solver.linear_atol,
+        rtol = ode_solver.linear_rtol,
+    )
+
+    """
+    N(q)(Q) = Qhat  => F(Q) = N(q)(Q) - Qhat
+
+    F(Q) == 0
+    ||F(Q^i) || / ||F(Q^0) || < tol
+
+    """
+    # ϵ is a sensity parameter for this problem, it determines the finite difference Jacobian dF = (F(Q + ϵdQ) - F(Q))/ϵ
+    # I have also try larger tol, but tol = 1e-3 does not work
+    nonlinearsolver =
+        JacobianFreeNewtonKrylovSolver(Q, linearsolver; tol = ode_solver.nonlinear_rtol, ϵ = ode_solver.nonlinear_ϵ, M = ode_solver.nonlinear_max_iterations)
+
+    # this is a second order time integrator, to change it to a first order time integrator
+    # change it ARK1ForwardBackwardEuler, which can reduce the cost by half at the cost of accuracy 
+    # and stability
+    # preconditioner_update_freq = 50 means updating the preconditioner every 50 Newton solves, 
+    # update it more freqent will accelerate the convergence of linear solves, but updating it 
+    # is very expensive
+    solver = ode_solver.solver_method(
+        dg,
+        vdg,
+        NonLinearBackwardEulerSolver(
+            nonlinearsolver;
+            isadjustable = true,
+            preconditioner_update_freq = ode_solver.preconditioner_update_freq,
+        ),
+        Q;
+        dt = dt,
+        t0 = t0,
+        split_explicit_implicit = false,
+        variant = NaiveVariant(),
+    )
+
+
+    return solver
+end
+
+

--- a/src/Driver/SolverTypes/SolverTypes.jl
+++ b/src/Driver/SolverTypes/SolverTypes.jl
@@ -81,6 +81,7 @@ solversetup(
 include("ExplicitSolverType.jl")
 include("ImplicitSolverType.jl")
 include("IMEXSolverType.jl")
+include("HEVISolverType.jl")
 include("MultirateSolverType.jl")
 include("MISSolverType.jl")
 include("SplitExplicitSolverType.jl")

--- a/src/Numerics/ODESolvers/BackwardEulerSolvers.jl
+++ b/src/Numerics/ODESolvers/BackwardEulerSolvers.jl
@@ -310,7 +310,8 @@ function (nlbesolver::NonLinBESolver)(Q, Qhat, α, p, t)
         Q,
         Qhat,
         p,
-        t,
+        t;
+        max_newton_iters = nlbesolver.nlsolver.M,
     )
 
 end

--- a/src/Numerics/SystemSolvers/jacobian_free_newton_krylov_solver.jl
+++ b/src/Numerics/SystemSolvers/jacobian_free_newton_krylov_solver.jl
@@ -71,15 +71,20 @@ function (op::JacobianAction)(JΔQ, dQ, args...)
     n = length(dQ)
     normdQ = norm(dQ, weighted_norm)
 
+    β = √ϵ
+
     if normdQ > ϵ
+        # for preconditioner reconstruction, it goes into this part
+        # e depends only on the active freedoms in the preconditioner reconstruction
         factor = FT(1 / (n * normdQ))
+        Qdq .= Q .* (abs.(dQ) .> 0)
+        e = factor * β * norm(Qdq, 1, false) + β
     else
-        # initial newton step, ΔQ = 0
         factor = FT(1 / n)
+        e = factor * β * norm(Q, 1, false) + β
     end
 
-    β = √ϵ
-    e = factor * β * norm(Q, 1, false) + β
+
 
     Qdq .= Q .+ e .* dQ
 

--- a/test/Atmos/EDMF/Artifacts.toml
+++ b/test/Atmos/EDMF/Artifacts.toml
@@ -1,5 +1,2 @@
 [PyCLES_output]
-git-tree-sha1 = "2855ea3b737aa771bea0de60aa7ecda3577c1905"
-
-[bomex_edmf]
-git-tree-sha1 = "c7b2a1f03b06f3f3e4d06b3112c90c543082b471"
+git-tree-sha1 = "61af161b398cb0daabeb2eb1d3c57c7ba3629514"

--- a/test/Atmos/EDMF/compute_mse.jl
+++ b/test/Atmos/EDMF/compute_mse.jl
@@ -19,7 +19,7 @@ PyCLES_output_dataset = ArtifactWrapper(
     "PyCLES_output",
     ArtifactFile[
     # ArtifactFile(url = "https://caltech.box.com/shared/static/johlutwhohvr66wn38cdo7a6rluvz708.nc", filename = "Rico.nc",),
-    # ArtifactFile(url = "https://caltech.box.com/shared/static/zraeiftuzlgmykzhppqwrym2upqsiwyb.nc", filename = "Gabls.nc",),
+    ArtifactFile(url = "https://caltech.box.com/shared/static/zraeiftuzlgmykzhppqwrym2upqsiwyb.nc", filename = "Gabls.nc",),
     # ArtifactFile(url = "https://caltech.box.com/shared/static/toyvhbwmow3nz5bfa145m5fmcb2qbfuz.nc", filename = "DYCOMS_RF01.nc",),
     # ArtifactFile(url = "https://caltech.box.com/shared/static/ivo4751camlph6u3k68ftmb1dl4z7uox.nc", filename = "TRMM_LBA.nc",),
     # ArtifactFile(url = "https://caltech.box.com/shared/static/4osqp0jpt4cny8fq2ukimgfnyi787vsy.nc", filename = "ARM_SGP.nc",),
@@ -29,8 +29,11 @@ PyCLES_output_dataset = ArtifactWrapper(
     ],
 )
 PyCLES_output_dataset_path = get_data_folder(PyCLES_output_dataset)
-data_files = Dict()
-data_files[:Bomex] = Dataset(joinpath(PyCLES_output_dataset_path, "Bomex.nc"), "r")
+#! format: on
+
+#! format: off
+# data_files = Dict()
+# data_files[:Bomex] = Dataset(joinpath(PyCLES_output_dataset_path, "Bomex.nc"), "r")
 # data_files[:Rico] = Dataset(joinpath(PyCLES_output_dataset_path, "Rico.nc"), "r")
 # data_files[:Gabls] = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
 # data_files[:DYCOMS_RF01] = Dataset(joinpath(PyCLES_output_dataset_path, "DYCOMS_RF01.nc"), "r")

--- a/test/Atmos/EDMF/report_mse.jl
+++ b/test/Atmos/EDMF/report_mse.jl
@@ -9,9 +9,16 @@ end
 
 include(joinpath(@__DIR__, "compute_mse.jl"))
 
+# Get PyCLES_output dataset folder:
+#! format: off
+data_files = Dict()
+data_files[:Bomex] = Dataset(joinpath(PyCLES_output_dataset_path, "Bomex.nc"), "r")
+#! format: on
+
 #! format: off
 best_mse = Dict()
 best_mse[:Bomex] = Dict()
+<<<<<<< HEAD
 best_mse[:Bomex]["ρ"] = 3.4943021267397123e-02
 best_mse[:Bomex]["ρu[1]"] = 3.0714039084256679e+03
 best_mse[:Bomex]["ρu[2]"] = 1.3375796498101822e-03
@@ -23,6 +30,19 @@ best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9577348413012515e+01
 best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4352188057391225e-02
 best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0101464252959325e+00
 best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0768120864370509e+01
+=======
+best_mse[:Bomex]["ρ"] = 3.0714039084256697e+03
+best_mse[:Bomex]["ρu[1]"] = 3.0714039084256697e+03
+best_mse[:Bomex]["ρu[2]"] = 4.8463531712315697e-02
+best_mse[:Bomex]["moisture.ρq_tot"] = 4.8463531712315697e-02
+best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.6626829120676109e+02
+best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5667200586224638e+01
+best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6455724508026486e+02
+best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9577347148791929e+01
+best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4352020358740801e-02
+best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0101465706351167e+00
+best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0768121066485671e+01
+>>>>>>> caf6e858b... Move second order moisture flux to new tend spec
 #! format: on
 
 sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + eps()
@@ -53,10 +73,30 @@ computed_mse = Dict(
     test_mse(computed_mse[:Bomex], best_mse[:Bomex], "moisture.ρq_tot")
     test_mse(computed_mse[:Bomex], best_mse[:Bomex], "turbconv.updraft[1].ρa")
     test_mse(computed_mse[:Bomex], best_mse[:Bomex], "turbconv.updraft[1].ρaw")
-    test_mse(computed_mse[:Bomex], best_mse[:Bomex], "turbconv.updraft[1].ρaθ_liq")
-    test_mse(computed_mse[:Bomex], best_mse[:Bomex], "turbconv.updraft[1].ρaq_tot")
-    test_mse(computed_mse[:Bomex], best_mse[:Bomex], "turbconv.environment.ρatke")
-    test_mse(computed_mse[:Bomex], best_mse[:Bomex], "turbconv.environment.ρaθ_liq_cv")
-    test_mse(computed_mse[:Bomex], best_mse[:Bomex], "turbconv.environment.ρaq_tot_cv")
+    test_mse(
+        computed_mse[:Bomex],
+        best_mse[:Bomex],
+        "turbconv.updraft[1].ρaθ_liq",
+    )
+    test_mse(
+        computed_mse[:Bomex],
+        best_mse[:Bomex],
+        "turbconv.updraft[1].ρaq_tot",
+    )
+    test_mse(
+        computed_mse[:Bomex],
+        best_mse[:Bomex],
+        "turbconv.environment.ρatke",
+    )
+    test_mse(
+        computed_mse[:Bomex],
+        best_mse[:Bomex],
+        "turbconv.environment.ρaθ_liq_cv",
+    )
+    test_mse(
+        computed_mse[:Bomex],
+        best_mse[:Bomex],
+        "turbconv.environment.ρaq_tot_cv",
+    )
     #! format: on
 end

--- a/test/Atmos/EDMF/report_mse_sbl.jl
+++ b/test/Atmos/EDMF/report_mse_sbl.jl
@@ -1,0 +1,88 @@
+using ClimateMachine
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+
+if parse(Bool, get(ENV, "CLIMATEMACHINE_PLOT_EDMF_COMPARISON", "false"))
+    plot_dir = joinpath(clima_dir, "output", "bomex_edmf", "pycles_comparison")
+else
+    plot_dir = nothing
+end
+
+include(joinpath(@__DIR__, "compute_mse.jl"))
+
+# Get PyCLES_output dataset folder:
+#! format: off
+data_files = Dict()
+data_files[:Gabls] = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
+#! format: on
+
+#! format: off
+best_mse = Dict()
+best_mse[:Gabls] = Dict()
+best_mse[:Gabls]["ρ"] = 3.4943021267397123e-02
+best_mse[:Gabls]["ρu[1]"] = 3.0714039084256679e+03
+best_mse[:Gabls]["ρu[2]"] = 1.3375796498101822e-03
+best_mse[:Gabls]["moisture.ρq_tot"] = 4.8463531712319707e-02
+best_mse[:Gabls]["turbconv.environment.ρatke"] = 6.7458994186482869e+02
+best_mse[:Gabls]["turbconv.environment.ρaθ_liq_cv"] = 8.5667200477293633e+01
+best_mse[:Gabls]["turbconv.environment.ρaq_tot_cv"] = 1.6455670738880309e+02
+best_mse[:Gabls]["turbconv.updraft[1].ρa"] = 7.9547300082766554e+01
+best_mse[:Gabls]["turbconv.updraft[1].ρaw"] = 8.4294492216319045e-02
+best_mse[:Gabls]["turbconv.updraft[1].ρaθ_liq"] = 9.0095767705492662e+00
+best_mse[:Gabls]["turbconv.updraft[1].ρaq_tot"] = 1.0767427989197111e+01
+#! format: on
+
+sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + eps()
+
+function test_mse(computed_mse, best_mse, key)
+    mse_not_regressed = sufficient_mse(computed_mse[key], best_mse[key])
+    @test mse_not_regressed
+    mse_not_regressed || @show key
+end
+
+computed_mse = Dict(
+    k => compute_mse(
+        solver_config.dg.grid,
+        solver_config.dg.balance_law,
+        time_data,
+        dons_arr,
+        data_files[k],
+        k,
+        best_mse[k],
+        plot_dir,
+    ) for k in keys(data_files)
+)
+
+@testset "Gabls EDMF Solution Quality Assurance (QA) tests" begin
+    #! format: off
+    test_mse(computed_mse[:Gabls], best_mse[:Gabls], "ρ")
+    test_mse(computed_mse[:Gabls], best_mse[:Gabls], "ρu[1]")
+    test_mse(computed_mse[:Gabls], best_mse[:Gabls], "moisture.ρq_tot")
+    test_mse(computed_mse[:Gabls], best_mse[:Gabls], "turbconv.updraft[1].ρa")
+    test_mse(computed_mse[:Gabls], best_mse[:Gabls], "turbconv.updraft[1].ρaw")
+    test_mse(
+        computed_mse[:Gabls],
+        best_mse[:Gabls],
+        "turbconv.updraft[1].ρaθ_liq",
+    )
+    test_mse(
+        computed_mse[:Gabls],
+        best_mse[:Gabls],
+        "turbconv.updraft[1].ρaq_tot",
+    )
+    test_mse(
+        computed_mse[:Gabls],
+        best_mse[:Gabls],
+        "turbconv.environment.ρatke",
+    )
+    test_mse(
+        computed_mse[:Gabls],
+        best_mse[:Gabls],
+        "turbconv.environment.ρaθ_liq_cv",
+    )
+    test_mse(
+        computed_mse[:Gabls],
+        best_mse[:Gabls],
+        "turbconv.environment.ρaq_tot_cv",
+    )
+    #! format: on
+end

--- a/test/Atmos/EDMF/stable_bl_edmf_implicit.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf_implicit.jl
@@ -118,8 +118,16 @@ function main(::Type{FT}) where {FT}
 
     config_type = SingleStackConfigType
 
-    ode_solver_type = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
+    ode_solver_type = ClimateMachine.HEVISolverType(
+        FT;
+        solver_method = ARK2ImplicitExplicitMidpoint,
+        linear_max_subspace_size = 30,
+        linear_atol = FT(-1.0),
+        linear_rtol = FT(5e-5),
+        nonlinear_max_iterations = 10,
+        nonlinear_rtol = FT(1e-4),
+        nonlinear_ϵ = FT(1.e-10),
+        preconditioner_update_freq = Int(50),
     )
 
     N_updrafts = 1
@@ -153,62 +161,62 @@ function main(::Type{FT}) where {FT}
         init_on_cpu = true,
         Courant_number = CFLmax,
     )
-    #################### Change the ode_solver to implicit solver
+    # #################### Change the ode_solver to implicit solver
 
-    dg = solver_config.dg
-    Q = solver_config.Q
-
-
-    vdg = DGModel(
-        driver_config;
-        state_auxiliary = dg.state_auxiliary,
-        direction = VerticalDirection(),
-    )
+    # dg = solver_config.dg
+    # Q = solver_config.Q
 
 
-    # linear solver relative tolerance rtol which should be slightly smaller than the nonlinear solver tol
-    linearsolver = BatchedGeneralizedMinimalResidual(
-        dg,
-        Q;
-        max_subspace_size = 30,
-        atol = -1.0,
-        rtol = 5e-5,
-    )
+    # vdg = DGModel(
+    #     driver_config;
+    #     state_auxiliary = dg.state_auxiliary,
+    #     direction = VerticalDirection(),
+    # )
 
-    """
-    N(q)(Q) = Qhat  => F(Q) = N(q)(Q) - Qhat
 
-    F(Q) == 0
-    ||F(Q^i) || / ||F(Q^0) || < tol
+    # # linear solver relative tolerance rtol which should be slightly smaller than the nonlinear solver tol
+    # linearsolver = BatchedGeneralizedMinimalResidual(
+    #     dg,
+    #     Q;
+    #     max_subspace_size = 30,
+    #     atol = -1.0,
+    #     rtol = 5e-5,
+    # )
 
-    """
-    # ϵ is a sensity parameter for this problem, it determines the finite difference Jacobian dF = (F(Q + ϵdQ) - F(Q))/ϵ
-    # I have also try larger tol, but tol = 1e-3 does not work
-    nonlinearsolver =
-        JacobianFreeNewtonKrylovSolver(Q, linearsolver; tol = 1e-4, ϵ = 1.e-10)
+    # """
+    # N(q)(Q) = Qhat  => F(Q) = N(q)(Q) - Qhat
 
-    # this is a second order time integrator, to change it to a first order time integrator
-    # change it ARK1ForwardBackwardEuler, which can reduce the cost by half at the cost of accuracy 
-    # and stability
-    # preconditioner_update_freq = 50 means updating the preconditioner every 50 Newton solves, 
-    # update it more freqent will accelerate the convergence of linear solves, but updating it 
-    # is very expensive
-    ode_solver = ARK2ImplicitExplicitMidpoint(
-        dg,
-        vdg,
-        NonLinearBackwardEulerSolver(
-            nonlinearsolver;
-            isadjustable = true,
-            preconditioner_update_freq = 50,
-        ),
-        Q;
-        dt = solver_config.dt,
-        t0 = 0,
-        split_explicit_implicit = false,
-        variant = NaiveVariant(),
-    )
+    # F(Q) == 0
+    # ||F(Q^i) || / ||F(Q^0) || < tol
 
-    solver_config.solver = ode_solver
+    # """
+    # # ϵ is a sensity parameter for this problem, it determines the finite difference Jacobian dF = (F(Q + ϵdQ) - F(Q))/ϵ
+    # # I have also try larger tol, but tol = 1e-3 does not work
+    # nonlinearsolver =
+    #     JacobianFreeNewtonKrylovSolver(Q, linearsolver; tol = 1e-4, ϵ = 1.e-10)
+
+    # # this is a second order time integrator, to change it to a first order time integrator
+    # # change it ARK1ForwardBackwardEuler, which can reduce the cost by half at the cost of accuracy 
+    # # and stability
+    # # preconditioner_update_freq = 50 means updating the preconditioner every 50 Newton solves, 
+    # # update it more freqent will accelerate the convergence of linear solves, but updating it 
+    # # is very expensive
+    # ode_solver = ARK2ImplicitExplicitMidpoint(
+    #     dg,
+    #     vdg,
+    #     NonLinearBackwardEulerSolver(
+    #         nonlinearsolver;
+    #         isadjustable = true,
+    #         preconditioner_update_freq = 50,
+    #     ),
+    #     Q;
+    #     dt = solver_config.dt,
+    #     t0 = 0,
+    #     split_explicit_implicit = false,
+    #     variant = NaiveVariant(),
+    # )
+
+    # solver_config.solver = ode_solver
 
     #######################################
     # --- Zero-out horizontal variations:


### PR DESCRIPTION
Improve Implicit Solver for EDMF

Co-authored-by: Charles Kawczynski <kawczynski.charles@gmail.com>
Co-authored-by: yairchn <yair.chn@gmail.com>
Co-authored-by: Ignacio Lopez-Gomez <ilopezgo@caltech.edu>
### Description

-  Step size modification: When we compute gradient in the Newton dF dQ = (F(Q + eps*dQ) - F(Q))/eps , but in the preconditioner reconstruction we use dF e = (F(Q + eps*e) - F(Q))/eps, in these two cases, dQ and e are quite different, therefore the eps need to be treated carefully.

-  Add EDMF tests


- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
