### PR TITLE
Add DOIs to .bib, remove urls

### DIFF
--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -8,7 +8,6 @@
   journal = {Geoscientific Model Development},
   volume = {8},
   number = {6},
-  url = {https://www.geosci-model-dev.net/8/1677/2015/},
   doi = {10.5194/gmd-8-1677-2015},
   pages = {1677--1707},
   year = {2015},
@@ -21,7 +20,7 @@
   journal = {Journal of the Atmospheric Sciences},
   volume = {29},
   number = {4},
-  url = {https://doi.org/10.1175/1520-0469(1972)029<0649:AASROA>2.0.CO;2},
+  doi = {10.1175/1520-0469(1972)029<0649:AASROA>2.0.CO;2},
   pages = {649--664},
   year = {1972}
 }
@@ -45,7 +44,6 @@
   volume = {118},
   number = {2},
   doi = {10.1175/1520-0469(2000)057<1052:ALESSO>2.0.CO;2},
-  url = {https://doi.org/10.1175/1520-0469(2000)057<1052:ALESSO>2.0.CO;2},
   pages = {247--272},
   month = {04},
   year = {2006},
@@ -60,7 +58,7 @@
   number = {3},
   pages = {501--517},
   year = {2004},
-  url = {https://doi.org/10.1137/S0036144502417715},
+  doi = {10.1137/S0036144502417715},
   publisher = {SIAM}
 }
 
@@ -78,6 +76,7 @@
   title = {Simulation of the Compressible {Taylor Green} Vortex using High-Order Flux Reconstruction Schemes},
   journal = {AIAA Aviation 7th AIAA theoretical fluid mechanics conference},
   year = {2014},
+  doi = {10.2514/6.2014-3210},
 }
 
 @article{Businger1971,
@@ -86,7 +85,7 @@
   journal = {Journal of the atmospheric Sciences},
   volume = {28},
   number = {2},
-  url = {https://doi.org/10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2},
+  doi = {10.1175/1520-0469(1971)028<0181:FPRITA>2.0.CO;2},
   pages = {181--189},
   year = {1971}
 }
@@ -97,6 +96,7 @@
   journal = {Journal of Applied Meteorology},
   volume = {29},
   number = {7},
+  doi = {10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2},
   pages = {652--657},
   year = {1990}
 }
@@ -109,6 +109,7 @@
   number = {15},
   pages = {9154--9162},
   year = {2019},
+  doi = {10.1029/2019GL083503},
   publisher = {Wiley Online Library}
 }
 
@@ -126,7 +127,7 @@
   journal = {Journal of the Atmospheric Sciences},
   volume = {39},
   number = {10},
-  url = {https://doi.org/10.1175/1520-0469(1982)039<2152:OTEOMO>2.0.CO;2},
+  doi = {10.1175/1520-0469(1982)039<2152:OTEOMO>2.0.CO;2},
   pages = {2152--2158},
   year = {1982}
 }
@@ -137,7 +138,7 @@
   journal = {Monthly Weather Review},
   volume = {118},
   number = {3},
-  url = {https://doi.org/10.1175/1520-0493(1990)118<0586:AOTPPM>2.0.CO;2},
+  doi = {10.1175/1520-0493(1990)118<0586:AOTPPM>2.0.CO;2},
   pages = {586--612},
   year = {1990}
 }
@@ -150,6 +151,7 @@
   number = {2},
   pages = {345--357},
   year = {1983},
+  doi = {10.1137/0720023},
   publisher = {SIAM}
 }
 
@@ -170,6 +172,7 @@
   journal = {SIAM Journal on Scientific Computing},
   volume = {35},
   number = {5},
+  doi = {10.1137/120876034},
   pages = {B1162--B1194},
   year = {2013},
   publisher = {SIAM}
@@ -181,7 +184,7 @@
   journal = {Monthly weather review},
   volume = {124},
   number = {3},
-  url = {https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2},
+  doi = {10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2},
   pages = {487--497},
   year = {1996}
 }
@@ -193,7 +196,7 @@
   volume = {55},
   number = {21},
   pages = {3283--3298},
-  url = {https://journals.ametsoc.org/doi/pdf/10.1175/1520-0469%281998%29055%3C3283%3ATCRMOL%3E2.0.CO%3B2},
+  doi = {10.1175/1520-0469(1998)055<3283:TCRMOL>2.0.CO;2},
   year = {1998}
 }
 
