### PR TITLE
Move rain sources to new tend spec

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -49,7 +49,7 @@ ClimateMachine.Atmos.DryModel
 ClimateMachine.Atmos.EquilMoist
 ClimateMachine.Atmos.NonEquilMoist
 ClimateMachine.Atmos.NoPrecipitation
-ClimateMachine.Atmos.Rain
+ClimateMachine.Atmos.RainModel
 ```
 
 ## Stabilization

--- a/docs/src/HowToGuides/Atmos/PrecipitationModelChoices.md
+++ b/docs/src/HowToGuides/Atmos/PrecipitationModelChoices.md
@@ -2,7 +2,7 @@
 
 The precipitation model in `Atmos.jl` describes the behavior
   of precipitating water in the atmosphere (i.e. rain and snow).
-There are two options available: `NoPrecipitation` and `Rain`.
+There are two options available: `NoPrecipitation` and `RainModel`.
 
 ## NoPrecipitation
 
@@ -16,9 +16,9 @@ In the first case `ρ q_tot` (total water specific humidity) is not removed
 In the second case `ρ q_tot` is removed if it exceeds a threshold.
 
 
-## Rain
+## RainModel
 
-The `Rain` model assumes that precipitating water is present but only in the
+The `RainModel` model assumes that precipitating water is present but only in the
   form of rain (liquid-phase precipitation).
 It adds `ρ q_rai` (air density times total rain water specific humidity)
   to state variables.

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -376,7 +376,7 @@ function config_dycoms(
     if precipitation_model == "noprecipitation"
         precipitation = NoPrecipitation()
     elseif precipitation_model == "rain"
-        source = (source..., Rain_1M())
+        source = (source..., Rain_1M()...)
         precipitation = RainModel()
     else
         @warn @sprintf(

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -97,12 +97,14 @@ function reverse_integral_set_auxiliary_state!(
     aux::Vars,
     integ::Vars,
 ) end
-function flux_radiation!(
+function flux_first_order!(
     ::RadiationModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 ) end
 
 # ------------------------ Begin Radiation Model ---------------------- #
@@ -178,13 +180,15 @@ function reverse_integral_set_auxiliary_state!(
     aux.∫dnz.radiation.attenuation_coeff = integral.radiation.attenuation_coeff
 end
 
-function flux_radiation!(
+function flux_first_order!(
     m::DYCOMSRadiation,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 )
     FT = eltype(flux)
     z = altitude(atmos, aux)
@@ -275,7 +279,7 @@ function init_dycoms!(problem, bl, state, aux, localgeo, t)
         state.moisture.ρq_liq = q_init.liq
         state.moisture.ρq_ice = q_init.ice
     end
-    if bl.precipitation isa Rain
+    if bl.precipitation isa RainModel
         state.precipitation.ρq_rai = FT(0)
     end
 
@@ -373,7 +377,7 @@ function config_dycoms(
         precipitation = NoPrecipitation()
     elseif precipitation_model == "rain"
         source = (source..., Rain_1M())
-        precipitation = Rain()
+        precipitation = RainModel()
     else
         @warn @sprintf(
             """

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -2,6 +2,7 @@ module Atmos
 
 export AtmosModel, AtmosAcousticLinearModel, AtmosAcousticGravityLinearModel
 
+using UnPack
 using CLIMAParameters
 using CLIMAParameters.Planet: grav, cp_d
 using CLIMAParameters.Atmos.SubgridScale: C_smag
@@ -395,6 +396,7 @@ include("tendencies_mass.jl")         # specify mass tendencies
 include("tendencies_momentum.jl")     # specify momentum tendencies
 include("tendencies_energy.jl")       # specify energy tendencies
 include("tendencies_moisture.jl")     # specify moisture tendencies
+include("tendencies_precipitation.jl")# specify precipitation tendencies
 
 include("problem.jl")
 include("ref_state.jl")

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -10,24 +10,44 @@ import ..BalanceLaws: eq_tends
 
 # --------- Some of these methods are generic or
 #           temporary during transition to new specification:
-filter_source(pv::PrognosticVariable, s) = nothing
+filter_source(pv, m, s) = nothing
 # Sources that have been added to new specification:
-filter_source(pv::PV, s::Subsidence{PV}) where {PV <: PrognosticVariable} = s
-filter_source(pv::PV, s::Gravity{PV}) where {PV <: Momentum} = s
-filter_source(pv::PV, s::GeostrophicForcing{PV}) where {PV <: Momentum} = s
-filter_source(pv::PV, s::Coriolis{PV}) where {PV <: Momentum} = s
-filter_source(pv::PV, s::RayleighSponge{PV}) where {PV <: Momentum} = s
-filter_source(pv::PV, s::CreateClouds{PV}) where {PV <: LiquidMoisture} = s
-filter_source(pv::PV, s::CreateClouds{PV}) where {PV <: IceMoisture} = s
+filter_source(pv::PV, m, s::Subsidence{PV}) where {PV <: PrognosticVariable} = s
+filter_source(pv::PV, m, s::Gravity{PV}) where {PV <: Momentum} = s
+filter_source(pv::PV, m, s::GeostrophicForcing{PV}) where {PV <: Momentum} = s
+filter_source(pv::PV, m, s::Coriolis{PV}) where {PV <: Momentum} = s
+filter_source(pv::PV, m, s::RayleighSponge{PV}) where {PV <: Momentum} = s
+filter_source(pv::PV, m, s::CreateClouds{PV}) where {PV <: LiquidMoisture} = s
+filter_source(pv::PV, m, s::CreateClouds{PV}) where {PV <: IceMoisture} = s
+filter_source(
+    pv::PV,
+    m,
+    s::RemovePrecipitation{PV},
+) where {PV <: Union{Mass, Energy, TotalMoisture}} = s
+
+filter_source(
+    pv::PV,
+    ::NonEquilMoist,
+    s::Rain_1M{PV},
+) where {PV <: LiquidMoisture} = s
+filter_source(
+    pv::PV,
+    ::MoistureModel,
+    s::Rain_1M{PV},
+) where {PV <: LiquidMoisture} = nothing
+filter_source(pv::PV, m::MoistureModel, s::Rain_1M{PV}) where {PV} = s
+
+filter_source(pv::PV, m::AtmosModel, s::Rain_1M{PV}) where {PV} =
+    filter_source(pv, m.moisture, s)
 
 # Filter sources / empty elements
 filter_sources(t::Tuple) = filter(x -> !(x == nothing), t)
-filter_sources(pv::PrognosticVariable, srcs) =
-    filter_sources(map(s -> filter_source(pv, s), srcs))
+filter_sources(pv::PrognosticVariable, m, srcs) =
+    filter_sources(map(s -> filter_source(pv, m, s), srcs))
 
 # Entry point
 eq_tends(pv::PrognosticVariable, m::AtmosModel, ::Source) =
-    filter_sources(pv, m.source)
+    filter_sources(pv, m, m.source)
 # ---------
 
 #####
@@ -50,6 +70,10 @@ eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Energy} =
 eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Moisture} =
     (Advect{PV}(),)
 
+# Precipitation
+eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Precipitation} =
+    ()
+
 #####
 ##### Second order fluxes
 #####
@@ -71,3 +95,10 @@ eq_tends(pv::PV, ::AtmosModel, ::Flux{SecondOrder}) where {PV <: Energy} =
 
 # Moisture
 eq_tends(pv::PV, ::AtmosModel, ::Flux{SecondOrder}) where {PV <: Moisture} = ()
+
+# Precipitation
+eq_tends(
+    pv::PV,
+    ::AtmosModel,
+    ::Flux{SecondOrder},
+) where {PV <: Precipitation} = ()

--- a/src/Atmos/Model/declare_prognostic_vars.jl
+++ b/src/Atmos/Model/declare_prognostic_vars.jl
@@ -2,6 +2,7 @@
 
 export Mass, Momentum, Energy
 export Moisture, TotalMoisture, LiquidMoisture, IceMoisture
+export Precipitation, Rain, Snow
 export Tracers
 
 struct Mass <: PrognosticVariable end
@@ -12,5 +13,9 @@ abstract type Moisture <: PrognosticVariable end
 struct TotalMoisture <: Moisture end
 struct LiquidMoisture <: Moisture end
 struct IceMoisture <: Moisture end
+
+abstract type Precipitation <: PrognosticVariable end
+struct Rain <: Precipitation end
+struct Snow <: Precipitation end
 
 struct Tracers <: PrognosticVariable end

--- a/src/Atmos/Model/get_prognostic_vars.jl
+++ b/src/Atmos/Model/get_prognostic_vars.jl
@@ -6,5 +6,14 @@ prognostic_vars(::DryModel) = ()
 prognostic_vars(::EquilMoist) = (TotalMoisture(),)
 prognostic_vars(::NonEquilMoist) =
     (TotalMoisture(), LiquidMoisture(), IceMoisture())
-prognostic_vars(m::AtmosModel) =
-    (Mass(), Momentum(), Energy(), prognostic_vars(m.moisture)...)
+
+prognostic_vars(::NoPrecipitation) = ()
+prognostic_vars(::RainModel) = (Rain(),)
+
+prognostic_vars(m::AtmosModel) = (
+    Mass(),
+    Momentum(),
+    Energy(),
+    prognostic_vars(m.moisture)...,
+    prognostic_vars(m.precipitation)...,
+)

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -19,6 +19,7 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
     direction,
 ) end
 function compute_gradient_flux!(
@@ -162,9 +163,9 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
     direction,
 )
-    ts = recover_thermo_state(atmos, state, aux)
     tend = Flux{FirstOrder}()
     args = (atmos, state, aux, t, ts, direction)
     flux.moisture.ρq_tot =
@@ -271,9 +272,9 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
     direction,
 )
-    ts = recover_thermo_state(atmos, state, aux)
     tend = Flux{FirstOrder}()
     args = (atmos, state, aux, t, ts, direction)
     flux.moisture.ρq_tot =

--- a/src/Atmos/Model/multiphysics_types.jl
+++ b/src/Atmos/Model/multiphysics_types.jl
@@ -1,5 +1,8 @@
 ##### Multi-physics types
 
+using ..Microphysics_0M
+using ..Microphysics
+
 export Subsidence
 struct Subsidence{PV, FT} <: TendencyDef{Source, PV}
     D::FT
@@ -19,3 +22,100 @@ struct PressureGradient{PV <: Momentum} <: TendencyDef{Flux{FirstOrder}, PV} end
 struct Pressure{PV <: Energy} <: TendencyDef{Flux{FirstOrder}, PV} end
 
 struct Advect{PV} <: TendencyDef{Flux{FirstOrder}, PV} end
+
+
+export RemovePrecipitation
+"""
+    RemovePrecipitation{PV} <: TendencyDef{Source, PV}
+A sink to `q_tot` when cloud condensate is exceeding a threshold.
+The threshold is defined either in terms of condensate or supersaturation.
+The removal rate is implemented as a relaxation term
+in the Microphysics_0M module.
+The default thresholds and timescale are defined in CLIMAParameters.jl.
+"""
+struct RemovePrecipitation{PV <: Union{Mass, Energy, TotalMoisture}} <:
+       TendencyDef{Source, PV}
+    " Set to true if using qc based threshold"
+    use_qc_thr::Bool
+end
+
+RemovePrecipitation(b::Bool) = (
+    RemovePrecipitation{Mass}(b),
+    RemovePrecipitation{Energy}(b),
+    RemovePrecipitation{TotalMoisture}(b),
+)
+
+function compute_precip_params(
+    s::RemovePrecipitation{PV},
+    aux,
+    ts,
+) where {PV <: Union{Mass, Energy, TotalMoisture}}
+    FT = eltype(aux)
+    S_qt::FT = 0
+    q = PhasePartition(ts)
+    λ::FT = liquid_fraction(ts)
+    I_l::FT = internal_energy_liquid(ts)
+    I_i::FT = internal_energy_ice(ts)
+    Φ::FT = gravitational_potential(atmos.orientation, aux)
+    if s.use_qc_thr
+        S_qt = remove_precipitation(atmos.param_set, q)
+    else
+        q_vap_sat = q_vap_saturation(ts)
+        S_qt = remove_precipitation(atmos.param_set, q, q_vap_sat)
+    end
+    return (S_qt = S_qt, λ = λ, I_l = I_l, I_i = I_i, Φ = Φ)
+end
+
+export Rain_1M
+"""
+    Rain_1M{FT} <: AbstractSource
+A collection of source/sink terms related to 1-moment rain microphysics.
+"""
+struct Rain_1M{
+    PV <: Union{Mass, Energy, TotalMoisture, LiquidMoisture, Rain},
+} <: TendencyDef{Source, PV} end
+
+Rain_1M() = (
+    Rain_1M{Mass}(),
+    Rain_1M{Energy}(),
+    Rain_1M{TotalMoisture}(),
+    Rain_1M{LiquidMoisture}(),
+    Rain_1M{Rain}(),
+)
+
+function compute_rain_params(atmos, state, aux, t, ts)
+    FT = eltype(state)
+
+    q = PhasePartition(ts)
+    T::FT = air_temperature(ts)
+    I_l::FT = internal_energy_liquid(ts)
+    q_rai::FT = state.precipitation.ρq_rai / state.ρ
+    Φ::FT = gravitational_potential(atmos.orientation, aux)
+
+    # autoconversion
+    src_q_rai_acnv = conv_q_liq_to_q_rai(atmos.param_set.microphys.rai, q.liq)
+    # accretion
+    src_q_rai_accr = accretion(
+        atmos.param_set,
+        atmos.param_set.microphys.liq,
+        atmos.param_set.microphys.rai,
+        q.liq,
+        q_rai,
+        state.ρ,
+    )
+    # rain evaporation
+    src_q_rai_evap = evaporation_sublimation(
+        atmos.param_set,
+        atmos.param_set.microphys.rai,
+        q,
+        q_rai,
+        state.ρ,
+        T,
+    )
+
+    S_qr::FT = src_q_rai_acnv + src_q_rai_accr + src_q_rai_evap
+    S_ql::FT = -src_q_rai_acnv - src_q_rai_accr
+    S_qt::FT = -S_qr
+
+    return (S_qt = S_qt, S_ql = S_ql, S_qr = S_qr, I_l = I_l, Φ = Φ)
+end

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -1,7 +1,7 @@
 #### Precipitation component in atmosphere model
 abstract type PrecipitationModel end
 
-export NoPrecipitation, Rain#, RainSnow
+export NoPrecipitation, RainModel#, RainSnow
 
 using ..Microphysics
 
@@ -14,13 +14,15 @@ function atmos_nodal_update_auxiliary_state!(
     aux::Vars,
     t::Real,
 ) end
-function flux_precipitation!(
+function flux_first_order!(
     ::PrecipitationModel,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 ) end
 function compute_gradient_flux!(
     ::PrecipitationModel,
@@ -57,18 +59,18 @@ struct NoPrecipitation <: PrecipitationModel end
 
 
 """
-    Rain <: PrecipitationModel
+    RainModel <: PrecipitationModel
 
 Precipitation model with rain only.
 """
-struct Rain <: PrecipitationModel end
+struct RainModel <: PrecipitationModel end
 
-vars_state(::Rain, ::Prognostic, FT) = @vars(ρq_rai::FT)
-vars_state(::Rain, ::Gradient, FT) = @vars(q_rai::FT)
-vars_state(::Rain, ::GradientFlux, FT) = @vars(∇q_rai::SVector{3, FT})
+vars_state(::RainModel, ::Prognostic, FT) = @vars(ρq_rai::FT)
+vars_state(::RainModel, ::Gradient, FT) = @vars(q_rai::FT)
+vars_state(::RainModel, ::GradientFlux, FT) = @vars(∇q_rai::SVector{3, FT})
 
 function atmos_nodal_update_auxiliary_state!(
-    precip::Rain,
+    precip::RainModel,
     atmos::AtmosModel,
     state::Vars,
     aux::Vars,
@@ -76,7 +78,7 @@ function atmos_nodal_update_auxiliary_state!(
 ) end
 
 function compute_gradient_argument!(
-    precip::Rain,
+    precip::RainModel,
     transform::Vars,
     state::Vars,
     aux::Vars,
@@ -87,7 +89,7 @@ function compute_gradient_argument!(
 end
 
 function compute_gradient_flux!(
-    precip::Rain,
+    precip::RainModel,
     diffusive::Vars,
     ∇transform::Grad,
     state::Vars,
@@ -98,13 +100,15 @@ function compute_gradient_flux!(
     diffusive.precipitation.∇q_rai = ∇transform.precipitation.q_rai
 end
 
-function flux_precipitation!(
-    precip::Rain,
+function flux_first_order!(
+    precip::RainModel,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 )
     FT = eltype(state)
     u = state.ρu / state.ρ
@@ -125,7 +129,7 @@ function flux_precipitation!(
 end
 
 function flux_second_order!(
-    precip::Rain,
+    precip::RainModel,
     flux::Grad,
     state::Vars,
     diffusive::Vars,
@@ -136,6 +140,6 @@ function flux_second_order!(
     d_q_rai = (-D_t) .* diffusive.precipitation.∇q_rai
     flux_second_order!(precip, flux, state, d_q_rai)
 end
-function flux_second_order!(precip::Rain, flux::Grad, state::Vars, d_q_rai)
+function flux_second_order!(precip::RainModel, flux::Grad, state::Vars, d_q_rai)
     flux.precipitation.ρq_rai += d_q_rai * state.ρ
 end

--- a/src/Atmos/Model/radiation.jl
+++ b/src/Atmos/Model/radiation.jl
@@ -29,13 +29,15 @@ function reverse_integral_load_auxiliary_state!(
     state::Vars,
     aux::Vars,
 ) end
-function flux_radiation!(
+function flux_first_order!(
     ::RadiationModel,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 ) end
 
 struct NoRadiation <: RadiationModel end

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -1,8 +1,7 @@
 using ..Microphysics_0M
 using ..Microphysics
-using CLIMAParameters.Planet: Omega
 
-export AbstractSource, RemovePrecipitation, CreateClouds, Rain_1M
+export RemovePrecipitation, Rain_1M
 
 # sources are applied additively
 @generated function atmos_source!(
@@ -30,8 +29,6 @@ export AbstractSource, RemovePrecipitation, CreateClouds, Rain_1M
         return nothing
     end
 end
-
-abstract type AbstractSource end
 
 function atmos_source!(
     ::Gravity,

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -1,7 +1,3 @@
-using ..Microphysics_0M
-using ..Microphysics
-
-export RemovePrecipitation, Rain_1M
 
 # sources are applied additively
 @generated function atmos_source!(
@@ -108,19 +104,6 @@ function atmos_source!(
     # Migrated to Σsources
 end
 
-"""
-    RemovePrecipitation{FT} <: AbstractSource
-
-A sink to `q_tot` when cloud condensate is exceeding a threshold.
-The threshold is defined either in terms of condensate or supersaturation.
-The removal rate is implemented as a relaxation term
-in the Microphysics_0M module.
-The default thresholds and timescale are defined in CLIMAParameters.jl.
-"""
-struct RemovePrecipitation <: AbstractSource
-    " Set to true if using qc based threshold"
-    use_qc_thr::Bool
-end
 function atmos_source!(
     s::RemovePrecipitation,
     atmos::AtmosModel,
@@ -131,37 +114,9 @@ function atmos_source!(
     t::Real,
     direction,
 )
-    FT = eltype(state)
-    ts = recover_thermo_state(atmos, state, aux)
-    if has_condensate(ts)
-
-        q = PhasePartition(ts)
-        T::FT = air_temperature(ts)
-        λ::FT = liquid_fraction(ts)
-        I_l::FT = internal_energy_liquid(ts)
-        I_i::FT = internal_energy_ice(ts)
-        Φ::FT = gravitational_potential(atmos.orientation, aux)
-
-        S_qt::FT = 0
-        if s.use_qc_thr
-            S_qt = remove_precipitation(atmos.param_set, q)
-        else
-            q_vap_sat = q_vap_saturation(ts)
-            S_qt = remove_precipitation(atmos.param_set, q, q_vap_sat)
-        end
-
-        source.moisture.ρq_tot += state.ρ * S_qt
-        source.ρ += state.ρ * S_qt
-        source.ρe += (λ * I_l + (1 - λ) * I_i + Φ) * state.ρ * S_qt
-    end
+    # Migrated to Σsources
 end
 
-"""
-    Rain_1M{FT} <: AbstractSource
-
-A collection of source/sink terms related to 1-moment rain microphysics.
-"""
-struct Rain_1M <: AbstractSource end
 function atmos_source!(
     ::Rain_1M,
     atmos::AtmosModel,
@@ -172,48 +127,5 @@ function atmos_source!(
     t::Real,
     direction,
 )
-    FT = eltype(state)
-
-    ts = recover_thermo_state(atmos, state, aux)
-    q = PhasePartition(ts)
-    T::FT = air_temperature(ts)
-    I_l::FT = internal_energy_liquid(ts)
-    q_rai::FT = state.precipitation.ρq_rai / state.ρ
-    Φ::FT = gravitational_potential(atmos.orientation, aux)
-
-    # autoconversion
-    src_q_rai_acnv = conv_q_liq_to_q_rai(atmos.param_set.microphys.rai, q.liq)
-    # accretion
-    src_q_rai_accr = accretion(
-        atmos.param_set,
-        atmos.param_set.microphys.liq,
-        atmos.param_set.microphys.rai,
-        q.liq,
-        q_rai,
-        state.ρ,
-    )
-    # rain evaporation
-    src_q_rai_evap = evaporation_sublimation(
-        atmos.param_set,
-        atmos.param_set.microphys.rai,
-        q,
-        q_rai,
-        state.ρ,
-        T,
-    )
-
-    S_qr::FT = src_q_rai_acnv + src_q_rai_accr + src_q_rai_evap
-    S_ql::FT = -src_q_rai_acnv - src_q_rai_accr
-    S_qt::FT = -S_qr
-
-    source.ρ += state.ρ * S_qt
-    source.moisture.ρq_tot += state.ρ * S_qt
-
-    if atmos.moisture isa NonEquilMoist
-        source.moisture.ρq_liq += state.ρ * S_ql
-    end
-
-    source.precipitation.ρq_rai += state.ρ * S_qr
-
-    source.ρe += state.ρ * S_qt * (Φ + I_l)
+    # Migrated to Σsources
 end

--- a/src/Atmos/Model/tendencies_energy.jl
+++ b/src/Atmos/Model/tendencies_energy.jl
@@ -68,3 +68,29 @@ function source(
     k̂ = vertical_unit_vector(m, aux)
     return -state.ρ * w_sub * dot(k̂, diffusive.∇h_tot)
 end
+
+function source(
+    s::RemovePrecipitation{Energy},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+    diffusive,
+)
+    if has_condensate(ts)
+        nt = compute_precip_params(s, aux, ts)
+        @unpack S_qt, λ, I_l, I_i, Φ = nt
+        return (λ * I_l + (1 - λ) * I_i + Φ) * state.ρ * S_qt
+    else
+        FT = eltype(state)
+        return FT(0)
+    end
+end
+
+function source(s::Rain_1M{Energy}, m, state, aux, t, ts, direction, diffusive)
+    nt = compute_rain_params(m, state, aux, t, ts)
+    @unpack S_qt, Φ, I_l = nt
+    return state.ρ * S_qt * (Φ + I_l)
+end

--- a/src/Atmos/Model/tendencies_mass.jl
+++ b/src/Atmos/Model/tendencies_mass.jl
@@ -39,3 +39,27 @@ function source(s::Subsidence{Mass}, m, state, aux, t, ts, direction, diffusive)
     k̂ = vertical_unit_vector(m, aux)
     return -state.ρ * w_sub * dot(k̂, diffusive.moisture.∇q_tot)
 end
+
+function source(
+    s::RemovePrecipitation{Mass},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+    diffusive,
+)
+    if has_condensate(ts)
+        nt = compute_precip_params(s, aux, ts)
+        return state.ρ * nt.S_qt
+    else
+        FT = eltype(state)
+        return FT(0)
+    end
+end
+
+function source(s::Rain_1M{Mass}, m, state, aux, t, ts, direction, diffusive)
+    nt = compute_rain_params(m, state, aux, t, ts)
+    return state.ρ * nt.S_qt
+end

--- a/src/Atmos/Model/tendencies_moisture.jl
+++ b/src/Atmos/Model/tendencies_moisture.jl
@@ -103,3 +103,50 @@ function source(
 
     return state.ρ * S_q_ice
 end
+
+function source(
+    s::RemovePrecipitation{TotalMoisture},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+    diffusive,
+)
+    if has_condensate(ts)
+        nt = compute_precip_params(s, aux, ts)
+        return state.ρ * nt.S_qt
+    else
+        FT = eltype(state)
+        return FT(0)
+    end
+end
+
+function source(
+    s::Rain_1M{TotalMoisture},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+    diffusive,
+)
+    nt = compute_rain_params(m, state, aux, t, ts)
+    return state.ρ * nt.S_qt
+end
+
+function source(
+    s::Rain_1M{LiquidMoisture},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+    diffusive,
+)
+    nt = compute_rain_params(m, state, aux, t, ts)
+    return state.ρ * nt.S_ql
+end

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -1,5 +1,7 @@
 ##### Momentum tendencies
 
+using CLIMAParameters.Planet: Omega
+
 #####
 ##### First order fluxes
 #####

--- a/src/Atmos/Model/tendencies_precipitation.jl
+++ b/src/Atmos/Model/tendencies_precipitation.jl
@@ -1,0 +1,18 @@
+##### Precipitation tendencies
+
+#####
+##### First order fluxes
+#####
+
+#####
+##### Second order fluxes
+#####
+
+#####
+##### Sources
+#####
+
+function source(s::Rain_1M{Rain}, m, state, aux, t, ts, direction, diffusive)
+    nt = compute_rain_params(m, state, aux, t, ts)
+    return state.ρ * nt.S_qr
+end

--- a/src/Atmos/Model/tracers.jl
+++ b/src/Atmos/Model/tracers.jl
@@ -56,13 +56,15 @@ function atmos_nodal_update_auxiliary_state!(
 )
     nothing
 end
-function flux_tracers!(
+function flux_first_order!(
     ::TracerModel,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 )
     nothing
 end
@@ -179,13 +181,15 @@ function compute_gradient_flux!(
 )
     diffusive.tracers.∇χ = ∇transform.tracers.χ
 end
-function flux_tracers!(
+function flux_first_order!(
     tr::NTracers,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 )
     u = state.ρu / state.ρ
     flux.tracers.ρχ += (state.tracers.ρχ .* u')'

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -79,6 +79,8 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 )
     return nothing
 end

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -126,7 +126,7 @@ function vars_atmos_les_default_simple(m::Union{EquilMoist, NonEquilMoist}, FT)
     end
 end
 vars_atmos_les_default_simple(::PrecipitationModel, FT) = @vars()
-function vars_atmos_les_default_simple(::Rain, FT)
+function vars_atmos_les_default_simple(::RainModel, FT)
     @vars begin
         qr::FT                  # q_rai
     end
@@ -226,7 +226,7 @@ function atmos_les_default_simple_sums!(
     return nothing
 end
 function atmos_les_default_simple_sums!(
-    precipitation::Rain,
+    precipitation::RainModel,
     state,
     gradflux,
     thermo,
@@ -310,7 +310,7 @@ function vars_atmos_les_default_ho(m::Union{EquilMoist, NonEquilMoist}, FT)
     end
 end
 vars_atmos_les_default_ho(::PrecipitationModel, FT) = @vars()
-function vars_atmos_les_default_ho(m::Rain, FT)
+function vars_atmos_les_default_ho(m::RainModel, FT)
     @vars begin
         var_qr::FT              # q_rai′q_rai′
         cov_w_qr::FT            # w′q_rai′
@@ -430,7 +430,7 @@ function atmos_les_default_ho_sums!(
     return nothing
 end
 function atmos_les_default_ho_sums!(
-    moist::Rain,
+    moist::RainModel,
     state,
     thermo,
     MH,
@@ -621,7 +621,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
             # for LWP
             ρq_liq_z[evk] += MH * thermo.moisture.q_liq * state.ρ * state.ρ
         end
-        if isa(bl.precipitation, Rain)
+        if isa(bl.precipitation, RainModel)
             # for RWP
             ρq_rai_z[evk] += MH * state.precipitation.ρq_rai * state.ρ
         end
@@ -651,7 +651,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
                 ρq_liq_z[evk] = tot_ρq_liq_z / MH_z[evk]
             end
         end
-        if isa(bl.precipitation, Rain)
+        if isa(bl.precipitation, RainModel)
             # for RWP
             tot_ρq_rai_z = MPI.Reduce(ρq_rai_z[evk], +, 0, mpicomm)
             if mpirank == 0
@@ -699,7 +699,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
         end
         # for RWP
         # FIXME properly
-        if isa(bl.precipitation, Rain)
+        if isa(bl.precipitation, RainModel)
             ρq_rai_z[evk] /= avg_rho
         end
 
@@ -782,7 +782,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
             varvals["cld_cover"] = cld_cover
             varvals["lwp"] = lwp
         end
-        if isa(bl.precipitation, Rain)
+        if isa(bl.precipitation, RainModel)
             varvals["rwp"] = rwp
         end
 

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -527,6 +527,8 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 ) where {FT}
     # Aliases:
     gm = state


### PR DESCRIPTION
This PR:
 - Adds a `source` validation assert: `@assert !any(isa.(source, Tuple))` to the `AtmosModel` to break early if we've incorrectly specified sources (e.g., not splatting them). This addresses #1779 but only for the AtmosModel.
 - Renames `Rain` to `RainModel`, and adds `Rain <: PrognosticVariable` and `Snow <: PrognosticVariable`.
 - Moves the `RemovePrecipitation` to the new tendency specification
 - Moves the `Rain_1M` to the new tendency specification

Here's the new table with `Dycoms` using non-equilibrium model with `RainModel`:
```
PDE: ∂_t Y_i + (∇•F_1(Y))_i + (∇•F_2(Y,G)))_i = (S(Y,G))_i
┌────────────────┬────────────────────────────┬─────────────────────────────────────────┬───────────┐
│       Equation │           Flux{FirstOrder} │                       Flux{SecondOrder} │    Source │
│          (Y_i) │                      (F_1) │                                   (F_2) │       (S) │
├────────────────┼────────────────────────────┼─────────────────────────────────────────┼───────────┤
│           Mass │                   (Advect) │                     (MoistureDiffusion) │ (Rain_1M) │
│       Momentum │ (Advect, PressureGradient) │                         (ViscousStress) │        () │
│         Energy │         (Advect, Pressure) │ (ViscousProduction, EnthalpyProduction) │ (Rain_1M) │
│  TotalMoisture │                   (Advect) │                                      () │ (Rain_1M) │
│ LiquidMoisture │                   (Advect) │                                      () │ (Rain_1M) │
│    IceMoisture │                   (Advect) │                                      () │        () │
│           Rain │                         () │                                      () │ (Rain_1M) │
└────────────────┴────────────────────────────┴─────────────────────────────────────────┴───────────┘
```

This PR builds on/supersedes #1786.

### Description

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
