### PR TITLE
Prep for new tendency spec

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -49,7 +49,7 @@ ClimateMachine.Atmos.DryModel
 ClimateMachine.Atmos.EquilMoist
 ClimateMachine.Atmos.NonEquilMoist
 ClimateMachine.Atmos.NoPrecipitation
-ClimateMachine.Atmos.Rain
+ClimateMachine.Atmos.RainModel
 ```
 
 ## Stabilization

--- a/docs/src/HowToGuides/Atmos/PrecipitationModelChoices.md
+++ b/docs/src/HowToGuides/Atmos/PrecipitationModelChoices.md
@@ -2,7 +2,7 @@
 
 The precipitation model in `Atmos.jl` describes the behavior
   of precipitating water in the atmosphere (i.e. rain and snow).
-There are two options available: `NoPrecipitation` and `Rain`.
+There are two options available: `NoPrecipitation` and `RainModel`.
 
 ## NoPrecipitation
 
@@ -16,9 +16,9 @@ In the first case `ρ q_tot` (total water specific humidity) is not removed
 In the second case `ρ q_tot` is removed if it exceeds a threshold.
 
 
-## Rain
+## RainModel
 
-The `Rain` model assumes that precipitating water is present but only in the
+The `RainModel` model assumes that precipitating water is present but only in the
   form of rain (liquid-phase precipitation).
 It adds `ρ q_rai` (air density times total rain water specific humidity)
   to state variables.

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -97,12 +97,14 @@ function reverse_integral_set_auxiliary_state!(
     aux::Vars,
     integ::Vars,
 ) end
-function flux_radiation!(
+function flux_first_order!(
     ::RadiationModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 ) end
 
 # ------------------------ Begin Radiation Model ---------------------- #
@@ -178,13 +180,15 @@ function reverse_integral_set_auxiliary_state!(
     aux.∫dnz.radiation.attenuation_coeff = integral.radiation.attenuation_coeff
 end
 
-function flux_radiation!(
+function flux_first_order!(
     m::DYCOMSRadiation,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 )
     FT = eltype(flux)
     z = altitude(atmos, aux)
@@ -275,7 +279,7 @@ function init_dycoms!(problem, bl, state, aux, localgeo, t)
         state.moisture.ρq_liq = q_init.liq
         state.moisture.ρq_ice = q_init.ice
     end
-    if bl.precipitation isa Rain
+    if bl.precipitation isa RainModel
         state.precipitation.ρq_rai = FT(0)
     end
 
@@ -373,7 +377,7 @@ function config_dycoms(
         precipitation = NoPrecipitation()
     elseif precipitation_model == "rain"
         source = (source..., Rain_1M())
-        precipitation = Rain()
+        precipitation = RainModel()
     else
         @warn @sprintf(
             """

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -19,6 +19,7 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
     direction,
 ) end
 function compute_gradient_flux!(
@@ -162,9 +163,9 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
     direction,
 )
-    ts = recover_thermo_state(atmos, state, aux)
     tend = Flux{FirstOrder}()
     args = (atmos, state, aux, t, ts, direction)
     flux.moisture.ρq_tot =
@@ -271,9 +272,9 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
     direction,
 )
-    ts = recover_thermo_state(atmos, state, aux)
     tend = Flux{FirstOrder}()
     args = (atmos, state, aux, t, ts, direction)
     flux.moisture.ρq_tot =

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -1,7 +1,7 @@
 #### Precipitation component in atmosphere model
 abstract type PrecipitationModel end
 
-export NoPrecipitation, Rain#, RainSnow
+export NoPrecipitation, RainModel#, RainSnow
 
 using ..Microphysics
 
@@ -14,13 +14,15 @@ function atmos_nodal_update_auxiliary_state!(
     aux::Vars,
     t::Real,
 ) end
-function flux_precipitation!(
+function flux_first_order!(
     ::PrecipitationModel,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 ) end
 function compute_gradient_flux!(
     ::PrecipitationModel,
@@ -57,18 +59,18 @@ struct NoPrecipitation <: PrecipitationModel end
 
 
 """
-    Rain <: PrecipitationModel
+    RainModel <: PrecipitationModel
 
 Precipitation model with rain only.
 """
-struct Rain <: PrecipitationModel end
+struct RainModel <: PrecipitationModel end
 
-vars_state(::Rain, ::Prognostic, FT) = @vars(ρq_rai::FT)
-vars_state(::Rain, ::Gradient, FT) = @vars(q_rai::FT)
-vars_state(::Rain, ::GradientFlux, FT) = @vars(∇q_rai::SVector{3, FT})
+vars_state(::RainModel, ::Prognostic, FT) = @vars(ρq_rai::FT)
+vars_state(::RainModel, ::Gradient, FT) = @vars(q_rai::FT)
+vars_state(::RainModel, ::GradientFlux, FT) = @vars(∇q_rai::SVector{3, FT})
 
 function atmos_nodal_update_auxiliary_state!(
-    precip::Rain,
+    precip::RainModel,
     atmos::AtmosModel,
     state::Vars,
     aux::Vars,
@@ -76,7 +78,7 @@ function atmos_nodal_update_auxiliary_state!(
 ) end
 
 function compute_gradient_argument!(
-    precip::Rain,
+    precip::RainModel,
     transform::Vars,
     state::Vars,
     aux::Vars,
@@ -87,7 +89,7 @@ function compute_gradient_argument!(
 end
 
 function compute_gradient_flux!(
-    precip::Rain,
+    precip::RainModel,
     diffusive::Vars,
     ∇transform::Grad,
     state::Vars,
@@ -98,13 +100,15 @@ function compute_gradient_flux!(
     diffusive.precipitation.∇q_rai = ∇transform.precipitation.q_rai
 end
 
-function flux_precipitation!(
-    precip::Rain,
+function flux_first_order!(
+    precip::RainModel,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 )
     FT = eltype(state)
     u = state.ρu / state.ρ
@@ -125,7 +129,7 @@ function flux_precipitation!(
 end
 
 function flux_second_order!(
-    precip::Rain,
+    precip::RainModel,
     flux::Grad,
     state::Vars,
     diffusive::Vars,
@@ -136,6 +140,6 @@ function flux_second_order!(
     d_q_rai = (-D_t) .* diffusive.precipitation.∇q_rai
     flux_second_order!(precip, flux, state, d_q_rai)
 end
-function flux_second_order!(precip::Rain, flux::Grad, state::Vars, d_q_rai)
+function flux_second_order!(precip::RainModel, flux::Grad, state::Vars, d_q_rai)
     flux.precipitation.ρq_rai += d_q_rai * state.ρ
 end

--- a/src/Atmos/Model/radiation.jl
+++ b/src/Atmos/Model/radiation.jl
@@ -29,13 +29,15 @@ function reverse_integral_load_auxiliary_state!(
     state::Vars,
     aux::Vars,
 ) end
-function flux_radiation!(
+function flux_first_order!(
     ::RadiationModel,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 ) end
 
 struct NoRadiation <: RadiationModel end

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -1,8 +1,7 @@
 using ..Microphysics_0M
 using ..Microphysics
-using CLIMAParameters.Planet: Omega
 
-export AbstractSource, RemovePrecipitation, CreateClouds, Rain_1M
+export RemovePrecipitation, Rain_1M
 
 # sources are applied additively
 @generated function atmos_source!(
@@ -30,8 +29,6 @@ export AbstractSource, RemovePrecipitation, CreateClouds, Rain_1M
         return nothing
     end
 end
-
-abstract type AbstractSource end
 
 function atmos_source!(
     ::Gravity,

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -1,5 +1,7 @@
 ##### Momentum tendencies
 
+using CLIMAParameters.Planet: Omega
+
 #####
 ##### First order fluxes
 #####

--- a/src/Atmos/Model/tracers.jl
+++ b/src/Atmos/Model/tracers.jl
@@ -56,13 +56,15 @@ function atmos_nodal_update_auxiliary_state!(
 )
     nothing
 end
-function flux_tracers!(
+function flux_first_order!(
     ::TracerModel,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 )
     nothing
 end
@@ -179,13 +181,15 @@ function compute_gradient_flux!(
 )
     diffusive.tracers.∇χ = ∇transform.tracers.χ
 end
-function flux_tracers!(
+function flux_first_order!(
     tr::NTracers,
     atmos::AtmosModel,
     flux::Grad,
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 )
     u = state.ρu / state.ρ
     flux.tracers.ρχ += (state.tracers.ρχ .* u')'

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -79,6 +79,8 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 )
     return nothing
 end

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -126,7 +126,7 @@ function vars_atmos_les_default_simple(m::Union{EquilMoist, NonEquilMoist}, FT)
     end
 end
 vars_atmos_les_default_simple(::PrecipitationModel, FT) = @vars()
-function vars_atmos_les_default_simple(::Rain, FT)
+function vars_atmos_les_default_simple(::RainModel, FT)
     @vars begin
         qr::FT                  # q_rai
     end
@@ -226,7 +226,7 @@ function atmos_les_default_simple_sums!(
     return nothing
 end
 function atmos_les_default_simple_sums!(
-    precipitation::Rain,
+    precipitation::RainModel,
     state,
     gradflux,
     thermo,
@@ -310,7 +310,7 @@ function vars_atmos_les_default_ho(m::Union{EquilMoist, NonEquilMoist}, FT)
     end
 end
 vars_atmos_les_default_ho(::PrecipitationModel, FT) = @vars()
-function vars_atmos_les_default_ho(m::Rain, FT)
+function vars_atmos_les_default_ho(m::RainModel, FT)
     @vars begin
         var_qr::FT              # q_rai′q_rai′
         cov_w_qr::FT            # w′q_rai′
@@ -430,7 +430,7 @@ function atmos_les_default_ho_sums!(
     return nothing
 end
 function atmos_les_default_ho_sums!(
-    moist::Rain,
+    moist::RainModel,
     state,
     thermo,
     MH,
@@ -621,7 +621,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
             # for LWP
             ρq_liq_z[evk] += MH * thermo.moisture.q_liq * state.ρ * state.ρ
         end
-        if isa(bl.precipitation, Rain)
+        if isa(bl.precipitation, RainModel)
             # for RWP
             ρq_rai_z[evk] += MH * state.precipitation.ρq_rai * state.ρ
         end
@@ -651,7 +651,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
                 ρq_liq_z[evk] = tot_ρq_liq_z / MH_z[evk]
             end
         end
-        if isa(bl.precipitation, Rain)
+        if isa(bl.precipitation, RainModel)
             # for RWP
             tot_ρq_rai_z = MPI.Reduce(ρq_rai_z[evk], +, 0, mpicomm)
             if mpirank == 0
@@ -699,7 +699,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
         end
         # for RWP
         # FIXME properly
-        if isa(bl.precipitation, Rain)
+        if isa(bl.precipitation, RainModel)
             ρq_rai_z[evk] /= avg_rho
         end
 
@@ -782,7 +782,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
             varvals["cld_cover"] = cld_cover
             varvals["lwp"] = lwp
         end
-        if isa(bl.precipitation, Rain)
+        if isa(bl.precipitation, RainModel)
             varvals["rwp"] = rwp
         end
 

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -527,6 +527,8 @@ function flux_first_order!(
     state::Vars,
     aux::Vars,
     t::Real,
+    ts,
+    direction,
 ) where {FT}
     # Aliases:
     gm = state


### PR DESCRIPTION
### Description

This PR:
 - Changes some method names (e.g., `flux_moisture!`) to `flux_first_order!`
 - Changes `Rain` to `RainModel`
 - Adds `ts::ThermodynamicState` and `direction` to `flux_first_order!`
 - Moves some things outside of `src/Atmos/Model/source.jl`
 - Adds a `source` validation assert: `@assert !any(isa.(source, Tuple))` to the `AtmosModel` to break early if we've incorrectly specified sources (e.g., not splatting them). This addresses #1779 but only for the AtmosModel.

This basically strips a bunch of things out from #1782.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
