### PR TITLE
TG-fix

### DIFF
--- a/experiments/AtmosLES/taylor_green.jl
+++ b/experiments/AtmosLES/taylor_green.jl
@@ -68,7 +68,7 @@ function init_greenvortex!(problem, bl, state, aux, localgeo, t)
     e_pot = FT(0)# potential energy
     Pinf = 101325
     Uzero = FT(100)
-    p = Pinf + (ρ * Uzero / 16) * (2 + cos(z)) * (cos(x) + cos(y))
+    p = Pinf + (ρ * Uzero^2 / 16) * (2 + cos(2 * z)) * (cos(2 * x) + cos(2 * y))
     u = Uzero * sin(x) * cos(y) * cos(z)
     v = -Uzero * cos(x) * sin(y) * cos(z)
     e_kin = 0.5 * (u^2 + v^2)


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
This is a correction to the Taylor-green Vortex case's (TGV) initial conditions, the initial pressure definition was incorrect and generates a solution very similar to the one we want, though the behavior is very similar to the TGV it's likely the faulty initial conditions were the main reason behind #1338. This correction solves issue #1338. 
<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