@@ -205,7 +208,7 @@
   number = {3},
   pages = {315--333},
   year = {2007},
-  url = {https://doi.org/10.1007/s10546-007-9177-6},
+  doi = {10.1007/s10546-007-9177-6},
   publisher = {Springer}
 }
 
@@ -214,6 +217,7 @@
   author = {Gryanik, Vladimir M and L{\"u}pkes, Christof and Grachev, Andrey and Sidorenko, Dmitry},
   journal = {Journal of the Atmospheric Sciences},
   volume = {-1},
+  doi = {10.1175/JAS-D-19-0255.1},
   year = {2020}
 }
 
@@ -223,6 +227,7 @@
   journal = {Journal of the atmospheric sciences},
   volume = {52},
   number = {23},
+  doi = {10.1175/1520-0469(1995)052<4344:POICCP>2.0.CO;2},
   pages = {4344--4366},
   year = {1995}
 }
@@ -235,7 +240,7 @@
   number = {10},
   pages = {1825--1830},
   year = {1994},
-  url = {https://doi.org/10.1175/1520-0477(1994)075<1825:APFTIO>2.0.CO;2},
+  doi = {10.1175/1520-0477(1994)075<1825:APFTIO>2.0.CO;2},
   publisher = {American Meteorological Society}
 }
 
@@ -255,6 +260,7 @@
   journal = {Monthly Weather Review},
   volume = {143},
   number = {11},
+  doi = {10.1175/MWR-D-14-00319.1},
   pages = {4393--4421},
   year = {2015}
 }
@@ -265,6 +271,7 @@
   journal = {Journal of Advances in Modeling Earth Systems},
   pages = {e2020MS002066},
   volume = {-1},
+  doi = {10.1029/2020MS002066},
   year = {2020},
   publisher = {Wiley Online Library}
 }
@@ -275,6 +282,7 @@
   journal = {Applied Numerical Mathematics},
   volume = {136},
   pages = {183--205},
+  doi = {10.1016/j.apnum.2018.10.007},
   year = {2019},
   publisher = {Elsevier}
 }
@@ -296,6 +304,7 @@
   number = {1-4},
   pages = {109--145},
   year = {1995},
+  doi = {10.1016/0169-8095(94)00090-Z},
   publisher = {Elsevier}
 }
 
@@ -305,6 +314,7 @@
   journal = {Journal of the atmospheric sciences},
   volume = {59},
   number = {11},
+  doi = {10.1175/1520-0469(2002)059<1872:TVODAC>2.0.CO;2},
   pages = {1872--1884},
   year = {2002}
 }
@@ -315,6 +325,7 @@
   journal = {Monthly Weather Review},
   volume = {142},
   number = {5},
+  doi = {10.1175/MWR-D-13-00068.1},
   pages = {2067--2081},
   year = {2014}
 }
@@ -327,7 +338,7 @@
   number = {3},
   pages = {301},
   year = {2006},
-  url = {https://doi.org/10.1007/s10915-005-9070-8},
+  doi = {10.1007/s10915-005-9070-8},
   publisher = {Springer}
 }
 
@@ -337,7 +348,7 @@
   journal = {Journal of the atmospheric sciences},
   volume = {58},
   number = {4},
-  url = {https://doi.org/10.1175/1520-0469(2001)058<0329:THKESA>2.0.CO;2},
+  doi = {10.1175/1520-0469(2001)058<0329:THKESA>2.0.CO;2},
   pages = {329--348},
   year = {2001}
 }
@@ -348,6 +359,7 @@
   journal = {Journal of the atmospheric sciences},
   volume = {57},
   number = {8},
+  doi = {10.1175/1520-0469(2000)057<1052:ALESSO>2.0.CO;2},
   pages = {1052--1068},
   year = {2000}
 }
@@ -358,7 +370,6 @@
   journal = {Geoscientific Model Development},
   volume = {5},
   number = {3},
-  url = {https://www.geosci-model-dev.net/5/887/2012/},
   doi = {10.5194/gmd-5-887-2012},
   pages = {887--901},
   year = {2012}
@@ -382,8 +393,6 @@
   volume = {14},
   number = {2},
   doi = {10.1111/j.2153-3490.1962.tb00128.x},
-  url = {https://onlinelibrary.wiley.com/doi/abs/10.1111/j.2153-3490.1962.tb00128.x},
-  eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1111/j.2153-3490.1962.tb00128.x},
   pages = {148--172},
   year = {1962},
   publisher = {Wiley Online Library}
@@ -412,6 +421,7 @@
   journal = {Journal of Climate},
   volume = {21},
   number = {15},
+  doi = {10.1175/2008JCLI2105.1},
   pages = {3642--3659},
   year = {2008}
 }
