### PR TITLE
Move radiation to new tendency spec

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -37,15 +37,17 @@ using ..Mesh.Grids:
     EveryDirection,
     Direction
 
-using ClimateMachine.BalanceLaws
-import ClimateMachine.BalanceLaws: flux, source
+using ..BalanceLaws
 using ClimateMachine.Problems
 
-import ClimateMachine.BalanceLaws:
+import ..BalanceLaws:
     vars_state,
     flux_first_order!,
     flux_second_order!,
     source!,
+    eq_tends,
+    flux,
+    source,
     wavespeed,
     boundary_conditions,
     boundary_state!,
@@ -441,7 +443,6 @@ equations.
     flux.ρu = Σfluxes(eq_tends(Momentum(), m, tend), args...) .* ρu_pad
     flux.ρe = Σfluxes(eq_tends(Energy(), m, tend), args...)
 
-    flux_first_order!(m.radiation, m, flux, state, aux, t, ts, direction)
     flux_first_order!(m.moisture, m, flux, state, aux, t, ts, direction)
     flux_first_order!(m.precipitation, m, flux, state, aux, t, ts, direction)
     flux_first_order!(m.tracers, m, flux, state, aux, t, ts, direction)

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -2,8 +2,6 @@
 ##### Tendency specification
 #####
 
-import ..BalanceLaws: eq_tends
-
 #####
 ##### Sources
 #####
@@ -63,8 +61,8 @@ eq_tends(pv::PV, m::AtmosModel, ::Flux{FirstOrder}) where {PV <: Momentum} =
     (Advect{PV}(), PressureGradient{PV}())
 
 # Energy
-eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Energy} =
-    (Advect{PV}(), Pressure{PV}())
+eq_tends(pv::PV, m::AtmosModel, tt::Flux{FirstOrder}) where {PV <: Energy} =
+    (Advect{PV}(), Pressure{PV}(), eq_tends(pv, m.radiation, tt)...)
 
 # Moisture
 eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Moisture} =

--- a/src/Atmos/Model/radiation.jl
+++ b/src/Atmos/Model/radiation.jl
@@ -4,6 +4,8 @@ abstract type RadiationModel end
 
 vars_state(::RadiationModel, ::AbstractStateType, FT) = @vars()
 
+eq_tends(pv::PV, ::RadiationModel, ::Flux{FirstOrder}) where {PV} = ()
+
 function atmos_nodal_update_auxiliary_state!(
     ::RadiationModel,
     ::AtmosModel,


### PR DESCRIPTION
### Description

This PR
 - Renames `DYCOMSRadiation` -> `DYCOMSRadiationModel`
 - Adds `DYCOMSRadiation` for the first order flux type
 - Moves the first order radiative flux to the new tendency specification
 - Deletes some unnecessary code (defined for `RadiationModel` in `dycoms.jl`)

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
