### PR TITLE
VTK support for multiple polynomial orders

### DIFF
--- a/src/InputOutput/VTK/writemesh.jl
+++ b/src/InputOutput/VTK/writemesh.jl
@@ -1,6 +1,6 @@
 using WriteVTK
 
-function vtk_connectivity_map(Nqi, Nqj = 1, Nqk = 1)
+function vtk_connectivity_map_highorder(Nqi, Nqj = 1, Nqk = 1)
     connectivity = Array{Int, 1}(undef, Nqi * Nqj * Nqk)
     L = LinearIndices((1:Nqi, 1:Nqj, 1:Nqk))
 
@@ -80,7 +80,7 @@ end
 #=
 This is the 1D WriteMesh routine
 =#
-function writemesh(
+function writemesh_highorder(
     base_name,
     x1;
     x2 = nothing,
@@ -90,7 +90,7 @@ function writemesh(
 )
     (Nqr, _) = size(x1)
 
-    con = vtk_connectivity_map(Nqr)
+    con = vtk_connectivity_map_highorder(Nqr)
 
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
     cells = Array{M, 1}(undef, length(realelems))
@@ -131,7 +131,7 @@ end
 #=
 This is the 2D WriteMesh routine
 =#
-function writemesh(
+function writemesh_highorder(
     base_name,
     x1,
     x2;
@@ -142,7 +142,7 @@ function writemesh(
     @assert size(x1) == size(x2)
     (Nqr, Nqs, _) = size(x1)
     @assert Nqr == Nqs
-    con = vtk_connectivity_map(Nqr, Nqs)
+    con = vtk_connectivity_map_highorder(Nqr, Nqs)
 
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
     cells = Array{M, 1}(undef, length(realelems))
@@ -179,7 +179,7 @@ end
 #=
 This is the 3D WriteMesh routine
 =#
-function writemesh(
+function writemesh_highorder(
     base_name,
     x1,
     x2,
@@ -189,7 +189,7 @@ function writemesh(
 )
     (Nqr, Nqs, Nqt, _) = size(x1)
     @assert Nqr == Nqs == Nqt
-    con = vtk_connectivity_map(Nqr, Nqs, Nqt)
+    con = vtk_connectivity_map_highorder(Nqr, Nqs, Nqt)
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
     cells = Array{M, 1}(undef, length(realelems))
     for (i, e) in enumerate(realelems)

--- a/src/InputOutput/VTK/writemesh.jl
+++ b/src/InputOutput/VTK/writemesh.jl
@@ -1,49 +1,49 @@
 using WriteVTK
 
-function vtk_connectivity_map_highorder(Nqi, Nqj = 1, Nqk = 1)
-    connectivity = Array{Int, 1}(undef, Nqi * Nqj * Nqk)
-    L = LinearIndices((1:Nqi, 1:Nqj, 1:Nqk))
+function vtk_connectivity_map_highorder(Nq1, Nq2 = 1, Nq3 = 1)
+    connectivity = Array{Int, 1}(undef, Nq1 * Nq2 * Nq3)
+    L = LinearIndices((1:Nq1, 1:Nq2, 1:Nq3))
 
     corners = (
         (1, 1, 1),
-        (Nqi, 1, 1),
-        (Nqi, Nqj, 1),
-        (1, Nqj, 1),
-        (1, 1, Nqk),
-        (Nqi, 1, Nqk),
-        (Nqi, Nqj, Nqk),
-        (1, Nqj, Nqk),
+        (Nq1, 1, 1),
+        (Nq1, Nq2, 1),
+        (1, Nq2, 1),
+        (1, 1, Nq3),
+        (Nq1, 1, Nq3),
+        (Nq1, Nq2, Nq3),
+        (1, Nq2, Nq3),
     )
     edges = (
-        (2:(Nqi - 1), 1:1, 1:1),
-        (Nqi:Nqi, 2:(Nqj - 1), 1:1),
-        (2:(Nqi - 1), Nqj:Nqj, 1:1),
-        (1:1, 2:(Nqj - 1), 1:1, 1:1),
-        (2:(Nqi - 1), 1:1, Nqk:Nqk),
-        (Nqi:Nqi, 2:(Nqj - 1), Nqk:Nqk),
-        (2:(Nqi - 1), Nqj:Nqj, Nqk:Nqk),
-        (1:1, 2:(Nqj - 1), Nqk:Nqk),
-        (1:1, 1:1, 2:(Nqk - 1)),
-        (Nqi:Nqi, 1:1, 2:(Nqk - 1)),
-        (1:1, Nqj:Nqj, 2:(Nqk - 1)),
-        (Nqi:Nqi, Nqj:Nqj, 2:(Nqk - 1)),
+        (2:(Nq1 - 1), 1:1, 1:1),
+        (Nq1:Nq1, 2:(Nq2 - 1), 1:1),
+        (2:(Nq1 - 1), Nq2:Nq2, 1:1),
+        (1:1, 2:(Nq2 - 1), 1:1, 1:1),
+        (2:(Nq1 - 1), 1:1, Nq3:Nq3),
+        (Nq1:Nq1, 2:(Nq2 - 1), Nq3:Nq3),
+        (2:(Nq1 - 1), Nq2:Nq2, Nq3:Nq3),
+        (1:1, 2:(Nq2 - 1), Nq3:Nq3),
+        (1:1, 1:1, 2:(Nq3 - 1)),
+        (Nq1:Nq1, 1:1, 2:(Nq3 - 1)),
+        (1:1, Nq2:Nq2, 2:(Nq3 - 1)),
+        (Nq1:Nq1, Nq2:Nq2, 2:(Nq3 - 1)),
     )
     faces = (
-        (1:1, 2:(Nqj - 1), 2:(Nqk - 1)),
-        (Nqi:Nqi, 2:(Nqj - 1), 2:(Nqk - 1)),
-        (2:(Nqi - 1), 1:1, 2:(Nqk - 1)),
-        (2:(Nqi - 1), Nqj:Nqj, 2:(Nqk - 1)),
-        (2:(Nqi - 1), 2:(Nqj - 1), 1:1),
-        (2:(Nqi - 1), 2:(Nqj - 1), Nqk:Nqk),
+        (1:1, 2:(Nq2 - 1), 2:(Nq3 - 1)),
+        (Nq1:Nq1, 2:(Nq2 - 1), 2:(Nq3 - 1)),
+        (2:(Nq1 - 1), 1:1, 2:(Nq3 - 1)),
+        (2:(Nq1 - 1), Nq2:Nq2, 2:(Nq3 - 1)),
+        (2:(Nq1 - 1), 2:(Nq2 - 1), 1:1),
+        (2:(Nq1 - 1), 2:(Nq2 - 1), Nq3:Nq3),
     )
-    if Nqj == Nqk == 1
-        @assert Nqi > 1
+    if Nq2 == Nq3 == 1
+        @assert Nq1 > 1
         corners = (corners[1:2]...,)
         edges = (edges[1],)
         faces = ()
-    elseif Nqk == 1
-        @assert Nqi > 1
-        @assert Nqj > 1
+    elseif Nq3 == 1
+        @assert Nq1 > 1
+        @assert Nq2 > 1
         corners = (corners[1:4]...,)
         edges = (edges[1:4]...,)
         faces = (faces[5],)
@@ -70,7 +70,7 @@ function vtk_connectivity_map_highorder(Nqi, Nqj = 1, Nqk = 1)
         end
     end
     # interior
-    for k in 2:(Nqk - 1), j in 2:(Nqj - 1), i in 2:(Nqi - 1)
+    for k in 2:(Nq3 - 1), j in 2:(Nq2 - 1), i in 2:(Nq1 - 1)
         connectivity[iter] = L[i, j, k]
         iter += 1
     end
@@ -88,15 +88,15 @@ function writemesh_highorder(
     fields = (),
     realelems = 1:size(x1)[end],
 )
-    (Nqr, _) = size(x1)
+    (Nq1, _) = size(x1)
 
-    con = vtk_connectivity_map_highorder(Nqr)
+    con = vtk_connectivity_map_highorder(Nq1)
 
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
     cells = Array{M, 1}(undef, length(realelems))
 
     for (i, e) in enumerate(realelems)
-        offset = (e - 1) * Nqr
+        offset = (e - 1) * Nq1
         cells[i] = MeshCell(VTKCellTypes.VTK_LAGRANGE_CURVE, offset .+ con)
     end
 
@@ -140,14 +140,14 @@ function writemesh_highorder(
     realelems = 1:size(x1)[end],
 )
     @assert size(x1) == size(x2)
-    (Nqr, Nqs, _) = size(x1)
-    @assert Nqr == Nqs
-    con = vtk_connectivity_map_highorder(Nqr, Nqs)
+    (Nq1, Nq2, _) = size(x1)
+    @assert Nq1 == Nq2
+    con = vtk_connectivity_map_highorder(Nq1, Nq2)
 
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
     cells = Array{M, 1}(undef, length(realelems))
     for (i, e) in enumerate(realelems)
-        offset = (e - 1) * Nqr * Nqs
+        offset = (e - 1) * Nq1 * Nq2
         cells[i] =
             MeshCell(VTKCellTypes.VTK_LAGRANGE_QUADRILATERAL, offset .+ con[:])
     end
@@ -187,13 +187,13 @@ function writemesh_highorder(
     fields = (),
     realelems = 1:size(x1)[end],
 )
-    (Nqr, Nqs, Nqt, _) = size(x1)
-    @assert Nqr == Nqs == Nqt
-    con = vtk_connectivity_map_highorder(Nqr, Nqs, Nqt)
+    (Nq1, Nq2, Nq3, _) = size(x1)
+    @assert Nq1 == Nq2 == Nq3
+    con = vtk_connectivity_map_highorder(Nq1, Nq2, Nq3)
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
     cells = Array{M, 1}(undef, length(realelems))
     for (i, e) in enumerate(realelems)
-        offset = (e - 1) * Nqr * Nqs * Nqt
+        offset = (e - 1) * Nq1 * Nq2 * Nq3
         cells[i] = MeshCell(VTKCellTypes.VTK_LAGRANGE_HEXAHEDRON, offset .+ con)
     end
 
@@ -214,18 +214,22 @@ end
 #=
 This is the 1D WriteMesh routine
 =#
-function writemesh_raw(base_name, x1;
+function writemesh_raw(
+    base_name,
+    x1;
     x2 = nothing,
     x3 = nothing,
-                       fields = (), realelems = 1:size(x1)[end])
-    (Nqr, _) = size(x1)
-    Nsubcells = (Nqr - 1)
+    fields = (),
+    realelems = 1:size(x1)[end],
+)
+    (Nq1, _) = size(x1)
+    Nsubcells = (Nq1 - 1)
 
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
     cells = Array{M, 1}(undef, Nsubcells * length(realelems))
     for e in realelems
-        offset = (e - 1) * Nqr
-        for i in 1:(Nqr - 1)
+        offset = (e - 1) * Nq1
+        for i in 1:(Nq1 - 1)
             cells[i + (e - 1) * Nsubcells] =
                 MeshCell(VTKCellTypes.VTK_LINE, offset .+ [i, i + 1])
         end
@@ -250,17 +254,17 @@ function writemesh_raw(
     realelems = 1:size(x1)[end],
 )
     @assert size(x1) == size(x2)
-    (Nqr, Nqs, _) = size(x1)
-    Nsubcells = (Nqr - 1) * (Nqs - 1)
+    (Nq1, Nq2, _) = size(x1)
+    Nsubcells = (Nq1 - 1) * (Nq2 - 1)
 
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
     cells = Array{M, 1}(undef, Nsubcells * length(realelems))
-    ind = LinearIndices((1:Nqr, 1:Nqs))
+    ind = LinearIndices((1:Nq1, 1:Nq2))
     for e in realelems
-        offset = (e - 1) * Nqr * Nqs
-        for j in 1:(Nqs - 1)
-            for i in 1:(Nqr - 1)
-                cells[i + (j - 1) * (Nqr - 1) + (e - 1) * Nsubcells] = MeshCell(
+        offset = (e - 1) * Nq1 * Nq2
+        for j in 1:(Nq2 - 1)
+            for i in 1:(Nq1 - 1)
+                cells[i + (j - 1) * (Nq1 - 1) + (e - 1) * Nsubcells] = MeshCell(
                     VTKCellTypes.VTK_PIXEL,
                     offset .+ ind[i:(i + 1), j:(j + 1)][:],
                 )
@@ -303,19 +307,19 @@ function writemesh_raw(
     fields = (),
     realelems = 1:size(x1)[end],
 )
-    (Nqr, Nqs, Nqt, _) = size(x1)
-    (Nr, Ns, Nt) = (Nqr - 1, Nqs - 1, Nqt - 1)
-    Nsubcells = Nr * Ns * Nt
+    (Nq1, Nq2, Nq3, _) = size(x1)
+    (N1, N2, N3) = (Nq1 - 1, Nq2 - 1, Nq3 - 1)
+    Nsubcells = N1 * N2 * N3
 
     M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
     cells = Array{M, 1}(undef, Nsubcells * length(realelems))
-    ind = LinearIndices((1:Nqr, 1:Nqs, 1:Nqt))
+    ind = LinearIndices((1:Nq1, 1:Nq2, 1:Nq3))
     for e in realelems
-        offset = (e - 1) * Nqr * Nqs * Nqt
-        for k in 1:Nt
-            for j in 1:Ns
-                for i in 1:Nr
-                    cells[i + (j - 1) * Nr + (k - 1) * Nr * Ns + (e - 1) * Nsubcells] =
+        offset = (e - 1) * Nq1 * Nq2 * Nq3
+        for k in 1:N3
+            for j in 1:N2
+                for i in 1:N1
+                    cells[i + (j - 1) * N1 + (k - 1) * N1 * N2 + (e - 1) * Nsubcells] =
                         MeshCell(
                             VTKCellTypes.VTK_VOXEL,
                             offset .+ ind[i:(i + 1), j:(j + 1), k:(k + 1)][:],

--- a/src/InputOutput/VTK/writemesh.jl
+++ b/src/InputOutput/VTK/writemesh.jl
@@ -210,3 +210,131 @@ function writemesh_highorder(
     end
     outfiles = vtk_save(vtkfile)
 end
+
+#=
+This is the 1D WriteMesh routine
+=#
+function writemesh_raw(base_name, x1;
+    x2 = nothing,
+    x3 = nothing,
+                       fields = (), realelems = 1:size(x1)[end])
+    (Nqr, _) = size(x1)
+    Nsubcells = (Nqr - 1)
+
+    M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
+    cells = Array{M, 1}(undef, Nsubcells * length(realelems))
+    for e in realelems
+        offset = (e - 1) * Nqr
+        for i in 1:(Nqr - 1)
+            cells[i + (e - 1) * Nsubcells] =
+                MeshCell(VTKCellTypes.VTK_LINE, offset .+ [i, i + 1])
+        end
+    end
+
+    vtkfile = vtk_grid("$(base_name)", @view(x1[:]), cells; compress = false)
+    for (name, v) in fields
+        vtk_point_data(vtkfile, v, name)
+    end
+    outfiles = vtk_save(vtkfile)
+end
+
+#=
+This is the 2D WriteMesh routine
+=#
+function writemesh_raw(
+    base_name,
+    x1,
+    x2;
+    x3 = nothing,
+    fields = (),
+    realelems = 1:size(x1)[end],
+)
+    @assert size(x1) == size(x2)
+    (Nqr, Nqs, _) = size(x1)
+    Nsubcells = (Nqr - 1) * (Nqs - 1)
+
+    M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
+    cells = Array{M, 1}(undef, Nsubcells * length(realelems))
+    ind = LinearIndices((1:Nqr, 1:Nqs))
+    for e in realelems
+        offset = (e - 1) * Nqr * Nqs
+        for j in 1:(Nqs - 1)
+            for i in 1:(Nqr - 1)
+                cells[i + (j - 1) * (Nqr - 1) + (e - 1) * Nsubcells] = MeshCell(
+                    VTKCellTypes.VTK_PIXEL,
+                    offset .+ ind[i:(i + 1), j:(j + 1)][:],
+                )
+            end
+        end
+    end
+
+    if x3 == nothing
+        vtkfile = vtk_grid(
+            "$(base_name)",
+            @view(x1[:]),
+            @view(x2[:]),
+            cells;
+            compress = false,
+        )
+    else
+        vtkfile = vtk_grid(
+            "$(base_name)",
+            @view(x1[:]),
+            @view(x2[:]),
+            @view(x3[:]),
+            cells;
+            compress = false,
+        )
+    end
+    for (name, v) in fields
+        vtk_point_data(vtkfile, v, name)
+    end
+    outfiles = vtk_save(vtkfile)
+end
+
+#=
+This is the 3D WriteMesh routine
+=#
+function writemesh_raw(
+    base_name,
+    x1,
+    x2,
+    x3;
+    fields = (),
+    realelems = 1:size(x1)[end],
+)
+    (Nqr, Nqs, Nqt, _) = size(x1)
+    (Nr, Ns, Nt) = (Nqr - 1, Nqs - 1, Nqt - 1)
+    Nsubcells = Nr * Ns * Nt
+
+    M = MeshCell{VTKCellTypes.VTKCellType, Array{Int, 1}}
+    cells = Array{M, 1}(undef, Nsubcells * length(realelems))
+    ind = LinearIndices((1:Nqr, 1:Nqs, 1:Nqt))
+    for e in realelems
+        offset = (e - 1) * Nqr * Nqs * Nqt
+        for k in 1:Nt
+            for j in 1:Ns
+                for i in 1:Nr
+                    cells[i + (j - 1) * Nr + (k - 1) * Nr * Ns + (e - 1) * Nsubcells] =
+                        MeshCell(
+                            VTKCellTypes.VTK_VOXEL,
+                            offset .+ ind[i:(i + 1), j:(j + 1), k:(k + 1)][:],
+                        )
+                end
+            end
+        end
+    end
+
+    vtkfile = vtk_grid(
+        "$(base_name)",
+        @view(x1[:]),
+        @view(x2[:]),
+        @view(x3[:]),
+        cells;
+        compress = false,
+    )
+    for (name, v) in fields
+        vtk_point_data(vtkfile, v, name)
+    end
+    outfiles = vtk_save(vtkfile)
+end

--- a/src/InputOutput/VTK/writevtk.jl
+++ b/src/InputOutput/VTK/writevtk.jl
@@ -171,33 +171,3 @@ function writevtk_helper(
         realelems = grid.topology.realelems,
     )
 end
-
-"""
-    writegrid(prefix, grid::DiscontinuousSpectralElementGrid)
-
-Write a vtk file for the grid.  The filename will start with `prefix` which
-may also contain a directory path.
-"""
-function writevtk(prefix, grid::DiscontinuousSpectralElementGrid)
-    dim = dimensionality(grid)
-    # XXX: Needs updating for multiple polynomial orders
-    N = polynomialorders(dg.grid)
-    # Currently only support single polynomial order
-    @assert all(N[1] .== N)
-    N = N[1]
-    Nq = N + 1
-
-    vgeo = grid.vgeo isa Array ? grid.vgeo : Array(grid.vgeo)
-
-    nelem = size(vgeo)[end]
-    Xid = (grid.x1id, grid.x2id, grid.x3id)
-    X = ntuple(
-        j -> reshape(
-            (@view vgeo[:, Xid[j], :]),
-            ntuple(j -> Nq, dim)...,
-            nelem,
-        ),
-        dim,
-    )
-    writemesh(prefix, X...; realelems = grid.topology.realelems)
-end

--- a/src/InputOutput/VTK/writevtk.jl
+++ b/src/InputOutput/VTK/writevtk.jl
@@ -164,7 +164,7 @@ function writevtk_helper(
     end
 
     fields = (fields..., auxfields...)
-    writemesh(
+    writemesh_highorder(
         prefix,
         X...;
         fields = fields,

--- a/test/InputOutput/VTK/runtests.jl
+++ b/test/InputOutput/VTK/runtests.jl
@@ -13,16 +13,16 @@ using ClimateMachine.VTK: writemesh_highorder, writemesh_raw
             (r, _) = GaussQuadrature.legendre(T, Nq, GaussQuadrature.both)
             s = dim > 1 ? r : [0]
             t = dim > 2 ? r : [0]
-            Nqi = length(r)
-            Nqj = length(s)
-            Nqk = length(t)
-            Np = Nqi * Nqj * Nqk
+            Nq1 = length(r)
+            Nq2 = length(s)
+            Nq3 = length(t)
+            Np = Nq1 * Nq2 * Nq3
 
-            x1 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
-            x2 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
-            x3 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
+            x1 = Array{T, 4}(undef, Nq1, Nq2, Nq3, nelem)
+            x2 = Array{T, 4}(undef, Nq1, Nq2, Nq3, nelem)
+            x3 = Array{T, 4}(undef, Nq1, Nq2, Nq3, nelem)
 
-            for e in 1:nelem, k in 1:Nqk, j in 1:Nqj, i in 1:Nqi
+            for e in 1:nelem, k in 1:Nq3, j in 1:Nq2, i in 1:Nq1
                 xoffset = nelem + 1 - 2e
                 x1[i, j, k, e], x2[i, j, k, e], x3[i, j, k, e] =
                     r[i] - xoffset, s[j], t[k]

--- a/test/InputOutput/VTK/runtests.jl
+++ b/test/InputOutput/VTK/runtests.jl
@@ -1,85 +1,87 @@
 using Test
 using GaussQuadrature
-using ClimateMachine.VTK: writemesh_highorder
+using ClimateMachine.VTK: writemesh_highorder, writemesh_raw
 
 @testset "VTK" begin
-    for dim in 1:3
-        N = 5
-        nelem = 3
-        T = Float64
+    for writemesh in (writemesh_highorder, writemesh_raw)
+        for dim in 1:3
+            N = 5
+            nelem = 3
+            T = Float64
 
-        Nq = N + 1
-        (r, _) = GaussQuadrature.legendre(T, Nq, GaussQuadrature.both)
-        s = dim > 1 ? r : [0]
-        t = dim > 2 ? r : [0]
-        Nqi = length(r)
-        Nqj = length(s)
-        Nqk = length(t)
-        Np = Nqi * Nqj * Nqk
+            Nq = N + 1
+            (r, _) = GaussQuadrature.legendre(T, Nq, GaussQuadrature.both)
+            s = dim > 1 ? r : [0]
+            t = dim > 2 ? r : [0]
+            Nqi = length(r)
+            Nqj = length(s)
+            Nqk = length(t)
+            Np = Nqi * Nqj * Nqk
 
-        x1 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
-        x2 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
-        x3 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
+            x1 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
+            x2 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
+            x3 = Array{T, 4}(undef, Nqi, Nqj, Nqk, nelem)
 
-        for e in 1:nelem, k in 1:Nqk, j in 1:Nqj, i in 1:Nqi
-            xoffset = nelem + 1 - 2e
-            x1[i, j, k, e], x2[i, j, k, e], x3[i, j, k, e] =
-                r[i] - xoffset, s[j], t[k]
-        end
+            for e in 1:nelem, k in 1:Nqk, j in 1:Nqj, i in 1:Nqi
+                xoffset = nelem + 1 - 2e
+                x1[i, j, k, e], x2[i, j, k, e], x3[i, j, k, e] =
+                    r[i] - xoffset, s[j], t[k]
+            end
 
-        if dim == 1
-            x1 = x1 .^ 3
-        elseif dim == 2
-            x1, x2 = x1 + sin.(π * x2) / 5, x2 + exp.(-x1 .^ 2)
-        else
-            x1, x2, x3 = x1 + sin.(π * x2) / 5,
-            x2 + exp.(-hypot.(x1, x3) .^ 2),
-            x3 + sin.(π * x1) / 5
-        end
-        d = exp.(sin.(hypot.(x1, x2, x3)))
-        s = copy(d)
+            if dim == 1
+                x1 = x1 .^ 3
+            elseif dim == 2
+                x1, x2 = x1 + sin.(π * x2) / 5, x2 + exp.(-x1 .^ 2)
+            else
+                x1, x2, x3 = x1 + sin.(π * x2) / 5,
+                x2 + exp.(-hypot.(x1, x3) .^ 2),
+                x3 + sin.(π * x1) / 5
+            end
+            d = exp.(sin.(hypot.(x1, x2, x3)))
+            s = copy(d)
 
-        if dim == 1
-            @test "test$(dim)d.vtu" == writemesh_highorder(
-                "test$(dim)d",
-                x1;
-                fields = (("d", d), ("s", s)),
-            )[1]
-            @test "test$(dim)d.vtu" == writemesh_highorder(
-                "test$(dim)d",
-                x1;
-                x2 = x2,
-                fields = (("d", d), ("s", s)),
-            )[1]
-            @test "test$(dim)d.vtu" == writemesh_highorder(
-                "test$(dim)d",
-                x1;
-                x2 = x2,
-                x3 = x3,
-                fields = (("d", d), ("s", s)),
-            )[1]
-        elseif dim == 2
-            @test "test$(dim)d.vtu" == writemesh_highorder(
-                "test$(dim)d",
-                x1,
-                x2;
-                fields = (("d", d), ("s", s)),
-            )[1]
-            @test "test$(dim)d.vtu" == writemesh_highorder(
-                "test$(dim)d",
-                x1,
-                x2;
-                x3 = x3,
-                fields = (("d", d), ("s", s)),
-            )[1]
-        elseif dim == 3
-            @test "test$(dim)d.vtu" == writemesh_highorder(
-                "test$(dim)d",
-                x1,
-                x2,
-                x3;
-                fields = (("d", d), ("s", s)),
-            )[1]
+            if dim == 1
+                @test "test$(dim)d.vtu" == writemesh(
+                    "test$(dim)d",
+                    x1;
+                    fields = (("d", d), ("s", s)),
+                )[1]
+                @test "test$(dim)d.vtu" == writemesh(
+                    "test$(dim)d",
+                    x1;
+                    x2 = x2,
+                    fields = (("d", d), ("s", s)),
+                )[1]
+                @test "test$(dim)d.vtu" == writemesh(
+                    "test$(dim)d",
+                    x1;
+                    x2 = x2,
+                    x3 = x3,
+                    fields = (("d", d), ("s", s)),
+                )[1]
+            elseif dim == 2
+                @test "test$(dim)d.vtu" == writemesh(
+                    "test$(dim)d",
+                    x1,
+                    x2;
+                    fields = (("d", d), ("s", s)),
+                )[1]
+                @test "test$(dim)d.vtu" == writemesh(
+                    "test$(dim)d",
+                    x1,
+                    x2;
+                    x3 = x3,
+                    fields = (("d", d), ("s", s)),
+                )[1]
+            elseif dim == 3
+                @test "test$(dim)d.vtu" == writemesh(
+                    "test$(dim)d",
+                    x1,
+                    x2,
+                    x3;
+                    fields = (("d", d), ("s", s)),
+                )[1]
+            end
         end
     end
 end

--- a/test/InputOutput/VTK/runtests.jl
+++ b/test/InputOutput/VTK/runtests.jl
@@ -87,3 +87,81 @@ using ClimateMachine.VTK: writemesh_highorder, writemesh_raw
         end
     end
 end
+
+
+using MPI
+MPI.Initialized() || MPI.Init()
+using ClimateMachine.Mesh.Topologies: BrickTopology
+using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
+using ClimateMachine.VTK: writevtk_helper
+
+let
+    mpicomm = MPI.COMM_SELF
+    for FT in (Float64,) #Float32)
+        for dim in 2:3
+            N = (2, 3, 4)[1:dim]
+            if dim == 2
+                Ne = (4, 5)
+                brickrange = (
+                    range(FT(0); length = Ne[1] + 1, stop = 1),
+                    range(FT(0); length = Ne[2] + 1, stop = 1),
+                )
+                topl = BrickTopology(
+                    mpicomm,
+                    brickrange,
+                    periodicity = (false, false),
+                )
+                warpfun =
+                    (x1, x2, _) -> begin
+                        (x1 + sin(x1 * x2), x2 + sin(2 * x1 * x2), 0)
+                    end
+            elseif dim == 3
+                Ne = (3, 4, 5)
+                brickrange = (
+                    range(FT(0); length = Ne[1] + 1, stop = 1),
+                    range(FT(0); length = Ne[2] + 1, stop = 1),
+                    range(FT(0); length = Ne[3] + 1, stop = 1),
+                )
+                topl = BrickTopology(
+                    mpicomm,
+                    brickrange,
+                    periodicity = (false, false, false),
+                )
+                warpfun =
+                    (x1, x2, x3) -> begin
+                        (
+                            x1 + (x1 - 1 / 2) * cos(2 * π * x2 * x3) / 4,
+                            x2 + exp(sin(2π * (x1 * x2 + x3))) / 20,
+                            x3 + x1 / 4 + x2^2 / 2 + sin(x1 * x2 * x3),
+                        )
+                    end
+            end
+            grid = DiscontinuousSpectralElementGrid(
+                topl,
+                FloatType = FT,
+                DeviceArray = Array,
+                polynomialorder = N,
+                meshwarp = warpfun,
+            )
+            Q = rand(FT, prod(N .+ 1), 3, prod(Ne))
+            prefix = "test$(dim)d_raw"
+            @test "$(prefix).vtu" == writevtk_helper(
+                prefix,
+                grid.vgeo,
+                Q,
+                grid,
+                ("a", "b", "c");
+                number_sample_points = 0,
+            )[1]
+            prefix = "test$(dim)d_high_order"
+            @test "$(prefix).vtu" == writevtk_helper(
+                prefix,
+                grid.vgeo,
+                Q,
+                grid,
+                ("a", "b", "c");
+                number_sample_points = 10,
+            )[1]
+        end
+    end
+end

--- a/test/InputOutput/VTK/runtests.jl
+++ b/test/InputOutput/VTK/runtests.jl
@@ -1,86 +1,88 @@
 using Test
-using GaussQuadrature
+using GaussQuadrature: legendre, both
 using ClimateMachine.VTK: writemesh_highorder, writemesh_raw
 
 @testset "VTK" begin
     for writemesh in (writemesh_highorder, writemesh_raw)
-        for dim in 1:3
-            N = 5
-            nelem = 3
-            T = Float64
+        Ns = writemesh == writemesh_raw ? ((4, 4, 4), (3, 5, 7)) : ((4, 4, 4),)
+        for N in Ns
+            for dim in 1:3
+                nelem = 3
+                T = Float64
 
-            Nq = N + 1
-            (r, _) = GaussQuadrature.legendre(T, Nq, GaussQuadrature.both)
-            s = dim > 1 ? r : [0]
-            t = dim > 2 ? r : [0]
-            Nq1 = length(r)
-            Nq2 = length(s)
-            Nq3 = length(t)
-            Np = Nq1 * Nq2 * Nq3
+                Nq = N .+ 1
+                r = legendre(T, Nq[1], both)[1]
+                s = dim < 2 ? [0] : legendre(T, Nq[2], both)[1]
+                t = dim < 3 ? [0] : legendre(T, Nq[3], both)[1]
+                Nq1 = length(r)
+                Nq2 = length(s)
+                Nq3 = length(t)
+                Np = Nq1 * Nq2 * Nq3
 
-            x1 = Array{T, 4}(undef, Nq1, Nq2, Nq3, nelem)
-            x2 = Array{T, 4}(undef, Nq1, Nq2, Nq3, nelem)
-            x3 = Array{T, 4}(undef, Nq1, Nq2, Nq3, nelem)
+                x1 = Array{T, 4}(undef, Nq1, Nq2, Nq3, nelem)
+                x2 = Array{T, 4}(undef, Nq1, Nq2, Nq3, nelem)
+                x3 = Array{T, 4}(undef, Nq1, Nq2, Nq3, nelem)
 
-            for e in 1:nelem, k in 1:Nq3, j in 1:Nq2, i in 1:Nq1
-                xoffset = nelem + 1 - 2e
-                x1[i, j, k, e], x2[i, j, k, e], x3[i, j, k, e] =
-                    r[i] - xoffset, s[j], t[k]
-            end
+                for e in 1:nelem, k in 1:Nq3, j in 1:Nq2, i in 1:Nq1
+                    xoffset = nelem + 1 - 2e
+                    x1[i, j, k, e], x2[i, j, k, e], x3[i, j, k, e] =
+                        r[i] - xoffset, s[j], t[k]
+                end
 
-            if dim == 1
-                x1 = x1 .^ 3
-            elseif dim == 2
-                x1, x2 = x1 + sin.(π * x2) / 5, x2 + exp.(-x1 .^ 2)
-            else
-                x1, x2, x3 = x1 + sin.(π * x2) / 5,
-                x2 + exp.(-hypot.(x1, x3) .^ 2),
-                x3 + sin.(π * x1) / 5
-            end
-            d = exp.(sin.(hypot.(x1, x2, x3)))
-            s = copy(d)
+                if dim == 1
+                    x1 = x1 .^ 3
+                elseif dim == 2
+                    x1, x2 = x1 + sin.(π * x2) / 5, x2 + exp.(-x1 .^ 2)
+                else
+                    x1, x2, x3 = x1 + sin.(π * x2) / 5,
+                    x2 + exp.(-hypot.(x1, x3) .^ 2),
+                    x3 + sin.(π * x1) / 5
+                end
+                d = exp.(sin.(hypot.(x1, x2, x3)))
+                s = copy(d)
 
-            if dim == 1
-                @test "test$(dim)d.vtu" == writemesh(
-                    "test$(dim)d",
-                    x1;
-                    fields = (("d", d), ("s", s)),
-                )[1]
-                @test "test$(dim)d.vtu" == writemesh(
-                    "test$(dim)d",
-                    x1;
-                    x2 = x2,
-                    fields = (("d", d), ("s", s)),
-                )[1]
-                @test "test$(dim)d.vtu" == writemesh(
-                    "test$(dim)d",
-                    x1;
-                    x2 = x2,
-                    x3 = x3,
-                    fields = (("d", d), ("s", s)),
-                )[1]
-            elseif dim == 2
-                @test "test$(dim)d.vtu" == writemesh(
-                    "test$(dim)d",
-                    x1,
-                    x2;
-                    fields = (("d", d), ("s", s)),
-                )[1]
-                @test "test$(dim)d.vtu" == writemesh(
-                    "test$(dim)d",
-                    x1,
-                    x2;
-                    x3 = x3,
-                    fields = (("d", d), ("s", s)),
-                )[1]
-            elseif dim == 3
-                @test "test$(dim)d.vtu" == writemesh(
-                    "test$(dim)d",
-                    x1,
-                    x2,
-                    x3;
-                    fields = (("d", d), ("s", s)),
-                )[1]
+                if dim == 1
+                    @test "test$(dim)d.vtu" == writemesh(
+                        "test$(dim)d",
+                        x1;
+                        fields = (("d", d), ("s", s)),
+                    )[1]
+                    @test "test$(dim)d.vtu" == writemesh(
+                        "test$(dim)d",
+                        x1;
+                        x2 = x2,
+                        fields = (("d", d), ("s", s)),
+                    )[1]
+                    @test "test$(dim)d.vtu" == writemesh(
+                        "test$(dim)d",
+                        x1;
+                        x2 = x2,
+                        x3 = x3,
+                        fields = (("d", d), ("s", s)),
+                    )[1]
+                elseif dim == 2
+                    @test "test$(dim)d.vtu" == writemesh(
+                        "test$(dim)d",
+                        x1,
+                        x2;
+                        fields = (("d", d), ("s", s)),
+                    )[1]
+                    @test "test$(dim)d.vtu" == writemesh(
+                        "test$(dim)d",
+                        x1,
+                        x2;
+                        x3 = x3,
+                        fields = (("d", d), ("s", s)),
+                    )[1]
+                elseif dim == 3
+                    @test "test$(dim)d.vtu" == writemesh(
+                        "test$(dim)d",
+                        x1,
+                        x2,
+                        x3;
+                        fields = (("d", d), ("s", s)),
+                    )[1]
+                end
             end
         end
     end

--- a/test/InputOutput/VTK/runtests.jl
+++ b/test/InputOutput/VTK/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using GaussQuadrature
-using ClimateMachine.VTK: writemesh
+using ClimateMachine.VTK: writemesh_highorder
 
 @testset "VTK" begin
     for dim in 1:3
@@ -40,15 +40,18 @@ using ClimateMachine.VTK: writemesh
         s = copy(d)
 
         if dim == 1
-            @test "test$(dim)d.vtu" ==
-                  writemesh("test$(dim)d", x1; fields = (("d", d), ("s", s)))[1]
-            @test "test$(dim)d.vtu" == writemesh(
+            @test "test$(dim)d.vtu" == writemesh_highorder(
+                "test$(dim)d",
+                x1;
+                fields = (("d", d), ("s", s)),
+            )[1]
+            @test "test$(dim)d.vtu" == writemesh_highorder(
                 "test$(dim)d",
                 x1;
                 x2 = x2,
                 fields = (("d", d), ("s", s)),
             )[1]
-            @test "test$(dim)d.vtu" == writemesh(
+            @test "test$(dim)d.vtu" == writemesh_highorder(
                 "test$(dim)d",
                 x1;
                 x2 = x2,
@@ -56,13 +59,13 @@ using ClimateMachine.VTK: writemesh
                 fields = (("d", d), ("s", s)),
             )[1]
         elseif dim == 2
-            @test "test$(dim)d.vtu" == writemesh(
+            @test "test$(dim)d.vtu" == writemesh_highorder(
                 "test$(dim)d",
                 x1,
                 x2;
                 fields = (("d", d), ("s", s)),
             )[1]
-            @test "test$(dim)d.vtu" == writemesh(
+            @test "test$(dim)d.vtu" == writemesh_highorder(
                 "test$(dim)d",
                 x1,
                 x2;
@@ -70,7 +73,7 @@ using ClimateMachine.VTK: writemesh
                 fields = (("d", d), ("s", s)),
             )[1]
         elseif dim == 3
-            @test "test$(dim)d.vtu" == writemesh(
+            @test "test$(dim)d.vtu" == writemesh_highorder(
                 "test$(dim)d",
                 x1,
                 x2,

--- a/test/Numerics/SystemSolvers/bandedsystem.jl
+++ b/test/Numerics/SystemSolvers/bandedsystem.jl
@@ -2,7 +2,6 @@ using ClimateMachine
 using MPI
 using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
-using ClimateMachine.VTK: writemesh
 using Logging
 using LinearAlgebra
 using Random


### PR DESCRIPTION
To support multiple polynomial orders this PR adds back in some of the
functionality from #1352. If subsampling is not asked for, the data is dumped at
the raw DG nodal values with the mesh defined from the degree of freedom boxes.
If subsampling is asked for, then the data is interpolated to an equally spaced
mesh in all directions and high-order lagrange elements are used.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