@@ -436,6 +446,7 @@
   number = {2},
   pages = {364--372},
   year = {2012},
+  doi = {10.1016/j.jcp.2011.09.003},
   publisher = {Elsevier}
 }
 
@@ -445,7 +456,6 @@
   journal = {Journal of Advances in Modeling Earth Systems},
   volume = {10},
   number = {12},
-  url = {https://doi.org/10.1029/2018MS001534},
   doi = {10.1029/2018MS001534},
   pages = {3159--3175},
   year = {2018},
@@ -486,6 +496,7 @@
   author = {Roberts, Steven and Sarshar, Arash and Sandu, Adrian},
   journal = {arXiv preprint arXiv:1812.00808},
   volume = {-1},
+  doi = {10.1137/19M1266952},
   year = {2019}
 }
 
@@ -497,7 +508,6 @@
   number = {1},
   pages = {93--114},
   year = {1996},
-  url = {https://linkinghub.elsevier.com/retrieve/pii/S0021999196900479},
   doi = {10.1006/jcph.1996.0047}
 }
 
@@ -507,6 +517,7 @@
   journal = {Journal of the Atmospheric Sciences},
   volume = {40},
   number = {5},
+  doi = {10.1175/1520-0469(1983)040<1185:TMAMSA>2.0.CO;2},
   pages = {1185--1206},
   year = {1983}
 }
@@ -517,6 +528,7 @@
   journal = {Journal of the Atmospheric Sciences},
   volume = {41},
   number = {20},
+  doi = {10.1175/1520-0469(1984)041<2949:TMAMSA>2.0.CO;2},
   pages = {2949--2972},
   year = {1984}
 }
@@ -529,6 +541,7 @@
   number = {3},
   pages = {856--869},
   year = {1986},
+  doi = {10.1137/0907058},
   publisher = {SIAM}
 }
 
@@ -552,7 +565,6 @@
   number = {10},
   issn = {0027-0644},
   doi = {10.1175/1520-0493(2002)130<2459:ANTFVC>2.0.CO;2},
-  url = {https://doi.org/10.1175/1520-0493(2002)130<2459:ANTFVC>2.0.CO;2},
   pages = {2459--2480},
   month = {10},
   year = {2002}
@@ -566,20 +578,21 @@
   number = {6},
   pages = {1395--1405},
   year = {2012},
+  doi = {10.5194/gmd-5-1395-2012},
   publisher = {Copernicus GmbH}
 }
 
 @article{Schlegel2009,
-  doi = {10.1016/j.cam.2008.08.009},
+  title = {Multirate Runge-Kutta schemes for advection equations},
+  author = {Martin Schlegel and Oswald Knoth and Martin Arnold and Ralf Wolke},
+  journal = {Journal of Computational and Applied Mathematics},
   year = {2009},
   month = {apr},
   publisher = {Elsevier {BV}},
   volume = {226},
   number = {2},
-  pages = {345--357},
-  author = {Martin Schlegel and Oswald Knoth and Martin Arnold and Ralf Wolke},
-  title = {Multirate Runge-Kutta schemes for advection equations},
-  journal = {Journal of Computational and Applied Mathematics}
+  doi = {10.1016/j.cam.2008.08.009},
+  pages = {345--357}
 }
 
 @article{Seifert2006,
@@ -590,6 +603,7 @@
   number = {1-2},
   pages = {45--66},
   year = {2006},
+  doi = {10.1007/s00703-005-0112-4},
   publisher = {Springer}
 }
 
@@ -601,6 +615,7 @@
   number = {2},
   pages = {439--471},
   year = {1988},
+  doi = {10.1016/0021-9991(88)90177-5},
   publisher = {Elsevier}
 }
 
@@ -610,9 +625,7 @@
   journal = {Journal of the Atmospheric Sciences},
   volume = {60},
   number = {10},
