### PR TITLE
Rename estimated remaining to est. wallclock end

### DIFF
--- a/src/Driver/Callbacks/Callbacks.jl
+++ b/src/Driver/Callbacks/Callbacks.jl
@@ -48,9 +48,9 @@ function GenericCallbacks.init!(cb::SummaryLogCallback, solver, Q, param, t)
     return nothing
 end
 function GenericCallbacks.call!(cb::SummaryLogCallback, solver, Q, param, t)
-    runtime_ms = Dates.now() - cb.wtimestart
-    runtime = Dates.format(
-        convert(Dates.DateTime, runtime_ms),
+    wallclock_time_ms = Dates.now() - cb.wtimestart
+    wallclock = Dates.format(
+        convert(Dates.DateTime, wallclock_time_ms),
         Dates.dateformat"HH:MM:SS",
     )
     normQ = norm(Q)
@@ -59,24 +59,28 @@ function GenericCallbacks.call!(cb::SummaryLogCallback, solver, Q, param, t)
     else
         simtime = @sprintf "%8.2f / %8.2f" t cb.stimeend
     end
-    runtime_s = runtime_ms.value / 1000
-    efficiency = @sprintf "%8.4f" t / runtime_s
-    estimated_remaining_ms =
-        Dates.Millisecond(ceil(Int, cb.stimeend * runtime_s / t * 1000))
+    wallclock_s = wallclock_time_ms.value / 1000
+    efficiency = @sprintf "%8.4f" t / wallclock_s
+
+    estimated_wallclock_end = cb.stimeend * wallclock_s / t
+
+    estimated_wallclock_end_ms =
+        Dates.Millisecond(ceil(Int, estimated_wallclock_end * 1000))
+
     estimated_remaining = Dates.format(
-        convert(Dates.DateTime, estimated_remaining_ms),
+        convert(Dates.DateTime, estimated_wallclock_end_ms),
         Dates.dateformat"HH:MM:SS",
     )
     @info @sprintf(
         """
         Update
             simtime = %s
-            runtime = %s
-            efficiency (simtime / runtime) = %s
-            remaining runtime (estimated) = %s
+            wallclock = %s
+            efficiency (simtime / wallclock) = %s
+            wallclock end (estimated) = %s
             norm(Q) = %.16e""",
         simtime,
-        runtime,
+        wallclock,
         efficiency,
         estimated_remaining,
         normQ,


### PR DESCRIPTION
### Description

This PR fixes the reported `remaining runtime (estimated)`, it is actually the estimated total (end) wall clock time.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
