### PR TITLE
Call modifier after turbulence_tensors

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -569,8 +569,6 @@ function. Contributions from subcomponents are then assembled (pointwise).
     flux.ρe = Σfluxes(eq_tends(Energy(), atmos, tend), args...)
 
     ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
-    ν, D_t, τ =
-        sponge_viscosity_modifier(atmos, atmos.viscoussponge, ν, D_t, τ, aux)
 
     flux_second_order!(atmos.moisture, flux, state, diffusive, aux, t, D_t)
     flux_second_order!(atmos.precipitation, flux, state, diffusive, aux, t, D_t)

--- a/src/Atmos/Model/tendencies_energy.jl
+++ b/src/Atmos/Model/tendencies_energy.jl
@@ -28,7 +28,6 @@ function flux(
     hyperdiff,
 )
     ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
-    ν, D_t, τ = sponge_viscosity_modifier(m, m.viscoussponge, ν, D_t, τ, aux)
     return τ * state.ρu
 end
 
@@ -44,7 +43,6 @@ function flux(
     hyperdiff,
 )
     ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
-    ν, D_t, τ = sponge_viscosity_modifier(m, m.viscoussponge, ν, D_t, τ, aux)
     d_h_tot = -D_t .* diffusive.∇h_tot
     return d_h_tot * state.ρ
 end

--- a/src/Atmos/Model/tendencies_mass.jl
+++ b/src/Atmos/Model/tendencies_mass.jl
@@ -24,7 +24,6 @@ function flux(
     hyperdiff,
 )
     ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
-    ν, D_t, τ = sponge_viscosity_modifier(m, m.viscoussponge, ν, D_t, τ, aux)
     d_q_tot = (-D_t) .* diffusive.moisture.∇q_tot
     return d_q_tot * state.ρ
 end

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -35,7 +35,6 @@ function flux(
     hyperdiff,
 )
     ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
-    ν, D_t, τ = sponge_viscosity_modifier(m, m.viscoussponge, ν, D_t, τ, aux)
     return τ * state.ρ
 end
 

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -247,8 +247,26 @@ for the returned quantities.
 - `aux` = Array of auxiliary variables
 - `t` = time
 """
-turbulence_tensors(m::TurbulenceClosureModel, bl::BalanceLaw, args...) =
-    turbulence_tensors(m, bl.orientation, bl.param_set, args...)
+function turbulence_tensors(
+    m::TurbulenceClosureModel,
+    bl::BalanceLaw,
+    state,
+    diffusive,
+    aux,
+    t,
+)
+    ν, D_t, τ = turbulence_tensors(
+        m,
+        bl.orientation,
+        bl.param_set,
+        state,
+        diffusive,
+        aux,
+        t,
+    )
+    ν, D_t, τ = sponge_viscosity_modifier(bl, bl.viscoussponge, ν, D_t, τ, aux)
+    return (ν, D_t, τ)
+end
 
 # We also provide generic math functions for use within the turbulence closures,
 # commonly used quantities such as the [principal tensor invariants](@ref tensor-invariants), handling of


### PR DESCRIPTION
### Description

It seems that `turbulence_tensors` is often, but not always, followed by a call to `sponge_viscosity_modifier`--should it be? This PR moves `sponge_viscosity_modifier` inside `turbulence_tensors`. I'm not sure if this is correct. Looping in @akshaysridhar.

This effectively adds calls to `sponge_viscosity_modifier` in a few places:

 - https://github.com/CliMA/ClimateMachine.jl/blob/master/src/Atmos/Model/bc_energy.jl#L69 - I don't think this will impact anything, since the sponge is above a certain altitude and the bc is (I assume) at the surface
 - https://github.com/CliMA/ClimateMachine.jl/blob/master/src/Atmos/Model/courant.jl#L68 - may improve the correctness of the reported the diffusive courant
 - https://github.com/CliMA/ClimateMachine.jl/blob/master/src/Diagnostics/atmos_les_default.jl#L162 - may improve the correctness of the diagnostics

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