-  eprint = {https://journals.ametsoc.org/doi/pdf/10.1175/1520-0469%282003%2960%3C1201%3AALESIS%3E2.0.CO%3B2},
   doi = {10.1175/1520-0469(2003)60<1201:ALESIS>2.0.CO;2},
-  url = {https://journals.ametsoc.org/doi/abs/10.1175/1520-0469%282003%2960%3C1201%3AALESIS%3E2.0.CO%3B2},
   pages = {1201--1219},
   year = {2003}
 }
@@ -625,7 +638,7 @@
   number = {1},
   pages = {381--387},
   year = {2004},
-  url = {https://doi.org/10.1063/1.1751381},
+  doi = {10.1063/1.1751381},
   organization = {American Institute of Physics}
 }
 
@@ -635,7 +648,6 @@
   journal = {Monthly weather review},
   volume = {91},
   number = {3},
-  url = {https://journals.ametsoc.org/mwr/article/91/3/99/98166},
   doi = {10.1175/1520-0493(1963)091<0099:GCEWTP>2.3.CO;2},
   pages = {99--164},
   year = {1963}
@@ -649,6 +661,7 @@
   number = {2},
   pages = {469--491},
   year = {2002},
+  doi = {10.1137/S0036142901389025},
   publisher = {SIAM}
 }
 
@@ -658,9 +671,7 @@
   journal = {Monthly weather review},
   volume = {133},
   number = {6},
-  url = {https://doi.org/10.1175/MWR2930.1},
   doi = {10.1175/MWR2930.1},
-  eprint = {https://doi.org/10.1175/MWR2930.1},
   pages = {1443--1462},
   year = {2005}
 }
@@ -672,8 +683,6 @@
   volume = {17},
   number = {1},
   doi = {10.1002/fld.1650170103},
-  url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/fld.1650170103},
-  eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/fld.1650170103},
   pages = {1--22},
   year = {1993},
   publisher = {Wiley Online Library}
@@ -690,16 +699,16 @@
 }
 
 @article{Tomita2008,
-  doi = {10.1137/070692273},
+  title = {A New Approach to Atmospheric General Circulation Model: Global Cloud Resolving Model {NICAM} and its Computational Performance},
+  author = {Hirofumi Tomita and Koji Goto and Masaki Satoh},
+  journal = {{SIAM} Journal on Scientific Computing},
   year = {2008},
   month = {jan},
   publisher = {Society for Industrial and Applied Mathematics ({SIAM})},
   volume = {30},
   number = {6},
-  pages = {2755--2776},
-  author = {Hirofumi Tomita and Koji Goto and Masaki Satoh},
-  title = {A New Approach to Atmospheric General Circulation Model: Global Cloud Resolving Model {NICAM} and its Computational Performance},
-  journal = {{SIAM} Journal on Scientific Computing}
+  doi = {10.1137/070692273},
+  pages = {2755--2776}
 }
 
 @book{Toro2013,
@@ -729,6 +738,7 @@
   number = {10},
   pages = {3670--3681},
   year = {2004},
+  doi = {10.1063/1.1785131},
   publisher = {AIP}
 }
 
@@ -740,7 +750,6 @@
   number = {8},
   pages = {085104},
   year = {2018},
-  url = {https://doi.org/10.1063/1.5037039},
   doi = {10.1063/1.5037039},
   publisher = {AIP Publishing LLC}
 }
@@ -752,6 +761,7 @@
   volume = {63},
   number = {3},
   pages = {881--900},
+  doi = {10.1175/JAS3655.1},
   year = {2006}
 }
 
@@ -774,7 +784,6 @@
   volume = {102},
   number = {1},
   doi = {10.1016/S0021-9991(05)80016-6},
-  url = {https://doi.org/10.1016/S0021-9991(05)80016-6},
   pages = {211--224},
   year = {1992},
   publisher = {Elsevier}
@@ -787,6 +796,7 @@
   volume = {62},
   number = {9},
   pages = {3034--3050},
+  doi = {10.1175/JAS3530.1},
   year = {2005}
 }
 
@@ -798,6 +808,7 @@
   number = {4},
   pages = {441--460},
   year = {1975},
+  doi = {10.1007/BF00223393},
   publisher = {Springer}
 }
 


### PR DESCRIPTION
### Description

I went to fix the bib entries whose hyperlinks point to the reference page and realized that these correspond to bib entries with missing DOI/URL/eprint attributes. This PR adds some missing DOIs. Also, in case these links are checked by Documenter, it makes sense to rely on DOIs over other URLs, so this PR also removes some of the URLs so long the DOIs exist.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
