### PR TITLE
Agl/kd/update soil bc

### DIFF
--- a/docs/list_of_apis.jl
+++ b/docs/list_of_apis.jl
@@ -17,6 +17,7 @@ apis = [
     "Ocean" => "APIs/Ocean/Ocean.md",
     "Land" => [
         "Land Model" => "APIs/Land/LandModel.md",
+        "Runoff Parameterizations" => "APIs/Land/Runoff.md",
         "Soil Water Parameterizations" =>
             "APIs/Land/SoilWaterParameterizations.md",
         "Soil Heat Parameterizations" =>

--- a/docs/src/APIs/Land/LandModel.md
+++ b/docs/src/APIs/Land/LandModel.md
@@ -25,6 +25,8 @@ ClimateMachine.Land.PhaseChange
 
 ## Boundary Conditions
 ```@docs
+ClimateMachine.Land.GeneralBoundaryConditions
+ClimateMachine.Land.SurfaceDrivenWaterBoundaryConditions
 ClimateMachine.Land.Dirichlet
 ClimateMachine.Land.Neumann
 ```

--- a/docs/src/APIs/Land/Runoff.md
+++ b/docs/src/APIs/Land/Runoff.md
@@ -1,0 +1,14 @@
+# Runoff
+
+```@meta
+CurrentModule = ClimateMachine.Land.Runoff
+```
+
+## Runoff types and functions
+```@docs
+AbstractPrecipModel
+DrivenConstantPrecip
+AbstractSurfaceRunoffModel
+NoRunoff
+compute_surface_flux
+```

--- a/src/Land/Model/LandModel.jl
+++ b/src/Land/Model/LandModel.jl
@@ -216,7 +216,10 @@ include("SoilWaterParameterizations.jl")
 using .SoilWaterParameterizations
 include("SoilHeatParameterizations.jl")
 using .SoilHeatParameterizations
+include("Runoff.jl")
+using .Runoff
 include("soil_model.jl")
+include("soil_boundary_types.jl")
 include("soil_water.jl")
 include("soil_heat.jl")
 include("soil_bc.jl")

--- a/src/Land/Model/Runoff.jl
+++ b/src/Land/Model/Runoff.jl
@@ -1,0 +1,97 @@
+module Runoff
+
+using ...VariableTemplates
+using DocStringExtensions
+
+export AbstractPrecipModel,
+    DrivenConstantPrecip,
+    AbstractSurfaceRunoffModel,
+    NoRunoff,
+    compute_surface_flux
+
+"""
+    AbstractPrecipModel{FT <: AbstractFloat}
+"""
+abstract type AbstractPrecipModel{FT <: AbstractFloat} end
+
+"""
+    DrivenConstantPrecip{FT, F} <: AbstractPrecipModel{FT}
+
+Instance of a precipitation distribution where the precipication value
+is constant across the domain. However, this value can change in time.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct DrivenConstantPrecip{FT, F} <: AbstractPrecipModel{FT}
+    "Mean precipitation in grid"
+    mp::F
+    function DrivenConstantPrecip{FT}(mp::F) where {FT, F}
+        new{FT, F}(mp)
+    end
+end
+
+function (dcp::DrivenConstantPrecip{FT})(t::Real) where {FT}
+    return FT(dcp.mp(t))
+end
+
+"""
+    AbstractSurfaceRunoffModel
+
+Abstract type for different surface runoff models. Currently, only
+`NoRunoff` is supported.
+"""
+abstract type AbstractSurfaceRunoffModel end
+
+"""
+    NoRunoff <: AbstractSurfaceRunoffModel
+
+Chosen when no runoff is to be modeled.
+"""
+struct NoRunoff <: AbstractSurfaceRunoffModel end
+
+
+"""
+    function compute_surface_runoff(
+        runoff_model::NoRunoff,
+        precip_model::AbstractPrecipModel,
+        state::Vars
+    )
+
+Returns zero for net surface runoff when `NoRunoff`
+is used.
+"""
+function compute_surface_runoff(
+    runoff_model::NoRunoff,
+    precip_model::AbstractPrecipModel{FT},
+    state::Vars,
+) where {FT}
+    return FT(0.0)
+end
+
+
+"""
+    compute_surface_flux(
+        runoff_model::AbstractSurfaceRunoffModel,
+        precip_model::AbstractPrecipModel{FT},
+        state::Vars,
+        t::Real,
+    ) where {FT}
+
+Given a runoff model and a precipitation distribution function, compute 
+the surface water flux. This can be a function of time, and state.
+"""
+function compute_surface_flux(
+    runoff_model::AbstractSurfaceRunoffModel,
+    precip_model::AbstractPrecipModel{FT},
+    state::Vars,
+    t::Real,
+) where {FT}
+    mean_p = precip_model(t)
+    net_runoff = compute_surface_runoff(runoff_model, precip_model, state)
+    net_flux = net_runoff - mean_p
+    return net_flux
+end
+
+
+end

--- a/src/Land/Model/land_bc.jl
+++ b/src/Land/Model/land_bc.jl
@@ -1,5 +1,3 @@
-export Dirichlet, Neumann
-
 boundary_conditions(::LandModel) = (1, 2)
 
 function boundary_state!(
@@ -37,43 +35,4 @@ function boundary_state!(
     args = (state⁺, aux⁺, n̂, state⁻, aux⁻, t)
     soil_boundary_state!(nf, bctype, land, land.soil, land.soil.water, args...)
     soil_boundary_state!(nf, bctype, land, land.soil, land.soil.heat, args...)
-end
-
-abstract type AbstractBoundaryFunctions end
-
-"""
-    struct Dirichlet{Fs, Fb} <: AbstractBoundaryFunctions
-
-A concrete type to hold the surface state and bottom state variable
-values/functions, if Dirichlet boundary conditions are desired.
-
-# Fields
-$(DocStringExtensions.FIELDS)
-"""
-Base.@kwdef struct Dirichlet{Fs, Fb} <: AbstractBoundaryFunctions
-    "Surface state boundary condition"
-    surface_state::Fs = nothing
-    "Bottom state boundary condition"
-    bottom_state::Fb = nothing
-end
-
-"""
-    struct Neumann{Fs, Fb} <: AbstractBoundaryFunctions
-
-A concrete type to hold the surface and/or bottom diffusive flux
-values/functions, if Neumann boundary conditions are desired.
-
-Note that these are intended to be scalar values. In the boundary_state!
-functions, they are multiplied by the `ẑ` vector (i.e. the normal vector `n̂`
-to the domain at the upper boundary, and -`n̂` at the lower boundary. These
-normal vectors point out of the domain.)
-
-# Fields
-$(DocStringExtensions.FIELDS)
-"""
-Base.@kwdef struct Neumann{Fs, Fb} <: AbstractBoundaryFunctions
-    "Surface flux boundary condition"
-    surface_flux::Fs = nothing
-    "Bottom flux boundary condition"
-    bottom_flux::Fb = nothing
 end

--- a/src/Land/Model/soil_bc.jl
+++ b/src/Land/Model/soil_bc.jl
@@ -1,4 +1,6 @@
-
+# General case - applies to PrescribedHeatModel or PrescribedWaterModel.
+# We can't dispach on boundaries at this point because Prescribed models
+# do not have that field.
 function soil_boundary_state!(
     nf,
     bctype,
@@ -37,7 +39,26 @@ function soil_boundary_state!(
 end
 
 
+# SoilWaterModel methods
 
+"""
+    function soil_boundary_state!(
+        nf,
+        land::LandModel,
+        soil::SoilModel,
+        water::SoilWaterModel,
+        state⁺::Vars,
+        aux⁺::Vars,
+        nM,
+        state⁻::Vars,
+        aux⁻::Vars,
+        bctype,
+        t,
+    )
+
+The Dirichlet-type method for `soil_boundary_state!` for the
+`SoilWaterModel`.
+"""
 function soil_boundary_state!(
     nf,
     bctype,
@@ -52,35 +73,43 @@ function soil_boundary_state!(
     t,
     _...,
 )
-    water_bc = water.dirichlet_bc
-    if bctype == 2
-        top_boundary_conditions!(
-            land,
-            soil,
-            water,
-            water_bc,
-            state⁺,
-            aux⁺,
-            state⁻,
-            aux⁻,
-            t,
-        )
-    elseif bctype == 1
-        bottom_boundary_conditions!(
-            land,
-            soil,
-            water,
-            water_bc,
-            state⁺,
-            aux⁺,
-            state⁻,
-            aux⁻,
-            t,
-        )
-    end
+    execute_based_on_boundaries!(
+        nf,
+        land,
+        soil,
+        water,
+        water.boundaries,
+        state⁺,
+        aux⁺,
+        nM,
+        state⁻,
+        aux⁻,
+        bctype,
+        t,
+    )
 end
 
 
+"""
+    function soil_boundary_state!(
+        nf,
+        land::LandModel,
+        soil::SoilModel,
+        water::SoilWaterModel,
+        state⁺::Vars,
+        diff⁺::Vars,
+        aux⁺::Vars,
+        n̂,
+        state⁻::Vars,
+        diff⁻::Vars,
+        aux⁻::Vars,
+        bctype,
+        t,
+    )
+
+The Neumann-type method for `soil_boundary_state!` for the
+`SoilWaterModel`.
+"""
 function soil_boundary_state!(
     nf,
     bctype,
@@ -97,41 +126,257 @@ function soil_boundary_state!(
     t,
     _...,
 )
-    water_bc = water.neumann_bc
+    execute_based_on_boundaries!(
+        nf,
+        land,
+        soil,
+        water,
+        water.boundaries,
+        state⁺,
+        diff⁺,
+        aux⁺,
+        n̂,
+        state⁻,
+        diff⁻,
+        aux⁻,
+        bctype,
+        t,
+    )
+end
+
+
+"""
+    function execute_based_on_boundaries!(
+        nf,
+        land::LandModel,
+        soil::SoilModel,
+        water::SoilWaterModel,
+        boundaries::SurfaceDrivenWaterBoundaryConditions,
+        state⁺::Vars,
+        aux⁺::Vars,
+        nM,
+        state⁻::Vars,
+        aux⁻::Vars,
+        bctype,
+        t,
+    )
+
+The Dirichlet-type boundary method for `execute_based_on_boundaries!` for the
+`SoilWaterModel` when used with `SurfaceDrivenWaterBoundaryConditions`. As
+`SurfaceDrivenWaterBoundaryConditions` are Neumann, this does nothing.
+"""
+function execute_based_on_boundaries!(
+    nf,
+    land::LandModel,
+    soil::SoilModel,
+    water::SoilWaterModel,
+    boundaries::SurfaceDrivenWaterBoundaryConditions,
+    state⁺::Vars,
+    aux⁺::Vars,
+    nM,
+    state⁻::Vars,
+    aux⁻::Vars,
+    bctype,
+    t,
+)
+    nothing
+end
+
+
+"""
+    function execute_based_on_boundaries!(
+        nf,
+        land::LandModel,
+        soil::SoilModel,
+        water::SoilWaterModel,
+        boundaries::SurfaceDrivenWaterBoundaryConditions,
+        state⁺::Vars,
+        diff⁺::Vars,
+        aux⁺::Vars,
+        n̂,
+        state⁻::Vars,
+        diff⁻::Vars,
+        aux⁻::Vars,
+        bctype,
+        t,
+    )
+ 
+The Neumann-type boundary method for `execute_based_on_boundaries!` for the
+`SoilWaterModel` when used with `SurfaceDrivenWaterBoundaryConditions`. This applies
+zero flux at the bottom of the domain, and a physical flux based on evaporation,
+precipitation, and runoff at the top.
+"""
+function execute_based_on_boundaries!(
+    nf,
+    land::LandModel,
+    soil::SoilModel,
+    water::SoilWaterModel,
+    boundaries::SurfaceDrivenWaterBoundaryConditions,
+    state⁺::Vars,
+    diff⁺::Vars,
+    aux⁺::Vars,
+    n̂,
+    state⁻::Vars,
+    diff⁻::Vars,
+    aux⁻::Vars,
+    bctype,
+    t,
+)
+    precip_model = boundaries.precip_model
+    runoff_model = boundaries.runoff_model
+    #compute surface flux
+    net_surface_flux =
+        compute_surface_flux(runoff_model, precip_model, state⁻, t)
+    #top
     if bctype == 2
-        top_boundary_conditions!(
-            land,
-            soil,
-            water,
-            water_bc,
-            state⁺,
-            diff⁺,
-            aux⁺,
-            n̂,
-            state⁻,
-            diff⁻,
-            aux⁻,
-            t,
-        )
+        diff⁺.soil.water.K∇h = n̂ * (-net_surface_flux)
+        #bottom
     elseif bctype == 1
-        bottom_boundary_conditions!(
-            land,
-            soil,
-            water,
-            water_bc,
-            state⁺,
-            diff⁺,
-            aux⁺,
-            n̂,
-            state⁻,
-            diff⁻,
-            aux⁻,
-            t,
-        )
+        diff⁺.soil.water.K∇h = n̂ * eltype(state⁻)(0.0)
+    end
+
+
+end
+
+"""
+    function execute_based_on_boundaries!(
+        nf,
+        land::LandModel,
+        soil::SoilModel,
+        water::SoilWaterModel,
+        boundaries::GeneralBoundaryConditions,
+        state⁺::Vars,
+        aux⁺::Vars,
+        nM,
+        state⁻::Vars,
+        aux⁻::Vars,
+        bctype,
+        t,
+    )
+
+The Dirichlet-type boundary method for `execute_based_on_boundaries!` for the
+`SoilWaterModel` when used with `GeneralBoundaryConditions`. This applies the
+user-supplied functions of space and time as Dirichlet conditions on `ϑ_l`.
+
+Note that not supplying a function (so that it is `nothing`) results in no
+boundary condition of this type applied.
+"""
+function execute_based_on_boundaries!(
+    nf,
+    land::LandModel,
+    soil::SoilModel,
+    water::SoilWaterModel,
+    boundaries::GeneralBoundaryConditions,
+    state⁺::Vars,
+    aux⁺::Vars,
+    nM,
+    state⁻::Vars,
+    aux⁻::Vars,
+    bctype,
+    t,
+)
+
+    bc = boundaries.dirichlet_bc
+    if bctype == 2
+        if bc.surface_state != nothing
+            state⁺.soil.water.ϑ_l = bc.surface_state(aux⁻, t)
+        else
+            nothing
+        end
+    elseif bctype == 1
+        if bc.bottom_state != nothing
+            state⁺.soil.water.ϑ_l = bc.bottom_state(aux⁻, t)
+        else
+            nothing
+        end
     end
 end
 
-# Heat
+"""
+    function execute_based_on_boundaries!(
+        nf,
+        land::LandModel,
+        soil::SoilModel,
+        water::SoilWaterModel,
+        boundaries::GeneralBoundaryConditions,
+        state⁺::Vars,
+        diff⁺::Vars,
+        aux⁺::Vars,
+        n̂,
+        state⁻::Vars,
+        diff⁻::Vars,
+        aux⁻::Vars,
+        bctype,
+        t,
+    )
+
+The Neumann-type boundary method for `execute_based_on_boundaries!` for the
+`SoilWaterModel` when used with `GeneralBoundaryConditions`. This applies the
+user-supplied functions of space and time as Neumann conditions on the flux,
+equal to -K∇h.
+
+Note that not supplying a function (so that it is `nothing`) results in no
+boundary condition of this type applied.
+"""
+function execute_based_on_boundaries!(
+    nf,
+    land::LandModel,
+    soil::SoilModel,
+    water::SoilWaterModel,
+    boundaries::GeneralBoundaryConditions,
+    state⁺::Vars,
+    diff⁺::Vars,
+    aux⁺::Vars,
+    n̂,
+    state⁻::Vars,
+    diff⁻::Vars,
+    aux⁻::Vars,
+    bctype,
+    t,
+)
+
+    bc = boundaries.neumann_bc
+    if bctype == 2
+        if bc.surface_flux != nothing
+            # Note that -K∇h is the flux, so we need a minus sign here.
+            diff⁺.soil.water.K∇h = n̂ * (-bc.surface_flux(aux⁻, t))
+        else
+            nothing
+        end
+    elseif bctype == 1
+        if bc.bottom_flux != nothing
+            # Note that -K∇h is the flux, so we add in a minus sign
+            # we add a second minus sign because we choose to specify a BC
+            # in terms of ẑ, not n̂, as then it doesnt change directions.
+            diff⁺.soil.water.K∇h = -n̂ * (-bc.bottom_flux(aux⁻, t))
+        else
+            nothing
+        end
+    end
+end
+
+
+
+# SoilHeatModel - GeneralBoundaryConditions only so far
+
+"""
+    function soil_boundary_state!(
+        nf,
+        bctype,
+        land::LandModel,
+        soil::SoilModel,
+        heat::SoilHeatModel,
+        state⁺::Vars,
+        aux⁺::Vars,
+        nM,
+        state⁻::Vars,
+        aux⁻::Vars,
+        t,
+    )
+
+The Dirichlet-type method for `soil_boundary_state!` for the
+`SoilHeatModel`.
+"""
 function soil_boundary_state!(
     nf,
     bctype,
@@ -146,34 +391,43 @@ function soil_boundary_state!(
     t,
     _...,
 )
-    heat_bc = heat.dirichlet_bc
-    if bctype == 2
-        top_boundary_conditions!(
-            land,
-            soil,
-            heat,
-            heat_bc,
-            state⁺,
-            aux⁺,
-            state⁻,
-            aux⁻,
-            t,
-        )
-    elseif bctype == 1
-        bottom_boundary_conditions!(
-            land,
-            soil,
-            heat,
-            heat_bc,
-            state⁺,
-            aux⁺,
-            state⁻,
-            aux⁻,
-            t,
-        )
-    end
+    execute_based_on_boundaries!(
+        nf,
+        land,
+        soil,
+        heat,
+        heat.boundaries,
+        state⁺,
+        aux⁺,
+        nM,
+        state⁻,
+        aux⁻,
+        bctype,
+        t,
+    )
 end
 
+
+"""
+    function soil_boundary_state!(
+        nf,
+        bctype,
+        land::LandModel,
+        soil::SoilModel,
+        heat::SoilHeatModel,
+        state⁺::Vars,
+        diff⁺::Vars,
+        aux⁺::Vars,
+        n̂,
+        state⁻::Vars,
+        diff⁻::Vars,
+        aux⁻::Vars,
+        t,
+    )
+
+The Neumann-type method for `soil_boundary_state!` for the
+`SoilHeatModel`.
+"""
 function soil_boundary_state!(
     nf,
     bctype,
@@ -190,198 +444,124 @@ function soil_boundary_state!(
     t,
     _...,
 )
-    heat_bc = heat.neumann_bc
+    execute_based_on_boundaries!(
+        nf,
+        land,
+        soil,
+        heat,
+        heat.boundaries,
+        state⁺,
+        diff⁺,
+        aux⁺,
+        n̂,
+        state⁻,
+        diff⁻,
+        aux⁻,
+        bctype,
+        t,
+    )
+end
+
+"""
+    function execute_based_on_boundaries!(
+        nf,
+        land::LandModel,
+        soil::SoilModel,
+        heat::SoilHeatModel,
+        boundaries::GeneralBoundaryConditions,
+        state⁺::Vars,
+        aux⁺::Vars,
+        nM,
+        state⁻::Vars,
+        aux⁻::Vars,
+        bctype,
+        t,
+    )
+
+The Dirichlet-type boundary method for `execute_based_on_boundaries!` for the
+`SoilHeatModel` when used with `GeneralBoundaryConditions`. This applies the
+user-supplied functions of space and time as Dirichlet conditions on `ρe_int`.
+
+Note that not supplying a function (so that it is `nothing`) results in no
+boundary condition of this type applied. Additionally, note that the user
+supplies a Dirichlet condition for temperature, and this is converted into
+a boundary condition on volumetric. internal energy.
+"""
+function execute_based_on_boundaries!(
+    nf,
+    land::LandModel,
+    soil::SoilModel,
+    heat::SoilHeatModel,
+    boundaries::GeneralBoundaryConditions,
+    state⁺::Vars,
+    aux⁺::Vars,
+    nM,
+    state⁻::Vars,
+    aux⁻::Vars,
+    bctype,
+    t,
+)
+    bc = boundaries.dirichlet_bc
     if bctype == 2
-        top_boundary_conditions!(
-            land,
-            soil,
-            heat,
-            heat_bc,
-            state⁺,
-            diff⁺,
-            aux⁺,
-            n̂,
-            state⁻,
-            diff⁻,
-            aux⁻,
-            t,
-        )
+        if bc.surface_state != nothing
+            ϑ_l, θ_i = get_water_content(land.soil.water, aux⁻, state⁻, t)
+            θ_l = volumetric_liquid_fraction(
+                ϑ_l,
+                land.soil.param_functions.porosity,
+            )
+            ρc_s = volumetric_heat_capacity(
+                θ_l,
+                θ_i,
+                land.soil.param_functions.ρc_ds,
+                land.param_set,
+            )
+
+            ρe_int_bc = volumetric_internal_energy(
+                θ_i,
+                ρc_s,
+                bc.surface_state(aux⁻, t),
+                land.param_set,
+            )
+
+            state⁺.soil.heat.ρe_int = ρe_int_bc
+        else
+            nothing
+        end
     elseif bctype == 1
-        bottom_boundary_conditions!(
-            land,
-            soil,
-            heat,
-            heat_bc,
-            state⁺,
-            diff⁺,
-            aux⁺,
-            n̂,
-            state⁻,
-            diff⁻,
-            aux⁻,
-            t,
-        )
-    end
-end
+        if bc.bottom_state != nothing
+            ϑ_l, θ_i = get_water_content(land.soil.water, aux⁻, state⁻, t)
+            θ_l = volumetric_liquid_fraction(
+                ϑ_l,
+                land.soil.param_functions.porosity,
+            )
+            ρc_s = volumetric_heat_capacity(
+                θ_l,
+                θ_i,
+                land.soil.param_functions.ρc_ds,
+                land.param_set,
+            )
 
+            ρe_int_bc = volumetric_internal_energy(
+                θ_i,
+                ρc_s,
+                bc.bottom_state(aux⁻, t),
+                land.param_set,
+            )
 
-# Water
-"""
-    top_boundary_conditions!(
-        land::LandModel,
-        soil::SoilModel,
-        water::SoilWaterModel,
-        bc::Neumann,
-        state⁺::Vars,
-        diff⁺::Vars,
-        aux⁺::Vars,
-        n̂,
-        state⁻::Vars,
-        diff⁻::Vars,
-        aux⁻::Vars,
-        t,
-    )
-
-Specify Neumann boundary conditions for the top of the soil, if given.
-"""
-function top_boundary_conditions!(
-    land::LandModel,
-    soil::SoilModel,
-    water::SoilWaterModel,
-    bc::Neumann,
-    state⁺::Vars,
-    diff⁺::Vars,
-    aux⁺::Vars,
-    n̂,
-    state⁻::Vars,
-    diff⁻::Vars,
-    aux⁻::Vars,
-    t,
-)
-    if bc.surface_flux != nothing
-        # Note that -K∇h is the flux, so we need a minus sign here.
-        diff⁺.soil.water.K∇h = n̂ * (-bc.surface_flux(aux⁻, t))
-    else
-        nothing
+            state⁺.soil.heat.ρe_int = ρe_int_bc
+        else
+            nothing
+        end
     end
 end
 
 """
-    top_boundary_conditions!(
-        land::LandModel,
-        soil::SoilModel,
-        water::SoilWaterModel,
-        bc::Dirichlet,
-        state⁺::Vars,
-        aux⁺::Vars,
-        state⁻::Vars,
-        aux⁻::Vars,
-        t,
-    )
-
-Specify Dirichlet boundary conditions for the top of the soil, if given.
-"""
-function top_boundary_conditions!(
-    land::LandModel,
-    soil::SoilModel,
-    water::SoilWaterModel,
-    bc::Dirichlet,
-    state⁺::Vars,
-    aux⁺::Vars,
-    state⁻::Vars,
-    aux⁻::Vars,
-    t,
-)
-    if bc.surface_state != nothing
-        state⁺.soil.water.ϑ_l = bc.surface_state(aux⁻, t)
-    else
-        nothing
-    end
-end
-
-"""
-    bottom_boundary_conditions!(
-        land::LandModel,
-        soil::SoilModel,
-        water::SoilWaterModel,
-        bc::Neumann,
-        state⁺::Vars,
-        diff⁺::Vars,
-        aux⁺::Vars,
-        n̂,
-        state⁻::Vars,
-        diff⁻::Vars,
-        aux⁻::Vars,
-        t,
-    )
-
-Specify Neumann boundary conditions for the bottom of the soil, if given.
-"""
-function bottom_boundary_conditions!(
-    land::LandModel,
-    soil::SoilModel,
-    water::SoilWaterModel,
-    bc::Neumann,
-    state⁺::Vars,
-    diff⁺::Vars,
-    aux⁺::Vars,
-    n̂,
-    state⁻::Vars,
-    diff⁻::Vars,
-    aux⁻::Vars,
-    t,
-)
-    if bc.bottom_flux != nothing
-        # Note that -K∇h is the flux, so we add in a minus sign
-        # we add a second minus sign because we choose to specify a BC
-        # in terms of ẑ, not n̂, as then it doesnt change directions.
-        diff⁺.soil.water.K∇h = -n̂ * (-bc.bottom_flux(aux⁻, t))
-    else
-        nothing
-    end
-end
-
-
-"""
-    bottom_boundary_conditions!(
-        land::LandModel,
-        soil::SoilModel,
-        water::SoilWaterModel,
-        bc::Dirichlet,
-        state⁺::Vars,
-        aux⁺::Vars,
-        state⁻::Vars,
-        aux⁻::Vars,
-        t,
-    )
-
-Specify Dirichlet boundary conditions for the bottom of the soil, if given.
-"""
-function bottom_boundary_conditions!(
-    land::LandModel,
-    soil::SoilModel,
-    water::SoilWaterModel,
-    bc::Dirichlet,
-    state⁺::Vars,
-    aux⁺::Vars,
-    state⁻::Vars,
-    aux⁻::Vars,
-    t,
-)
-    if bc.bottom_state != nothing
-        state⁺.soil.water.ϑ_l = bc.bottom_state(aux⁻, t)
-    else
-        nothing
-    end
-end
-
-## Heat
-"""
-    top_boundary_conditions!(
+    function execute_based_on_boundaries!(
+        nf,
         land::LandModel,
         soil::SoilModel,
         heat::SoilHeatModel,
-        bc::Neumann,
+        boundaries::GeneralBoundaryConditions,
         state⁺::Vars,
         diff⁺::Vars,
         aux⁺::Vars,
@@ -389,16 +569,24 @@ end
         state⁻::Vars,
         diff⁻::Vars,
         aux⁻::Vars,
+        bctype,
         t,
     )
 
-Specify Neumann boundary conditions for the top of the soil, if given.
+The Neumann-type boundary method for `execute_based_on_boundaries!` for the
+`SoilHeatModel` when used with `GeneralBoundaryConditions`. This applies the
+user-supplied functions of space and time as Neumann conditions on the flux,
+equal to -κ∇T.
+
+Note that not supplying a function (so that it is `nothing`) results in no
+boundary condition of this type applied.
 """
-function top_boundary_conditions!(
+function execute_based_on_boundaries!(
+    nf,
     land::LandModel,
     soil::SoilModel,
     heat::SoilHeatModel,
-    bc::Neumann,
+    boundaries::GeneralBoundaryConditions,
     state⁺::Vars,
     diff⁺::Vars,
     aux⁺::Vars,
@@ -406,154 +594,24 @@ function top_boundary_conditions!(
     state⁻::Vars,
     diff⁻::Vars,
     aux⁻::Vars,
+    bctype,
     t,
 )
-    if bc.surface_flux != nothing
-        # Again, the flux is -κ∇T
-        diff⁺.soil.heat.κ∇T = n̂ * (-bc.surface_flux(aux⁻, t))
-    else
-        nothing
-    end
-end
-
-"""
-    top_boundary_conditions!(
-        land::LandModel,
-        soil::SoilModel,
-        water::SoilWaterModel,
-        bc::Dirichlet,
-        state⁺::Vars,
-        aux⁺::Vars,
-        state⁻::Vars,
-        aux⁻::Vars,
-        t,
-    )
-
-Specify Dirichlet boundary conditions for the top of the soil, if given.
-"""
-function top_boundary_conditions!(
-    land::LandModel,
-    soil::SoilModel,
-    heat::SoilHeatModel,
-    bc::Dirichlet,
-    state⁺::Vars,
-    aux⁺::Vars,
-    state⁻::Vars,
-    aux⁻::Vars,
-    t,
-)
-    if bc.surface_state != nothing
-        ϑ_l, θ_i = get_water_content(land.soil.water, aux⁻, state⁻, t)
-        eff_porosity = land.soil.param_functions.porosity - θ_i
-        θ_l = volumetric_liquid_fraction(ϑ_l, eff_porosity)
-        ρc_s = volumetric_heat_capacity(
-            θ_l,
-            θ_i,
-            land.soil.param_functions.ρc_ds,
-            land.param_set,
-        )
-
-        ρe_int_bc = volumetric_internal_energy(
-            θ_i,
-            ρc_s,
-            bc.surface_state(aux⁻, t),
-            land.param_set,
-        )
-
-        state⁺.soil.heat.ρe_int = ρe_int_bc
-    else
-        nothing
-    end
-end
-
-"""
-    bottom_boundary_conditions!(
-        land::LandModel,
-        soil::SoilModel,
-        heat::SoilHeatModel,
-        bc::Neumann,
-        state⁺::Vars,
-        diff⁺::Vars,
-        aux⁺::Vars,
-        n̂,
-        state⁻::Vars,
-        diff⁻::Vars,
-        aux⁻::Vars,
-        t,
-    )
-
-Specify Neumann boundary conditions for the bottom of the soil, if given.
-"""
-function bottom_boundary_conditions!(
-    land::LandModel,
-    soil::SoilModel,
-    heat::SoilHeatModel,
-    bc::Neumann,
-    state⁺::Vars,
-    diff⁺::Vars,
-    aux⁺::Vars,
-    n̂,
-    state⁻::Vars,
-    diff⁻::Vars,
-    aux⁻::Vars,
-    t,
-)
-    if bc.bottom_flux != nothing
-        # two minus signs - the flux is minus κ∇T, and n̂ is -ẑ at the
-        # bottom of the domain.
-        diff⁺.soil.heat.κ∇T = -n̂ * (-bc.bottom_flux(aux⁻, t))
-    else
-        nothing
-    end
-end
-
-
-"""
-    bottom_boundary_conditions!(
-        land::LandModel,
-        soil::SoilModel,
-        heat::SoilHeatModel,
-        bc::Dirichlet,
-        state⁺::Vars,
-        aux⁺::Vars,
-        state⁻::Vars,
-        aux⁻::Vars,
-        t,
-    )
-
-Specify Dirichlet boundary conditions for the bottom of the soil, if given.
-"""
-function bottom_boundary_conditions!(
-    land::LandModel,
-    soil::SoilModel,
-    heat::SoilHeatModel,
-    bc::Dirichlet,
-    state⁺::Vars,
-    aux⁺::Vars,
-    state⁻::Vars,
-    aux⁻::Vars,
-    t,
-)
-    if bc.bottom_state != nothing
-        ϑ_l, θ_i = get_water_content(land.soil.water, aux⁻, state⁻, t)
-        eff_porosity = land.soil.param_functions.porosity - θ_i
-        θ_l = volumetric_liquid_fraction(ϑ_l, eff_porosity)
-        ρc_s = volumetric_heat_capacity(
-            θ_l,
-            θ_i,
-            land.soil.param_functions.ρc_ds,
-            land.param_set,
-        )
-
-        ρe_int_bc = volumetric_internal_energy(
-            θ_i,
-            ρc_s,
-            bc.bottom_state(aux⁻, t),
-            land.param_set,
-        )
-
-        state⁺.soil.heat.ρe_int = ρe_int_bc
-    else
-        nothing
+    bc = boundaries.neumann_bc
+    if bctype == 2
+        if bc.surface_flux != nothing
+            # Again, the flux is -κ∇T
+            diff⁺.soil.heat.κ∇T = n̂ * (-bc.surface_flux(aux⁻, t))
+        else
+            nothing
+        end
+    elseif bctype == 1
+        if bc.bottom_flux != nothing
+            # two minus signs - the flux is minus κ∇T, and n̂ is -ẑ at the
+            # bottom of the domain.
+            diff⁺.soil.heat.κ∇T = -n̂ * (-bc.bottom_flux(aux⁻, t))
+        else
+            nothing
+        end
     end
 end

--- a/src/Land/Model/soil_boundary_types.jl
+++ b/src/Land/Model/soil_boundary_types.jl
@@ -1,0 +1,129 @@
+export Dirichlet,
+    Neumann, GeneralBoundaryConditions, SurfaceDrivenWaterBoundaryConditions
+
+abstract type AbstractBoundaryFunctions end
+
+"""
+    struct Dirichlet{Fs, Fb} <: AbstractBoundaryFunctions
+
+A concrete type to hold the surface state and bottom state variable 
+values/functions, if Dirichlet boundary conditions are desired.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct Dirichlet{Fs, Fb} <: AbstractBoundaryFunctions
+    "Surface state boundary condition"
+    surface_state::Fs = nothing
+    "Bottom state boundary condition"
+    bottom_state::Fb = nothing
+end
+
+"""
+    struct Neumann{Fs, Fb} <: AbstractBoundaryFunctions
+
+A concrete type to hold the surface and/or bottom diffusive flux 
+values/functions, if Neumann boundary conditions are desired.
+
+Note that these are intended to be scalar values. In the boundary_state!
+functions, they are multiplied by the `ẑ` vector (i.e. the normal vector `n̂`
+to the domain at the upper boundary, and -`n̂` at the lower boundary. These
+normal vectors point out of the domain.)
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct Neumann{Fs, Fb} <: AbstractBoundaryFunctions
+    "Surface flux boundary condition"
+    surface_flux::Fs = nothing
+    "Bottom flux boundary condition"
+    bottom_flux::Fb = nothing
+end
+
+
+
+"""
+   AbstractBoundaryConditions 
+"""
+abstract type AbstractBoundaryConditions end
+
+
+"""
+    GeneralBoundaryConditions{D, N} <: AbstractBoundaryConditions
+
+A concrete example of the abstract type `AbstractBoundaryConditions`; to be used
+when the user wishes to supply specific functions of space and time for
+boundary conditions, at either the top or bottom of the domain, and either
+of type Neumann or Dirichlet.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct GeneralBoundaryConditions{D, N} <: AbstractBoundaryConditions
+    "Place to store Dirichlet Boundary conditions"
+    dirichlet_bc::D
+    "Place to store Neumann Boundary conditions"
+    neumann_bc::N
+end
+
+
+"""
+    GeneralBoundaryConditions(
+        dirichlet_bc::AbstractBoundaryFunctions = Dirichlet(),
+        neumann_bc::AbstractBoundaryFunctions = Neumann(),
+    )
+
+Constructor for the GeneralBoundaryConditions object. The default
+is `nothing` boundary functions for the top and bottom of the domain,
+for both Dirichlet and Neumann types. The user must change these in order
+to apply boundary conditions.
+"""
+function GeneralBoundaryConditions(
+    dirichlet_bc::AbstractBoundaryFunctions = Dirichlet(),
+    neumann_bc::AbstractBoundaryFunctions = Neumann(),
+)
+    args = (dirichlet_bc, neumann_bc)
+    return GeneralBoundaryConditions{typeof.(args)...}(args...)
+end
+
+
+
+"""
+    SurfaceDrivenWaterBoundaryConditions{FT, PD, RD} <: AbstractBoundaryConditions
+
+A concrete example of AbstractBoundaryConditions; this is to be used when the user wishes to 
+apply physical fluxes of water at the top of the domain (according to precipitation, runoff, and 
+evaporation rates) and zero flux at the bottom of the domain.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct SurfaceDrivenWaterBoundaryConditions{FT, PD, RD} <:
+       AbstractBoundaryConditions where {FT, PD, RD}
+    "Precipitation model"
+    precip_model::PD
+    "Runoff model"
+    runoff_model::RD
+end
+
+
+"""
+    SurfaceDrivenWaterBoundaryConditions(
+        ::Type{FT};
+        precip_model::AbstractPrecipModel{FT} = DrivenConstantPrecip{FT}(),
+        runoff_model::AbstractSurfaceRunoffModel{FT} = NoRunoff(),
+    ) where {FT}
+
+Constructor for the SurfaceDrivenWaterBoundaryConditions object. The default
+is a constant precipitation rate on the subgrid scale, and no runoff.
+"""
+function SurfaceDrivenWaterBoundaryConditions(
+    ::Type{FT};
+    precip_model::AbstractPrecipModel{FT} = DrivenConstantPrecip{FT}(
+        (t) -> (0.0),
+    ),
+    runoff_model::AbstractSurfaceRunoffModel = NoRunoff(),
+) where {FT}
+    args = (precip_model, runoff_model)
+    return SurfaceDrivenWaterBoundaryConditions{FT, typeof.(args)...}(args...)
+end

--- a/src/Land/Model/soil_heat.jl
+++ b/src/Land/Model/soil_heat.jl
@@ -29,26 +29,23 @@ function PrescribedTemperatureModel(T::Function = (aux, t) -> eltype(aux)(0.0))
 end
 
 """
-    SoilHeatModel{FT, FiT, BCD, BCN} <: AbstractHeatModel
+    SoilHeatModel{FT, FiT, BCT} <: AbstractHeatModel
 The necessary components for the Heat Equation in a soil water matrix.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct SoilHeatModel{FT, FiT, BCD, BCN} <: AbstractHeatModel
+struct SoilHeatModel{FT, FiT, BCT} <: AbstractHeatModel
     "Initial conditions for temperature"
     initialT::FiT
-    "Dirichlet BC structure"
-    dirichlet_bc::BCD
-    "Neumann BC structure"
-    neumann_bc::BCN
+    "Boundary Condition Type"
+    boundaries::BCT
 end
 
 """
     SoilHeatModel(
         ::Type{FT};
         initialT::FT = FT(NaN),
-        dirichlet_bc::AbstractBoundaryFunctions = Dirichlet(),
-        neumann_bc::AbstractBoundaryFunctions = Neumann(),
+        boundaries::AbstractBoundaryConditions,
     ) where {FT}
 
 Constructor for the SoilHeatModel.
@@ -56,10 +53,9 @@ Constructor for the SoilHeatModel.
 function SoilHeatModel(
     ::Type{FT};
     initialT = (aux) -> FT(NaN),
-    dirichlet_bc::AbstractBoundaryFunctions = Dirichlet(),
-    neumann_bc::AbstractBoundaryFunctions = Neumann(),
+    boundaries::AbstractBoundaryConditions,
 ) where {FT}
-    args = (initialT, dirichlet_bc, neumann_bc)
+    args = (initialT, boundaries)
     return SoilHeatModel{FT, typeof.(args)...}(args...)
 end
 

--- a/src/Land/Model/soil_water.jl
+++ b/src/Land/Model/soil_water.jl
@@ -45,7 +45,7 @@ function PrescribedWaterModel(
 end
 
 """
-    SoilWaterModel{FT, IF, VF, MF, HM, Fiϑl, Fiθi, BCD, BCN} <: AbstractWaterModel
+    SoilWaterModel{FT, IF, VF, MF, HM, Fiϑl, Fiθi, BCT} <: AbstractWaterModel
 
 The necessary components for solving the equations for water (liquid or ice) in soil. 
 
@@ -61,8 +61,7 @@ liquid and ice form, and water content is conserved upon phase change.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct SoilWaterModel{FT, IF, VF, MF, HM, Fiϑl, Fiθi, BCD, BCN} <:
-       AbstractWaterModel
+struct SoilWaterModel{FT, IF, VF, MF, HM, Fiϑl, Fiθi, BCT} <: AbstractWaterModel
     "Impedance Factor - will be 1 or ice dependent"
     impedance_factor::IF
     "Viscosity Factor - will be 1 or temperature dependent"
@@ -75,10 +74,8 @@ struct SoilWaterModel{FT, IF, VF, MF, HM, Fiϑl, Fiθi, BCD, BCN} <:
     initialϑ_l::Fiϑl
     "Initial condition: volumetric ice fraction"
     initialθ_i::Fiθi
-    "Dirichlet boundary condition structure"
-    dirichlet_bc::BCD
-    "Neumann boundary condition  structure"
-    neumann_bc::BCN
+    "Boundary Condition Type"
+    boundaries::BCT
 end
 
 """
@@ -90,8 +87,7 @@ end
         hydraulics::AbstractHydraulicsModel{FT} = vanGenuchten{FT}(),
         initialϑ_l = (aux) -> FT(NaN),
         initialθ_i = (aux) -> FT(0.0),
-        dirichlet_bc::AbstractBoundaryFunctions = Dirichlet(),
-        neumann_bc::AbstractBoundaryFunctions = Neumann(),
+        boundaries::AbstractBoundaryConditions,
     ) where {FT}
 
 Constructor for the SoilWaterModel. Defaults imply a constant K = K_sat model.
@@ -104,8 +100,7 @@ function SoilWaterModel(
     hydraulics::AbstractHydraulicsModel{FT} = vanGenuchten{FT}(),
     initialϑ_l::Function = (aux) -> eltype(aux)(NaN),
     initialθ_i::Function = (aux) -> eltype(aux)(0.0),
-    dirichlet_bc::AbstractBoundaryFunctions = Dirichlet(),
-    neumann_bc::AbstractBoundaryFunctions = Neumann(),
+    boundaries::AbstractBoundaryConditions,
 ) where {FT}
     args = (
         impedance_factor,
@@ -114,8 +109,7 @@ function SoilWaterModel(
         hydraulics,
         initialϑ_l,
         initialθ_i,
-        dirichlet_bc,
-        neumann_bc,
+        boundaries,
     )
     return SoilWaterModel{FT, typeof.(args)...}(args...)
 end

--- a/test/Land/Model/freeze_thaw_alone.jl
+++ b/test/Land/Model/freeze_thaw_alone.jl
@@ -85,6 +85,11 @@ using ClimateMachine.BalanceLaws:
     surface_flux = (aux, t) -> eltype(aux)(0.0)
     surface_state = nothing
     bottom_state = nothing
+
+    bc = GeneralBoundaryConditions(
+        Dirichlet(surface_state = surface_state, bottom_state = bottom_state),
+        Neumann(surface_flux = surface_flux, bottom_flux = bottom_flux),
+    )
     ϑ_l0 = (aux) -> eltype(aux)(1e-10)
     θ_i0 = (aux) -> eltype(aux)(0.33)
 
@@ -92,14 +97,7 @@ using ClimateMachine.BalanceLaws:
         FT;
         initialϑ_l = ϑ_l0,
         initialθ_i = θ_i0,
-        dirichlet_bc = Dirichlet(
-            surface_state = surface_state,
-            bottom_state = bottom_state,
-        ),
-        neumann_bc = Neumann(
-            surface_flux = surface_flux,
-            bottom_flux = bottom_flux,
-        ),
+        boundaries = bc,
     )
 
     soil_heat_model =

--- a/test/Land/Model/haverkamp_implicit_test.jl
+++ b/test/Land/Model/haverkamp_implicit_test.jl
@@ -69,16 +69,16 @@ haverkamp_dataset_path = get_data_folder(haverkamp_dataset)
     bottom_flux = (aux, t) -> aux.soil.water.K * bottom_flux_multiplier
     ϑ_l0 = (aux) -> initial_moisture
 
+    bc = GeneralBoundaryConditions(
+        Dirichlet(surface_state = surface_state, bottom_state = nothing),
+        Neumann(surface_flux = nothing, bottom_flux = bottom_flux),
+    )
     soil_water_model = SoilWaterModel(
         FT;
         moisture_factor = MoistureDependent{FT}(),
         hydraulics = Haverkamp{FT}(),
         initialϑ_l = ϑ_l0,
-        dirichlet_bc = Dirichlet(
-            surface_state = surface_state,
-            bottom_state = nothing,
-        ),
-        neumann_bc = Neumann(surface_flux = nothing, bottom_flux = bottom_flux),
+        boundaries = bc,
     )
 
     m_soil = SoilModel(soil_param_functions, soil_water_model, soil_heat_model)

--- a/test/Land/Model/haverkamp_test.jl
+++ b/test/Land/Model/haverkamp_test.jl
@@ -68,16 +68,17 @@ haverkamp_dataset_path = get_data_folder(haverkamp_dataset)
     bottom_flux = (aux, t) -> aux.soil.water.K * eltype(aux)(-1)
     ϑ_l0 = (aux) -> eltype(aux)(0.24)
 
+    bc = GeneralBoundaryConditions(
+        Dirichlet(surface_state = surface_state, bottom_state = nothing),
+        Neumann(surface_flux = nothing, bottom_flux = bottom_flux),
+    )
+
     soil_water_model = SoilWaterModel(
         FT;
         moisture_factor = MoistureDependent{FT}(),
         hydraulics = Haverkamp{FT}(),
         initialϑ_l = ϑ_l0,
-        dirichlet_bc = Dirichlet(
-            surface_state = surface_state,
-            bottom_state = nothing,
-        ),
-        neumann_bc = Neumann(surface_flux = nothing, bottom_flux = bottom_flux),
+        boundaries = bc,
     )
 
     m_soil = SoilModel(soil_param_functions, soil_water_model, soil_heat_model)

--- a/test/Land/Model/heat_analytic_unit_test.jl
+++ b/test/Land/Model/heat_analytic_unit_test.jl
@@ -76,15 +76,15 @@ const FT = Float32
         (aux, t) -> eltype(aux)(0.0),
     )
 
-    soil_heat_model = SoilHeatModel(
-        FT;
-        initialT = T_init,
-        dirichlet_bc = Dirichlet(
+    bc = GeneralBoundaryConditions(
+        Dirichlet(
             surface_state = heat_surface_state,
             bottom_state = heat_bottom_state,
         ),
-        neumann_bc = Neumann(surface_flux = nothing, bottom_flux = nothing),
+        Neumann(surface_flux = nothing, bottom_flux = nothing),
     )
+
+    soil_heat_model = SoilHeatModel(FT; initialT = T_init, boundaries = bc)
 
     m_soil = SoilModel(soil_param_functions, soil_water_model, soil_heat_model)
     sources = ()

--- a/test/Land/Model/runtests.jl
+++ b/test/Land/Model/runtests.jl
@@ -4,4 +4,5 @@ using Test, Pkg
     include("test_water_parameterizations.jl")
     include("prescribed_twice.jl")
     include("freeze_thaw_alone.jl")
+    include("test_runoff_functions.jl")
 end

--- a/test/Land/Model/test_bc.jl
+++ b/test/Land/Model/test_bc.jl
@@ -47,18 +47,12 @@ using ClimateMachine.BalanceLaws:
     surface_state = (aux, t) -> eltype(aux)(0.2)
     bottom_state = nothing
     ϑ_l0 = (aux) -> eltype(aux)(0.2)
-    soil_water_model = SoilWaterModel(
-        FT;
-        initialϑ_l = ϑ_l0,
-        dirichlet_bc = Dirichlet(
-            surface_state = surface_state,
-            bottom_state = bottom_state,
-        ),
-        neumann_bc = Neumann(
-            surface_flux = surface_flux,
-            bottom_flux = bottom_flux,
-        ),
+    bc = GeneralBoundaryConditions(
+        Dirichlet(surface_state = surface_state, bottom_state = bottom_state),
+        Neumann(surface_flux = surface_flux, bottom_flux = bottom_flux),
     )
+
+    soil_water_model = SoilWaterModel(FT; initialϑ_l = ϑ_l0, boundaries = bc)
     soil_heat_model = PrescribedTemperatureModel()
 
     m_soil = SoilModel(soil_param_functions, soil_water_model, soil_heat_model)

--- a/test/Land/Model/test_runoff_functions.jl
+++ b/test/Land/Model/test_runoff_functions.jl
@@ -1,0 +1,43 @@
+# Test functions used in runoff modeling.
+using MPI
+using OrderedCollections
+using StaticArrays
+using Test
+
+using CLIMAParameters
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using ClimateMachine
+using ClimateMachine.Land.Runoff
+using ClimateMachine.VariableTemplates
+
+
+@testset "Runoff testing" begin
+    F = Float32
+    runoff_model = NoRunoff()
+    precip_model = DrivenConstantPrecip{F}((t) -> (2 * t))
+    struct RunoffTestModel end
+
+    function state(m::RunoffTestModel, T)
+        @vars begin
+            θ_i::T
+            ϑ_l::T
+        end
+    end
+
+    model = RunoffTestModel()
+
+    st = state(model, F)
+    v = Vars{st}(zeros(MVector{varsize(st), F}))
+
+    flux_bc =
+        compute_surface_flux.(
+            Ref(runoff_model),
+            Ref(precip_model),
+            Ref(v),
+            [1, 2, 3, 4],
+        )
+    @test flux_bc ≈ F.([-2, -4, -6, -8])
+    @test eltype(flux_bc) == F
+end

--- a/tutorials/Land/Soil/Coupled/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Coupled/equilibrium_test.jl
@@ -240,7 +240,14 @@ end;
 surface_water_flux = (aux, t) -> eltype(aux)(0.0)
 bottom_water_flux = (aux, t) -> eltype(aux)(0.0)
 surface_water_state = nothing
-bottom_water_state = nothing;
+bottom_water_state = nothing
+water_bc = GeneralBoundaryConditions(
+    Dirichlet(
+        surface_state = surface_water_state,
+        bottom_state = bottom_water_state,
+    ),
+    Neumann(surface_flux = surface_water_flux, bottom_flux = bottom_water_flux),
+);
 
 # As we are not including the equations for phase changes in this tutorial,
 # we chose temperatures that are above the freezing point of water.
@@ -249,7 +256,14 @@ bottom_water_state = nothing;
 surface_heat_flux = (aux, t) -> eltype(aux)(0.0)
 bottom_heat_flux = (aux, t) -> eltype(aux)(0.0)
 surface_heat_state = nothing
-bottom_heat_state = nothing;
+bottom_heat_state = nothing
+heat_bc = GeneralBoundaryConditions(
+    Dirichlet(
+        surface_state = surface_heat_state,
+        bottom_state = bottom_heat_state,
+    ),
+    Neumann(surface_flux = surface_heat_flux, bottom_flux = bottom_heat_flux),
+);
 
 
 # Next, we define the required `init_soil!` function, which takes the user
@@ -285,14 +299,7 @@ soil_water_model = SoilWaterModel(
     moisture_factor = MoistureDependent{FT}(),
     hydraulics = vanGenuchten{FT}(α = vg_α, n = vg_n),
     initialϑ_l = ϑ_l0,
-    dirichlet_bc = Dirichlet(
-        surface_state = surface_water_state,
-        bottom_state = bottom_water_state,
-    ),
-    neumann_bc = Neumann(
-        surface_flux = surface_water_flux,
-        bottom_flux = bottom_water_flux,
-    ),
+    boundaries = water_bc,
 );
 
 
@@ -307,18 +314,7 @@ soil_water_model = SoilWaterModel(
 # tutorial.
 
 # Repeat for heat:
-soil_heat_model = SoilHeatModel(
-    FT;
-    initialT = T_init,
-    dirichlet_bc = Dirichlet(
-        surface_state = surface_heat_state,
-        bottom_state = bottom_heat_state,
-    ),
-    neumann_bc = Neumann(
-        surface_flux = surface_heat_flux,
-        bottom_flux = bottom_heat_flux,
-    ),
-);
+soil_heat_model = SoilHeatModel(FT; initialT = T_init, boundaries = heat_bc);
 
 
 # Combine into a single soil model:

--- a/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
+++ b/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
@@ -306,19 +306,12 @@ soil_water_model = PrescribedWaterModel(
 # to indicate that they do not want to supply a boundary condition of that type.
 # For example, below we indicate that we are applying (and supplying!) a Dirichlet
 # condition at the top of the domain, and a Neumann condition at the bottom.
+bc = GeneralBoundaryConditions(
+    Dirichlet(surface_state = heat_surface_state, bottom_state = nothing),
+    Neumann(surface_flux = nothing, bottom_flux = heat_bottom_flux),
+)
 
-soil_heat_model = SoilHeatModel(
-    FT;
-    initialT = T_init,
-    dirichlet_bc = Dirichlet(
-        surface_state = heat_surface_state,
-        bottom_state = nothing,
-    ),
-    neumann_bc = Neumann(
-        surface_flux = nothing,
-        bottom_flux = heat_bottom_flux,
-    ),
-);
+soil_heat_model = SoilHeatModel(FT; initialT = T_init, boundaries = bc);
 
 # The full soil model requires a heat model and a water model, as well as the
 # soil parameter functions:

--- a/tutorials/Land/Soil/Water/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Water/equilibrium_test.jl
@@ -142,6 +142,10 @@ surface_flux = (aux, t) -> eltype(aux)(0.0)
 bottom_flux = (aux, t) -> eltype(aux)(0.0)
 surface_state = nothing
 bottom_state = nothing
+bc = GeneralBoundaryConditions(
+    Dirichlet(surface_state = surface_state, bottom_state = bottom_state),
+    Neumann(surface_flux = surface_flux, bottom_flux = bottom_flux),
+)
 
 # Define the initial state function. The default for `θ_i` is zero.
 ϑ_l0 = (aux) -> eltype(aux)(0.494);
@@ -157,14 +161,7 @@ soil_water_model = SoilWaterModel(
     moisture_factor = MoistureDependent{FT}(),
     hydraulics = vanGenuchten{FT}(n = 2.0),
     initialϑ_l = ϑ_l0,
-    dirichlet_bc = Dirichlet(
-        surface_state = surface_state,
-        bottom_state = bottom_state,
-    ),
-    neumann_bc = Neumann(
-        surface_flux = surface_flux,
-        bottom_flux = bottom_flux,
-    ),
+    boundaries = bc,
 );
 
 # Create the soil model - the coupled soil water and soil heat models.


### PR DESCRIPTION
### Description
This updates how we handle the soil boundary conditions. Previously, we had in place functionality so that the user could provide arbitrary boundary conditions - either Neumann or Dirichlet, at the top or at the bottom of the domain. This was useful for comparing with textbook examples, for simple sanity checks, and for comparing to lab experiments. These conditions were supplied as functions of space and time.

Moving forwards, however, we need to also handle boundary conditions that are a function of state, that can handle different models for runoff, evaporation, etc. These would be boundary conditions used in comparing with field data, for example.
In this case, the boundary conditions are more structured and are now physically motivated functions at the top and bottom of the domain. They would not be simple functions the user specifies at at driver level, but rather correspond to a particular class of boundary conditions (that the user would opt to use at the driver level).

To account for this, we added a layer of methods that dispatch on AbstractBoundaryConditions - either GeneralBoundaryConditions, which executes something like what we had in place already, or e.g. PhysicalFluxBoundaryConditions, which employ zero flux at the bottom of the domain and could account for precipitation and runoff in the flux for water at the top of the domain. For now, this 2nd option only exists for the SoilWaterModel. Adding it for the heat model can come later.

All tutorials and integration tests have been updated to reflect the change.

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
