### PR TITLE
Add missing call to rain source

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -774,7 +774,8 @@ function source!(
     source.ρ = Σsources(eq_tends(Mass(), m, tend), args...)
     source.ρu = Σsources(eq_tends(Momentum(), m, tend), args...) .* ρu_pad
     source.ρe = Σsources(eq_tends(Energy(), m, tend), args...)
-    source!(m.moisture, m, source, state, diffusive, aux, t, direction)
+    source!(m.moisture, source, args...)
+    source!(m.precipitation, source, args...)
 
     atmos_source!(m.source, m, source, state, diffusive, aux, t, direction)
 end

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -86,16 +86,7 @@ vars_state(::DryModel, ::Auxiliary, FT) = @vars(θ_v::FT, air_T::FT)
     nothing
 end
 
-function source!(
-    m::DryModel,
-    atmos::AtmosModel,
-    source::Vars,
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
-    direction,
-) end
+source!(::DryModel, args...) = nothing
 
 """
     EquilMoist
@@ -192,16 +183,16 @@ end
 
 function source!(
     m::EquilMoist,
-    atmos::AtmosModel,
     source::Vars,
+    atmos::AtmosModel,
     state::Vars,
-    diffusive::Vars,
     aux::Vars,
     t::Real,
+    ts,
     direction,
+    diffusive::Vars,
 )
     tend = Source()
-    ts = recover_thermo_state(atmos, state, aux)
     args = (atmos, state, aux, t, ts, direction, diffusive)
     source.moisture.ρq_tot =
         Σsources(eq_tends(TotalMoisture(), atmos, tend), args...)
@@ -317,16 +308,16 @@ end
 
 function source!(
     m::NonEquilMoist,
-    atmos::AtmosModel,
     source::Vars,
+    atmos::AtmosModel,
     state::Vars,
-    diffusive::Vars,
     aux::Vars,
     t::Real,
+    ts,
     direction,
+    diffusive::Vars,
 )
     tend = Source()
-    ts = recover_thermo_state(atmos, state, aux)
     args = (atmos, state, aux, t, ts, direction, diffusive)
     source.moisture.ρq_tot =
         Σsources(eq_tends(TotalMoisture(), atmos, tend), args...)

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -50,6 +50,8 @@ function compute_gradient_argument!(
     t::Real,
 ) end
 
+source!(::PrecipitationModel, args...) = nothing
+
 """
     NoPrecipitation <: PrecipitationModel
 
@@ -142,4 +144,21 @@ function flux_second_order!(
 end
 function flux_second_order!(precip::RainModel, flux::Grad, state::Vars, d_q_rai)
     flux.precipitation.ρq_rai += d_q_rai * state.ρ
+end
+
+function source!(
+    m::RainModel,
+    source::Vars,
+    atmos::AtmosModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+    ts,
+    direction,
+    diffusive::Vars,
+)
+    tend = Source()
+    args = (atmos, state, aux, t, ts, direction, diffusive)
+    source.precipitation.ρq_rai =
+        Σsources(eq_tends(Rain(), atmos, tend), args...)
 end


### PR DESCRIPTION
### Description

This PR
 - Adds a missing call to `source!` for the precipitation model.
 - Re-orders the arguments so that we can pass them through in the same order as `source`

@trontrytel This should fix the dycoms with rain QA run.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
