### PR TITLE
GCM test case: polynomial order set to 5

### DIFF
--- a/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
+++ b/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
@@ -312,9 +312,9 @@ function main()
 
     # Driver configuration parameters
     FT = Float64                             # floating type precision
-    poly_order = 3                           # discontinuous Galerkin polynomial order
-    n_horz = 12                              # horizontal element number
-    n_vert = 6                               # vertical element number
+    poly_order = 5                           # discontinuous Galerkin polynomial order
+    n_horz = 8                              # horizontal element number
+    n_vert = 4                               # vertical element number
     n_days::FT = 0.1
     timestart::FT = 0                        # start time (s)
     timeend::FT = n_days * day(param_set)    # end time (s)

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -213,9 +213,9 @@ end
 function main()
     # Driver configuration parameters
     FT = Float64                             # floating type precision
-    poly_order = 3                           # discontinuous Galerkin polynomial order
-    n_horz = 12                              # horizontal element number
-    n_vert = 6                               # vertical element number
+    poly_order = 5                           # discontinuous Galerkin polynomial order
+    n_horz = 8                              # horizontal element number
+    n_vert = 4                               # vertical element number
     n_days::FT = 1
     timestart::FT = 0                        # start time (s)
     timeend::FT = n_days * day(param_set)    # end time (s)

--- a/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
+++ b/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
@@ -307,9 +307,9 @@ function main()
 
     # Driver configuration parameters
     FT = Float64                             # floating type precision
-    poly_order = 3                           # discontinuous Galerkin polynomial order
-    n_horz = 12                              # horizontal element number
-    n_vert = 6                               # vertical element number
+    poly_order = 5                           # discontinuous Galerkin polynomial order
+    n_horz = 8                              # horizontal element number
+    n_vert = 4                               # vertical element number
     n_days::FT = 1
     timestart::FT = 0                        # start time (s)
     timeend::FT = n_days * day(param_set)    # end time (s)

--- a/experiments/AtmosGCM/nonhydrostatic_gravity_wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic_gravity_wave.jl
@@ -171,9 +171,9 @@ end
 function main()
     # Driver configuration parameters
     FT = Float64                             # floating type precision
-    poly_order = 4                           # discontinuous Galerkin polynomial order
-    n_horz = 12                               # horizontal element number
-    n_vert = 5                               # vertical element number
+    poly_order = 5                           # discontinuous Galerkin polynomial order
+    n_horz = 8                               # horizontal element number
+    n_vert = 4                               # vertical element number
     timestart = FT(0)                        # start time (s)
     timeend = FT(3600)                       # end time (s)
 

--- a/experiments/TestCase/baroclinic_wave.jl
+++ b/experiments/TestCase/baroclinic_wave.jl
@@ -220,9 +220,9 @@ function main()
 
     # Driver configuration parameters
     FT = Float64                             # floating type precision
-    poly_order = 3                           # discontinuous Galerkin polynomial order
-    n_horz = 12                              # horizontal element number
-    n_vert = 6                               # vertical element number
+    poly_order = 5                           # discontinuous Galerkin polynomial order
+    n_horz = 8                              # horizontal element number
+    n_vert = 4                               # vertical element number
     n_days::FT = 1
     timestart::FT = 0                        # start time (s)
     timeend::FT = n_days * day(param_set)    # end time (s)

--- a/experiments/TestCase/solid_body_rotation.jl
+++ b/experiments/TestCase/solid_body_rotation.jl
@@ -79,9 +79,9 @@ end
 function main()
     # Driver configuration parameters
     FT = Float64                             # floating type precision
-    poly_order = 3                           # discontinuous Galerkin polynomial order
-    n_horz = 12                              # horizontal element number
-    n_vert = 6                               # vertical element number
+    poly_order = 5                           # discontinuous Galerkin polynomial order
+    n_horz = 8                              # horizontal element number
+    n_vert = 4                               # vertical element number
     timestart::FT = 0                        # start time (s)
     timeend::FT = 7200
 


### PR DESCRIPTION
### Description

This PR changes the polynomial order from 3 to 5 in GCM test case drivers:
- solid body rotation
- baroclinic wave

Horizontal and vertical element numbers are changed accordingly so that the default resolution remains roughly the same. 

Tests have been performed to make sure that with the above changes, the solid body rotation test still holds the initial condition; and the baroclinic wave test can survive 30 days and generate reasonable outputs.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
