### PR TITLE
Move first order rain flux to new tend spec

### DIFF
--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -69,8 +69,11 @@ eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Moisture} =
     (Advect{PV}(),)
 
 # Precipitation
-eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Precipitation} =
-    ()
+eq_tends(
+    pv::PV,
+    m::AtmosModel,
+    tt::Flux{FirstOrder},
+) where {PV <: Precipitation} = (eq_tends(pv, m.precipitation, tt)...,)
 
 #####
 ##### Second order fluxes

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -3,6 +3,8 @@ abstract type PrecipitationModel end
 
 export NoPrecipitation, RainModel#, RainSnow
 
+eq_tends(pv::PV, m::PrecipitationModel, ::Flux{O}) where {PV, O} = ()
+
 using ..Microphysics
 
 vars_state(::PrecipitationModel, ::AbstractStateType, FT) = @vars()
@@ -102,6 +104,33 @@ function compute_gradient_flux!(
     diffusive.precipitation.∇q_rai = ∇transform.precipitation.q_rai
 end
 
+"""
+    RainFlux{PV} <: TendencyDef{Flux{FirstOrder}, PV <: Rain}
+
+Computes the rain flux as a sum of air velocity and rain terminal velocity
+multiplied by the advected variable
+"""
+struct RainFlux{PV <: Rain} <: TendencyDef{Flux{FirstOrder}, PV} end
+
+function flux(::RainFlux{Rain}, m, state, aux, t, ts, direction)
+    FT = eltype(state)
+    u = state.ρu / state.ρ
+    q_rai = state.precipitation.ρq_rai / state.ρ
+
+    v_term::FT = FT(0)
+    if q_rai > FT(0)
+        v_term = terminal_velocity(
+            m.param_set,
+            m.param_set.microphys.rai,
+            state.ρ,
+            q_rai,
+        )
+    end
+
+    k̂ = vertical_unit_vector(m, aux)
+    return state.precipitation.ρq_rai * (u - k̂ * v_term)
+end
+
 function flux_first_order!(
     precip::RainModel,
     atmos::AtmosModel,
@@ -112,22 +141,9 @@ function flux_first_order!(
     ts,
     direction,
 )
-    FT = eltype(state)
-    u = state.ρu / state.ρ
-    q_rai = state.precipitation.ρq_rai / state.ρ
-
-    v_term::FT = FT(0)
-    if q_rai > FT(0)
-        v_term = terminal_velocity(
-            atmos.param_set,
-            atmos.param_set.microphys.rai,
-            state.ρ,
-            q_rai,
-        )
-    end
-
-    k̂ = vertical_unit_vector(atmos, aux)
-    flux.precipitation.ρq_rai += state.precipitation.ρq_rai * (u - k̂ * v_term)
+    tend = Flux{FirstOrder}()
+    args = (atmos, state, aux, t, ts, direction)
+    flux.precipitation.ρq_rai = Σfluxes(eq_tends(Rain(), atmos, tend), args...)
 end
 
 function flux_second_order!(
@@ -162,3 +178,10 @@ function source!(
     source.precipitation.ρq_rai =
         Σsources(eq_tends(Rain(), atmos, tend), args...)
 end
+
+#####
+##### Tendency specifications
+#####
+
+eq_tends(pv::PV, ::RainModel, ::Flux{FirstOrder}) where {PV <: Rain} =
+    (RainFlux{PV}(),)


### PR DESCRIPTION
### Description

Move first order rain fluxes to new tendency specification.

I think that this is looking forward a bit, but, I put `eq_tends` for `Rain` in `precipitation.jl` instead of in `AtmosModel.jl`, since all we really need to do is "forward" `eq_tends` into the submodel components. That way we don't clutter `AtmosModel.jl` with all of the submodel tendencies.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
