### PR TITLE
Add `DGFVModel` interface

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -318,10 +318,55 @@ steps:
       queue: central
       slurm_ntasks: 2
 
+  - label: "cpu_fvm_advection_sphere"
+    key: "cpu_fvm_advection_sphere"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl "
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 2
+
+  - label: "cpu_fvm_swirl"
+    key: "cpu_fvm_swirl"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_swirl.jl "
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 2
+
   - label: "cpu_fvm_advection"
     key: "cpu_fvm_advection"
     command:
       - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl "
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 2
+
+  - label: "cpu_fvm_advection_diffusion"
+    key: "cpu_fvm_advection_diffusion"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion.jl "
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 2
+
+  - label: "cpu_fvm_advection_diffusion_periodic"
+    key: "cpu_fvm_advection_diffusion_periodic"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_periodic.jl "
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 2
+
+  - label: "cpu_fvm_isentropicvortex"
+    key: "cpu_fvm_isentropicvortex"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/Euler/fvm_isentropicvortex.jl "
     agents:
       config: cpu
       queue: central
@@ -736,10 +781,60 @@ steps:
       slurm_ntasks: 2
       slurm_gres: "gpu:1"
 
+  - label: "gpu_fvm_advection_sphere"
+    key: "gpu_fvm_advection_sphere"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 2
+      slurm_gres: "gpu:1"
+
+  - label: "gpu_fvm_swirl"
+    key: "gpu_fvm_swirl"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_swirl.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 2
+      slurm_gres: "gpu:1"
+
   - label: "gpu_fvm_advection"
     key: "gpu_fvm_advection"
     command:
       - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 2
+      slurm_gres: "gpu:1"
+
+  - label: "gpu_fvm_advection_diffusion"
+    key: "gpu_fvm_advection_diffusion"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 2
+      slurm_gres: "gpu:1"
+
+  - label: "gpu_fvm_advection_diffusion_periodic"
+    key: "gpu_fvm_advection_diffusion_periodic"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_periodic.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 2
+      slurm_gres: "gpu:1"
+
+  - label: "gpu_fvm_isentropicvortex"
+    key: "gpu_fvm_isentropicvortex"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/Euler/fvm_isentropicvortex.jl "
     agents:
       config: gpu
       queue: central

--- a/docs/list_of_apis.jl
+++ b/docs/list_of_apis.jl
@@ -48,6 +48,8 @@ apis = [
         "DG Methods" => "APIs/Numerics/DGMethods/DGMethods.md",
         "Courant" => "APIs/Numerics/DGMethods/Courant.md",
         "Numerical Fluxes" => "APIs/Numerics/DGMethods/NumericalFluxes.md",
+        "Finite Volume Reconstructions" =>
+            "APIs/Numerics/DGMethods/FVReconstructions.md",
     ],
     "Utilities" => [
         "Variable Templates" => "APIs/Utilities/VariableTemplates.md",

--- a/docs/src/APIs/Numerics/DGMethods/DGMethods.md
+++ b/docs/src/APIs/Numerics/DGMethods/DGMethods.md
@@ -7,7 +7,7 @@ CurrentModule = ClimateMachine.DGMethods
 ```@docs
 SpaceDiscretization
 DGModel
-DGFVMModel
+DGFVModel
 remainder_DGModel
 continuous_field_gradient!
 courant

--- a/docs/src/APIs/Numerics/DGMethods/DGMethods.md
+++ b/docs/src/APIs/Numerics/DGMethods/DGMethods.md
@@ -5,7 +5,9 @@ CurrentModule = ClimateMachine.DGMethods
 ```
 
 ```@docs
+SpaceDiscretization
 DGModel
+DGFVMModel
 remainder_DGModel
 continuous_field_gradient!
 courant

--- a/docs/src/APIs/Numerics/DGMethods/FVReconstructions.md
+++ b/docs/src/APIs/Numerics/DGMethods/FVReconstructions.md
@@ -1,0 +1,16 @@
+# Numerical Fluxes
+
+```@meta
+CurrentModule = ClimateMachine.DGMethods.FVReconstructions
+```
+
+## Types
+
+```@docs
+    AbstractReconstruction
+    AbstractSlopeLimiter
+    width
+    FVConstant
+    FVLinear
+    VanLeer
+```

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -173,11 +173,30 @@ subtype `BL`.
 """
 function compute_gradient_argument! end
 
+function compute_gradient_argument!(
+    balance_law::BalanceLaw,
+    transformstate::AbstractArray,
+    state_prognostic::AbstractArray,
+    state_auxiliary::AbstractArray,
+    t,
+)
+    FT = eltype(transformstate)
+    compute_gradient_argument!(
+        balance_law,
+        Vars{vars_state(balance_law, Gradient(), FT)}(transformstate),
+        Vars{vars_state(balance_law, Prognostic(), FT)}(state_prognostic),
+        Vars{vars_state(balance_law, Auxiliary(), FT)}(state_auxiliary),
+        t,
+    )
+end
+
+
 """
     compute_gradient_flux!(
         ::BL,
         state_gradient_flux::Vars,
         ∇transformstate::Grad,
+        state_prognostic::Vars,
         state_auxiliary::Vars,
         t::Real
     )
@@ -187,6 +206,25 @@ Transformation of gradients to the diffusive variables for a
 `∇transformstate`
 """
 function compute_gradient_flux! end
+
+function compute_gradient_flux!(
+    balance_law::BalanceLaw,
+    state_gradient_flux::AbstractArray,
+    ∇transformstate::AbstractArray,
+    state_prognostic::AbstractArray,
+    state_auxiliary::AbstractArray,
+    t,
+)
+    FT = eltype(state_gradient_flux)
+    compute_gradient_flux!(
+        balance_law,
+        Vars{vars_state(balance_law, GradientFlux(), FT)}(state_gradient_flux),
+        Grad{vars_state(balance_law, Gradient(), FT)}(∇transformstate),
+        Vars{vars_state(balance_law, Prognostic(), FT)}(state_prognostic),
+        Vars{vars_state(balance_law, Auxiliary(), FT)}(state_auxiliary),
+        t,
+    )
+end
 
 """
     transform_post_gradient_laplacian!(

--- a/src/InputOutput/VTK/writevtk.jl
+++ b/src/InputOutput/VTK/writevtk.jl
@@ -3,11 +3,11 @@ import KernelAbstractions: CPU
 using ..Mesh.Grids
 using ..Mesh.Elements: interpolationmatrix
 using ..MPIStateArrays
-using ..DGMethods
+using ..DGMethods: SpaceDiscretization
 using ..TicToc
 
 """
-    writevtk(prefix, Q::MPIStateArray, dg::DGModel [, fieldnames];
+    writevtk(prefix, Q::MPIStateArray, dg::SpaceDiscretization [, fieldnames];
              number_sample_points = 0)
 
 Write a vtk file for all the fields in the state array `Q` using geometry and
@@ -27,7 +27,7 @@ elements are used connecting the degree of freedom boxes.
 function writevtk(
     prefix,
     Q::MPIStateArray,
-    dg::DGModel,
+    dg::SpaceDiscretization,
     fieldnames = nothing;
     number_sample_points = 0,
 )
@@ -46,7 +46,7 @@ function writevtk(
 end
 
 """
-    writevtk(prefix, Q::MPIStateArray, dg::DGModel, fieldnames,
+    writevtk(prefix, Q::MPIStateArray, dg::SpaceDiscretization, fieldnames,
              state_auxiliary::MPIStateArray, auxfieldnames;
              number_sample_points = 0)
 
@@ -73,7 +73,7 @@ elements are used connecting the degree of freedom boxes.
 function writevtk(
     prefix,
     Q::MPIStateArray,
-    dg::DGModel,
+    dg::SpaceDiscretization,
     fieldnames,
     state_auxiliary,
     auxfieldnames;

--- a/src/InputOutput/VTK/writevtk.jl
+++ b/src/InputOutput/VTK/writevtk.jl
@@ -40,7 +40,7 @@ function writevtk(
         h_Q,
         dg.grid,
         fieldnames;
-        number_sample_points = 0,
+        number_sample_points = number_sample_points,
     )
     return nothing
 end

--- a/src/Numerics/DGMethods/DGFVModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGFVModel_kernels.jl
@@ -385,6 +385,875 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
     end
 end
 
+@kernel function vert_fvm_interface_tendency!(
+    balance_law::BalanceLaw,
+    ::Val{info},
+    ::Val{nvertelem},
+    ::Val{periodicstack},
+    ::VerticalDirection,
+    reconstruction!::FVLinear,
+    numerical_flux_first_order,
+    numerical_flux_second_order,
+    tendency,
+    state_prognostic,
+    state_gradient_flux,
+    state_auxiliary,
+    vgeo,
+    sgeo,
+    t,
+    elemtobndy,
+    elems,
+    α,
+) where {info, nvertelem, periodicstack}
+    @uniform begin
+        dim = info.dim
+        FT = eltype(state_prognostic)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
+        num_state_gradient_flux = number_states(balance_law, GradientFlux())
+        num_state_hyperdiffusion = number_states(balance_law, Hyperdiffusive())
+        @assert num_state_hyperdiffusion == 0
+
+        vsp = Vars{vars_state(balance_law, Prognostic(), FT)}
+        vsa = Vars{vars_state(balance_law, Auxiliary(), FT)}
+
+        nface = info.nface
+        Np = info.Np
+        Nqk = info.Nqk # can only be 1 for the FVM method!
+        @assert Nqk == 1
+
+        @assert nvertelem >= 3
+
+        # We only have the vertical faces
+        faces = (nface - 1):nface
+
+        # +/- indicate top/bottom elements
+        # top and bottom indicate face states
+
+        local_flux = MArray{Tuple{num_state_prognostic}, FT}(undef)
+
+        local_state_prognostic = MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_prognostic⁺ = MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_prognostic⁻ = MArray{Tuple{num_state_prognostic}, FT}(undef)
+
+        local_state_primitive = MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_primitive⁺ = MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_primitive⁻ = MArray{Tuple{num_state_prognostic}, FT}(undef)
+
+        local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_auxiliary⁺ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_auxiliary⁻ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+
+        local_state_gradient_flux⁻ =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_gradient_flux =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_gradient_flux⁺ =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+
+        local_state_hyperdiffusion⁻ =
+            MArray{Tuple{num_state_hyperdiffusion}, FT}(undef)
+        local_state_hyperdiffusion =
+            MArray{Tuple{num_state_hyperdiffusion}, FT}(undef)
+        local_state_hyperdiffusion⁺ =
+            MArray{Tuple{num_state_hyperdiffusion}, FT}(undef)
+
+        local_state_primitive_bottom =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_primitive_top =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+
+        local_state_prognostic_bottom =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_prognostic_top =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+
+        local_state_auxiliary_bottom =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_auxiliary_top =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
+
+        local_state_prognostic⁻_top =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_prognostic⁺_bottom =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+
+        local_state_auxiliary⁻_top =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_auxiliary⁺_bottom =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
+
+
+        local_state_prognostic_boundary =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_auxiliary_boundary =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_gradient_flux_boundary =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+
+        # XXX: will revisit this later for FVM
+        fill!(local_state_prognostic_boundary, NaN)
+        fill!(local_state_auxiliary_boundary, NaN)
+        fill!(local_state_gradient_flux_boundary, NaN)
+
+        # The remainder model needs to know which direction of face the model is
+        # being evaluated for. In this case we only have `VerticalDirection()`
+        # faces
+        face_direction = (VerticalDirection(),)
+    end
+
+    # Get the horizontal group IDs
+    grp_H = @index(Group, Linear)
+
+    # Determine the index for the element at the bottom of the stack
+    eHI = (grp_H - 1) * nvertelem + 1
+
+    # Compute bottom stack element index minus one (so we can add vert element
+    # number directly)
+    eH = elems[eHI] - 1
+
+    # Which degree of freedom do we handle in the element
+    n = @index(Local, Linear)
+
+    # Loads the data for a given element
+    function load_data!(
+        local_state_prognostic,
+        local_state_auxiliary,
+        local_state_gradient_flux,
+        e,
+    )
+        @unroll for s in 1:num_state_prognostic
+            local_state_prognostic[s] = state_prognostic[n, s, e]
+        end
+
+        @unroll for s in 1:num_state_auxiliary
+            local_state_auxiliary[s] = state_auxiliary[n, s, e]
+        end
+
+        @unroll for s in 1:num_state_gradient_flux
+            local_state_gradient_flux[s] = state_gradient_flux[n, s, e]
+        end
+    end
+
+    # We need to compute the first element we handles bottom flux (only for nonperiodic boundary condition)
+    # elements will just copied from the prior element)
+    @inbounds begin
+        eV = 1
+        # the first element
+        e = eH + eV
+
+        # bottom face
+        f_bottom = faces[1]
+        # surface mass
+        sM_bottom = sgeo[_sM, n, f_bottom, e]
+        cw = vgeo[n, _M, e]
+        vMI = vgeo[n, _MI, e]
+
+        # outward normal for this the bottom face
+        normal_vector_bottom = SVector(
+            sgeo[_n1, n, f_bottom, e],
+            sgeo[_n2, n, f_bottom, e],
+            sgeo[_n3, n, f_bottom, e],
+        )
+
+        if periodicstack
+            e⁻ = eH + nvertelem
+            e⁺ = e + 1
+            cw⁻ = vgeo[n, _M, e⁻]
+            cw⁺ = vgeo[n, _M, e⁺]
+
+            load_data!(
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_state_gradient_flux⁻,
+                e⁻,
+            )
+            load_data!(
+                local_state_prognostic,
+                local_state_auxiliary,
+                local_state_gradient_flux,
+                e,
+            )
+            load_data!(
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
+                local_state_gradient_flux⁺,
+                e⁺,
+            )
+
+            prognostic_to_primitive!(
+                balance_law,
+                local_state_primitive⁻,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+            )
+            prognostic_to_primitive!(
+                balance_law,
+                local_state_primitive,
+                local_state_prognostic,
+                local_state_auxiliary,
+            )
+            prognostic_to_primitive!(
+                balance_law,
+                local_state_primitive⁺,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
+            )
+
+            cell_states_primitive = (
+                local_state_primitive⁻,
+                local_state_primitive,
+                local_state_primitive⁺,
+            )
+
+            cell_weights = SVector(cw⁻, cw, cw⁺)
+
+            # Linear Reconstuction
+            reconstruction!(
+                local_state_primitive_bottom,
+                local_state_primitive_top,
+                cell_states_primitive,
+                cell_weights,
+            )
+
+            # TODO
+            local_state_auxiliary_bottom .= local_state_auxiliary
+            local_state_auxiliary_top .= local_state_auxiliary
+
+            primitive_to_prognostic!(
+                balance_law,
+                local_state_prognostic_bottom,
+                local_state_primitive_bottom,
+                local_state_auxiliary_bottom,
+            )
+
+            primitive_to_prognostic!(
+                balance_law,
+                local_state_prognostic_top,
+                local_state_primitive_top,
+                local_state_auxiliary_top,
+            )
+
+            # this is used for the stack top element
+            local_state_prognostic⁺_bottom .= local_state_prognostic_bottom
+            local_state_auxiliary⁺_bottom .= local_state_auxiliary_bottom
+            local_state_prognostic⁻_top .= local_state_prognostic_top
+            local_state_auxiliary⁻_top .= local_state_auxiliary_top
+
+        else
+
+            e⁺ = e + 1
+            load_data!(
+                local_state_prognostic,
+                local_state_auxiliary,
+                local_state_gradient_flux,
+                e,
+            )
+            load_data!(
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
+                local_state_gradient_flux⁺,
+                e⁺,
+            )
+
+            prognostic_to_primitive!(
+                balance_law,
+                local_state_primitive,
+                local_state_prognostic,
+                local_state_auxiliary,
+            )
+            cell_states_primitive = (local_state_primitive,)
+            cell_weights = SVector(cw)
+
+            # Constant reconstruction
+            reconstruction!(
+                local_state_primitive_bottom,
+                local_state_primitive_top,
+                cell_states_primitive,
+                cell_weights,
+            )
+
+            # TODO
+            local_state_auxiliary_bottom .= local_state_auxiliary
+            local_state_auxiliary_top .= local_state_auxiliary
+
+            primitive_to_prognostic!(
+                balance_law,
+                local_state_prognostic_bottom,
+                local_state_primitive_bottom,
+                local_state_auxiliary_bottom,
+            )
+
+            primitive_to_prognostic!(
+                balance_law,
+                local_state_prognostic_top,
+                local_state_primitive_top,
+                local_state_auxiliary_top,
+            )
+
+            fill!(local_flux, -zero(eltype(local_flux)))
+            # TODO
+            bctag = elemtobndy[f_bottom, e]
+            local_state_prognostic⁻ .= local_state_prognostic_bottom
+            local_state_auxiliary⁻ .= local_state_auxiliary_bottom
+            numerical_boundary_flux_first_order!(
+                numerical_flux_first_order,
+                bctag,
+                balance_law,
+                local_flux,
+                normal_vector_bottom,
+                local_state_prognostic_bottom,
+                local_state_auxiliary_bottom,
+                # TODO 
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                t,
+                face_direction,
+                local_state_prognostic_boundary,
+                local_state_auxiliary_boundary,
+            )
+
+            local_state_prognostic⁻ .= local_state_prognostic_bottom
+            local_state_gradient_flux⁻ .= local_state_gradient_flux
+            local_state_hyperdiffusion⁻ .= local_state_hyperdiffusion
+            local_state_auxiliary⁻ .= local_state_auxiliary_bottom
+            numerical_boundary_flux_second_order!(
+                numerical_flux_second_order,
+                bctag,
+                balance_law,
+                local_flux,
+                normal_vector_bottom,
+                #
+                local_state_prognostic_bottom,
+                local_state_gradient_flux,
+                local_state_hyperdiffusion,
+                local_state_auxiliary_bottom,
+                #
+                local_state_prognostic⁻,
+                local_state_gradient_flux⁻,
+                local_state_hyperdiffusion⁻,
+                local_state_auxiliary⁻,
+                t,
+                local_state_prognostic_boundary,
+                local_state_gradient_flux_boundary,
+                local_state_auxiliary_boundary,
+            )
+
+            @unroll for s in 1:num_state_prognostic
+                tendency[n, s, e] -= α * vMI * sM_bottom * (local_flux[s])
+            end
+
+            #TODO
+            local_state_prognostic⁻_top .= local_state_prognostic_top
+            local_state_auxiliary⁻_top .= local_state_auxiliary_top
+
+        end
+    end
+
+    # Loop up the vertical stack to update the minus side element (we have the
+    # bottom flux from the previous element, so only need to calculate the top
+    # flux)
+    @inbounds for eV in 2:(nvertelem - 1)
+        e = eH + eV
+        e⁻ = e - 1
+        e⁺ = e + 1
+
+        # volume mass inverse
+        cw⁻, cw, cw⁺ = vgeo[n, _M, e⁻], vgeo[n, _M, e], vgeo[n, _M, e⁺]
+
+        # Compute the top face numerical flux
+        # The minus side is the bottom element
+        # The plus side is the top element
+        f_bottom = faces[1]
+        # surface mass
+        sM_bottom = sgeo[_sM, n, f_bottom, e]
+
+        # outward normal with respect to the element
+        normal_vector_bottom = SVector(
+            sgeo[_n1, n, f_bottom, e],
+            sgeo[_n2, n, f_bottom, e],
+            sgeo[_n3, n, f_bottom, e],
+        )
+
+
+        # Load plus side data (minus data is already set)
+        local_state_prognostic⁻ .= local_state_prognostic
+        local_state_auxiliary⁻ .= local_state_auxiliary
+        local_state_gradient_flux⁻ .= local_state_gradient_flux
+        local_state_prognostic .= local_state_prognostic⁺
+        local_state_auxiliary .= local_state_auxiliary⁺
+        local_state_gradient_flux .= local_state_gradient_flux⁺
+        load_data!(
+            local_state_prognostic⁺,
+            local_state_auxiliary⁺,
+            local_state_gradient_flux⁺,
+            e⁺,
+        )
+
+
+        prognostic_to_primitive!(
+            balance_law,
+            local_state_primitive⁻,
+            local_state_prognostic⁻,
+            local_state_auxiliary⁻,
+        )
+
+        prognostic_to_primitive!(
+            balance_law,
+            local_state_primitive,
+            local_state_prognostic,
+            local_state_auxiliary,
+        )
+
+        prognostic_to_primitive!(
+            balance_law,
+            local_state_primitive⁺,
+            local_state_prognostic⁺,
+            local_state_auxiliary⁺,
+        )
+
+
+        cell_states_primitive = (
+            local_state_primitive⁻,
+            local_state_primitive,
+            local_state_primitive⁺,
+        )
+
+        cell_weights = SVector(cw⁻, cw, cw⁺)
+
+        # Linear Reconstuction
+        reconstruction!(
+            local_state_primitive_bottom,
+            local_state_primitive_top,
+            cell_states_primitive,
+            cell_weights,
+        )
+
+        # TODO
+        local_state_auxiliary_bottom .= local_state_auxiliary
+        local_state_auxiliary_top .= local_state_auxiliary
+
+        primitive_to_prognostic!(
+            balance_law,
+            local_state_prognostic_bottom,
+            local_state_primitive_bottom,
+            local_state_auxiliary_bottom,
+        )
+
+        primitive_to_prognostic!(
+            balance_law,
+            local_state_prognostic_top,
+            local_state_primitive_top,
+            local_state_auxiliary_top,
+        )
+
+        ###  TODO HYDROSTATIC BALANCE RECONSTRUCTION
+
+        # compute the flux
+        fill!(local_flux, -zero(eltype(local_flux)))
+
+        numerical_flux_first_order!(
+            numerical_flux_first_order,
+            balance_law,
+            local_flux,
+            normal_vector_bottom,
+            local_state_prognostic_bottom,
+            local_state_auxiliary_bottom,
+            local_state_prognostic⁻_top,
+            local_state_auxiliary⁻_top,
+            t,
+            face_direction,
+        )
+
+        numerical_flux_second_order!(
+            numerical_flux_second_order,
+            balance_law,
+            local_flux,
+            normal_vector_bottom,
+            #
+            # local_state_prognostic_bottom,
+            local_state_prognostic,
+            local_state_gradient_flux,
+            local_state_hyperdiffusion,
+            # local_state_auxiliary_bottom,
+            local_state_auxiliary,
+            #
+            # local_state_prognostic⁻_top,
+            local_state_prognostic⁻,
+            local_state_gradient_flux⁻,
+            local_state_hyperdiffusion⁻,
+            # local_state_auxiliary⁻_top,
+            local_state_auxiliary⁻,
+            t,
+        )
+
+        # Update RHS (in outer face loop): M⁻¹ Mfᵀ(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆))
+        # TODO: This isn't correct:
+        # FIXME: Should we pretch these?
+        vMI = vgeo[n, _MI, e⁻]
+        @unroll for s in 1:num_state_prognostic
+            tendency[n, s, e⁻] += α * vMI * sM_bottom * (local_flux[s])
+        end
+        vMI = vgeo[n, _MI, e]
+        @unroll for s in 1:num_state_prognostic
+            tendency[n, s, e] -= α * vMI * sM_bottom * (local_flux[s])
+        end
+
+        local_state_prognostic⁻_top .= local_state_prognostic_top
+        local_state_auxiliary⁻_top .= local_state_auxiliary_top
+    end
+
+    # The top element
+    @inbounds begin
+        eV = nvertelem
+        # the first element
+        e = eH + eV
+        # bottom face
+        f_bottom, f_top = faces[1], faces[2]
+
+        # surface mass
+        sM_bottom, sM_top = sgeo[_sM, n, f_bottom, e], sgeo[_sM, n, f_top, e]
+        cw = vgeo[n, _M, e]
+        # outward normal for this face
+        # outward normal for this the bottom face
+        normal_vector_bottom = SVector(
+            sgeo[_n1, n, f_bottom, e],
+            sgeo[_n2, n, f_bottom, e],
+            sgeo[_n3, n, f_bottom, e],
+        )
+
+        # outward normal for this the bottom face
+        normal_vector_top = SVector(
+            sgeo[_n1, n, f_top, e],
+            sgeo[_n2, n, f_top, e],
+            sgeo[_n3, n, f_top, e],
+        )
+
+        if periodicstack
+
+            e⁻ = e - 1
+            e⁺ = eH + 1
+            cw⁻ = vgeo[n, _M, e⁻]
+            cw⁺ = vgeo[n, _M, e⁺]
+
+            local_state_prognostic⁻ .= local_state_prognostic
+            local_state_auxiliary⁻ .= local_state_auxiliary
+            local_state_gradient_flux⁻ .= local_state_gradient_flux
+            local_state_prognostic .= local_state_prognostic⁺
+            local_state_auxiliary .= local_state_auxiliary⁺
+            local_state_gradient_flux .= local_state_gradient_flux⁺
+            load_data!(
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
+                local_state_gradient_flux⁺,
+                e⁺,
+            )
+
+            prognostic_to_primitive!(
+                balance_law,
+                local_state_primitive⁻,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+            )
+            prognostic_to_primitive!(
+                balance_law,
+                local_state_primitive,
+                local_state_prognostic,
+                local_state_auxiliary,
+            )
+            prognostic_to_primitive!(
+                balance_law,
+                local_state_primitive⁺,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
+            )
+
+            cell_states_primitive = (
+                local_state_primitive⁻,
+                local_state_primitive,
+                local_state_primitive⁺,
+            )
+
+            cell_weights = SVector(cw⁻, cw, cw⁺)
+
+            # Linear Reconstuction
+            reconstruction!(
+                local_state_primitive_bottom,
+                local_state_primitive_top,
+                cell_states_primitive,
+                cell_weights,
+            )
+
+            # TODO
+            local_state_auxiliary_bottom .= local_state_auxiliary
+            local_state_auxiliary_top .= local_state_auxiliary
+
+            primitive_to_prognostic!(
+                balance_law,
+                local_state_prognostic_bottom,
+                local_state_primitive_bottom,
+                local_state_auxiliary_bottom,
+            )
+
+            primitive_to_prognostic!(
+                balance_law,
+                local_state_prognostic_top,
+                local_state_primitive_top,
+                local_state_auxiliary_top,
+            )
+
+            # compute the bottom flux
+            fill!(local_flux, -zero(eltype(local_flux)))
+
+            numerical_flux_first_order!(
+                numerical_flux_first_order,
+                balance_law,
+                local_flux,
+                normal_vector_bottom,
+                local_state_prognostic_bottom,
+                local_state_auxiliary_bottom,
+                local_state_prognostic⁻_top,
+                local_state_auxiliary⁻_top,
+                t,
+                face_direction,
+            )
+
+            numerical_flux_second_order!(
+                numerical_flux_second_order,
+                balance_law,
+                local_flux,
+                normal_vector_bottom,
+                #
+                # local_state_prognostic_bottom,
+                local_state_prognostic,
+                local_state_gradient_flux,
+                local_state_hyperdiffusion,
+                # local_state_auxiliary_bottom,
+                local_state_auxiliary,
+                #
+                # local_state_prognostic⁻_top,
+                local_state_prognostic⁻,
+                local_state_gradient_flux⁻,
+                local_state_hyperdiffusion⁻,
+                # local_state_auxiliary⁻_top,
+                local_state_auxiliary⁻,
+                t,
+            )
+
+            # Update RHS (in outer face loop): M⁻¹ Mfᵀ(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆))
+            # TODO: This isn't correct:
+            # FIXME: Should we pretch these?
+            vMI = vgeo[n, _MI, e⁻]
+            @unroll for s in 1:num_state_prognostic
+                tendency[n, s, e⁻] += α * vMI * sM_bottom * (local_flux[s])
+            end
+            vMI = vgeo[n, _MI, e]
+            @unroll for s in 1:num_state_prognostic
+                tendency[n, s, e] -= α * vMI * sM_bottom * (local_flux[s])
+            end
+
+            # compute the top flux
+            fill!(local_flux, -zero(eltype(local_flux)))
+
+            numerical_flux_first_order!(
+                numerical_flux_first_order,
+                balance_law,
+                local_flux,
+                normal_vector_top,
+                local_state_prognostic_top,
+                local_state_auxiliary_top,
+                local_state_prognostic⁺_bottom,
+                local_state_auxiliary⁺_bottom,
+                t,
+                face_direction,
+            )
+
+            numerical_flux_second_order!(
+                numerical_flux_second_order,
+                balance_law,
+                local_flux,
+                normal_vector_top,
+                #
+                # local_state_prognostic_top,
+                local_state_prognostic,
+                local_state_gradient_flux,
+                local_state_hyperdiffusion,
+                # local_state_auxiliary_top,
+                local_state_auxiliary,
+                #
+                # local_state_prognostic⁺_bottom,
+                local_state_prognostic⁺,
+                local_state_gradient_flux⁺,
+                local_state_hyperdiffusion⁺,
+                # local_state_auxiliary⁺_bottom,
+                local_state_auxiliary⁺,
+                t,
+            )
+
+            # Update RHS (in outer face loop): M⁻¹ Mfᵀ(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆))
+
+            vMI = vgeo[n, _MI, e]
+            @unroll for s in 1:num_state_prognostic
+                tendency[n, s, e] -= α * vMI * sM_top * (local_flux[s])
+            end
+            vMI = vgeo[n, _MI, e⁺]
+            @unroll for s in 1:num_state_prognostic
+                tendency[n, s, e⁺] += α * vMI * sM_top * (local_flux[s])
+            end
+
+
+        else
+            e⁻ = e - 1
+
+            # Reset arrays to the top element value
+            local_state_gradient_flux⁻ .= local_state_gradient_flux
+            local_state_prognostic .= local_state_prognostic⁺
+            local_state_auxiliary .= local_state_auxiliary⁺
+            local_state_gradient_flux .= local_state_gradient_flux⁺
+            local_state_auxiliary_bottom .= local_state_auxiliary
+            local_state_auxiliary_top .= local_state_auxiliary
+
+            prognostic_to_primitive!(
+                balance_law,
+                local_state_primitive,
+                local_state_prognostic,
+                local_state_auxiliary,
+            )
+            cell_states_primitive = (local_state_primitive,)
+            cell_weights = SVector(cw)
+
+            # Constant reconstruction
+            reconstruction!(
+                local_state_primitive_bottom,
+                local_state_primitive_top,
+                cell_states_primitive,
+                cell_weights,
+            )
+
+            primitive_to_prognostic!(
+                balance_law,
+                local_state_prognostic_bottom,
+                local_state_primitive_bottom,
+                local_state_auxiliary_bottom,
+            )
+
+            primitive_to_prognostic!(
+                balance_law,
+                local_state_prognostic_top,
+                local_state_primitive_top,
+                local_state_auxiliary_top,
+            )
+
+            # bottom flux
+            fill!(local_flux, -zero(eltype(local_flux)))
+
+            numerical_flux_first_order!(
+                numerical_flux_first_order,
+                balance_law,
+                local_flux,
+                normal_vector_bottom,
+                local_state_prognostic_bottom,
+                local_state_auxiliary_bottom,
+                local_state_prognostic⁻_top,
+                local_state_auxiliary⁻_top,
+                t,
+                face_direction,
+            )
+
+            numerical_flux_second_order!(
+                numerical_flux_second_order,
+                balance_law,
+                local_flux,
+                normal_vector_bottom,
+                #
+                local_state_prognostic_bottom,
+                local_state_gradient_flux,
+                local_state_hyperdiffusion,
+                local_state_auxiliary_bottom,
+                #
+                local_state_prognostic⁻_top,
+                local_state_gradient_flux⁻,
+                local_state_hyperdiffusion⁻,
+                local_state_auxiliary⁻_top,
+                t,
+            )
+
+
+
+
+            # Update RHS (in outer face loop): M⁻¹ Mfᵀ(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆))
+            # TODO: This isn't correct:
+            # FIXME: Should we pretch these?
+            vMI = vgeo[n, _MI, e]
+            @unroll for s in 1:num_state_prognostic
+                tendency[n, s, e] -= α * vMI * sM_bottom * (local_flux[s])
+            end
+            vMI = vgeo[n, _MI, e⁻]
+            @unroll for s in 1:num_state_prognostic
+                tendency[n, s, e⁻] += α * vMI * sM_bottom * (local_flux[s])
+            end
+
+
+            bctag = elemtobndy[f_top, e]
+
+            fill!(local_flux, -zero(eltype(local_flux)))
+
+            local_state_prognostic⁺ .= local_state_prognostic_top
+            local_state_auxiliary⁺ .= local_state_auxiliary_top
+
+            numerical_boundary_flux_first_order!(
+                numerical_flux_first_order,
+                bctag,
+                balance_law,
+                local_flux,
+                normal_vector_top,
+                local_state_prognostic_top,
+                local_state_auxiliary_top,
+                #TODO
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
+                t,
+                face_direction,
+                local_state_prognostic_boundary,
+                local_state_auxiliary_boundary,
+            )
+
+            local_state_prognostic⁺ .= local_state_prognostic_top
+            local_state_gradient_flux⁺ .= local_state_gradient_flux
+            local_state_hyperdiffusion⁺ .= local_state_hyperdiffusion
+            local_state_auxiliary⁺ .= local_state_auxiliary_top
+
+            numerical_boundary_flux_second_order!(
+                numerical_flux_second_order,
+                bctag,
+                balance_law,
+                local_flux,
+                normal_vector_top,
+                #
+                local_state_prognostic_top,
+                local_state_gradient_flux,
+                local_state_hyperdiffusion,
+                local_state_auxiliary_top,
+                #
+                local_state_prognostic⁺,
+                local_state_gradient_flux⁺,
+                local_state_hyperdiffusion⁺,
+                local_state_auxiliary⁺,
+                #
+                t,
+                local_state_prognostic_boundary,
+                local_state_gradient_flux_boundary,
+                local_state_auxiliary_boundary,
+            )
+
+            vMI = vgeo[n, _MI, e]
+            @unroll for s in 1:num_state_prognostic
+                tendency[n, s, e] -= α * vMI * sM_top * (local_flux[s])
+            end
+        end
+    end
+end
+
 @kernel function vert_fvm_interface_gradients!(
     balance_law::BalanceLaw,
     ::Val{info},

--- a/src/Numerics/DGMethods/DGFVModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGFVModel_kernels.jl
@@ -1,5 +1,8 @@
-using .FVReconstructions: FVConstant, FVLinear
-using ..BalanceLaws: prognostic_to_primitive!, primitive_to_prognostic!
+import .FVReconstructions: FVConstant, FVLinear
+import ..BalanceLaws:
+    prognostic_to_primitive!, primitive_to_prognostic!, Primitive
+import .FVReconstructions: width
+import StaticArrays: SUnitRange
 
 @doc """
     function vert_fvm_interface_tendency!(
@@ -44,354 +47,7 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
     ::Val{nvertelem},
     ::Val{periodicstack},
     ::VerticalDirection,
-    ::FVConstant,
-    numerical_flux_first_order,
-    numerical_flux_second_order,
-    tendency,
-    state_prognostic,
-    state_gradient_flux,
-    state_auxiliary,
-    _,
-    sgeo,
-    t,
-    elemtobndy,
-    elems,
-    α,
-) where {info, nvertelem, periodicstack}
-    @uniform begin
-        dim = info.dim
-        FT = eltype(state_prognostic)
-        num_state_prognostic = number_states(balance_law, Prognostic())
-        num_state_gradient_flux = number_states(balance_law, GradientFlux())
-        num_state_auxiliary = number_states(balance_law, Auxiliary())
-        num_state_hyperdiffusion = number_states(balance_law, Hyperdiffusive())
-        @assert num_state_hyperdiffusion == 0
-
-        nface = info.nface
-        Np = info.Np
-        Nqk = info.Nqk # Can only be 1 for the FVM method!
-        @assert Nqk == 1
-
-        # We only have the vertical faces
-        faces = (nface - 1):nface
-
-        local_state_prognostic⁻ = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_gradient_flux⁻ =
-            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-        local_state_auxiliary⁻ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
-        local_state_hyperdiffusion⁻ =
-            MArray{Tuple{num_state_hyperdiffusion}, FT}(undef)
-
-        local_state_prognostic⁺ = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_gradient_flux⁺ =
-            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-        local_state_auxiliary⁺ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
-        local_state_hyperdiffusion⁺ =
-            MArray{Tuple{num_state_hyperdiffusion}, FT}(undef)
-
-        local_state_prognostic_bottom1 =
-            MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_gradient_flux_bottom1 =
-            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-        local_state_auxiliary_bottom1 =
-            MArray{Tuple{num_state_auxiliary}, FT}(undef)
-
-        # XXX: will revisit this later for FVM
-        fill!(local_state_prognostic_bottom1, NaN)
-        fill!(local_state_gradient_flux_bottom1, NaN)
-        fill!(local_state_auxiliary_bottom1, NaN)
-
-        local_flux_top = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_flux_bottom = MArray{Tuple{num_state_prognostic}, FT}(undef)
-
-        sM = MArray{Tuple{2}, FT}(undef)
-
-        # The remainder model needs to know which direction of face the model is
-        # being evaluated for. In this case we only have `VerticalDirection()`
-        # faces
-        face_direction = (EveryDirection(), VerticalDirection())
-    end
-
-    # Get the horizontal group IDs
-    grp_H = @index(Group, Linear)
-
-    # Determine the index for the element at the bottom of the stack
-    eHI = (grp_H - 1) * nvertelem + 1
-
-    # Compute bottom stack element index minus one (so we can add vert element
-    # number directly)
-    eH = elems[eHI] - 1
-
-    # Which degree of freedom do we handle in the element
-    n = @index(Local, Linear)
-
-    # Loads the data for a given element
-    function load_data!(
-        local_state_prognostic,
-        local_state_auxiliary,
-        local_state_gradient_flux,
-        e,
-    )
-        @unroll for s in 1:num_state_prognostic
-            local_state_prognostic[s] = state_prognostic[n, s, e]
-        end
-
-        @unroll for s in 1:num_state_auxiliary
-            local_state_auxiliary[s] = state_auxiliary[n, s, e]
-        end
-
-        @unroll for s in 1:num_state_gradient_flux
-            local_state_gradient_flux[s] = state_gradient_flux[n, s, e]
-        end
-    end
-
-    # We need to compute the first element we handles bottom flux (future
-    # elements will just copied from the prior element)
-    @inbounds begin
-        eV = 1
-
-        # Minus is the top
-        e⁻ = eH + eV
-
-        # bottom face
-        f⁻ = faces[1]
-
-        # surface mass
-        sM[1] = sgeo[_sM, n, f⁻, e⁻]
-
-        # outward normal for this face
-        normal_vector = SVector(
-            sgeo[_n1, n, f⁻, e⁻],
-            sgeo[_n2, n, f⁻, e⁻],
-            sgeo[_n3, n, f⁻, e⁻],
-        )
-
-        # determine the plus side element (bottom)
-        e⁺, bctag = if periodicstack
-            eH + nvertelem, 0
-        else
-            e⁻, elemtobndy[f⁻, e⁻]
-        end
-
-        # Load minus and plus side data
-        load_data!(
-            local_state_prognostic⁻,
-            local_state_auxiliary⁻,
-            local_state_gradient_flux⁻,
-            e⁻,
-        )
-        load_data!(
-            local_state_prognostic⁺,
-            local_state_auxiliary⁺,
-            local_state_gradient_flux⁺,
-            e⁺,
-        )
-
-        # compute the flux
-        fill!(local_flux_bottom, -zero(eltype(local_flux_bottom)))
-        if bctag == 0
-            numerical_flux_first_order!(
-                numerical_flux_first_order,
-                balance_law,
-                local_flux_bottom,
-                normal_vector,
-                local_state_prognostic⁻,
-                local_state_auxiliary⁻,
-                local_state_prognostic⁺,
-                local_state_auxiliary⁺,
-                t,
-                face_direction,
-            )
-            numerical_flux_second_order!(
-                numerical_flux_second_order,
-                balance_law,
-                local_flux_bottom,
-                normal_vector,
-                local_state_prognostic⁻,
-                local_state_gradient_flux⁻,
-                local_state_hyperdiffusion⁻,
-                local_state_auxiliary⁻,
-                local_state_prognostic⁺,
-                local_state_gradient_flux⁺,
-                local_state_hyperdiffusion⁺,
-                local_state_auxiliary⁺,
-                t,
-            )
-        else
-            numerical_boundary_flux_first_order!(
-                numerical_flux_first_order,
-                bctag,
-                balance_law,
-                local_flux_bottom,
-                normal_vector,
-                local_state_prognostic⁻,
-                local_state_auxiliary⁻,
-                local_state_prognostic⁺,
-                local_state_auxiliary⁺,
-                t,
-                face_direction,
-                local_state_prognostic_bottom1,
-                local_state_auxiliary_bottom1,
-            )
-            numerical_boundary_flux_second_order!(
-                numerical_flux_second_order,
-                bctag,
-                balance_law,
-                local_flux_bottom,
-                normal_vector,
-                local_state_prognostic⁻,
-                local_state_gradient_flux⁻,
-                local_state_hyperdiffusion⁻,
-                local_state_auxiliary⁻,
-                local_state_prognostic⁺,
-                local_state_gradient_flux⁺,
-                local_state_hyperdiffusion⁺,
-                local_state_auxiliary⁺,
-                t,
-                local_state_prognostic_bottom1,
-                local_state_gradient_flux_bottom1,
-                local_state_auxiliary_bottom1,
-            )
-        end
-    end
-
-    # Loop up the vertical stack to update the minus side element (we have the
-    # bottom flux from the previous element, so only need to calculate the top
-    # flux)
-    @inbounds for eV in 1:nvertelem
-        e⁻ = eH + eV
-
-        # volume mass inverse
-        vMI = sgeo[_vMI, n, faces[1], e⁻]
-
-        # Compute the top face numerical flux
-        # The minus side is the bottom element
-        # The plus side is the top element
-        f⁻ = faces[2]
-
-        # surface mass
-        sM[2] = sgeo[_sM, n, f⁻, e⁻]
-
-        # normal with respect to the minus side
-        normal_vector = SVector(
-            sgeo[_n1, n, f⁻, e⁻],
-            sgeo[_n2, n, f⁻, e⁻],
-            sgeo[_n3, n, f⁻, e⁻],
-        )
-
-        # determine the plus side element (top)
-        e⁺, bctag = if eV != nvertelem
-            e⁻ + 1, 0
-        elseif periodicstack
-            eH + 1, 0
-        else
-            e⁻, elemtobndy[f⁻, e⁻]
-        end
-
-        # Load plus side data (minus data is already set)
-        load_data!(
-            local_state_prognostic⁺,
-            local_state_auxiliary⁺,
-            local_state_gradient_flux⁺,
-            e⁺,
-        )
-
-        # compute the flux
-        fill!(local_flux_top, -zero(eltype(local_flux_top)))
-        if bctag == 0
-            numerical_flux_first_order!(
-                numerical_flux_first_order,
-                balance_law,
-                local_flux_top,
-                normal_vector,
-                local_state_prognostic⁻,
-                local_state_auxiliary⁻,
-                local_state_prognostic⁺,
-                local_state_auxiliary⁺,
-                t,
-                face_direction,
-            )
-            numerical_flux_second_order!(
-                numerical_flux_second_order,
-                balance_law,
-                local_flux_top,
-                normal_vector,
-                local_state_prognostic⁻,
-                local_state_gradient_flux⁻,
-                local_state_hyperdiffusion⁻,
-                local_state_auxiliary⁻,
-                local_state_prognostic⁺,
-                local_state_gradient_flux⁺,
-                local_state_hyperdiffusion⁺,
-                local_state_auxiliary⁺,
-                t,
-            )
-        else
-            numerical_boundary_flux_first_order!(
-                numerical_flux_first_order,
-                bctag,
-                balance_law,
-                local_flux_top,
-                normal_vector,
-                local_state_prognostic⁻,
-                local_state_auxiliary⁻,
-                local_state_prognostic⁺,
-                local_state_auxiliary⁺,
-                t,
-                face_direction,
-                local_state_prognostic_bottom1,
-                local_state_auxiliary_bottom1,
-            )
-            numerical_boundary_flux_second_order!(
-                numerical_flux_second_order,
-                bctag,
-                balance_law,
-                local_flux_top,
-                normal_vector,
-                local_state_prognostic⁻,
-                local_state_gradient_flux⁻,
-                local_state_hyperdiffusion⁻,
-                local_state_auxiliary⁻,
-                local_state_prognostic⁺,
-                local_state_gradient_flux⁺,
-                local_state_hyperdiffusion⁺,
-                local_state_auxiliary⁺,
-                t,
-                local_state_prognostic_bottom1,
-                local_state_gradient_flux_bottom1,
-                local_state_auxiliary_bottom1,
-            )
-        end
-
-        # Update RHS M⁻¹ Mfᵀ(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆))
-        @unroll for s in 1:num_state_prognostic
-            # FIXME: Should we pretch these?
-            tendency[n, s, e⁻] -=
-                α *
-                vMI *
-                (sM[2] * (local_flux_top[s]) + sM[1] * (local_flux_bottom[s]))
-        end
-
-        # Set the flux bottom flux for the next element
-        local_flux_bottom .= -local_flux_top
-
-        # set the surface mass matrix
-        sM[1] = sM[2]
-
-        # the current plus side is the next minus side
-        local_state_prognostic⁻ .= local_state_prognostic⁺
-        local_state_auxiliary⁻ .= local_state_auxiliary⁺
-        local_state_gradient_flux⁻ .= local_state_gradient_flux⁺
-    end
-end
-
-@kernel function vert_fvm_interface_tendency!(
-    balance_law::BalanceLaw,
-    ::Val{info},
-    ::Val{nvertelem},
-    ::Val{periodicstack},
-    ::VerticalDirection,
-    reconstruction!::FVLinear,
+    reconstruction!,
     numerical_flux_first_order,
     numerical_flux_second_order,
     tendency,
@@ -409,98 +65,105 @@ end
         dim = info.dim
         FT = eltype(state_prognostic)
         num_state_prognostic = number_states(balance_law, Prognostic())
+        num_state_primitive = number_states(balance_law, Primitive())
         num_state_auxiliary = number_states(balance_law, Auxiliary())
         num_state_gradient_flux = number_states(balance_law, GradientFlux())
-        num_state_hyperdiffusion = number_states(balance_law, Hyperdiffusive())
-        @assert num_state_hyperdiffusion == 0
-
-        vsp = Vars{vars_state(balance_law, Prognostic(), FT)}
-        vsa = Vars{vars_state(balance_law, Auxiliary(), FT)}
+        num_state_hyperdiffusive = number_states(balance_law, Hyperdiffusive())
+        @assert num_state_hyperdiffusive == 0
 
         nface = info.nface
         Np = info.Np
-        Nqk = info.Nqk # can only be 1 for the FVM method!
+        Nqk = info.Nqk # Can only be 1 for the FVM method!
         @assert Nqk == 1
-
-        @assert nvertelem >= 3
 
         # We only have the vertical faces
         faces = (nface - 1):nface
 
-        # +/- indicate top/bottom elements
-        # top and bottom indicate face states
+        stencil_width = width(reconstruction!)
 
+        # If this fails the `@nif` below needs to change
+        @assert stencil_width < 4
+
+        # In the case of stencil_width = 0 we still need two values to evaluate
+        # the fluxes, so the minimum stencil diameter is 2
+        stencil_diameter = max(2, 2stencil_width + 1)
+
+        # Value in the stencil that corresponds to the top face with respect to
+        # face being updated
+        stencil_center = max(stencil_width, 1) + 1
+
+        # 1 → element i, face i - 1/2 (bottom face)
+        # 2 → element i, face i + 1/2 (top face)
+        local_state_face_prognostic = ntuple(Val(2)) do _
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+        end
+
+        local_cell_weights = MArray{Tuple{stencil_diameter}, FT}(undef)
+
+        # Two mass matrix inverse corresponding to +/- cells
+        vMI = MArray{Tuple{2}, FT}(undef)
+
+        # Storing the value below element when walking up the stack
+        # cell i-1, face i - 1/2
+        local_state_face_prognostic_neighbor =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+
+        local_state_face_primitive = ntuple(Val(2)) do _
+            MArray{Tuple{num_state_primitive}, FT}(undef)
+        end
+
+        # Storage for all the values in the stencil
+        local_state_prognostic = ntuple(Val(stencil_diameter)) do _
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+        end
+
+
+        # Need to wrap in SVector so we can use views later
+        local_state_primitive = SVector(ntuple(Val(stencil_diameter)) do _
+            MArray{Tuple{num_state_primitive}, FT}(undef)
+        end...)
+
+        local_state_auxiliary = ntuple(Val(stencil_diameter)) do _
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        end
+
+        # FIXME: These two arrays could be smaller
+        # (only 2 elements not stencil_diameter)
+        local_state_gradient_flux = ntuple(Val(stencil_diameter)) do _
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        end
+
+        local_state_hyperdiffusive = ntuple(Val(stencil_diameter)) do _
+            MArray{Tuple{num_state_hyperdiffusive}, FT}(undef)
+        end
+
+        # Storage for the numerical flux
         local_flux = MArray{Tuple{num_state_prognostic}, FT}(undef)
 
-        local_state_prognostic = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_prognostic⁺ = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_prognostic⁻ = MArray{Tuple{num_state_prognostic}, FT}(undef)
-
-        local_state_primitive = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_primitive⁺ = MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_primitive⁻ = MArray{Tuple{num_state_prognostic}, FT}(undef)
-
-        local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
-        local_state_auxiliary⁺ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
-        local_state_auxiliary⁻ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
-
-        local_state_gradient_flux⁻ =
+        # Storage for the extra boundary points for some BCs
+        local_state_prognostic_bottom1 =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_gradient_flux_bottom1 =
             MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-        local_state_gradient_flux =
-            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-        local_state_gradient_flux⁺ =
-            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-
-        local_state_hyperdiffusion⁻ =
-            MArray{Tuple{num_state_hyperdiffusion}, FT}(undef)
-        local_state_hyperdiffusion =
-            MArray{Tuple{num_state_hyperdiffusion}, FT}(undef)
-        local_state_hyperdiffusion⁺ =
-            MArray{Tuple{num_state_hyperdiffusion}, FT}(undef)
-
-        local_state_primitive_bottom =
-            MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_primitive_top =
-            MArray{Tuple{num_state_prognostic}, FT}(undef)
-
-        local_state_prognostic_bottom =
-            MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_prognostic_top =
-            MArray{Tuple{num_state_prognostic}, FT}(undef)
-
-        local_state_auxiliary_bottom =
+        local_state_auxiliary_bottom1 =
             MArray{Tuple{num_state_auxiliary}, FT}(undef)
-        local_state_auxiliary_top =
-            MArray{Tuple{num_state_auxiliary}, FT}(undef)
-
-        local_state_prognostic⁻_top =
-            MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_prognostic⁺_bottom =
-            MArray{Tuple{num_state_prognostic}, FT}(undef)
-
-        local_state_auxiliary⁻_top =
-            MArray{Tuple{num_state_auxiliary}, FT}(undef)
-        local_state_auxiliary⁺_bottom =
-            MArray{Tuple{num_state_auxiliary}, FT}(undef)
-
-
-        local_state_prognostic_boundary =
-            MArray{Tuple{num_state_prognostic}, FT}(undef)
-        local_state_auxiliary_boundary =
-            MArray{Tuple{num_state_auxiliary}, FT}(undef)
-        local_state_gradient_flux_boundary =
-            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
 
         # XXX: will revisit this later for FVM
-        fill!(local_state_prognostic_boundary, NaN)
-        fill!(local_state_auxiliary_boundary, NaN)
-        fill!(local_state_gradient_flux_boundary, NaN)
+        fill!(local_state_prognostic_bottom1, NaN)
+        fill!(local_state_gradient_flux_bottom1, NaN)
+        fill!(local_state_auxiliary_bottom1, NaN)
 
         # The remainder model needs to know which direction of face the model is
         # being evaluated for. In this case we only have `VerticalDirection()`
         # faces
         face_direction = (VerticalDirection(),)
     end
+
+    # Optimization ideas:
+    #  - More than 1 thread per stack
+    #  - shift pointers not data
+    #  - Don't keep wide stencil for all variables / data
+    #  - Don't load periodic data when domain is not periodic
 
     # Get the horizontal group IDs
     grp_H = @index(Group, Linear)
@@ -523,732 +186,414 @@ end
         e,
     )
         @unroll for s in 1:num_state_prognostic
-            local_state_prognostic[s] = state_prognostic[n, s, e]
+            @inbounds local_state_prognostic[s] = state_prognostic[n, s, e]
         end
 
         @unroll for s in 1:num_state_auxiliary
-            local_state_auxiliary[s] = state_auxiliary[n, s, e]
+            @inbounds local_state_auxiliary[s] = state_auxiliary[n, s, e]
         end
 
         @unroll for s in 1:num_state_gradient_flux
-            local_state_gradient_flux[s] = state_gradient_flux[n, s, e]
+            @inbounds local_state_gradient_flux[s] =
+                state_gradient_flux[n, s, e]
         end
     end
 
-    # We need to compute the first element we handles bottom flux (only for nonperiodic boundary condition)
-    # elements will just copied from the prior element)
+    # To update the first element we either need to apply a BCS on the bottom
+    # face in the nonperiodic case, or we need to reconstruct the periodic value
+    # for the bottom face
     @inbounds begin
-        eV = 1
-        # the first element
-        e = eH + eV
+        # If periodic, we are doing the reconstruction in element periodically
+        # below the first element, otherwise we are reconstructing the first
+        # element
+        eV = periodicstack ? nvertelem : 1
 
-        # bottom face
-        f_bottom = faces[1]
-        # surface mass
-        sM_bottom = sgeo[_sM, n, f_bottom, e]
-        cw = vgeo[n, _M, e]
-        vMI = vgeo[n, _MI, e]
+        # Figure out the data we need
+        els = ntuple(Val(stencil_diameter)) do k
+            eH + mod1(eV - 1 + k - (stencil_center - 1), nvertelem)
+        end
 
-        # outward normal for this the bottom face
-        normal_vector_bottom = SVector(
-            sgeo[_n1, n, f_bottom, e],
-            sgeo[_n2, n, f_bottom, e],
-            sgeo[_n3, n, f_bottom, e],
-        )
+        # Load all the stencil data
+        @unroll for k in 1:stencil_diameter
+            load_data!(
+                local_state_prognostic[k],
+                local_state_auxiliary[k],
+                local_state_gradient_flux[k],
+                els[k],
+            )
+            # If local cell weights are NOT _M we need to load _vMI out of sgeo
+            local_cell_weights[k] = vgeo[n, _M, els[k]]
+        end
 
+        # Transform all the data into primitive variables
+        @unroll for k in 1:stencil_diameter
+            prognostic_to_primitive!(
+                balance_law,
+                local_state_primitive[k],
+                local_state_prognostic[k],
+                local_state_auxiliary[k],
+            )
+        end
+        vMI[2] = 1 / local_cell_weights[stencil_center]
+
+        # If we are periodic we reconstruct the top and bottom values for eV
+        # then start with eV update in loop below
         if periodicstack
-            e⁻ = eH + nvertelem
-            e⁺ = e + 1
-            cw⁻ = vgeo[n, _M, e⁻]
-            cw⁺ = vgeo[n, _M, e⁺]
-
-            load_data!(
-                local_state_prognostic⁻,
-                local_state_auxiliary⁻,
-                local_state_gradient_flux⁻,
-                e⁻,
-            )
-            load_data!(
-                local_state_prognostic,
-                local_state_auxiliary,
-                local_state_gradient_flux,
-                e,
-            )
-            load_data!(
-                local_state_prognostic⁺,
-                local_state_auxiliary⁺,
-                local_state_gradient_flux⁺,
-                e⁺,
-            )
-
-            prognostic_to_primitive!(
-                balance_law,
-                local_state_primitive⁻,
-                local_state_prognostic⁻,
-                local_state_auxiliary⁻,
-            )
-            prognostic_to_primitive!(
-                balance_law,
-                local_state_primitive,
-                local_state_prognostic,
-                local_state_auxiliary,
-            )
-            prognostic_to_primitive!(
-                balance_law,
-                local_state_primitive⁺,
-                local_state_prognostic⁺,
-                local_state_auxiliary⁺,
-            )
-
-            cell_states_primitive = (
-                local_state_primitive⁻,
-                local_state_primitive,
-                local_state_primitive⁺,
-            )
-
-            cell_weights = SVector(cw⁻, cw, cw⁺)
-
-            # Linear Reconstuction
+            # Reconstruct the top and bottom values
+            rng1, rng2 = stencil_center .+ (-stencil_width, stencil_width)
+            rng = SUnitRange(rng1, rng2)
             reconstruction!(
-                local_state_primitive_bottom,
-                local_state_primitive_top,
-                cell_states_primitive,
-                cell_weights,
+                local_state_face_primitive[1],
+                local_state_face_primitive[2],
+                local_state_primitive[rng],
+                local_cell_weights[rng],
             )
 
-            # TODO
-            local_state_auxiliary_bottom .= local_state_auxiliary
-            local_state_auxiliary_top .= local_state_auxiliary
-
-            primitive_to_prognostic!(
-                balance_law,
-                local_state_prognostic_bottom,
-                local_state_primitive_bottom,
-                local_state_auxiliary_bottom,
-            )
-
-            primitive_to_prognostic!(
-                balance_law,
-                local_state_prognostic_top,
-                local_state_primitive_top,
-                local_state_auxiliary_top,
-            )
-
-            # this is used for the stack top element
-            local_state_prognostic⁺_bottom .= local_state_prognostic_bottom
-            local_state_auxiliary⁺_bottom .= local_state_auxiliary_bottom
-            local_state_prognostic⁻_top .= local_state_prognostic_top
-            local_state_auxiliary⁻_top .= local_state_auxiliary_top
-
+            # Transform the values back to prognostic state
+            @unroll for f in 1:2
+                primitive_to_prognostic!(
+                    balance_law,
+                    local_state_face_prognostic[f],
+                    local_state_face_primitive[f],
+                    # Use the cell auxiliary data
+                    local_state_auxiliary[stencil_center],
+                )
+            end
         else
 
-            e⁺ = e + 1
-            load_data!(
-                local_state_prognostic,
-                local_state_auxiliary,
-                local_state_gradient_flux,
-                e,
-            )
-            load_data!(
-                local_state_prognostic⁺,
-                local_state_auxiliary⁺,
-                local_state_gradient_flux⁺,
-                e⁺,
+            bctag = elemtobndy[faces[1], eH + eV]
+
+            sM = sgeo[_sM, n, faces[1], eH + eV]
+            normal = SVector(
+                sgeo[_n1, n, faces[1], eH + eV],
+                sgeo[_n2, n, faces[1], eH + eV],
+                sgeo[_n3, n, faces[1], eH + eV],
             )
 
-            prognostic_to_primitive!(
-                balance_law,
-                local_state_primitive,
-                local_state_prognostic,
-                local_state_auxiliary,
-            )
-            cell_states_primitive = (local_state_primitive,)
-            cell_weights = SVector(cw)
-
-            # Constant reconstruction
+            # Reconstruction using only eVs cell value
+            rng = SUnitRange(stencil_center, stencil_center)
             reconstruction!(
-                local_state_primitive_bottom,
-                local_state_primitive_top,
-                cell_states_primitive,
-                cell_weights,
+                local_state_face_primitive[1],
+                local_state_face_primitive[2],
+                local_state_primitive[rng],
+                local_cell_weights[rng],
             )
 
-            # TODO
-            local_state_auxiliary_bottom .= local_state_auxiliary
-            local_state_auxiliary_top .= local_state_auxiliary
-
-            primitive_to_prognostic!(
-                balance_law,
-                local_state_prognostic_bottom,
-                local_state_primitive_bottom,
-                local_state_auxiliary_bottom,
-            )
-
-            primitive_to_prognostic!(
-                balance_law,
-                local_state_prognostic_top,
-                local_state_primitive_top,
-                local_state_auxiliary_top,
-            )
-
-            fill!(local_flux, -zero(eltype(local_flux)))
-            # TODO
-            bctag = elemtobndy[f_bottom, e]
-            local_state_prognostic⁻ .= local_state_prognostic_bottom
-            local_state_auxiliary⁻ .= local_state_auxiliary_bottom
-            numerical_boundary_flux_first_order!(
-                numerical_flux_first_order,
-                bctag,
-                balance_law,
-                local_flux,
-                normal_vector_bottom,
-                local_state_prognostic_bottom,
-                local_state_auxiliary_bottom,
-                # TODO 
-                local_state_prognostic⁻,
-                local_state_auxiliary⁻,
-                t,
-                face_direction,
-                local_state_prognostic_boundary,
-                local_state_auxiliary_boundary,
-            )
-
-            local_state_prognostic⁻ .= local_state_prognostic_bottom
-            local_state_gradient_flux⁻ .= local_state_gradient_flux
-            local_state_hyperdiffusion⁻ .= local_state_hyperdiffusion
-            local_state_auxiliary⁻ .= local_state_auxiliary_bottom
-            numerical_boundary_flux_second_order!(
-                numerical_flux_second_order,
-                bctag,
-                balance_law,
-                local_flux,
-                normal_vector_bottom,
-                #
-                local_state_prognostic_bottom,
-                local_state_gradient_flux,
-                local_state_hyperdiffusion,
-                local_state_auxiliary_bottom,
-                #
-                local_state_prognostic⁻,
-                local_state_gradient_flux⁻,
-                local_state_hyperdiffusion⁻,
-                local_state_auxiliary⁻,
-                t,
-                local_state_prognostic_boundary,
-                local_state_gradient_flux_boundary,
-                local_state_auxiliary_boundary,
-            )
-
-            @unroll for s in 1:num_state_prognostic
-                tendency[n, s, e] -= α * vMI * sM_bottom * (local_flux[s])
+            # Transform the values back to prognostic state
+            @unroll for k in 1:2
+                primitive_to_prognostic!(
+                    balance_law,
+                    local_state_face_prognostic[k],
+                    local_state_face_primitive[k],
+                    # Use the cell auxiliary data
+                    local_state_auxiliary[stencil_center],
+                )
             end
 
-            #TODO
-            local_state_prognostic⁻_top .= local_state_prognostic_top
-            local_state_auxiliary⁻_top .= local_state_auxiliary_top
-
-        end
-    end
-
-    # Loop up the vertical stack to update the minus side element (we have the
-    # bottom flux from the previous element, so only need to calculate the top
-    # flux)
-    @inbounds for eV in 2:(nvertelem - 1)
-        e = eH + eV
-        e⁻ = e - 1
-        e⁺ = e + 1
-
-        # volume mass inverse
-        cw⁻, cw, cw⁺ = vgeo[n, _M, e⁻], vgeo[n, _M, e], vgeo[n, _M, e⁺]
-
-        # Compute the top face numerical flux
-        # The minus side is the bottom element
-        # The plus side is the top element
-        f_bottom = faces[1]
-        # surface mass
-        sM_bottom = sgeo[_sM, n, f_bottom, e]
-
-        # outward normal with respect to the element
-        normal_vector_bottom = SVector(
-            sgeo[_n1, n, f_bottom, e],
-            sgeo[_n2, n, f_bottom, e],
-            sgeo[_n3, n, f_bottom, e],
-        )
-
-
-        # Load plus side data (minus data is already set)
-        local_state_prognostic⁻ .= local_state_prognostic
-        local_state_auxiliary⁻ .= local_state_auxiliary
-        local_state_gradient_flux⁻ .= local_state_gradient_flux
-        local_state_prognostic .= local_state_prognostic⁺
-        local_state_auxiliary .= local_state_auxiliary⁺
-        local_state_gradient_flux .= local_state_gradient_flux⁺
-        load_data!(
-            local_state_prognostic⁺,
-            local_state_auxiliary⁺,
-            local_state_gradient_flux⁺,
-            e⁺,
-        )
-
-
-        prognostic_to_primitive!(
-            balance_law,
-            local_state_primitive⁻,
-            local_state_prognostic⁻,
-            local_state_auxiliary⁻,
-        )
-
-        prognostic_to_primitive!(
-            balance_law,
-            local_state_primitive,
-            local_state_prognostic,
-            local_state_auxiliary,
-        )
-
-        prognostic_to_primitive!(
-            balance_law,
-            local_state_primitive⁺,
-            local_state_prognostic⁺,
-            local_state_auxiliary⁺,
-        )
-
-
-        cell_states_primitive = (
-            local_state_primitive⁻,
-            local_state_primitive,
-            local_state_primitive⁺,
-        )
-
-        cell_weights = SVector(cw⁻, cw, cw⁺)
-
-        # Linear Reconstuction
-        reconstruction!(
-            local_state_primitive_bottom,
-            local_state_primitive_top,
-            cell_states_primitive,
-            cell_weights,
-        )
-
-        # TODO
-        local_state_auxiliary_bottom .= local_state_auxiliary
-        local_state_auxiliary_top .= local_state_auxiliary
-
-        primitive_to_prognostic!(
-            balance_law,
-            local_state_prognostic_bottom,
-            local_state_primitive_bottom,
-            local_state_auxiliary_bottom,
-        )
-
-        primitive_to_prognostic!(
-            balance_law,
-            local_state_prognostic_top,
-            local_state_primitive_top,
-            local_state_auxiliary_top,
-        )
-
-        ###  TODO HYDROSTATIC BALANCE RECONSTRUCTION
-
-        # compute the flux
-        fill!(local_flux, -zero(eltype(local_flux)))
-
-        numerical_flux_first_order!(
-            numerical_flux_first_order,
-            balance_law,
-            local_flux,
-            normal_vector_bottom,
-            local_state_prognostic_bottom,
-            local_state_auxiliary_bottom,
-            local_state_prognostic⁻_top,
-            local_state_auxiliary⁻_top,
-            t,
-            face_direction,
-        )
-
-        numerical_flux_second_order!(
-            numerical_flux_second_order,
-            balance_law,
-            local_flux,
-            normal_vector_bottom,
-            #
-            # local_state_prognostic_bottom,
-            local_state_prognostic,
-            local_state_gradient_flux,
-            local_state_hyperdiffusion,
-            # local_state_auxiliary_bottom,
-            local_state_auxiliary,
-            #
-            # local_state_prognostic⁻_top,
-            local_state_prognostic⁻,
-            local_state_gradient_flux⁻,
-            local_state_hyperdiffusion⁻,
-            # local_state_auxiliary⁻_top,
-            local_state_auxiliary⁻,
-            t,
-        )
-
-        # Update RHS (in outer face loop): M⁻¹ Mfᵀ(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆))
-        # TODO: This isn't correct:
-        # FIXME: Should we pretch these?
-        vMI = vgeo[n, _MI, e⁻]
-        @unroll for s in 1:num_state_prognostic
-            tendency[n, s, e⁻] += α * vMI * sM_bottom * (local_flux[s])
-        end
-        vMI = vgeo[n, _MI, e]
-        @unroll for s in 1:num_state_prognostic
-            tendency[n, s, e] -= α * vMI * sM_bottom * (local_flux[s])
-        end
-
-        local_state_prognostic⁻_top .= local_state_prognostic_top
-        local_state_auxiliary⁻_top .= local_state_auxiliary_top
-    end
-
-    # The top element
-    @inbounds begin
-        eV = nvertelem
-        # the first element
-        e = eH + eV
-        # bottom face
-        f_bottom, f_top = faces[1], faces[2]
-
-        # surface mass
-        sM_bottom, sM_top = sgeo[_sM, n, f_bottom, e], sgeo[_sM, n, f_top, e]
-        cw = vgeo[n, _M, e]
-        # outward normal for this face
-        # outward normal for this the bottom face
-        normal_vector_bottom = SVector(
-            sgeo[_n1, n, f_bottom, e],
-            sgeo[_n2, n, f_bottom, e],
-            sgeo[_n3, n, f_bottom, e],
-        )
-
-        # outward normal for this the bottom face
-        normal_vector_top = SVector(
-            sgeo[_n1, n, f_top, e],
-            sgeo[_n2, n, f_top, e],
-            sgeo[_n3, n, f_top, e],
-        )
-
-        if periodicstack
-
-            e⁻ = e - 1
-            e⁺ = eH + 1
-            cw⁻ = vgeo[n, _M, e⁻]
-            cw⁺ = vgeo[n, _M, e⁺]
-
-            local_state_prognostic⁻ .= local_state_prognostic
-            local_state_auxiliary⁻ .= local_state_auxiliary
-            local_state_gradient_flux⁻ .= local_state_gradient_flux
-            local_state_prognostic .= local_state_prognostic⁺
-            local_state_auxiliary .= local_state_auxiliary⁺
-            local_state_gradient_flux .= local_state_gradient_flux⁺
-            load_data!(
-                local_state_prognostic⁺,
-                local_state_auxiliary⁺,
-                local_state_gradient_flux⁺,
-                e⁺,
-            )
-
-            prognostic_to_primitive!(
-                balance_law,
-                local_state_primitive⁻,
-                local_state_prognostic⁻,
-                local_state_auxiliary⁻,
-            )
-            prognostic_to_primitive!(
-                balance_law,
-                local_state_primitive,
-                local_state_prognostic,
-                local_state_auxiliary,
-            )
-            prognostic_to_primitive!(
-                balance_law,
-                local_state_primitive⁺,
-                local_state_prognostic⁺,
-                local_state_auxiliary⁺,
-            )
-
-            cell_states_primitive = (
-                local_state_primitive⁻,
-                local_state_primitive,
-                local_state_primitive⁺,
-            )
-
-            cell_weights = SVector(cw⁻, cw, cw⁺)
-
-            # Linear Reconstuction
-            reconstruction!(
-                local_state_primitive_bottom,
-                local_state_primitive_top,
-                cell_states_primitive,
-                cell_weights,
-            )
-
-            # TODO
-            local_state_auxiliary_bottom .= local_state_auxiliary
-            local_state_auxiliary_top .= local_state_auxiliary
-
-            primitive_to_prognostic!(
-                balance_law,
-                local_state_prognostic_bottom,
-                local_state_primitive_bottom,
-                local_state_auxiliary_bottom,
-            )
-
-            primitive_to_prognostic!(
-                balance_law,
-                local_state_prognostic_top,
-                local_state_primitive_top,
-                local_state_auxiliary_top,
-            )
-
-            # compute the bottom flux
-            fill!(local_flux, -zero(eltype(local_flux)))
-
-            numerical_flux_first_order!(
-                numerical_flux_first_order,
-                balance_law,
-                local_flux,
-                normal_vector_bottom,
-                local_state_prognostic_bottom,
-                local_state_auxiliary_bottom,
-                local_state_prognostic⁻_top,
-                local_state_auxiliary⁻_top,
-                t,
-                face_direction,
-            )
-
-            numerical_flux_second_order!(
-                numerical_flux_second_order,
-                balance_law,
-                local_flux,
-                normal_vector_bottom,
-                #
-                # local_state_prognostic_bottom,
-                local_state_prognostic,
-                local_state_gradient_flux,
-                local_state_hyperdiffusion,
-                # local_state_auxiliary_bottom,
-                local_state_auxiliary,
-                #
-                # local_state_prognostic⁻_top,
-                local_state_prognostic⁻,
-                local_state_gradient_flux⁻,
-                local_state_hyperdiffusion⁻,
-                # local_state_auxiliary⁻_top,
-                local_state_auxiliary⁻,
-                t,
-            )
-
-            # Update RHS (in outer face loop): M⁻¹ Mfᵀ(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆))
-            # TODO: This isn't correct:
-            # FIXME: Should we pretch these?
-            vMI = vgeo[n, _MI, e⁻]
-            @unroll for s in 1:num_state_prognostic
-                tendency[n, s, e⁻] += α * vMI * sM_bottom * (local_flux[s])
-            end
-            vMI = vgeo[n, _MI, e]
-            @unroll for s in 1:num_state_prognostic
-                tendency[n, s, e] -= α * vMI * sM_bottom * (local_flux[s])
-            end
-
-            # compute the top flux
-            fill!(local_flux, -zero(eltype(local_flux)))
-
-            numerical_flux_first_order!(
-                numerical_flux_first_order,
-                balance_law,
-                local_flux,
-                normal_vector_top,
-                local_state_prognostic_top,
-                local_state_auxiliary_top,
-                local_state_prognostic⁺_bottom,
-                local_state_auxiliary⁺_bottom,
-                t,
-                face_direction,
-            )
-
-            numerical_flux_second_order!(
-                numerical_flux_second_order,
-                balance_law,
-                local_flux,
-                normal_vector_top,
-                #
-                # local_state_prognostic_top,
-                local_state_prognostic,
-                local_state_gradient_flux,
-                local_state_hyperdiffusion,
-                # local_state_auxiliary_top,
-                local_state_auxiliary,
-                #
-                # local_state_prognostic⁺_bottom,
-                local_state_prognostic⁺,
-                local_state_gradient_flux⁺,
-                local_state_hyperdiffusion⁺,
-                # local_state_auxiliary⁺_bottom,
-                local_state_auxiliary⁺,
-                t,
-            )
-
-            # Update RHS (in outer face loop): M⁻¹ Mfᵀ(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆))
-
-            vMI = vgeo[n, _MI, e]
-            @unroll for s in 1:num_state_prognostic
-                tendency[n, s, e] -= α * vMI * sM_top * (local_flux[s])
-            end
-            vMI = vgeo[n, _MI, e⁺]
-            @unroll for s in 1:num_state_prognostic
-                tendency[n, s, e⁺] += α * vMI * sM_top * (local_flux[s])
-            end
-
-
-        else
-            e⁻ = e - 1
-
-            # Reset arrays to the top element value
-            local_state_gradient_flux⁻ .= local_state_gradient_flux
-            local_state_prognostic .= local_state_prognostic⁺
-            local_state_auxiliary .= local_state_auxiliary⁺
-            local_state_gradient_flux .= local_state_gradient_flux⁺
-            local_state_auxiliary_bottom .= local_state_auxiliary
-            local_state_auxiliary_top .= local_state_auxiliary
-
-            prognostic_to_primitive!(
-                balance_law,
-                local_state_primitive,
-                local_state_prognostic,
-                local_state_auxiliary,
-            )
-            cell_states_primitive = (local_state_primitive,)
-            cell_weights = SVector(cw)
-
-            # Constant reconstruction
-            reconstruction!(
-                local_state_primitive_bottom,
-                local_state_primitive_top,
-                cell_states_primitive,
-                cell_weights,
-            )
-
-            primitive_to_prognostic!(
-                balance_law,
-                local_state_prognostic_bottom,
-                local_state_primitive_bottom,
-                local_state_auxiliary_bottom,
-            )
-
-            primitive_to_prognostic!(
-                balance_law,
-                local_state_prognostic_top,
-                local_state_primitive_top,
-                local_state_auxiliary_top,
-            )
-
-            # bottom flux
-            fill!(local_flux, -zero(eltype(local_flux)))
-
-            numerical_flux_first_order!(
-                numerical_flux_first_order,
-                balance_law,
-                local_flux,
-                normal_vector_bottom,
-                local_state_prognostic_bottom,
-                local_state_auxiliary_bottom,
-                local_state_prognostic⁻_top,
-                local_state_auxiliary⁻_top,
-                t,
-                face_direction,
-            )
-
-            numerical_flux_second_order!(
-                numerical_flux_second_order,
-                balance_law,
-                local_flux,
-                normal_vector_bottom,
-                #
-                local_state_prognostic_bottom,
-                local_state_gradient_flux,
-                local_state_hyperdiffusion,
-                local_state_auxiliary_bottom,
-                #
-                local_state_prognostic⁻_top,
-                local_state_gradient_flux⁻,
-                local_state_hyperdiffusion⁻,
-                local_state_auxiliary⁻_top,
-                t,
-            )
-
-
-
-
-            # Update RHS (in outer face loop): M⁻¹ Mfᵀ(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆))
-            # TODO: This isn't correct:
-            # FIXME: Should we pretch these?
-            vMI = vgeo[n, _MI, e]
-            @unroll for s in 1:num_state_prognostic
-                tendency[n, s, e] -= α * vMI * sM_bottom * (local_flux[s])
-            end
-            vMI = vgeo[n, _MI, e⁻]
-            @unroll for s in 1:num_state_prognostic
-                tendency[n, s, e⁻] += α * vMI * sM_bottom * (local_flux[s])
-            end
-
-
-            bctag = elemtobndy[f_top, e]
-
-            fill!(local_flux, -zero(eltype(local_flux)))
-
-            local_state_prognostic⁺ .= local_state_prognostic_top
-            local_state_auxiliary⁺ .= local_state_auxiliary_top
+            # Fill ghost cell data
+            fill!(local_flux, -zero(FT))
+            local_state_face_prognostic_neighbor .=
+                local_state_face_prognostic[1]
+            local_state_auxiliary[stencil_center - 1] .=
+                local_state_auxiliary[stencil_center]
 
             numerical_boundary_flux_first_order!(
                 numerical_flux_first_order,
                 bctag,
                 balance_law,
                 local_flux,
-                normal_vector_top,
-                local_state_prognostic_top,
-                local_state_auxiliary_top,
-                #TODO
-                local_state_prognostic⁺,
-                local_state_auxiliary⁺,
+                normal,
+                local_state_face_prognostic[1],
+                local_state_auxiliary[stencil_center],
+                local_state_face_prognostic_neighbor,
+                local_state_auxiliary[stencil_center - 1],
                 t,
                 face_direction,
-                local_state_prognostic_boundary,
-                local_state_auxiliary_boundary,
+                local_state_prognostic_bottom1,
+                local_state_auxiliary_bottom1,
             )
 
-            local_state_prognostic⁺ .= local_state_prognostic_top
-            local_state_gradient_flux⁺ .= local_state_gradient_flux
-            local_state_hyperdiffusion⁺ .= local_state_hyperdiffusion
-            local_state_auxiliary⁺ .= local_state_auxiliary_top
+            # Fill / reset ghost cell data
+            local_state_prognostic[stencil_center - 1] .=
+                local_state_prognostic[stencil_center]
+            local_state_gradient_flux[stencil_center - 1] .=
+                local_state_gradient_flux[stencil_center]
+            local_state_hyperdiffusive[stencil_center - 1] .=
+                local_state_hyperdiffusive[stencil_center]
+            local_state_auxiliary[stencil_center - 1] .=
+                local_state_auxiliary[stencil_center]
 
             numerical_boundary_flux_second_order!(
                 numerical_flux_second_order,
                 bctag,
                 balance_law,
                 local_flux,
-                normal_vector_top,
-                #
-                local_state_prognostic_top,
-                local_state_gradient_flux,
-                local_state_hyperdiffusion,
-                local_state_auxiliary_top,
-                #
-                local_state_prognostic⁺,
-                local_state_gradient_flux⁺,
-                local_state_hyperdiffusion⁺,
-                local_state_auxiliary⁺,
-                #
+                normal,
+                local_state_prognostic[stencil_center],
+                local_state_gradient_flux[stencil_center],
+                local_state_hyperdiffusive[stencil_center],
+                local_state_auxiliary[stencil_center],
+                local_state_prognostic[stencil_center - 1],
+                local_state_gradient_flux[stencil_center - 1],
+                local_state_hyperdiffusive[stencil_center - 1],
+                local_state_auxiliary[stencil_center - 1],
                 t,
-                local_state_prognostic_boundary,
-                local_state_gradient_flux_boundary,
-                local_state_auxiliary_boundary,
+                local_state_prognostic_bottom1,
+                local_state_gradient_flux_bottom1,
+                local_state_auxiliary_bottom1,
             )
 
-            vMI = vgeo[n, _MI, e]
+            # Compute boundary flux and add it in bottom element of the mesh
             @unroll for s in 1:num_state_prognostic
-                tendency[n, s, e] -= α * vMI * sM_top * (local_flux[s])
+                tendency[n, s, eH + eV] -= α * sM * vMI[2] * local_flux[s]
+            end
+        end
+
+        # The rest of the elements in the stack
+        # Compute flux and update for face between elements eV and eV - 1
+        #    top face of eV - 1
+        #    bottom face of eV
+        # For the reconstruction arrays `stencil_center - 1` corresponds to `eV
+        # - 1` and `stencil_center` corresponds to `eV`
+        #
+        # Loop for periodic case has to go beyond the top element so we compute
+        # the flux through the top face of vertical element `nvertelem` and
+        # bottom face of vertical element 1
+        for eV_up in (periodicstack ? (1:nvertelem) : (2:nvertelem))
+            # mod1 handles periodicity
+            eV_dn = mod1(eV_up - 1, nvertelem)
+
+            # Shift data in storage in order to load new upper element for
+            # reconstruction
+            # FIXME: shift pointers not data?
+            @unroll for k in 1:(stencil_diameter - 1)
+                local_state_prognostic[k] .= local_state_prognostic[k + 1]
+                local_state_primitive[k] .= local_state_primitive[k + 1]
+                local_state_auxiliary[k] .= local_state_auxiliary[k + 1]
+                local_state_gradient_flux[k] .= local_state_gradient_flux[k + 1]
+                local_cell_weights[k] = local_cell_weights[k + 1]
+            end
+
+            # Update volume mass inverse as we move up the stack of elements
+            vMI[1] = vMI[2]
+
+            # Load surface metrics for the face we will update (bottom face of
+            # `eV_up`)
+            sM = sgeo[_sM, n, faces[1], eH + eV_up]
+            normal = SVector(
+                sgeo[_n1, n, faces[1], eH + eV_up],
+                sgeo[_n2, n, faces[1], eH + eV_up],
+                sgeo[_n3, n, faces[1], eH + eV_up],
+            )
+
+            # Reconstruction for eV_dn was computed in last time through the
+            # loop, so we need to store the upper reconstructed values to
+            # compute flux for this face
+            local_state_face_prognostic_neighbor .=
+                local_state_face_prognostic[2]
+
+            # Next data we need to load (assume periodic, mod1, for now  will
+            # mask out below as needed for boundary conditions)
+            eV_load = mod1(eV_up + stencil_width, nvertelem)
+
+            # Get element number
+            e_load = eH + eV_load
+
+            # Load the next cell into the end of the element arrays
+            load_data!(
+                local_state_prognostic[stencil_diameter],
+                local_state_auxiliary[stencil_diameter],
+                local_state_gradient_flux[stencil_diameter],
+                e_load,
+            )
+
+            # Get local volume mass matrix inverse
+            local_cell_weights[stencil_diameter] = vgeo[n, _M, e_load]
+            vMI[2] = 1 / local_cell_weights[stencil_center]
+
+            # Tranform the prognostic data to primitive data
+            prognostic_to_primitive!(
+                balance_law,
+                local_state_primitive[stencil_diameter],
+                local_state_prognostic[stencil_diameter],
+                local_state_auxiliary[stencil_diameter],
+            )
+
+            # Do the reconstruction! for this cell and compute the values at the
+            # bottom (1) and top (2) faces of element `eV_up`
+            if periodicstack ||
+               stencil_width < eV_up < nvertelem - stencil_width + 1
+                # If we are in the interior or periodic just use the
+                # reconstruction
+                rng1, rng2 = stencil_center .+ (-stencil_width, stencil_width)
+                rng = SUnitRange(rng1, rng2)
+                reconstruction!(
+                    local_state_face_primitive[1],
+                    local_state_face_primitive[2],
+                    local_state_primitive[rng],
+                    local_cell_weights[rng],
+                )
+            elseif eV_up <= stencil_width
+                # Bottom of the element stack requires reconstruct using a
+                # subset of the elements
+                # Values around stencil center that we need for this
+                # reconstruction
+                Base.Cartesian.@nif 4 w -> (eV_up == w) w -> begin
+                    rng1, rng2 = stencil_center .+ (1 - w, w - 1)
+                    rng = SUnitRange(rng1, rng2)
+                    reconstruction!(
+                        local_state_face_primitive[1],
+                        local_state_face_primitive[2],
+                        local_state_primitive[rng],
+                        local_cell_weights[rng],
+                    )
+                end w -> throw(BoundsError(local_state_primitive, w))
+            elseif eV_up >= nvertelem - stencil_width + 1
+                # Top of the element stack requires reconstruct using a
+                # subset of the elements
+                Base.Cartesian.@nif 4 w -> (w == (nvertelem - eV_up + 1)) w ->
+                    begin
+                        rng1, rng2 = stencil_center .+ (1 - w, w - 1)
+                        rng = SUnitRange(rng1, rng2)
+                        reconstruction!(
+                            local_state_face_primitive[1],
+                            local_state_face_primitive[2],
+                            local_state_primitive[rng],
+                            local_cell_weights[rng],
+                        )
+                    end w -> throw(BoundsError(local_state_primitive, w))
+            end
+
+            # Transform reconstructed primitive values to prognostic
+            @unroll for k in 1:2
+                primitive_to_prognostic!(
+                    balance_law,
+                    local_state_face_prognostic[k],
+                    local_state_face_primitive[k],
+                    # Use the cell auxiliary data
+                    local_state_auxiliary[stencil_center],
+                )
+            end
+
+            # Compute the flux for the bottom face of the element we are
+            # considering
+            fill!(local_flux, -zero(FT))
+            numerical_flux_first_order!(
+                numerical_flux_first_order,
+                balance_law,
+                local_flux,
+                normal,
+                local_state_face_prognostic[1],
+                local_state_auxiliary[stencil_center],
+                local_state_face_prognostic_neighbor,
+                local_state_auxiliary[stencil_center - 1],
+                t,
+                face_direction,
+            )
+
+            numerical_flux_second_order!(
+                numerical_flux_second_order,
+                balance_law,
+                local_flux,
+                normal,
+                local_state_prognostic[stencil_center],
+                local_state_gradient_flux[stencil_center],
+                local_state_hyperdiffusive[stencil_center],
+                local_state_auxiliary[stencil_center],
+                local_state_prognostic[stencil_center - 1],
+                local_state_gradient_flux[stencil_center - 1],
+                local_state_hyperdiffusive[stencil_center - 1],
+                local_state_auxiliary[stencil_center - 1],
+                t,
+            )
+
+            # Update the bottom element:
+            # numerical flux is computed with respect to the top element, so
+            # `+=` is used to reverse the flux
+            @unroll for s in 1:num_state_prognostic
+                tendency[n, s, eH + eV_dn] += α * sM * vMI[1] * local_flux[s]
+            end
+
+            # Update the top element
+            @unroll for s in 1:num_state_prognostic
+                tendency[n, s, eH + eV_up] -= α * sM * vMI[2] * local_flux[s]
+            end
+
+            # If we have a boundary and we are on the top element update the
+            # boundary face
+            if !periodicstack && eV_up == nvertelem
+                # Load surface metrics for the face we will update
+                # (top face of `eV_up`)
+                bctag = elemtobndy[faces[2], eH + eV_up]
+                sM = sgeo[_sM, n, faces[2], eH + eV_up]
+                normal = SVector(
+                    sgeo[_n1, n, faces[2], eH + eV_up],
+                    sgeo[_n2, n, faces[2], eH + eV_up],
+                    sgeo[_n3, n, faces[2], eH + eV_up],
+                )
+
+                # Since we are at the last element to update, we can safely use
+                # `stencil_center - 1` to store the ghost data
+
+                fill!(local_flux, -zero(FT))
+
+                # Fill ghost cell data
+                # Use the top reconstruction (since handling top face)
+                local_state_face_prognostic_neighbor .=
+                    local_state_face_prognostic[2]
+                local_state_auxiliary[stencil_center - 1] .=
+                    local_state_auxiliary[stencil_center]
+                numerical_boundary_flux_first_order!(
+                    numerical_flux_first_order,
+                    bctag,
+                    balance_law,
+                    local_flux,
+                    normal,
+                    # Use the top reconstruction (since handling top face)
+                    local_state_face_prognostic[2],
+                    local_state_auxiliary[stencil_center],
+                    local_state_face_prognostic_neighbor,
+                    local_state_auxiliary[stencil_center - 1],
+                    t,
+                    face_direction,
+                    local_state_prognostic_bottom1,
+                    local_state_auxiliary_bottom1,
+                )
+
+                # Fill / reset ghost cell data
+                local_state_prognostic[stencil_center - 1] .=
+                    local_state_prognostic[stencil_center]
+                local_state_gradient_flux[stencil_center - 1] .=
+                    local_state_gradient_flux[stencil_center]
+                local_state_hyperdiffusive[stencil_center - 1] .=
+                    local_state_hyperdiffusive[stencil_center]
+                local_state_auxiliary[stencil_center - 1] .=
+                    local_state_auxiliary[stencil_center]
+                numerical_boundary_flux_second_order!(
+                    numerical_flux_second_order,
+                    bctag,
+                    balance_law,
+                    local_flux,
+                    normal,
+                    local_state_prognostic[stencil_center],
+                    local_state_gradient_flux[stencil_center],
+                    local_state_hyperdiffusive[stencil_center],
+                    local_state_auxiliary[stencil_center],
+                    local_state_prognostic[stencil_center - 1],
+                    local_state_gradient_flux[stencil_center - 1],
+                    local_state_hyperdiffusive[stencil_center - 1],
+                    local_state_auxiliary[stencil_center - 1],
+                    t,
+                    local_state_prognostic_bottom1,
+                    local_state_gradient_flux_bottom1,
+                    local_state_auxiliary_bottom1,
+                )
+
+                # In this case we only update the element eV_up (not eV_dn)
+                @unroll for s in 1:num_state_prognostic
+                    tendency[n, s, eH + eV_up] -=
+                        α * sM * vMI[2] * local_flux[s]
+                end
             end
         end
     end

--- a/src/Numerics/DGMethods/DGFVModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGFVModel_kernels.jl
@@ -1,0 +1,586 @@
+using .FVReconstructions: FVConstant, FVLinear
+using ..BalanceLaws: prognostic_to_primitive!, primitive_to_prognostic!
+
+@doc """
+    function vert_fvm_interface_tendency!(
+        balance_law::BalanceLaw,
+        ::Val{info},
+        ::Val{nvertelem},
+        ::Val{periodicstack},
+        ::VerticalDirection,
+        numerical_flux_first_order,
+        tendency,
+        state_prognostic,
+        state_auxiliary,
+        vgeo,
+        sgeo,
+        t,
+        vmap⁻,
+        vmap⁺,
+        elemtobndy,
+        elems,
+        α,
+    )
+
+Compute kernel for evaluating the interface tendencies using vertical FVM
+reconstructions with a DG method of the form:
+
+∫ₑ ψ⋅ ∂q/∂t dx - ∫ₑ ∇ψ⋅(Fⁱⁿᵛ + Fᵛⁱˢᶜ) dx + ∮ₑ n̂ ψ⋅(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆) dS,
+
+or equivalently in matrix form:
+
+dQ/dt = M⁻¹(MS + DᵀM(Fⁱⁿᵛ + Fᵛⁱˢᶜ) + ∑ᶠ LᵀMf(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆)).
+
+This kernel computes the surface terms: M⁻¹ ∑ᶠ LᵀMf(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆)), where M
+is the mass matrix, Mf is the face mass matrix, L is an interpolator from
+volume to face, and Fⁱⁿᵛ⋆, Fᵛⁱˢᶜ⋆ are the numerical fluxes for the inviscid
+and viscous fluxes, respectively.
+
+A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
+""" vert_fvm_interface_tendency!
+@kernel function vert_fvm_interface_tendency!(
+    balance_law::BalanceLaw,
+    ::Val{info},
+    ::Val{nvertelem},
+    ::Val{periodicstack},
+    ::VerticalDirection,
+    ::FVConstant,
+    numerical_flux_first_order,
+    numerical_flux_second_order,
+    tendency,
+    state_prognostic,
+    state_gradient_flux,
+    state_auxiliary,
+    _,
+    sgeo,
+    t,
+    elemtobndy,
+    elems,
+    α,
+) where {info, nvertelem, periodicstack}
+    @uniform begin
+        dim = info.dim
+        FT = eltype(state_prognostic)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        num_state_gradient_flux = number_states(balance_law, GradientFlux())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
+        num_state_hyperdiffusion = number_states(balance_law, Hyperdiffusive())
+        @assert num_state_hyperdiffusion == 0
+
+        nface = info.nface
+        Np = info.Np
+        Nqk = info.Nqk # Can only be 1 for the FVM method!
+        @assert Nqk == 1
+
+        # We only have the vertical faces
+        faces = (nface - 1):nface
+
+        local_state_prognostic⁻ = MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_gradient_flux⁻ =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_auxiliary⁻ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_hyperdiffusion⁻ =
+            MArray{Tuple{num_state_hyperdiffusion}, FT}(undef)
+
+        local_state_prognostic⁺ = MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_gradient_flux⁺ =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_auxiliary⁺ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_hyperdiffusion⁺ =
+            MArray{Tuple{num_state_hyperdiffusion}, FT}(undef)
+
+        local_state_prognostic_bottom1 =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_gradient_flux_bottom1 =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_auxiliary_bottom1 =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
+
+        # XXX: will revisit this later for FVM
+        fill!(local_state_prognostic_bottom1, NaN)
+        fill!(local_state_gradient_flux_bottom1, NaN)
+        fill!(local_state_auxiliary_bottom1, NaN)
+
+        local_flux_top = MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_flux_bottom = MArray{Tuple{num_state_prognostic}, FT}(undef)
+
+        sM = MArray{Tuple{2}, FT}(undef)
+
+        # The remainder model needs to know which direction of face the model is
+        # being evaluated for. In this case we only have `VerticalDirection()`
+        # faces
+        face_direction = (EveryDirection(), VerticalDirection())
+    end
+
+    # Get the horizontal group IDs
+    grp_H = @index(Group, Linear)
+
+    # Determine the index for the element at the bottom of the stack
+    eHI = (grp_H - 1) * nvertelem + 1
+
+    # Compute bottom stack element index minus one (so we can add vert element
+    # number directly)
+    eH = elems[eHI] - 1
+
+    # Which degree of freedom do we handle in the element
+    n = @index(Local, Linear)
+
+    # Loads the data for a given element
+    function load_data!(
+        local_state_prognostic,
+        local_state_auxiliary,
+        local_state_gradient_flux,
+        e,
+    )
+        @unroll for s in 1:num_state_prognostic
+            local_state_prognostic[s] = state_prognostic[n, s, e]
+        end
+
+        @unroll for s in 1:num_state_auxiliary
+            local_state_auxiliary[s] = state_auxiliary[n, s, e]
+        end
+
+        @unroll for s in 1:num_state_gradient_flux
+            local_state_gradient_flux[s] = state_gradient_flux[n, s, e]
+        end
+    end
+
+    # We need to compute the first element we handles bottom flux (future
+    # elements will just copied from the prior element)
+    @inbounds begin
+        eV = 1
+
+        # Minus is the top
+        e⁻ = eH + eV
+
+        # bottom face
+        f⁻ = faces[1]
+
+        # surface mass
+        sM[1] = sgeo[_sM, n, f⁻, e⁻]
+
+        # outward normal for this face
+        normal_vector = SVector(
+            sgeo[_n1, n, f⁻, e⁻],
+            sgeo[_n2, n, f⁻, e⁻],
+            sgeo[_n3, n, f⁻, e⁻],
+        )
+
+        # determine the plus side element (bottom)
+        e⁺, bctag = if periodicstack
+            eH + nvertelem, 0
+        else
+            e⁻, elemtobndy[f⁻, e⁻]
+        end
+
+        # Load minus and plus side data
+        load_data!(
+            local_state_prognostic⁻,
+            local_state_auxiliary⁻,
+            local_state_gradient_flux⁻,
+            e⁻,
+        )
+        load_data!(
+            local_state_prognostic⁺,
+            local_state_auxiliary⁺,
+            local_state_gradient_flux⁺,
+            e⁺,
+        )
+
+        # compute the flux
+        fill!(local_flux_bottom, -zero(eltype(local_flux_bottom)))
+        if bctag == 0
+            numerical_flux_first_order!(
+                numerical_flux_first_order,
+                balance_law,
+                local_flux_bottom,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
+                t,
+                face_direction,
+            )
+            numerical_flux_second_order!(
+                numerical_flux_second_order,
+                balance_law,
+                local_flux_bottom,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_gradient_flux⁻,
+                local_state_hyperdiffusion⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺,
+                local_state_gradient_flux⁺,
+                local_state_hyperdiffusion⁺,
+                local_state_auxiliary⁺,
+                t,
+            )
+        else
+            numerical_boundary_flux_first_order!(
+                numerical_flux_first_order,
+                bctag,
+                balance_law,
+                local_flux_bottom,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
+                t,
+                face_direction,
+                local_state_prognostic_bottom1,
+                local_state_auxiliary_bottom1,
+            )
+            numerical_boundary_flux_second_order!(
+                numerical_flux_second_order,
+                bctag,
+                balance_law,
+                local_flux_bottom,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_gradient_flux⁻,
+                local_state_hyperdiffusion⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺,
+                local_state_gradient_flux⁺,
+                local_state_hyperdiffusion⁺,
+                local_state_auxiliary⁺,
+                t,
+                local_state_prognostic_bottom1,
+                local_state_gradient_flux_bottom1,
+                local_state_auxiliary_bottom1,
+            )
+        end
+    end
+
+    # Loop up the vertical stack to update the minus side element (we have the
+    # bottom flux from the previous element, so only need to calculate the top
+    # flux)
+    @inbounds for eV in 1:nvertelem
+        e⁻ = eH + eV
+
+        # volume mass inverse
+        vMI = sgeo[_vMI, n, faces[1], e⁻]
+
+        # Compute the top face numerical flux
+        # The minus side is the bottom element
+        # The plus side is the top element
+        f⁻ = faces[2]
+
+        # surface mass
+        sM[2] = sgeo[_sM, n, f⁻, e⁻]
+
+        # normal with respect to the minus side
+        normal_vector = SVector(
+            sgeo[_n1, n, f⁻, e⁻],
+            sgeo[_n2, n, f⁻, e⁻],
+            sgeo[_n3, n, f⁻, e⁻],
+        )
+
+        # determine the plus side element (top)
+        e⁺, bctag = if eV != nvertelem
+            e⁻ + 1, 0
+        elseif periodicstack
+            eH + 1, 0
+        else
+            e⁻, elemtobndy[f⁻, e⁻]
+        end
+
+        # Load plus side data (minus data is already set)
+        load_data!(
+            local_state_prognostic⁺,
+            local_state_auxiliary⁺,
+            local_state_gradient_flux⁺,
+            e⁺,
+        )
+
+        # compute the flux
+        fill!(local_flux_top, -zero(eltype(local_flux_top)))
+        if bctag == 0
+            numerical_flux_first_order!(
+                numerical_flux_first_order,
+                balance_law,
+                local_flux_top,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
+                t,
+                face_direction,
+            )
+            numerical_flux_second_order!(
+                numerical_flux_second_order,
+                balance_law,
+                local_flux_top,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_gradient_flux⁻,
+                local_state_hyperdiffusion⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺,
+                local_state_gradient_flux⁺,
+                local_state_hyperdiffusion⁺,
+                local_state_auxiliary⁺,
+                t,
+            )
+        else
+            numerical_boundary_flux_first_order!(
+                numerical_flux_first_order,
+                bctag,
+                balance_law,
+                local_flux_top,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
+                t,
+                face_direction,
+                local_state_prognostic_bottom1,
+                local_state_auxiliary_bottom1,
+            )
+            numerical_boundary_flux_second_order!(
+                numerical_flux_second_order,
+                bctag,
+                balance_law,
+                local_flux_top,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_gradient_flux⁻,
+                local_state_hyperdiffusion⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺,
+                local_state_gradient_flux⁺,
+                local_state_hyperdiffusion⁺,
+                local_state_auxiliary⁺,
+                t,
+                local_state_prognostic_bottom1,
+                local_state_gradient_flux_bottom1,
+                local_state_auxiliary_bottom1,
+            )
+        end
+
+        # Update RHS M⁻¹ Mfᵀ(Fⁱⁿᵛ⋆ + Fᵛⁱˢᶜ⋆))
+        @unroll for s in 1:num_state_prognostic
+            # FIXME: Should we pretch these?
+            tendency[n, s, e⁻] -=
+                α *
+                vMI *
+                (sM[2] * (local_flux_top[s]) + sM[1] * (local_flux_bottom[s]))
+        end
+
+        # Set the flux bottom flux for the next element
+        local_flux_bottom .= -local_flux_top
+
+        # set the surface mass matrix
+        sM[1] = sM[2]
+
+        # the current plus side is the next minus side
+        local_state_prognostic⁻ .= local_state_prognostic⁺
+        local_state_auxiliary⁻ .= local_state_auxiliary⁺
+        local_state_gradient_flux⁻ .= local_state_gradient_flux⁺
+    end
+end
+
+@kernel function vert_fvm_interface_gradients!(
+    balance_law::BalanceLaw,
+    ::Val{info},
+    ::Val{nvertelem},
+    ::Val{periodicstack},
+    ::VerticalDirection,
+    state_prognostic,
+    state_gradient_flux,
+    state_auxiliary,
+    vgeo,
+    sgeo,
+    t,
+    elemtobndy,
+    elems,
+) where {info, nvertelem, periodicstack}
+    @uniform begin
+
+        dim = info.dim
+        FT = eltype(state_prognostic)
+        num_state_prognostic = number_states(balance_law, Prognostic())
+        ngradstate = number_states(balance_law, Gradient())
+        num_state_gradient_flux = number_states(balance_law, GradientFlux())
+        num_state_auxiliary = number_states(balance_law, Auxiliary())
+        nface = info.nface
+        Np = info.Np
+        faces = (nface - 1, nface)
+
+        # Storage for the prognostic state for e-1, e, e+1
+        local_state_prognostic =
+            ntuple(_ -> MArray{Tuple{num_state_prognostic}, FT}(undef), Val(3))
+
+        # Storage for the auxiliary state for e-1, e, e+1
+        local_state_auxiliary =
+            ntuple(_ -> MArray{Tuple{num_state_auxiliary}, FT}(undef), Val(3))
+
+        # Storage for the transform state for e-1, e, e+1
+        # e.g., the state we take the gradient of
+        l_grad_arg = ntuple(_ -> MArray{Tuple{ngradstate}, FT}(undef), Val(3))
+
+        # Storage for the contribution to the gradient from these faces
+        l_nG = MArray{Tuple{3, ngradstate}, FT}(undef)
+
+        l_nG_bc = MArray{Tuple{3, ngradstate}, FT}(undef)
+
+        # Storage for the state gradient flux locally
+        local_state_gradient_flux =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+
+        local_state_prognostic_bottom1 =
+            MArray{Tuple{num_state_prognostic}, FT}(undef)
+        local_state_auxiliary_bottom1 =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
+
+        # XXX: will revisit this later for FVM
+        fill!(local_state_prognostic_bottom1, NaN)
+        fill!(local_state_auxiliary_bottom1, NaN)
+    end
+
+    # Element index
+    eI = @index(Group, Linear)
+    # Index of a quadrature point on a face
+    n = @index(Local, Linear)
+
+    @inbounds begin
+        e = elems[eI]
+        eV = mod1(e, nvertelem)
+
+        # Figure out the element above and below e
+        e_dn, bc_dn = if eV > 1
+            e - 1, 0
+        elseif periodicstack
+            e + nvertelem - 1, 0
+        else
+            e, elemtobndy[faces[1], e]
+        end
+
+        e_up, bc_up = if eV < nvertelem
+            e + 1, 0
+        elseif periodicstack
+            e - nvertelem + 1, 0
+        else
+            e, elemtobndy[faces[2], e]
+        end
+
+        bctag = (bc_dn, bc_up)
+
+        els = (e_dn, e, e_up)
+
+        # Load the normal vectors and surface mass matrix on the faces
+        normal_vector = ntuple(
+            k -> SVector(
+                sgeo[_n1, n, faces[k], e],
+                sgeo[_n2, n, faces[k], e],
+                sgeo[_n3, n, faces[k], e],
+            ),
+            Val(2),
+        )
+        sM = ntuple(k -> sgeo[_sM, n, faces[k], e], Val(2))
+
+        # Volume mass same on both faces
+        vMI = sgeo[_vMI, n, faces[1], e]
+
+        # Get the mass matrix for each of the elements
+        M = ntuple(k -> vgeo[n, _M, els[k]], Val(3))
+
+        # Load prognostic data
+        @unroll for k in 1:3
+            @unroll for s in 1:num_state_prognostic
+                local_state_prognostic[k][s] = state_prognostic[n, s, els[k]]
+            end
+        end
+
+        # Load auxiliary data
+        @unroll for k in 1:3
+            @unroll for s in 1:num_state_auxiliary
+                local_state_auxiliary[k][s] = state_auxiliary[n, s, els[k]]
+            end
+        end
+
+        # Transform to the gradient argument (i.e., the values we take the
+        # gradient of)
+        @unroll for k in 1:3
+            fill!(l_grad_arg[k], -zero(eltype(l_grad_arg[k])))
+            compute_gradient_argument!(
+                balance_law,
+                l_grad_arg[k],
+                local_state_prognostic[k],
+                local_state_auxiliary[k],
+                t,
+            )
+        end
+
+        # Compute the surface integral contribution from these two faces:
+        #   M⁻¹ Lᵀ Mf n̂ G*
+        # Since this is FVM we do not subtract the interior state
+        fill!(l_nG, -zero(eltype(l_nG)))
+        @unroll for f in 1:2
+            if bctag[f] == 0
+                @unroll for s in 1:ngradstate
+                    # Interpolate to the face (using the mass matrix for the
+                    # interpolation weights) -- "the gradient numerical flux"
+                    G =
+                        (
+                            M[f] * l_grad_arg[f + 1][s] +
+                            M[f + 1] * l_grad_arg[f][s]
+                        ) / (M[f] + M[f + 1])
+
+                    # Compute the surface integral for this component and face
+                    # multiplied by the normal to get the rotation to the
+                    # physical space
+                    @unroll for i in 1:3
+                        l_nG[i, s] += vMI * sM[f] * normal_vector[f][i] * G
+                    end
+                end
+            else
+                # Computes G* incorporating boundary conditions
+                numerical_boundary_flux_gradient!(
+                    CentralNumericalFluxGradient(),
+                    bctag[f],
+                    balance_law,
+                    l_nG_bc,
+                    normal_vector[f],
+                    l_grad_arg[2],
+                    local_state_prognostic[2],
+                    local_state_auxiliary[2],
+                    l_grad_arg[2f - 1],
+                    local_state_prognostic[2f - 1],
+                    local_state_auxiliary[2f - 1],
+                    t,
+                    local_state_prognostic_bottom1,
+                    local_state_auxiliary_bottom1,
+                )
+
+                @unroll for s in 1:ngradstate
+                    @unroll for i in 1:3
+                        l_nG[i, s] += vMI * sM[f] * l_nG_bc[i, s]
+                    end
+                end
+            end
+        end
+
+        # Applies linear transformation of gradients to the diffusive variables
+        # for storage
+        compute_gradient_flux!(
+            balance_law,
+            local_state_gradient_flux,
+            l_nG,
+            local_state_prognostic[2],
+            local_state_auxiliary[2],
+            t,
+        )
+
+        # This is the surface integral evaluated discretely
+        # M^(-1) Mf G*
+        @unroll for s in 1:num_state_gradient_flux
+            state_gradient_flux[n, s, e] += local_state_gradient_flux[s]
+        end
+    end
+end

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -59,6 +59,7 @@ export DGModel,
     courant
 
 include("custom_filter.jl")
+include("FVReconstructions.jl")
 include("NumericalFluxes.jl")
 include("DGModel.jl")
 include("DGModel_kernels.jl")

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -49,6 +49,7 @@ import ..BalanceLaws:
     reverse_integral_set_auxiliary_state!
 
 export DGModel,
+    DGFVMModel,
     init_ode_state,
     restart_ode_state,
     restart_auxiliary_state,

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -49,7 +49,7 @@ import ..BalanceLaws:
     reverse_integral_set_auxiliary_state!
 
 export DGModel,
-    DGFVMModel,
+    DGFVModel,
     init_ode_state,
     restart_ode_state,
     restart_auxiliary_state,
@@ -63,6 +63,7 @@ include("FVReconstructions.jl")
 include("NumericalFluxes.jl")
 include("DGModel.jl")
 include("DGModel_kernels.jl")
+include("DGFVModel_kernels.jl")
 include("create_states.jl")
 
 """

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -1728,8 +1728,10 @@ function launch_volume_tendency!(
     end
 
     # Vertical kernel
-    if spacedisc.direction isa EveryDirection ||
-       spacedisc.direction isa VerticalDirection
+    if spacedisc isa DGModel && (
+        spacedisc.direction isa EveryDirection ||
+        spacedisc.direction isa VerticalDirection
+    )
 
         # Vertical polynomial degree
         vertical_polyorder = info.N[info.dim]

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -1,7 +1,59 @@
 using .NumericalFluxes:
     CentralNumericalFluxHigherOrder, CentralNumericalFluxDivergence
 
-struct DGModel{BL, G, NFND, NFD, GNF, AS, DS, HDS, D, DD, MD}
+"""
+    SpaceDiscretization
+
+Supertype for spatial discretizations.
+
+Must have the following properties:
+
+    - `grid`
+    - `balance_law`
+    - `state_auxiliary`
+"""
+abstract type SpaceDiscretization end
+
+struct DGFVMModel{BL, G, NFND, AS, D, MD} <: SpaceDiscretization
+    balance_law::BL
+    grid::G
+    numerical_flux_first_order::NFND
+    state_auxiliary::AS
+    direction::D
+    modeldata::MD
+end
+
+function DGFVMModel(
+    balance_law,
+    grid,
+    numerical_flux_first_order;
+    fill_nan = false,
+    state_auxiliary = create_state(
+        balance_law,
+        grid,
+        Auxiliary(),
+        fill_nan = fill_nan,
+    ),
+    direction = EveryDirection(),
+    modeldata = nothing,
+)
+    # Make sure we are FVM in the vertical
+    @assert polynomialorders(grid)[end] == 0
+    @assert isstacked(grid.topology)
+    state_auxiliary =
+        init_state(state_auxiliary, balance_law, grid, direction, Auxiliary())
+    DGFVMModel(
+        balance_law,
+        grid,
+        numerical_flux_first_order,
+        state_auxiliary,
+        direction,
+        modeldata,
+    )
+end
+
+struct DGModel{BL, G, NFND, NFD, GNF, AS, DS, HDS, D, DD, MD} <:
+       SpaceDiscretization
     balance_law::BL
     grid::G
     numerical_flux_first_order::NFND
@@ -57,9 +109,9 @@ end
 # Include the remainder model for composing DG models and balance laws
 include("remainder.jl")
 
-# TODO: dont need to actually pass DG model (just need the grid)
-function basic_grid_info(dg::DGModel)
-    grid = dg.grid
+basic_grid_info(spacedisc::SpaceDiscretization) =
+    basic_grid_info(spacedisc.grid)
+function basic_grid_info(grid)
     dim = dimensionality(grid)
     # Tuple of polynomial degrees (N₁, N₂, N₃)
     N = polynomialorders(grid)
@@ -101,14 +153,28 @@ function basic_grid_info(dg::DGModel)
     return merge(grid_info, topology_info)
 end
 
-function basic_launch_info(dg::DGModel)
-    device = array_device(dg.state_auxiliary)
-    grid_info = basic_grid_info(dg)
+function basic_launch_info(spacedisc::SpaceDiscretization)
+    device = array_device(spacedisc.state_auxiliary)
+    grid_info = basic_grid_info(spacedisc.grid)
     return merge(grid_info, (device = device,))
 end
 
+function (spacedisc::SpaceDiscretization)(
+    tendency,
+    state_prognostic,
+    param,
+    t;
+    increment = false,
+)
+    # TODO deprecate increment argument
+    spacedisc(tendency, state_prognostic, param, t, true, increment)
+end
+
 """
-    (dg::DGModel)(tendency, state_prognostic, nothing, t, α, β)
+    (dgfvm::DGFVMModel)(tendency, state_prognostic, _, t, α, β)
+
+Uses spectral element discontinuous Galerkin in the horizontal and finite volume
+in the vertical to compute the tendency.
 
 Computes the tendency terms compatible with `IncrementODEProblem`
 
@@ -117,13 +183,129 @@ Computes the tendency terms compatible with `IncrementODEProblem`
 The 4-argument form will just compute
 
     tendency .= dQdt(state_prognostic, p, t)
-
 """
-function (dg::DGModel)(tendency, state_prognostic, param, t; increment = false)
-    # TODO deprecate increment argument
-    dg(tendency, state_prognostic, param, t, true, increment)
+function (dgfvm::DGFVMModel)(tendency, state_prognostic, _, t, α, β)
+    device = array_device(state_prognostic)
+
+    FT = eltype(state_prognostic)
+    num_state_prognostic = number_states(dgfvm.balance_law, Prognostic())
+    @assert 0 == number_states(dgfvm.balance_law, GradientFlux())
+    @assert 0 == number_states(dgfvm.balance_law, Hyperdiffusive())
+    num_state_tendency = size(tendency, 2)
+
+    if num_state_prognostic < num_state_tendency && β != 1
+        # If we don't operate on the full state, then we need to scale here instead of volume_tendency!
+        tendency .*= β
+        β = β != 0 # if β==0 then we can avoid the memory load in volume_tendency!
+    end
+
+    communicate =
+        !(
+            isstacked(dgfvm.grid.topology) &&
+            typeof(dgfvm.direction) <: VerticalDirection
+        )
+
+    #JK update_auxiliary_state!(
+    #JK     dg,
+    #JK     dg.balance_law,
+    #JK     state_prognostic,
+    #JK     t,
+    #JK     dg.grid.topology.realelems,
+    #JK )
+
+    exchange_state_prognostic = NoneEvent()
+
+    comp_stream = Event(device)
+
+    if communicate
+        exchange_state_prognostic = MPIStateArrays.begin_ghost_exchange!(
+            state_prognostic;
+            dependencies = comp_stream,
+        )
+    end
+
+    # TODO: Add diffusion calls
+
+    ###################
+    # RHS Computation #
+    ###################
+    comp_stream = launch_volume_tendency!(
+        dgfvm,
+        tendency,
+        state_prognostic,
+        t,
+        α,
+        β;
+        dependencies = (comp_stream,),
+    )
+
+    comp_stream = launch_interface_tendency!(
+        dgfvm,
+        tendency,
+        state_prognostic,
+        t,
+        α,
+        β;
+        surface = :interior,
+        dependencies = (comp_stream,),
+    )
+
+    if communicate
+        # TODO: gradient and hyperdiffusion communication
+        exchange_state_prognostic = MPIStateArrays.end_ghost_exchange!(
+            state_prognostic;
+            dependencies = exchange_state_prognostic,
+        )
+
+        # update_aux may start asynchronous work on the compute device and
+        # we synchronize those here through a device event.
+        wait(device, exchange_state_prognostic)
+        #JK update_auxiliary_state!(
+        #JK     dg,
+        #JK     dg.balance_law,
+        #JK     state_prognostic,
+        #JK     t,
+        #JK     dg.grid.topology.ghostelems,
+        #JK )
+        #JK exchange_state_prognostic = Event(device)
+    end
+
+    comp_stream = launch_interface_tendency!(
+        dgfvm,
+        tendency,
+        state_prognostic,
+        t,
+        α,
+        β;
+        surface = :exterior,
+        dependencies = (
+            comp_stream,
+            exchange_state_prognostic,
+            #JK exchange_state_gradient_flux,
+            #JK exchange_Qhypervisc_grad,
+        ),
+    )
+
+    # The synchronization here through a device event prevents CuArray based and
+    # other default stream kernels from launching before the work scheduled in
+    # this function is finished.
+    wait(device, comp_stream)
 end
 
+"""
+    (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
+
+Uses spectral element discontinuous Galerkin in all direction to compute the
+tendency.
+
+Computes the tendency terms compatible with `IncrementODEProblem`
+
+    tendency .= α .* dQdt(state_prognostic, p, t) .+ β .* tendency
+
+The 4-argument form will just compute
+
+    tendency .= dQdt(state_prognostic, p, t)
+"""
 function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
 
     device = array_device(state_prognostic)
@@ -429,15 +611,16 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
 end
 
 function init_ode_state(
-    dg::DGModel,
+    spacedisc::SpaceDiscretization,
     args...;
     init_on_cpu = false,
     fill_nan = false,
 )
-    device = arraytype(dg.grid) <: Array ? CPU() : CUDADevice()
+    grid = spacedisc.grid
+    balance_law = spacedisc.balance_law
+    state_auxiliary = spacedisc.state_auxiliary
 
-    balance_law = dg.balance_law
-    grid = dg.grid
+    device = arraytype(grid) <: Array ? CPU() : CUDADevice()
 
     state_prognostic =
         create_state(balance_law, grid, Prognostic(), fill_nan = fill_nan)
@@ -445,7 +628,6 @@ function init_ode_state(
     topology = grid.topology
     Np = dofs_per_element(grid)
 
-    state_auxiliary = dg.state_auxiliary
     dim = dimensionality(grid)
     N = polynomialorders(grid)
     nrealelem = length(topology.realelems)
@@ -1475,7 +1657,7 @@ end
 Launches horizontal and vertical volume kernels for computing tendencies (sources, sinks, etc).
 """
 function launch_volume_tendency!(
-    dg,
+    spacedisc,
     tendency,
     state_prognostic,
     t,
@@ -1483,13 +1665,22 @@ function launch_volume_tendency!(
     β;
     dependencies,
 )
-    Qhypervisc_grad, _ = dg.states_higher_order
+    # XXX: This is until FVM with diffusion is implemented
+    if spacedisc isa DGFVMModel
+        @assert 0 == number_states(spacedisc.balance_law, GradientFlux())
+        @assert 0 == number_states(spacedisc.balance_law, Hyperdiffusive())
+        Qhypervisc_grad_data = nothing
+        grad_flux_data = nothing
+    elseif spacedisc isa DGModel
+        Qhypervisc_grad_data = spacedisc.states_higher_order[1].data
+        grad_flux_data = spacedisc.state_gradient_flux.data
+    end
 
     # Workgroup is determined by the number of quadrature points
     # in the horizontal direction. For each horizontal quadrature
     # point, we operate on a stack of quadrature in the vertical
     # direction. (Iteration space is in the horizontal)
-    info = basic_launch_info(dg)
+    info = basic_launch_info(spacedisc)
 
     # We assume (in 3-D) that both x and y directions
     # are discretized using the same polynomial order, Nq[1] == Nq[2].
@@ -1501,68 +1692,71 @@ function launch_volume_tendency!(
 
     # If the model direction is EveryDirection, we need to perform
     # both horizontal AND vertical kernel calls; otherwise, we only
-    # call the kernel corresponding to the model direction `dg.diffusion_direction`
-    if dg.direction isa EveryDirection || dg.direction isa HorizontalDirection
+    # call the kernel corresponding to the model direction
+    # `spacedisc.diffusion_direction`
+    if spacedisc.direction isa EveryDirection ||
+       spacedisc.direction isa HorizontalDirection
 
         # Horizontal polynomial degree
         horizontal_polyorder = info.N[1]
         # Horizontal quadrature weights and differentiation matrix
-        horizontal_ω = dg.grid.ω[1]
-        horizontal_D = dg.grid.D[1]
+        horizontal_ω = spacedisc.grid.ω[1]
+        horizontal_D = spacedisc.grid.D[1]
 
         comp_stream = volume_tendency!(info.device, workgroup)(
-            dg.balance_law,
+            spacedisc.balance_law,
             Val(info),
-            dg.direction,
+            spacedisc.direction,
             HorizontalDirection(),
             tendency.data,
             state_prognostic.data,
-            dg.state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            dg.state_auxiliary.data,
-            dg.grid.vgeo,
+            grad_flux_data,
+            Qhypervisc_grad_data,
+            spacedisc.state_auxiliary.data,
+            spacedisc.grid.vgeo,
             t,
             horizontal_ω,
             horizontal_D,
-            dg.grid.topology.realelems,
+            spacedisc.grid.topology.realelems,
             α,
             β,
             # If the model direction is horizontal, we want to be sure to add sources
-            dg.direction isa HorizontalDirection,
+            spacedisc.direction isa HorizontalDirection,
             ndrange = ndrange,
             dependencies = comp_stream,
         )
     end
 
     # Vertical kernel
-    if dg.direction isa EveryDirection || dg.direction isa VerticalDirection
+    if spacedisc.direction isa EveryDirection ||
+       spacedisc.direction isa VerticalDirection
 
         # Vertical polynomial degree
         vertical_polyorder = info.N[info.dim]
         # Vertical quadrature weights and differentiation matrix
-        vertical_ω = dg.grid.ω[info.dim]
-        vertical_D = dg.grid.D[info.dim]
+        vertical_ω = spacedisc.grid.ω[info.dim]
+        vertical_D = spacedisc.grid.D[info.dim]
 
         comp_stream = volume_tendency!(info.device, workgroup)(
-            dg.balance_law,
+            spacedisc.balance_law,
             Val(info),
-            dg.direction,
+            spacedisc.direction,
             VerticalDirection(),
             tendency.data,
             state_prognostic.data,
-            dg.state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            dg.state_auxiliary.data,
-            dg.grid.vgeo,
+            grad_flux_data,
+            Qhypervisc_grad_data,
+            spacedisc.state_auxiliary.data,
+            spacedisc.grid.vgeo,
             t,
             vertical_ω,
             vertical_D,
-            dg.grid.topology.realelems,
+            spacedisc.grid.topology.realelems,
             α,
             # If we are computing the volume gradient in every direction, we
             # need to increment into the appropriate fields _after_ the
             # horizontal computation.
-            dg.direction isa EveryDirection ? true : β,
+            spacedisc.direction isa EveryDirection ? true : β,
             # Boolean to add source. In the case of EveryDirection, we always add the sources
             # in the vertical kernel. Here, we make the assumption that we're either computing
             # in every direction, or _just_ the vertical direction.
@@ -1575,15 +1769,25 @@ function launch_volume_tendency!(
     return comp_stream
 end
 
+# XXX: This is just to maskout the second order flux for the start of FVM development
+import .NumericalFluxes
+struct NothingFlux <: NumericalFluxes.NumericalFluxSecondOrder end
+function NumericalFluxes.numerical_flux_second_order!(::NothingFlux, _...) end
+function NumericalFluxes.numerical_boundary_flux_second_order!(
+    ::NothingFlux,
+    _...,
+) end
+
+
 """
-    launch_interface_tendency!(dg, state_prognostic, t; surface::Symbol, dependencies)
+    launch_interface_tendency!(spacedisc, state_prognostic, t; surface::Symbol, dependencies)
 
 Launches horizontal and vertical interface kernels for computing tendencies (sources, sinks, etc).
 The argument `surface` is either `:interior` or `:exterior`, which denotes whether we are computing
 values on boundaries which are interior (exterior resp.) to the _parallel_ boundary.
 """
 function launch_interface_tendency!(
-    dg,
+    spacedisc,
     tendency,
     state_prognostic,
     t,
@@ -1593,22 +1797,34 @@ function launch_interface_tendency!(
     dependencies,
 )
     @assert surface === :interior || surface === :exterior
-    Qhypervisc_grad, _ = dg.states_higher_order
+    # XXX: This is until FVM with diffusion is implemented
+    if spacedisc isa DGFVMModel
+        @assert 0 == number_states(spacedisc.balance_law, GradientFlux())
+        @assert 0 == number_states(spacedisc.balance_law, Hyperdiffusive())
+        Qhypervisc_grad_data = nothing
+        grad_flux_data = nothing
+        numerical_flux_second_order = NothingFlux()
+    elseif spacedisc isa DGModel
+        Qhypervisc_grad_data = spacedisc.states_higher_order[1].data
+        grad_flux_data = spacedisc.state_gradient_flux.data
+        numerical_flux_second_order = spacedisc.numerical_flux_second_order
+    end
 
-    info = basic_launch_info(dg)
+    info = basic_launch_info(spacedisc)
     comp_stream = dependencies
 
     # If the model direction is EveryDirection, we need to perform
     # both horizontal AND vertical kernel calls; otherwise, we only
-    # call the kernel corresponding to the model direction `dg.diffusion_direction`
-    if dg.direction isa EveryDirection || dg.direction isa HorizontalDirection
+    # call the kernel corresponding to the model direction `spacedisc.diffusion_direction`
+    if spacedisc.direction isa EveryDirection ||
+       spacedisc.direction isa HorizontalDirection
 
         workgroup = info.Nfp_v
         if surface === :interior
-            elems = dg.grid.interiorelems
+            elems = spacedisc.grid.interiorelems
             ndrange = workgroup * info.ninteriorelem
         else
-            elems = dg.grid.exteriorelems
+            elems = spacedisc.grid.exteriorelems
             ndrange = workgroup * info.nexteriorelem
         end
 
@@ -1616,22 +1832,22 @@ function launch_interface_tendency!(
         horizontal_polyorder = info.N[1]
 
         comp_stream = interface_tendency!(info.device, workgroup)(
-            dg.balance_law,
+            spacedisc.balance_law,
             Val(info),
             HorizontalDirection(),
-            dg.numerical_flux_first_order,
-            dg.numerical_flux_second_order,
+            spacedisc.numerical_flux_first_order,
+            numerical_flux_second_order,
             tendency.data,
             state_prognostic.data,
-            dg.state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            dg.state_auxiliary.data,
-            dg.grid.vgeo,
-            dg.grid.sgeo,
+            grad_flux_data,
+            Qhypervisc_grad_data,
+            spacedisc.state_auxiliary.data,
+            spacedisc.grid.vgeo,
+            spacedisc.grid.sgeo,
             t,
-            dg.grid.vmap⁻,
-            dg.grid.vmap⁺,
-            dg.grid.elemtobndy,
+            spacedisc.grid.vmap⁻,
+            spacedisc.grid.vmap⁺,
+            spacedisc.grid.elemtobndy,
             elems,
             α;
             ndrange = ndrange,
@@ -1640,14 +1856,15 @@ function launch_interface_tendency!(
     end
 
     # Vertical kernel call
-    if dg.direction isa EveryDirection || dg.direction isa VerticalDirection
+    if spacedisc.direction isa EveryDirection ||
+       spacedisc.direction isa VerticalDirection
 
         workgroup = info.Nfp_h
         if surface === :interior
-            elems = dg.grid.interiorelems
+            elems = spacedisc.grid.interiorelems
             ndrange = workgroup * info.ninteriorelem
         else
-            elems = dg.grid.exteriorelems
+            elems = spacedisc.grid.exteriorelems
             ndrange = workgroup * info.nexteriorelem
         end
 
@@ -1655,22 +1872,22 @@ function launch_interface_tendency!(
         vertical_polyorder = info.N[info.dim]
 
         comp_stream = interface_tendency!(info.device, workgroup)(
-            dg.balance_law,
+            spacedisc.balance_law,
             Val(info),
             VerticalDirection(),
-            dg.numerical_flux_first_order,
-            dg.numerical_flux_second_order,
+            spacedisc.numerical_flux_first_order,
+            numerical_flux_second_order,
             tendency.data,
             state_prognostic.data,
-            dg.state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            dg.state_auxiliary.data,
-            dg.grid.vgeo,
-            dg.grid.sgeo,
+            grad_flux_data,
+            Qhypervisc_grad_data,
+            spacedisc.state_auxiliary.data,
+            spacedisc.grid.vgeo,
+            spacedisc.grid.sgeo,
             t,
-            dg.grid.vmap⁻,
-            dg.grid.vmap⁺,
-            dg.grid.elemtobndy,
+            spacedisc.grid.vmap⁻,
+            spacedisc.grid.vmap⁺,
+            spacedisc.grid.elemtobndy,
             elems,
             α;
             ndrange = ndrange,

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -1864,8 +1864,10 @@ function launch_volume_tendency!(
             spacedisc.grid.topology.realelems,
             α,
             β,
-            # If the model direction is horizontal, we want to be sure to add sources
-            spacedisc.direction isa HorizontalDirection,
+            # If the model direction is horizontal or FV in the vertical,
+            # we want to be sure to add sources
+            spacedisc.direction isa HorizontalDirection ||
+            spacedisc isa DGFVModel,
             ndrange = ndrange,
             dependencies = comp_stream,
         )
@@ -2066,6 +2068,9 @@ function launch_interface_tendency!(
                 # If we are computing in every direction, we need to
                 # increment after we compute the horizontal values
                 spacedisc.direction isa EveryDirection,
+                # If we are computing in vertical direction, we need to
+                # add sources here
+                spacedisc.direction isa VerticalDirection,
                 ndrange = ndrange,
                 dependencies = comp_stream,
             )

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -388,7 +388,7 @@ function (dgfvm::DGFVModel)(tendency, state_prognostic, _, t, α, β)
             comp_stream,
             exchange_state_prognostic,
             exchange_state_gradient_flux,
-            #JK exchange_Qhypervisc_grad,
+            # XXX: This is disabled until FVM with hyperdiffusion for DG is implemented: exchange_Qhypervisc_grad,
         ),
     )
 
@@ -426,7 +426,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
     @assert num_state_prognostic ≤ num_state_tendency
 
     if num_state_prognostic < num_state_tendency && β != 1
-        # if we don't operate on the full state, then we need to scale here instead of volume_tendency!
+        # If we don't operate on the full state, then we need to scale here instead of volume_tendency!
         tendency .*= β
         β = β != 0 # if β==0 then we can avoid the memory load in volume_tendency!
     end
@@ -485,7 +485,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
                 dependencies = exchange_state_prognostic,
             )
 
-            # update_aux may start asynchronous work on the compute device and
+            # Update_aux may start asynchronous work on the compute device and
             # we synchronize those here through a device event.
             wait(device, exchange_state_prognostic)
             update_auxiliary_state!(
@@ -523,7 +523,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
         end
 
         if num_state_gradient_flux > 0
-            # update_aux_diffusive may start asynchronous work on the compute device
+            # Update_aux_diffusive may start asynchronous work on the compute device
             # and we synchronize those here through a device event.
             wait(device, comp_stream)
             update_auxiliary_state_gradient!(
@@ -655,7 +655,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
                         dependencies = exchange_state_gradient_flux,
                     )
 
-                # update_aux_diffusive may start asynchronous work on the
+                # Update_aux_diffusive may start asynchronous work on the
                 # compute device and we synchronize those here through a device
                 # event.
                 wait(device, exchange_state_gradient_flux)
@@ -680,7 +680,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
                 dependencies = exchange_state_prognostic,
             )
 
-            # update_aux may start asynchronous work on the compute device and
+            # Update_aux may start asynchronous work on the compute device and
             # we synchronize those here through a device event.
             wait(device, exchange_state_prognostic)
             update_auxiliary_state!(
@@ -985,7 +985,7 @@ function update_auxiliary_state!(
 
     knl_nodal_update_auxiliary_state! =
         kernel_nodal_update_auxiliary_state!(device, min(Np, 1024))
-    ### update state_auxiliary variables
+    ### Update state_auxiliary variables
     event = Event(device)
     if diffusive
         event = knl_nodal_update_auxiliary_state!(

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -323,7 +323,7 @@ function (dgfvm::DGFVModel)(tendency, state_prognostic, _, t, α, β)
         t,
         α,
         β;
-        dependencies = (comp_stream,),
+        dependencies = comp_stream,
     )
 
     comp_stream = launch_interface_tendency!(
@@ -334,7 +334,7 @@ function (dgfvm::DGFVModel)(tendency, state_prognostic, _, t, α, β)
         α,
         β;
         surface = :interior,
-        dependencies = (comp_stream,),
+        dependencies = comp_stream,
     )
 
     if communicate
@@ -1432,7 +1432,10 @@ function launch_interface_gradients!(
                 spacedisc.grid.sgeo,
                 t,
                 spacedisc.grid.elemtobndy,
-                elems;
+                elems,
+                # If we are computing in every direction, we need to
+                # increment after we compute the horizontal values
+                spacedisc.direction isa EveryDirection,
                 ndrange = ndrange,
                 dependencies = comp_stream,
             )
@@ -2058,7 +2061,11 @@ function launch_interface_tendency!(
                 t,
                 spacedisc.grid.elemtobndy,
                 elems,
-                α;
+                α,
+                β,
+                # If we are computing in every direction, we need to
+                # increment after we compute the horizontal values
+                spacedisc.direction isa EveryDirection,
                 ndrange = ndrange,
                 dependencies = comp_stream,
             )

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -14,19 +14,28 @@ Must have the following properties:
 """
 abstract type SpaceDiscretization end
 
-struct DGFVMModel{BL, G, NFND, AS, D, MD} <: SpaceDiscretization
+struct DGFVModel{BL, G, FVR, NFND, NFD, GNF, AS, DS, D, DD, MD} <:
+       SpaceDiscretization
     balance_law::BL
     grid::G
+    fv_reconstruction::FVR
     numerical_flux_first_order::NFND
+    numerical_flux_second_order::NFD
+    numerical_flux_gradient::GNF
     state_auxiliary::AS
+    state_gradient_flux::DS
     direction::D
+    diffusion_direction::DD
     modeldata::MD
 end
 
-function DGFVMModel(
+function DGFVModel(
     balance_law,
     grid,
-    numerical_flux_first_order;
+    fv_reconstruction,
+    numerical_flux_first_order,
+    numerical_flux_second_order,
+    numerical_flux_gradient;
     fill_nan = false,
     state_auxiliary = create_state(
         balance_law,
@@ -34,7 +43,9 @@ function DGFVMModel(
         Auxiliary(),
         fill_nan = fill_nan,
     ),
+    state_gradient_flux = create_state(balance_law, grid, GradientFlux()),
     direction = EveryDirection(),
+    diffusion_direction = direction,
     modeldata = nothing,
 )
     # Make sure we are FVM in the vertical
@@ -42,12 +53,17 @@ function DGFVMModel(
     @assert isstacked(grid.topology)
     state_auxiliary =
         init_state(state_auxiliary, balance_law, grid, direction, Auxiliary())
-    DGFVMModel(
+    DGFVModel(
         balance_law,
         grid,
+        fv_reconstruction,
         numerical_flux_first_order,
+        numerical_flux_second_order,
+        numerical_flux_gradient,
         state_auxiliary,
+        state_gradient_flux,
         direction,
+        diffusion_direction,
         modeldata,
     )
 end
@@ -171,7 +187,7 @@ function (spacedisc::SpaceDiscretization)(
 end
 
 """
-    (dgfvm::DGFVMModel)(tendency, state_prognostic, _, t, α, β)
+    (dgfvm::DGFVModel)(tendency, state_prognostic, _, t, α, β)
 
 Uses spectral element discontinuous Galerkin in the horizontal and finite volume
 in the vertical to compute the tendency.
@@ -184,12 +200,12 @@ The 4-argument form will just compute
 
     tendency .= dQdt(state_prognostic, p, t)
 """
-function (dgfvm::DGFVMModel)(tendency, state_prognostic, _, t, α, β)
+function (dgfvm::DGFVModel)(tendency, state_prognostic, _, t, α, β)
     device = array_device(state_prognostic)
 
     FT = eltype(state_prognostic)
     num_state_prognostic = number_states(dgfvm.balance_law, Prognostic())
-    @assert 0 == number_states(dgfvm.balance_law, GradientFlux())
+    num_state_gradient_flux = number_states(dgfvm.balance_law, GradientFlux())
     @assert 0 == number_states(dgfvm.balance_law, Hyperdiffusive())
     num_state_tendency = size(tendency, 2)
 
@@ -205,14 +221,15 @@ function (dgfvm::DGFVMModel)(tendency, state_prognostic, _, t, α, β)
             typeof(dgfvm.direction) <: VerticalDirection
         )
 
-    #JK update_auxiliary_state!(
-    #JK     dg,
-    #JK     dg.balance_law,
-    #JK     state_prognostic,
-    #JK     t,
-    #JK     dg.grid.topology.realelems,
-    #JK )
+    update_auxiliary_state!(
+        dgfvm,
+        dgfvm.balance_law,
+        state_prognostic,
+        t,
+        dgfvm.grid.topology.realelems,
+    )
 
+    exchange_state_gradient_flux = NoneEvent()
     exchange_state_prognostic = NoneEvent()
 
     comp_stream = Event(device)
@@ -224,7 +241,77 @@ function (dgfvm::DGFVMModel)(tendency, state_prognostic, _, t, α, β)
         )
     end
 
-    # TODO: Add diffusion calls
+    if num_state_gradient_flux > 0
+        ########################
+        # Gradient Computation #
+        ########################
+
+        comp_stream = launch_volume_gradients!(
+            dgfvm,
+            state_prognostic,
+            t;
+            dependencies = comp_stream,
+        )
+
+        comp_stream = launch_interface_gradients!(
+            dgfvm,
+            state_prognostic,
+            t;
+            surface = :interior,
+            dependencies = comp_stream,
+        )
+
+        if communicate
+            exchange_state_prognostic = MPIStateArrays.end_ghost_exchange!(
+                state_prognostic;
+                dependencies = exchange_state_prognostic,
+            )
+
+            # Update_aux may start asynchronous work on the compute device and
+            # we synchronize those here through a device event.
+            wait(device, exchange_state_prognostic)
+            update_auxiliary_state!(
+                dgfvm,
+                dgfvm.balance_law,
+                state_prognostic,
+                t,
+                dgfvm.grid.topology.ghostelems,
+            )
+            exchange_state_prognostic = Event(device)
+        end
+
+        comp_stream = launch_interface_gradients!(
+            dgfvm,
+            state_prognostic,
+            t;
+            surface = :exterior,
+            dependencies = (comp_stream, exchange_state_prognostic),
+        )
+
+        if communicate
+            if num_state_gradient_flux > 0
+                exchange_state_gradient_flux =
+                    MPIStateArrays.begin_ghost_exchange!(
+                        dgfvm.state_gradient_flux,
+                        dependencies = comp_stream,
+                    )
+            end
+        end
+
+        if num_state_gradient_flux > 0
+            # Update_aux_diffusive may start asynchronous work on the compute device
+            # and we synchronize those here through a device event.
+            wait(device, comp_stream)
+            update_auxiliary_state_gradient!(
+                dgfvm,
+                dgfvm.balance_law,
+                state_prognostic,
+                t,
+                dgfvm.grid.topology.realelems,
+            )
+            comp_stream = Event(device)
+        end
+    end
 
     ###################
     # RHS Computation #
@@ -251,23 +338,42 @@ function (dgfvm::DGFVMModel)(tendency, state_prognostic, _, t, α, β)
     )
 
     if communicate
-        # TODO: gradient and hyperdiffusion communication
-        exchange_state_prognostic = MPIStateArrays.end_ghost_exchange!(
-            state_prognostic;
-            dependencies = exchange_state_prognostic,
-        )
+        if num_state_gradient_flux > 0
+            exchange_state_gradient_flux = MPIStateArrays.end_ghost_exchange!(
+                dgfvm.state_gradient_flux;
+                dependencies = exchange_state_gradient_flux,
+            )
 
-        # update_aux may start asynchronous work on the compute device and
-        # we synchronize those here through a device event.
-        wait(device, exchange_state_prognostic)
-        #JK update_auxiliary_state!(
-        #JK     dg,
-        #JK     dg.balance_law,
-        #JK     state_prognostic,
-        #JK     t,
-        #JK     dg.grid.topology.ghostelems,
-        #JK )
-        #JK exchange_state_prognostic = Event(device)
+            # Update_aux_diffusive may start asynchronous work on the
+            # compute device and we synchronize those here through a device
+            # event.
+            wait(device, exchange_state_gradient_flux)
+            update_auxiliary_state_gradient!(
+                dgfvm,
+                dgfvm.balance_law,
+                state_prognostic,
+                t,
+                dgfvm.grid.topology.ghostelems,
+            )
+            exchange_state_gradient_flux = Event(device)
+        else
+            exchange_state_prognostic = MPIStateArrays.end_ghost_exchange!(
+                state_prognostic;
+                dependencies = exchange_state_prognostic,
+            )
+
+            # Update_aux may start asynchronous work on the compute device and
+            # we synchronize those here through a device event.
+            wait(device, exchange_state_prognostic)
+            update_auxiliary_state!(
+                dgfvm,
+                dgfvm.balance_law,
+                state_prognostic,
+                t,
+                dgfvm.grid.topology.ghostelems,
+            )
+            exchange_state_prognostic = Event(device)
+        end
     end
 
     comp_stream = launch_interface_tendency!(
@@ -281,7 +387,7 @@ function (dgfvm::DGFVMModel)(tendency, state_prognostic, _, t, α, β)
         dependencies = (
             comp_stream,
             exchange_state_prognostic,
-            #JK exchange_state_gradient_flux,
+            exchange_state_gradient_flux,
             #JK exchange_Qhypervisc_grad,
         ),
     )
@@ -765,15 +871,7 @@ function init_state_auxiliary!(
     wait(device, event)
 end
 
-function update_auxiliary_state_gradient!(
-    dg::DGModel,
-    balance_law,
-    state_prognostic,
-    t,
-    elems,
-)
-    return false
-end
+update_auxiliary_state_gradient!(::SpaceDiscretization, _...) = false
 
 function indefinite_stack_integral!(
     dg::DGModel,
@@ -867,16 +965,16 @@ end
 # TODO: this should really be a separate function
 function update_auxiliary_state!(
     f!,
-    dg::DGModel,
+    spacedisc::SpaceDiscretization,
     m::BalanceLaw,
     state_prognostic::MPIStateArray,
     t::Real,
-    elems::UnitRange = dg.grid.topology.realelems;
+    elems::UnitRange = spacedisc.grid.topology.realelems;
     diffusive = false,
 )
     device = array_device(state_prognostic)
 
-    grid = dg.grid
+    grid = spacedisc.grid
     topology = grid.topology
 
     dim = dimensionality(grid)
@@ -896,8 +994,8 @@ function update_auxiliary_state!(
             Val(N),
             f!,
             state_prognostic.data,
-            dg.state_auxiliary.data,
-            dg.state_gradient_flux.data,
+            spacedisc.state_auxiliary.data,
+            spacedisc.state_gradient_flux.data,
             t,
             elems,
             grid.activedofs;
@@ -911,7 +1009,7 @@ function update_auxiliary_state!(
             Val(N),
             f!,
             state_prognostic.data,
-            dg.state_auxiliary.data,
+            spacedisc.state_auxiliary.data,
             t,
             elems,
             grid.activedofs;
@@ -1116,19 +1214,25 @@ function hyperdiff_indexmap(balance_law, ::Type{FT}) where {FT}
 end
 
 """
-    launch_volume_gradients!(dg, state_prognostic, t; dependencies)
+    launch_volume_gradients!(spacedisc, state_prognostic, t; dependencies)
 
 Launches horizontal and vertical kernels for computing the volume gradients.
 """
-function launch_volume_gradients!(dg, state_prognostic, t; dependencies)
+function launch_volume_gradients!(spacedisc, state_prognostic, t; dependencies)
     FT = eltype(state_prognostic)
-    Qhypervisc_grad, _ = dg.states_higher_order
+    # XXX: This is until FVM with hyperdiffusion for DG is implemented
+    if spacedisc isa DGFVModel
+        @assert 0 == number_states(spacedisc.balance_law, Hyperdiffusive())
+        Qhypervisc_grad_data = nothing
+    elseif spacedisc isa DGModel
+        Qhypervisc_grad_data = spacedisc.states_higher_order[1].data
+    end
 
     # Workgroup is determined by the number of quadrature points
     # in the horizontal direction. For each horizontal quadrature
     # point, we operate on a stack of quadrature in the vertical
     # direction. (Iteration space is in the horizontal)
-    info = basic_launch_info(dg)
+    info = basic_launch_info(spacedisc)
 
     # We assume (in 3-D) that both x and y directions
     # are discretized using the same polynomial order, Nq[1] == Nq[2].
@@ -1140,56 +1244,58 @@ function launch_volume_gradients!(dg, state_prognostic, t; dependencies)
 
     # If the model direction is EveryDirection, we need to perform
     # both horizontal AND vertical kernel calls; otherwise, we only
-    # call the kernel corresponding to the model direction `dg.diffusion_direction`
-    if dg.diffusion_direction isa EveryDirection ||
-       dg.diffusion_direction isa HorizontalDirection
+    # call the kernel corresponding to the model direction `spacedisc.diffusion_direction`
+    if spacedisc.diffusion_direction isa EveryDirection ||
+       spacedisc.diffusion_direction isa HorizontalDirection
 
         # We assume N₁ = N₂, so the same polyorder, quadrature weights,
         # and differentiation operators are used
         horizontal_polyorder = info.N[1]
-        horizontal_D = dg.grid.D[1]
+        horizontal_D = spacedisc.grid.D[1]
         comp_stream = volume_gradients!(info.device, workgroup)(
-            dg.balance_law,
+            spacedisc.balance_law,
             Val(info),
             HorizontalDirection(),
             state_prognostic.data,
-            dg.state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            dg.state_auxiliary.data,
-            dg.grid.vgeo,
+            spacedisc.state_gradient_flux.data,
+            Qhypervisc_grad_data,
+            spacedisc.state_auxiliary.data,
+            spacedisc.grid.vgeo,
             t,
             horizontal_D,
-            Val(hyperdiff_indexmap(dg.balance_law, FT)),
-            dg.grid.topology.realelems,
+            Val(hyperdiff_indexmap(spacedisc.balance_law, FT)),
+            spacedisc.grid.topology.realelems,
             ndrange = ndrange,
             dependencies = comp_stream,
         )
     end
 
     # Now we call the kernel corresponding to the vertical direction
-    if dg.diffusion_direction isa EveryDirection ||
-       dg.diffusion_direction isa VerticalDirection
+    if spacedisc isa DGModel && (
+        spacedisc.diffusion_direction isa EveryDirection ||
+        spacedisc.diffusion_direction isa VerticalDirection
+    )
 
         # Vertical polynomial degree and differentiation matrix
         vertical_polyorder = info.N[info.dim]
-        vertical_D = dg.grid.D[info.dim]
+        vertical_D = spacedisc.grid.D[info.dim]
         comp_stream = volume_gradients!(info.device, workgroup)(
-            dg.balance_law,
+            spacedisc.balance_law,
             Val(info),
             VerticalDirection(),
             state_prognostic.data,
-            dg.state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            dg.state_auxiliary.data,
-            dg.grid.vgeo,
+            spacedisc.state_gradient_flux.data,
+            Qhypervisc_grad_data,
+            spacedisc.state_auxiliary.data,
+            spacedisc.grid.vgeo,
             t,
             vertical_D,
-            Val(hyperdiff_indexmap(dg.balance_law, FT)),
-            dg.grid.topology.realelems,
+            Val(hyperdiff_indexmap(spacedisc.balance_law, FT)),
+            spacedisc.grid.topology.realelems,
             # If we are computing the volume gradient in every direction, we
             # need to increment into the appropriate fields _after_ the
             # horizontal computation.
-            !(dg.diffusion_direction isa VerticalDirection),
+            !(spacedisc.diffusion_direction isa VerticalDirection),
             ndrange = ndrange,
             dependencies = comp_stream,
         )
@@ -1198,7 +1304,7 @@ function launch_volume_gradients!(dg, state_prognostic, t; dependencies)
 end
 
 """
-    launch_interface_gradients!(dg, state_prognostic, t; surface::Symbol, dependencies)
+    launch_interface_gradients!(spacedisc, state_prognostic, t; surface::Symbol, dependencies)
 
 Launches horizontal and vertical kernels for computing the interface gradients.
 The argument `surface` is either `:interior` or `:exterior`, which denotes whether
@@ -1206,54 +1312,60 @@ we are computing interface gradients on boundaries which are interior (exterior 
 to the _parallel_ boundary.
 """
 function launch_interface_gradients!(
-    dg,
+    spacedisc,
     state_prognostic,
     t;
     surface::Symbol,
     dependencies,
 )
     @assert surface === :interior || surface === :exterior
+    # XXX: This is until FVM with DG hyperdiffusion is implemented
+    if spacedisc isa DGFVModel
+        @assert 0 == number_states(spacedisc.balance_law, Hyperdiffusive())
+        Qhypervisc_grad_data = nothing
+    elseif spacedisc isa DGModel
+        Qhypervisc_grad_data = spacedisc.states_higher_order[1].data
+    end
 
     FT = eltype(state_prognostic)
-    Qhypervisc_grad, _ = dg.states_higher_order
 
-    info = basic_launch_info(dg)
+    info = basic_launch_info(spacedisc)
     comp_stream = dependencies
 
     # If the model direction is EveryDirection, we need to perform
     # both horizontal AND vertical kernel calls; otherwise, we only
-    # call the kernel corresponding to the model direction `dg.diffusion_direction`
-    if dg.diffusion_direction isa EveryDirection ||
-       dg.diffusion_direction isa HorizontalDirection
+    # call the kernel corresponding to the model direction `spacedisc.diffusion_direction`
+    if spacedisc.diffusion_direction isa EveryDirection ||
+       spacedisc.diffusion_direction isa HorizontalDirection
 
         workgroup = info.Nfp_v
         if surface === :interior
-            elems = dg.grid.interiorelems
+            elems = spacedisc.grid.interiorelems
             ndrange = workgroup * info.ninteriorelem
         else
-            elems = dg.grid.exteriorelems
+            elems = spacedisc.grid.exteriorelems
             ndrange = workgroup * info.nexteriorelem
         end
 
         # Hoirzontal polynomial order (assumes same for both horizontal directions)
         horizontal_polyorder = info.N[1]
 
-        comp_stream = interface_gradients!(info.device, workgroup)(
-            dg.balance_law,
+        comp_stream = dgsem_interface_gradients!(info.device, workgroup)(
+            spacedisc.balance_law,
             Val(info),
             HorizontalDirection(),
-            dg.numerical_flux_gradient,
+            spacedisc.numerical_flux_gradient,
             state_prognostic.data,
-            dg.state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            dg.state_auxiliary.data,
-            dg.grid.vgeo,
-            dg.grid.sgeo,
+            spacedisc.state_gradient_flux.data,
+            Qhypervisc_grad_data,
+            spacedisc.state_auxiliary.data,
+            spacedisc.grid.vgeo,
+            spacedisc.grid.sgeo,
             t,
-            dg.grid.vmap⁻,
-            dg.grid.vmap⁺,
-            dg.grid.elemtobndy,
-            Val(hyperdiff_indexmap(dg.balance_law, FT)),
+            spacedisc.grid.vmap⁻,
+            spacedisc.grid.vmap⁺,
+            spacedisc.grid.elemtobndy,
+            Val(hyperdiff_indexmap(spacedisc.balance_law, FT)),
             elems;
             ndrange = ndrange,
             dependencies = comp_stream,
@@ -1261,41 +1373,72 @@ function launch_interface_gradients!(
     end
 
     # Vertical interface kernel call
-    if dg.diffusion_direction isa EveryDirection ||
-       dg.diffusion_direction isa VerticalDirection
+    if spacedisc.diffusion_direction isa EveryDirection ||
+       spacedisc.diffusion_direction isa VerticalDirection
 
         workgroup = info.Nfp_h
         if surface === :interior
-            elems = dg.grid.interiorelems
+            elems = spacedisc.grid.interiorelems
             ndrange = workgroup * info.ninteriorelem
         else
-            elems = dg.grid.exteriorelems
+            elems = spacedisc.grid.exteriorelems
             ndrange = workgroup * info.nexteriorelem
         end
 
         # Vertical polynomial degree
         vertical_polyorder = info.N[info.dim]
 
-        comp_stream = interface_gradients!(info.device, workgroup)(
-            dg.balance_law,
-            Val(info),
-            VerticalDirection(),
-            dg.numerical_flux_gradient,
-            state_prognostic.data,
-            dg.state_gradient_flux.data,
-            Qhypervisc_grad.data,
-            dg.state_auxiliary.data,
-            dg.grid.vgeo,
-            dg.grid.sgeo,
-            t,
-            dg.grid.vmap⁻,
-            dg.grid.vmap⁺,
-            dg.grid.elemtobndy,
-            Val(hyperdiff_indexmap(dg.balance_law, FT)),
-            elems;
-            ndrange = ndrange,
-            dependencies = comp_stream,
-        )
+        if spacedisc isa DGModel
+            comp_stream = dgsem_interface_gradients!(info.device, workgroup)(
+                spacedisc.balance_law,
+                Val(info),
+                VerticalDirection(),
+                spacedisc.numerical_flux_gradient,
+                state_prognostic.data,
+                spacedisc.state_gradient_flux.data,
+                Qhypervisc_grad_data,
+                spacedisc.state_auxiliary.data,
+                spacedisc.grid.vgeo,
+                spacedisc.grid.sgeo,
+                t,
+                spacedisc.grid.vmap⁻,
+                spacedisc.grid.vmap⁺,
+                spacedisc.grid.elemtobndy,
+                Val(hyperdiff_indexmap(spacedisc.balance_law, FT)),
+                elems;
+                ndrange = ndrange,
+                dependencies = comp_stream,
+            )
+        elseif spacedisc isa DGFVModel
+            # Make sure FVM in the vertical
+            @assert info.N[info.dim] == 0
+
+            # The FVM will only work on stacked grids!
+            @assert isstacked(spacedisc.grid.topology)
+            nvertelem = spacedisc.grid.topology.stacksize
+            periodicstack = spacedisc.grid.topology.periodicstack
+
+            # 1 thread per degree freedom per element
+            comp_stream = vert_fvm_interface_gradients!(info.device, workgroup)(
+                spacedisc.balance_law,
+                Val(info),
+                Val(nvertelem),
+                Val(periodicstack),
+                VerticalDirection(),
+                state_prognostic.data,
+                spacedisc.state_gradient_flux.data,
+                spacedisc.state_auxiliary.data,
+                spacedisc.grid.vgeo,
+                spacedisc.grid.sgeo,
+                t,
+                spacedisc.grid.elemtobndy,
+                elems;
+                ndrange = ndrange,
+                dependencies = comp_stream,
+            )
+        else
+            error("unknown spatial discretization: $(typeof(spacedisc))")
+        end
     end
     return comp_stream
 end
@@ -1652,7 +1795,7 @@ function launch_interface_gradients_of_laplacians!(
 end
 
 """
-    launch_volume_tendency!(dg, state_prognostic, t; dependencies)
+    launch_volume_tendency!(spacedisc, state_prognostic, t; dependencies)
 
 Launches horizontal and vertical volume kernels for computing tendencies (sources, sinks, etc).
 """
@@ -1665,16 +1808,14 @@ function launch_volume_tendency!(
     β;
     dependencies,
 )
-    # XXX: This is until FVM with diffusion is implemented
-    if spacedisc isa DGFVMModel
-        @assert 0 == number_states(spacedisc.balance_law, GradientFlux())
+    # XXX: This is until FVM with hyperdiffusion is implemented
+    if spacedisc isa DGFVModel
         @assert 0 == number_states(spacedisc.balance_law, Hyperdiffusive())
         Qhypervisc_grad_data = nothing
-        grad_flux_data = nothing
     elseif spacedisc isa DGModel
         Qhypervisc_grad_data = spacedisc.states_higher_order[1].data
-        grad_flux_data = spacedisc.state_gradient_flux.data
     end
+    grad_flux_data = spacedisc.state_gradient_flux.data
 
     # Workgroup is determined by the number of quadrature points
     # in the horizontal direction. For each horizontal quadrature
@@ -1771,16 +1912,6 @@ function launch_volume_tendency!(
     return comp_stream
 end
 
-# XXX: This is just to maskout the second order flux for the start of FVM development
-import .NumericalFluxes
-struct NothingFlux <: NumericalFluxes.NumericalFluxSecondOrder end
-function NumericalFluxes.numerical_flux_second_order!(::NothingFlux, _...) end
-function NumericalFluxes.numerical_boundary_flux_second_order!(
-    ::NothingFlux,
-    _...,
-) end
-
-
 """
     launch_interface_tendency!(spacedisc, state_prognostic, t; surface::Symbol, dependencies)
 
@@ -1800,24 +1931,22 @@ function launch_interface_tendency!(
 )
     @assert surface === :interior || surface === :exterior
     # XXX: This is until FVM with diffusion is implemented
-    if spacedisc isa DGFVMModel
-        @assert 0 == number_states(spacedisc.balance_law, GradientFlux())
+    if spacedisc isa DGFVModel
         @assert 0 == number_states(spacedisc.balance_law, Hyperdiffusive())
         Qhypervisc_grad_data = nothing
-        grad_flux_data = nothing
-        numerical_flux_second_order = NothingFlux()
     elseif spacedisc isa DGModel
         Qhypervisc_grad_data = spacedisc.states_higher_order[1].data
-        grad_flux_data = spacedisc.state_gradient_flux.data
-        numerical_flux_second_order = spacedisc.numerical_flux_second_order
     end
+    grad_flux_data = spacedisc.state_gradient_flux.data
+    numerical_flux_second_order = spacedisc.numerical_flux_second_order
 
     info = basic_launch_info(spacedisc)
     comp_stream = dependencies
 
     # If the model direction is EveryDirection, we need to perform
     # both horizontal AND vertical kernel calls; otherwise, we only
-    # call the kernel corresponding to the model direction `spacedisc.diffusion_direction`
+    # call the kernel corresponding to the model direction
+    # `spacedisc.diffusion_direction`
     if spacedisc.direction isa EveryDirection ||
        spacedisc.direction isa HorizontalDirection
 
@@ -1830,10 +1959,11 @@ function launch_interface_tendency!(
             ndrange = workgroup * info.nexteriorelem
         end
 
-        # Hoirzontal polynomial order (assumes same for both horizontal directions)
+        # Hoirzontal polynomial order (assumes same for both horizontal
+        # directions)
         horizontal_polyorder = info.N[1]
 
-        comp_stream = interface_tendency!(info.device, workgroup)(
+        comp_stream = dgsem_interface_tendency!(info.device, workgroup)(
             spacedisc.balance_law,
             Val(info),
             HorizontalDirection(),
@@ -1860,41 +1990,81 @@ function launch_interface_tendency!(
     # Vertical kernel call
     if spacedisc.direction isa EveryDirection ||
        spacedisc.direction isa VerticalDirection
+        elems =
+            surface === :interior ? elems = spacedisc.grid.interiorelems :
+            spacedisc.grid.exteriorelems
 
-        workgroup = info.Nfp_h
-        if surface === :interior
-            elems = spacedisc.grid.interiorelems
-            ndrange = workgroup * info.ninteriorelem
+        if spacedisc isa DGModel
+            workgroup = info.Nfp_h
+            ndrange = workgroup * length(elems)
+
+            # Vertical polynomial degree
+            vertical_polyorder = info.N[info.dim]
+
+            comp_stream = dgsem_interface_tendency!(info.device, workgroup)(
+                spacedisc.balance_law,
+                Val(info),
+                VerticalDirection(),
+                spacedisc.numerical_flux_first_order,
+                numerical_flux_second_order,
+                tendency.data,
+                state_prognostic.data,
+                grad_flux_data,
+                Qhypervisc_grad_data,
+                spacedisc.state_auxiliary.data,
+                spacedisc.grid.vgeo,
+                spacedisc.grid.sgeo,
+                t,
+                spacedisc.grid.vmap⁻,
+                spacedisc.grid.vmap⁺,
+                spacedisc.grid.elemtobndy,
+                elems,
+                α;
+                ndrange = ndrange,
+                dependencies = comp_stream,
+            )
+        elseif spacedisc isa DGFVModel
+            # Make sure FVM in the vertical
+            @assert info.N[info.dim] == 0
+
+            # The FVM will only work on stacked grids!
+            @assert isstacked(spacedisc.grid.topology)
+
+            # Figute out the stacking of the mesh
+            nvertelem = spacedisc.grid.topology.stacksize
+            nhorzelem = div(length(elems), nvertelem)
+            periodicstack = spacedisc.grid.topology.periodicstack
+
+            # 2-D workgroup
+            workgroup = info.Nfp_h
+            ndrange = workgroup * nhorzelem
+
+            # XXX: This will need to be updated to diffusion
+            comp_stream = vert_fvm_interface_tendency!(info.device, workgroup)(
+                spacedisc.balance_law,
+                Val(info),
+                Val(nvertelem),
+                Val(periodicstack),
+                VerticalDirection(),
+                spacedisc.fv_reconstruction,
+                spacedisc.numerical_flux_first_order,
+                numerical_flux_second_order,
+                tendency.data,
+                state_prognostic.data,
+                grad_flux_data,
+                spacedisc.state_auxiliary.data,
+                spacedisc.grid.vgeo,
+                spacedisc.grid.sgeo,
+                t,
+                spacedisc.grid.elemtobndy,
+                elems,
+                α;
+                ndrange = ndrange,
+                dependencies = comp_stream,
+            )
         else
-            elems = spacedisc.grid.exteriorelems
-            ndrange = workgroup * info.nexteriorelem
+            error("unknown spatial discretization: $(typeof(spacedisc))")
         end
-
-        # Vertical polynomial degree
-        vertical_polyorder = info.N[info.dim]
-
-        comp_stream = interface_tendency!(info.device, workgroup)(
-            spacedisc.balance_law,
-            Val(info),
-            VerticalDirection(),
-            spacedisc.numerical_flux_first_order,
-            numerical_flux_second_order,
-            tendency.data,
-            state_prognostic.data,
-            grad_flux_data,
-            Qhypervisc_grad_data,
-            spacedisc.state_auxiliary.data,
-            spacedisc.grid.vgeo,
-            spacedisc.grid.sgeo,
-            t,
-            spacedisc.grid.vmap⁻,
-            spacedisc.grid.vmap⁺,
-            spacedisc.grid.elemtobndy,
-            elems,
-            α;
-            ndrange = ndrange,
-            dependencies = comp_stream,
-        )
     end
 
     return comp_stream

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -8,7 +8,8 @@ using .NumericalFluxes:
     numerical_boundary_flux_first_order!,
     numerical_boundary_flux_second_order!,
     numerical_boundary_flux_divergence!,
-    numerical_boundary_flux_higher_order!
+    numerical_boundary_flux_higher_order!,
+    CentralNumericalFluxGradient
 
 using ..Mesh.Geometry
 
@@ -599,7 +600,7 @@ end
 end
 
 @doc """
-    function interface_tendency!(
+    function dgsem_interface_tendency!(
         balance_law::BalanceLaw,
         ::Val{dim},
         ::Val{polyorder},
@@ -635,8 +636,8 @@ where M is the mass matrix, Mf is the face mass matrix, L is an interpolator
 from volume to face, and Fⁱⁿᵛ⋆, Fᵛⁱˢᶜ⋆
 are the numerical fluxes for the inviscid and viscous
 fluxes, respectively.
-""" interface_tendency!
-@kernel function interface_tendency!(
+""" dgsem_interface_tendency!
+@kernel function dgsem_interface_tendency!(
     balance_law::BalanceLaw,
     ::Val{info},
     direction,
@@ -1415,7 +1416,7 @@ end
 end
 
 @doc """
-    function interface_gradients!(
+    function dgsem_interface_gradients!(
         balance_law::BalanceLaw,
         ::Val{dim},
         ::Val{polyorder},
@@ -1448,8 +1449,8 @@ This kernel computes the interface gradient term: M⁻¹ LᵀMf(G* - G),
 where M is the mass matrix, Mf is the face mass matrix, L is an interpolator
 from volume to face, G is the
 auxiliary gradient flux, and G* is the associated numerical flux.
-""" interface_gradients!
-@kernel function interface_gradients!(
+""" dgsem_interface_gradients!
+@kernel function dgsem_interface_gradients!(
     balance_law::BalanceLaw,
     ::Val{info},
     direction,

--- a/src/Numerics/DGMethods/FVReconstructions.jl
+++ b/src/Numerics/DGMethods/FVReconstructions.jl
@@ -1,5 +1,6 @@
 module FVReconstructions
 using KernelAbstractions.Extras: @unroll
+import StaticArrays: SUnitRange, SVector
 
 """
     AbstractReconstruction
@@ -10,7 +11,7 @@ Concrete types must provide implementions of
     - `width(recon)`
        returns the width of the reconstruction. Total number of points used in
        reconstruction of top and bottom states is `2width(recon) + 1`
-       - (::AbstractReconstruction)(state_top, state_bottom, cell_states::NTuple,
+       - (::AbstractReconstruction)(state_top, state_bottom, cell_states::SVector,
                                     cell_weights)
       compute the reconstruction
 
@@ -59,9 +60,9 @@ struct FVConstant <: AbstractReconstruction end
 
 width(::FVConstant) = 0
 
-function (::FVConstant)(state_bot, state_top, cell_states::NTuple{1}, _)
-    state_top .= cell_states[1]
-    state_bot .= cell_states[1]
+function (::FVConstant)(state_bot, state_top, cell_states::SVector{1}, _)
+    @inbounds state_top .= cell_states[1]
+    @inbounds state_bot .= cell_states[1]
 end
 """
     FVLinear{W = 1} <: AbstractReconstruction
@@ -101,11 +102,11 @@ width(::FVLinear{W}) where {W} = W
 function (fvrecon::FVLinear)(
     state_bot,
     state_top,
-    cell_states::NTuple{3},
+    cell_states::SVector{3},
     cell_weights,
 )
-    wi_top = 1 / (cell_weights[3] + cell_weights[2])
-    wi_bot = 1 / (cell_weights[2] + cell_weights[1])
+    @inbounds wi_top = 1 / (cell_weights[3] + cell_weights[2])
+    @inbounds wi_bot = 1 / (cell_weights[2] + cell_weights[1])
     @inbounds @unroll for s in 1:length(state_top)
         # Compute the edge gradient approximations
         Δ_top = wi_top * (cell_states[3][s] - cell_states[2][s])
@@ -123,7 +124,7 @@ end
 function (fvrecon::FVLinear)(
     state_bot,
     state_top,
-    cell_states::NTuple{1},
+    cell_states::SVector{1},
     cell_weights,
 )
     FVConstant()(state_bot, state_top, cell_states, cell_weights)
@@ -132,16 +133,12 @@ end
 function (fvrecon::FVLinear)(
     state_bot,
     state_top,
-    cell_states::NTuple{D},
+    cell_states::SVector{D},
     cell_weights,
 ) where {D}
     W = div(D - 1, 2)
-    fvrecon(
-        state_bot,
-        state_top,
-        cell_states[W .+ (0:2)],
-        cell_weights[W .+ (0:2)],
-    )
+    rng = SUnitRange(W, W + 2)
+    @inbounds fvrecon(state_bot, state_top, cell_states[rng], cell_weights[rng])
 end
 
 """

--- a/src/Numerics/DGMethods/FVReconstructions.jl
+++ b/src/Numerics/DGMethods/FVReconstructions.jl
@@ -1,0 +1,146 @@
+module FVReconstructions
+using KernelAbstractions.Extras: @unroll
+
+"""
+    AbstractReconstruction
+
+Supertype for FV reconstructions.
+
+Concrete types must provide implementions of
+    - `width(recon)`
+       returns the width of the reconstruction. Total number of points used in
+       reconstruction of top and bottom states is `2width(recon) + 1`
+       - (::AbstractReconstruction)(state_top, state_bottom, cell_states::NTuple,
+                                    cell_weights)
+      compute the reconstruction
+
+```
+(::AbstractReconstruction)(
+        state_top,
+        state_bottom,
+        cell_states,
+        cell_weights,
+    )
+```
+
+Perform the finite volume reconstruction for the top and bottom states using the
+tuple of `cell_states` values using the `cell_weights`.
+"""
+abstract type AbstractReconstruction end
+function (::AbstractReconstruction) end
+
+"""
+    AbstractSlopeLimiter
+
+Supertype for FV slope limiter
+
+Given two values `Δ1` and `Δ2`, should return the value of
+```
+Δ2 * ϕ(Δ1 / Δ2)
+```
+where `0 ≤ ϕ(r) ≤ 2` is the slope limiter
+"""
+abstract type AbstractSlopeLimiter end
+
+"""
+    width(recon::AbstractReconstruction)
+
+Returns the width of the stencil need for the FV reconstruction `recon`. Total
+number of values used in the reconstruction are `2width(recon) + 1`
+"""
+width(recon::AbstractReconstruction) = throw(MethodError(width, (recon,)))
+
+"""
+    FVConstant <: AbstractReconstruction
+
+Reconstruction type for cell centered finite volume methods (e.g., constants)
+"""
+struct FVConstant <: AbstractReconstruction end
+
+width(::FVConstant) = 0
+
+function (::FVConstant)(
+    state_bot,
+    state_top,
+    cell_states::NTuple{1},
+    _,
+) where {FT}
+    state_top .= cell_states[1]
+    state_bot .= cell_states[1]
+end
+"""
+    FVLinear <: AbstractReconstruction
+
+Reconstruction type for limited linear reconstruction finite volume methods
+"""
+struct FVLinear{L} <: AbstractReconstruction
+    limiter::L
+    FVLinear(limiter = VanLeer()) = new{typeof(limiter)}(limiter)
+end
+
+width(::FVLinear) = 1
+
+function (fvrecon::FVLinear)(
+    state_bot,
+    state_top,
+    cell_states::NTuple{3},
+    cell_weights,
+) where {FT}
+    wi_top = 1 / (cell_weights[3] + cell_weights[2])
+    wi_bot = 1 / (cell_weights[2] + cell_weights[1])
+    @inbounds @unroll for s in 1:length(state_top)
+        # Compute the edge gradient approximations
+        Δ_top = wi_top * (cell_states[3][s] - cell_states[2][s])
+        Δ_bot = wi_bot * (cell_states[2][s] - cell_states[1][s])
+
+        # Compute the limited slope
+        Δ = fvrecon.limiter(Δ_top, Δ_bot)
+
+        # Compute the reconstructions at the cell edges
+        state_top[s] = cell_states[2][s] + Δ * cell_weights[2]
+        state_bot[s] = cell_states[2][s] - Δ * cell_weights[2]
+    end
+end
+
+function (fvrecon::FVLinear)(
+    state_bot,
+    state_top,
+    cell_states::NTuple{1},
+    cell_weights,
+) where {FT}
+    FVConstant()(state_bot, state_top, cell_states, cell_weights)
+end
+
+"""
+    VanLeer <: AbstractSlopeLimiter
+
+Classic Van-Leer limiter
+```
+   ϕ(r) = (r + |r|) / (1 + r)
+```
+
+### References
+    @article{van1974towards,
+      title = {Towards the ultimate conservative difference scheme. II.
+               Monotonicity and conservation combined in a second-order scheme},
+      author = {Van Leer, Bram},
+      journal = {Journal of computational physics},
+      volume = {14},
+      number = {4},
+      pages = {361--370},
+      year = {1974},
+      doi = {10.1016/0021-9991(74)90019-9}
+    }
+"""
+struct VanLeer <: AbstractSlopeLimiter end
+
+function (::VanLeer)(Δ_top, Δ_bot)
+    FT = eltype(Δ_top)
+    if Δ_top * Δ_bot > 0
+        return 2Δ_top * Δ_bot / (Δ_top + Δ_bot)
+    else
+        return FT(0)
+    end
+end
+
+end

--- a/src/Numerics/DGMethods/FVReconstructions.jl
+++ b/src/Numerics/DGMethods/FVReconstructions.jl
@@ -59,33 +59,51 @@ struct FVConstant <: AbstractReconstruction end
 
 width(::FVConstant) = 0
 
-function (::FVConstant)(
-    state_bot,
-    state_top,
-    cell_states::NTuple{1},
-    _,
-) where {FT}
+function (::FVConstant)(state_bot, state_top, cell_states::NTuple{1}, _)
     state_top .= cell_states[1]
     state_bot .= cell_states[1]
 end
 """
-    FVLinear <: AbstractReconstruction
+    FVLinear{W = 1} <: AbstractReconstruction
 
-Reconstruction type for limited linear reconstruction finite volume methods
+Reconstruction type for limited linear reconstruction finite volume methods.
+
+!!! note
+   The optional type parameter `W` is mainly for debugging purposes and allows
+   the stencil to be artificially widened to make sure the kernels work with
+   wide stencils.
+
+    FVLinear(limiter = VanLeer())
+    FVLinear{W}(limiter = VanLeer())
+
+Construct the `FVLinear` reconstruction type with the given slope `limiter`
 """
-struct FVLinear{L} <: AbstractReconstruction
+struct FVLinear{W, L} <: AbstractReconstruction
     limiter::L
-    FVLinear(limiter = VanLeer()) = new{typeof(limiter)}(limiter)
+
 end
 
-width(::FVLinear) = 1
+"""
+    FVLinear(limiter = VanLeer())
+    FVLinear{W}(limiter = VanLeer())
+
+Construct the `FVLinear` reconstruction type with the given slope `limiter` and
+optional width `W`.
+"""
+function FVLinear{W}(limiter = VanLeer()) where {W}
+    @assert W > 0
+    FVLinear{W, typeof(limiter)}(limiter)
+end
+FVLinear(limiter = VanLeer()) = FVLinear{1}(limiter)
+
+width(::FVLinear{W}) where {W} = W
 
 function (fvrecon::FVLinear)(
     state_bot,
     state_top,
     cell_states::NTuple{3},
     cell_weights,
-) where {FT}
+)
     wi_top = 1 / (cell_weights[3] + cell_weights[2])
     wi_bot = 1 / (cell_weights[2] + cell_weights[1])
     @inbounds @unroll for s in 1:length(state_top)
@@ -107,8 +125,23 @@ function (fvrecon::FVLinear)(
     state_top,
     cell_states::NTuple{1},
     cell_weights,
-) where {FT}
+)
     FVConstant()(state_bot, state_top, cell_states, cell_weights)
+end
+
+function (fvrecon::FVLinear)(
+    state_bot,
+    state_top,
+    cell_states::NTuple{D},
+    cell_weights,
+) where {D}
+    W = div(D - 1, 2)
+    fvrecon(
+        state_bot,
+        state_top,
+        cell_states[W .+ (0:2)],
+        cell_weights[W .+ (0:2)],
+    )
 end
 
 """

--- a/src/Numerics/Mesh/Topologies.jl
+++ b/src/Numerics/Mesh/Topologies.jl
@@ -261,9 +261,10 @@ stacked to be contiguous. This is a convenience wrapper around
 struct StackedBrickTopology{dim, T, nb} <: AbstractStackedTopology{dim, T, nb}
     topology::BoxElementTopology{dim, T, nb}
     stacksize::Int64
+    periodicstack::Bool
 end
 function Base.getproperty(a::StackedBrickTopology, p::Symbol)
-    return p == :stacksize ? getfield(a, p) :
+    return p in (:stacksize, :periodicstack) ? getfield(a, p) :
            getproperty(getfield(a, :topology), p)
 end
 
@@ -279,8 +280,12 @@ struct StackedCubedSphereTopology{T, nb} <: AbstractStackedTopology{3, T, nb}
     stacksize::Int64
 end
 function Base.getproperty(a::StackedCubedSphereTopology, p::Symbol)
-    return p == :stacksize ? getfield(a, p) :
-           getproperty(getfield(a, :topology), p)
+    if p == :periodicstack
+        return false
+    else
+        return p == :stacksize ? getfield(a, p) :
+               getproperty(getfield(a, :topology), p)
+    end
 end
 
 """ A wrapper for the BrickTopology """
@@ -740,6 +745,7 @@ function StackedBrickTopology(
             bndytoface,
         ),
         stacksize,
+        periodicity[end],
     )
 end
 

--- a/test/Numerics/DGMethods/Euler/fvm_isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/fvm_isentropicvortex.jl
@@ -1,0 +1,363 @@
+using ClimateMachine
+using ClimateMachine.Atmos
+using ClimateMachine.BalanceLaws
+using ClimateMachine.ConfigTypes
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.DGMethods.FVReconstructions: FVConstant, FVLinear
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.Mesh.Geometry
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.ODESolvers
+using ClimateMachine.Orientations
+using ClimateMachine.SystemSolvers
+using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.VariableTemplates
+using ClimateMachine.VTK
+
+using CLIMAParameters
+using CLIMAParameters.Planet: kappa_d
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+
+const output_vtk = false
+
+function main()
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 4
+    numlevels = integration_testing ? 4 : 1
+
+    expected_error = Dict()
+
+    # Just to make it shorter and aligning
+    Roe = RoeNumericalFlux
+
+    # Float64, Dim 2, degree 4 in the horizontal, FV order 1, refinement level
+    expected_error[Float64, FVConstant(), Roe, 1] = 3.5317756615538940e+01
+    expected_error[Float64, FVConstant(), Roe, 2] = 2.5104217086071472e+01
+    expected_error[Float64, FVConstant(), Roe, 3] = 1.6169569358521223e+01
+    expected_error[Float64, FVConstant(), Roe, 4] = 9.4731749125284708e+00
+
+    expected_error[Float64, FVLinear(), Roe, 1] = 2.6132907774912638e+01
+    expected_error[Float64, FVLinear(), Roe, 2] = 8.8198392537283006e+00
+    expected_error[Float64, FVLinear(), Roe, 3] = 2.4517109427575416e+00
+    expected_error[Float64, FVLinear(), Roe, 4] = 7.4154384427579900e-01
+
+
+    dims = 2
+    @testset "$(@__FILE__)" begin
+        for FT in (Float64,)
+            for NumericalFlux in (Roe,)
+                setup = IsentropicVortexSetup{FT}()
+                for fvmethod in (FVConstant(), FVLinear())
+                    @info @sprintf """Configuration
+                                      FT                = %s
+                                      ArrayType         = %s
+                                      FV Reconstruction = %s
+                                      NumericalFlux     = %s
+                                      dims              = %d
+                                      """ FT ArrayType fvmethod NumericalFlux dims
+                    errors = Vector{FT}(undef, numlevels)
+
+                    for level in 1:numlevels
+
+                        # Match element numbers
+                        numelems = (
+                            2^(level - 1) * 5,
+                            2^(level - 1) * 5 * polynomialorder,
+                        )
+
+                        errors[level] = test_run(
+                            mpicomm,
+                            ArrayType,
+                            fvmethod,
+                            polynomialorder,
+                            numelems,
+                            NumericalFlux,
+                            setup,
+                            FT,
+                            dims,
+                            level,
+                        )
+
+                        @test errors[level] ≈
+                              expected_error[FT, fvmethod, NumericalFlux, level]
+                    end
+                    @info begin
+                        msg = ""
+                        for l in 1:(numlevels - 1)
+                            rate = log2(errors[l]) - log2(errors[l + 1])
+                            msg *= @sprintf(
+                                "\n  rate for level %d = %e\n",
+                                l,
+                                rate
+                            )
+                        end
+                        msg
+                    end
+                end
+
+            end
+        end
+    end
+end
+
+function test_run(
+    mpicomm,
+    ArrayType,
+    fvmethod,
+    polynomialorder,
+    numelems,
+    NumericalFlux,
+    setup,
+    FT,
+    dims,
+    level,
+)
+    brickrange = ntuple(dims) do dim
+        range(
+            -setup.domain_halflength;
+            length = numelems[dim] + 1,
+            stop = setup.domain_halflength,
+        )
+    end
+
+    topology = StackedBrickTopology(
+        mpicomm,
+        brickrange;
+        periodicity = ntuple(_ -> true, dims),
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = (polynomialorder, 0),
+    )
+
+    problem = AtmosProblem(
+        boundaryconditions = (),
+        init_state_prognostic = isentropicvortex_initialcondition!,
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        param_set;
+        problem = problem,
+        orientation = NoOrientation(),
+        ref_state = NoReferenceState(),
+        turbulence = ConstantDynamicViscosity(FT(0)),
+        moisture = DryModel(),
+        source = (),
+    )
+
+    dgfvm = DGFVModel(
+        model,
+        grid,
+        fvmethod,
+        NumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+
+    timeend = FT(2 * setup.domain_halflength / 10 / setup.translation_speed)
+
+    # Determine the time step
+    elementsize = minimum(step.(brickrange))
+    dt =
+        elementsize / soundspeed_air(model.param_set, setup.T∞) /
+        polynomialorder^2
+    nsteps = ceil(Int, timeend / dt)
+    dt = timeend / nsteps
+
+    Q = init_ode_state(dgfvm, FT(0), setup)
+    lsrk = LSRK54CarpenterKennedy(dgfvm, Q; dt = dt, t0 = 0)
+
+    eng0 = norm(Q)
+    dims == 2 && (numelems = (numelems..., 0))
+    @info @sprintf """Starting refinement level %d
+                      numelems  = (%d, %d, %d)
+                      dt        = %.16e
+                      norm(Q₀)  = %.16e
+                      """ level numelems... dt eng0
+
+    # Set up the information callback
+    starttime = Ref(now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            runtime = Dates.format(
+                convert(DateTime, now() - starttime[]),
+                dateformat"HH:MM:SS",
+            )
+            @info @sprintf """Update
+                              simtime = %.16e
+                              runtime = %s
+                              norm(Q) = %.16e
+                              """ gettime(lsrk) runtime energy
+        end
+    end
+    callbacks = (cbinfo,)
+
+    if output_vtk
+        # Create vtk dir
+        vtkdir =
+            "vtk_isentropicvortex" *
+            "_poly$(polynomialorder)_dims$(dims)_$(ArrayType)_$(FT)_level$(level)"
+        mkpath(vtkdir)
+
+        vtkstep = 0
+        # Output initial step
+        do_output(mpicomm, vtkdir, vtkstep, dgfvm, Q, Q, model)
+
+        # Setup the output callback
+        outputtime = timeend
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dgfvm, gettime(lsrk), setup)
+            do_output(mpicomm, vtkdir, vtkstep, dgfvm, Q, Qe, model)
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    solve!(Q, lsrk; timeend = timeend, callbacks = callbacks)
+
+    # Final statistics
+    Qe = init_ode_state(dgfvm, timeend, setup)
+    engf = norm(Q)
+    engfe = norm(Qe)
+    errf = euclidean_distance(Q, Qe)
+    @info @sprintf """Finished refinement level %d
+    norm(Q)                 = %.16e
+    norm(Q) / norm(Q₀)      = %.16e
+    norm(Q) - norm(Q₀)      = %.16e
+    norm(Q - Qe)            = %.16e
+    norm(Q - Qe) / norm(Qe) = %.16e
+    """ level engf engf / eng0 engf - eng0 errf errf / engfe
+    errf
+end
+
+Base.@kwdef struct IsentropicVortexSetup{FT}
+    p∞::FT = 10^5
+    T∞::FT = 300
+    ρ∞::FT = air_density(param_set, FT(T∞), FT(p∞))
+    translation_speed::FT = 150
+    translation_angle::FT = pi / 4
+    vortex_speed::FT = 50
+    vortex_radius::FT = 1 // 200
+    domain_halflength::FT = 1 // 20
+end
+
+function isentropicvortex_initialcondition!(
+    problem,
+    bl,
+    state,
+    aux,
+    localgeo,
+    t,
+    args...,
+)
+    setup = first(args)
+    FT = eltype(state)
+    x = MVector(localgeo.coord)
+
+    ρ∞ = setup.ρ∞
+    p∞ = setup.p∞
+    T∞ = setup.T∞
+    translation_speed = setup.translation_speed
+    α = setup.translation_angle
+    vortex_speed = setup.vortex_speed
+    R = setup.vortex_radius
+    L = setup.domain_halflength
+
+    u∞ = SVector(translation_speed * cos(α), translation_speed * sin(α), 0)
+
+    x .-= u∞ * t
+    # Make the function periodic
+    x .-= floor.((x .+ L) / 2L) * 2L
+
+    @inbounds begin
+        r = sqrt(x[1]^2 + x[2]^2)
+        δu_x = -vortex_speed * x[2] / R * exp(-(r / R)^2 / 2)
+        δu_y = vortex_speed * x[1] / R * exp(-(r / R)^2 / 2)
+    end
+    u = u∞ .+ SVector(δu_x, δu_y, 0)
+
+    _kappa_d::FT = kappa_d(param_set)
+    T = T∞ * (1 - _kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
+    # Adiabatic/isentropic relation
+    p = p∞ * (T / T∞)^(FT(1) / _kappa_d)
+    ts = PhaseDry_pT(bl.param_set, p, T)
+    ρ = air_density(ts)
+
+    e_pot = FT(0)
+    state.ρ = ρ
+    state.ρu = ρ * u
+    e_kin = u' * u / 2
+    state.ρe = ρ * total_energy(e_kin, e_pot, ts)
+end
+
+function do_output(
+    mpicomm,
+    vtkdir,
+    vtkstep,
+    dgfvm,
+    Q,
+    Qe,
+    model,
+    testname = "isentropicvortex",
+)
+    ## Name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+    exactnames = statenames .* "_exact"
+
+    writevtk(filename, Q, dgfvm, statenames, Qe, exactnames)
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## Name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+main()

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -343,7 +343,7 @@ end
 
 has_variable_coefficients(::AdvectionDiffusionProblem) = false
 function update_auxiliary_state!(
-    dg::DGModel,
+    dg::DGFVMModel,
     m::AdvectionDiffusion,
     Q::MPIStateArray,
     t::Real,

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -343,7 +343,7 @@ end
 
 has_variable_coefficients(::AdvectionDiffusionProblem) = false
 function update_auxiliary_state!(
-    dg::DGFVMModel,
+    dg::DGFVModel,
     m::AdvectionDiffusion,
     Q::MPIStateArray,
     t::Real,

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model.jl
@@ -26,6 +26,7 @@ import ClimateMachine.BalanceLaws:
     transform_post_gradient_laplacian!
 
 using ClimateMachine.Mesh.Geometry: LocalGeometry
+using ClimateMachine.DGMethods: SpaceDiscretization
 using ClimateMachine.DGMethods.NumericalFluxes:
     NumericalFluxFirstOrder,
     NumericalFluxSecondOrder,
@@ -343,14 +344,14 @@ end
 
 has_variable_coefficients(::AdvectionDiffusionProblem) = false
 function update_auxiliary_state!(
-    dg::DGFVModel,
+    spacedisc::SpaceDiscretization,
     m::AdvectionDiffusion,
     Q::MPIStateArray,
     t::Real,
     elems::UnitRange,
 )
     if has_variable_coefficients(m.problem)
-        update_auxiliary_state!(dg, m, Q, t, elems) do m, state, aux, t
+        update_auxiliary_state!(spacedisc, m, Q, t, elems) do m, state, aux, t
             update_velocity_diffusion!(m.problem, m, state, aux, t)
         end
         return true

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
@@ -41,7 +41,7 @@ function init_velocity_diffusion!(
     # Direction of flow is n with magnitude α
     aux.advection.u = α * n
 
-    # diffusion of strength β in the n direction
+    # Diffusion of strength β in the n direction
     aux.diffusion.D = β * n * n'
 end
 
@@ -73,7 +73,7 @@ function Neumann_data!(
 end
 
 function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
-    ## name of the file that this MPI rank will write
+    ## Name of the file that this MPI rank will write
     filename = @sprintf(
         "%s/%s_mpirank%04d_step%04d",
         vtkdir,
@@ -89,10 +89,10 @@ function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
 
     ## Generate the pvtu file for these vtk files
     if MPI.Comm_rank(mpicomm) == 0
-        ## name of the pvtu file
+        ## Name of the pvtu file
         pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
 
-        ## name of each of the ranks vtk files
+        ## Name of each of the ranks vtk files
         prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
@@ -202,11 +202,11 @@ function test_run(
     end
     callbacks = (cbinfo,)
     if ~isnothing(vtkdir)
-        # create vtk dir
+        # Create vtk dir
         mkpath(vtkdir)
 
         vtkstep = 0
-        # output initial step
+        # Output initial step
         do_output(
             mpicomm,
             vtkdir,
@@ -218,7 +218,7 @@ function test_run(
             "advection_diffusion",
         )
 
-        # setup the output callback
+        # Setup the output callback
         cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
             vtkstep += 1
             Qe = init_ode_state(dg, gettime(ode_solver))
@@ -361,7 +361,7 @@ let
                             linearsolvertype,
                             fluxBC,
                         )
-                        # test the errors significantly larger than floating point epsilon
+                        # Test the errors significantly larger than floating point epsilon
                         if !(dim == 2 && l == 4 && FT == Float32)
                             @test result[l] ≈ FT(expected_result[dim, l, FT])
                         end

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl
@@ -207,26 +207,25 @@ let
 
     mpicomm = MPI.COMM_WORLD
 
-    polynomialorder = 0
     base_num_elem = 4
 
     expected_result = Dict()
-    expected_result[2, 1, Float64] = 5.3831781708924931e-01
-    expected_result[2, 2, Float64] = 3.0915831779382535e-01
-    expected_result[2, 3, Float64] = 1.7236683956106186e-01
-    expected_result[2, 4, Float64] = 9.2677511626195891e-02
-    expected_result[3, 1, Float64] = 6.2473789212892050e-01
-    expected_result[3, 2, Float64] = 3.6921367786807441e-01
-    expected_result[3, 3, Float64] = 2.0788964073457664e-01
-    expected_result[3, 4, Float64] = 1.1262653616064706e-01
-    expected_result[2, 1, Float32] = 5.3831773996353149e-01
-    expected_result[2, 2, Float32] = 3.0915820598602295e-01
-    expected_result[2, 3, Float32] = 1.7236681282520294e-01
-    expected_result[2, 4, Float32] = 9.2677429318428040e-02
-    expected_result[3, 1, Float32] = 6.2473779916763306e-01
-    expected_result[3, 2, Float32] = 3.6921373009681702e-01
-    expected_result[3, 3, Float32] = 2.0788973569869995e-01
-    expected_result[3, 4, Float32] = 1.1262649297714233e-01
+    expected_result[2, 1, Float64] = 3.1975803201004632e-01
+    expected_result[2, 2, Float64] = 1.8627674551822404e-01
+    expected_result[2, 3, Float64] = 1.0405818305399551e-01
+    expected_result[2, 4, Float64] = 5.5997036645317050e-02
+    expected_result[3, 1, Float64] = 2.7529128252186852e-01
+    expected_result[3, 2, Float64] = 1.6737691447662753e-01
+    expected_result[3, 3, Float64] = 9.6809054521915947e-02
+    expected_result[3, 4, Float64] = 5.3410417324053723e-02
+    expected_result[2, 1, Float32] = 3.1975793838500977e-01
+    expected_result[2, 2, Float32] = 1.8627668917179108e-01
+    expected_result[2, 3, Float32] = 1.0405827313661575e-01
+    expected_result[2, 4, Float32] = 5.5997163057327271e-02
+    expected_result[3, 1, Float32] = 2.7529123425483704e-01
+    expected_result[3, 2, Float32] = 1.6737693548202515e-01
+    expected_result[3, 3, Float32] = 9.6808202564716339e-02
+    expected_result[3, 4, Float32] = 5.3404398262500763e-02
 
     @testset "$(@__FILE__)" begin
         for FT in (Float64, Float32)
@@ -236,6 +235,7 @@ let
                 4 : 1
             result = zeros(FT, numlevels)
             for dim in 2:3
+                polynomialorder = (ntuple(j -> 2, dim - 1)..., 0)
                 n =
                     dim == 2 ? SVector{3, FT}(1 / sqrt(2), 1 / sqrt(2), 0) :
                     SVector{3, FT}(1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3))
@@ -254,7 +254,7 @@ let
                         periodicity = periodicity,
                         boundary = bc,
                     )
-                    dt = (α / 4) / (Ne * max(1, polynomialorder)^2)
+                    dt = (α / 4) / (Ne * max(1, maximum(polynomialorder))^2)
                     @info "time step" dt
 
                     timeend = FT(1 // 4)

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl
@@ -68,12 +68,12 @@ function do_output(mpicomm, vtkdir, vtkstep, dgfvm, Q, Qe, model, testname)
 
     writevtk(filename, Q, dgfvm, statenames, Qe, exactnames)
 
-    ## generate the pvtu file for these vtk files
+    ## Generate the pvtu file for these vtk files
     if MPI.Comm_rank(mpicomm) == 0
-        ## name of the pvtu file
+        ## Name of the pvtu file
         pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
 
-        ## name of each of the ranks vtk files
+        ## Name of each of the ranks vtk files
         prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
             @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
         end
@@ -153,11 +153,11 @@ function test_run(
     end
     callbacks = (cbinfo,)
     if ~isnothing(vtkdir)
-        # create vtk dir
+        # Create vtk dir
         mkpath(vtkdir)
 
         vtkstep = 0
-        # output initial step
+        # Output initial step
         do_output(
             mpicomm,
             vtkdir,
@@ -169,7 +169,7 @@ function test_run(
             "advection_diffusion",
         )
 
-        # setup the output callback
+        # Setup the output callback
         cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
             vtkstep += 1
             Qe = init_ode_state(dgfvm, gettime(lsrk))

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion.jl
@@ -389,7 +389,7 @@ function main()
                 ClimateMachine.Settings.integration_testing ?
                 (FT == Float64 ? 4 : 3) : 1
             for dim in 2:3
-                for fvmethod in (FVConstant(), FVLinear())
+                for fvmethod in (FVConstant(), FVLinear(), FVLinear{3}())
                     polynomialorders = (4, 0)
                     result = Dict()
                     for level in 1:numlevels
@@ -411,9 +411,10 @@ function main()
                             FT,
                             vtkdir,
                         )
+                        fv_key = fvmethod isa FVLinear ? FVLinear() : fvmethod
                         @test all(
                             result[level] .≈
-                            FT.(expected_result[dim, level, FT, fvmethod]),
+                            FT.(expected_result[dim, level, FT, fv_key]),
                         )
                     end
                     @info begin

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion.jl
@@ -1,0 +1,439 @@
+using MPI
+using ClimateMachine
+using Logging
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.DGMethods.FVReconstructions: FVConstant, FVLinear
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.ODESolvers
+using LinearAlgebra
+using Printf
+using Test
+import ClimateMachine.VTK: writevtk, writepvtu
+import ClimateMachine.GenericCallbacks:
+    EveryXWallTimeSeconds, EveryXSimulationSteps
+using Dates
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+
+const output = parse(Bool, lowercase(get(ENV, "JULIA_CLIMA_OUTPUT", "false")))
+
+include("advection_diffusion_model.jl")
+
+struct Pseudo1D{n1, n2, n3, α, β, μ, δ} <: AdvectionDiffusionProblem end
+
+function init_velocity_diffusion!(
+    ::Pseudo1D{n1, n2, n3, α, β},
+    aux::Vars,
+    geom::LocalGeometry,
+) where {n1, n2, n3, α, β}
+    # Direction of flow is n1 (resp n2 or n3) with magnitude α
+    aux.advection.u = hcat(α * n1, α * n2, α * n3)
+
+    # Diffusion of strength β in the n1 and n2 directions
+    aux.diffusion.D = hcat(β * n1 * n1', β * n2 * n2', β * n3 * n3')
+end
+
+function initial_condition!(
+    ::Pseudo1D{n1, n2, n3, α, β, μ, δ},
+    state,
+    aux,
+    localgeo,
+    t,
+) where {n1, n2, n3, α, β, μ, δ}
+    ξn1 = dot(n1, localgeo.coord)
+    ξn2 = dot(n2, localgeo.coord)
+    ξn3 = dot(n3, localgeo.coord)
+    ρ1 = exp(-(ξn1 - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
+    ρ2 = exp(-(ξn2 - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
+    ρ3 = exp(-(ξn3 - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
+    state.ρ = (ρ1, ρ2, ρ3)
+end
+
+Dirichlet_data!(P::Pseudo1D, x...) = initial_condition!(P, x...)
+
+function Neumann_data!(
+    ::Pseudo1D{n1, n2, n3, α, β, μ, δ},
+    ∇state,
+    aux,
+    x,
+    t,
+) where {n1, n2, n3, α, β, μ, δ}
+    ξn1 = dot(n1, x)
+    ξn2 = dot(n2, x)
+    ξn3 = dot(n3, x)
+    ∇ρ1 =
+        -(
+            2n1 * (ξn1 - μ - α * t) / (4 * β * (δ + t)) *
+            exp(-(ξn1 - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
+        )
+    ∇ρ2 =
+        -(
+            2n2 * (ξn2 - μ - α * t) / (4 * β * (δ + t)) *
+            exp(-(ξn2 - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
+        )
+    ∇ρ3 =
+        -(
+            2n3 * (ξn3 - μ - α * t) / (4 * β * (δ + t)) *
+            exp(-(ξn3 - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
+        )
+    ∇state.ρ = hcat(∇ρ1, ∇ρ2, ∇ρ3)
+end
+
+function do_output(mpicomm, vtkdir, vtkstep, dgfvm, Q, Qe, model, testname)
+    ## Name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+    exactnames = statenames .* "_exact"
+
+    writevtk(filename, Q, dgfvm, statenames, Qe, exactnames)
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## Name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## Name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+
+function test_run(
+    mpicomm,
+    dim,
+    fvmethod,
+    polynomialorders,
+    level,
+    ArrayType,
+    FT,
+    vtkdir,
+)
+
+    n_hd =
+        dim == 2 ? SVector{3, FT}(1, 0, 0) :
+        SVector{3, FT}(1 / sqrt(2), 1 / sqrt(2), 0)
+
+    n_vd = dim == 2 ? SVector{3, FT}(0, 1, 0) : SVector{3, FT}(0, 0, 1)
+
+    n_dg =
+        dim == 2 ? SVector{3, FT}(1 / sqrt(2), 1 / sqrt(2), 0) :
+        SVector{3, FT}(1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3))
+
+    α = FT(1)
+    β = FT(1 // 100)
+    μ = FT(-1 // 2)
+    δ = FT(1 // 10)
+
+    # Grid/topology information
+    base_num_elem = 4
+    Ne = 2^(level - 1) * base_num_elem
+    N = polynomialorders
+    L = ntuple(j -> FT(j == dim ? 1 : N[1]) / 4, dim)
+    brickrange = ntuple(j -> range(-L[j]; length = Ne + 1, stop = L[j]), dim)
+    periodicity = ntuple(j -> false, dim)
+    bc = ntuple(j -> (1, 2), dim)
+
+    topl = StackedBrickTopology(
+        mpicomm,
+        brickrange;
+        periodicity = periodicity,
+        boundary = bc,
+    )
+
+    dt = (α / 4) * L[1] / (Ne * polynomialorders[1]^2)
+    timeend = 1
+    outputtime = timeend / 10
+    @info "time step" dt
+
+    @info @sprintf """Test parameters:
+    FVM Reconstruction          = %s
+    ArrayType                   = %s
+    FloatType                   = %s
+    Dimension                   = %s
+    Horizontal polynomial order = %s
+    Vertical polynomial order   = %s
+      """ fvmethod ArrayType FT dim polynomialorders[1] polynomialorders[end]
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = polynomialorders,
+    )
+
+    # Model being tested
+    model = AdvectionDiffusion{dim}(
+        Pseudo1D{n_hd, n_vd, n_dg, α, β, μ, δ}(),
+        num_equations = 3,
+    )
+
+    # Main DG discretization
+    dgfvm = DGFVModel(
+        model,
+        grid,
+        fvmethod,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient();
+        direction = EveryDirection(),
+    )
+
+    # Initialize all relevant state arrays and create solvers
+    Q = init_ode_state(dgfvm, FT(0))
+
+    eng0 = norm(Q, dims = (1, 3))
+    @info @sprintf """Starting
+    norm(Q₀) = %.16e""" eng0[1]
+
+    solver = LSRK54CarpenterKennedy(dgfvm, Q; dt = dt, t0 = 0)
+
+    # Set up the information callback
+    starttime = Ref(Dates.now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = Dates.now()
+        else
+            energy = norm(Q)
+            @info @sprintf(
+                """Update
+                simtime = %.16e
+                runtime = %s
+                norm(Q) = %.16e""",
+                gettime(solver),
+                Dates.format(
+                    convert(Dates.DateTime, Dates.now() - starttime[]),
+                    Dates.dateformat"HH:MM:SS",
+                ),
+                energy
+            )
+        end
+    end
+    callbacks = (cbinfo,)
+    if ~isnothing(vtkdir)
+        # Create vtk dir
+        mkpath(vtkdir)
+
+        vtkstep = 0
+        # Output initial step
+        do_output(
+            mpicomm,
+            vtkdir,
+            vtkstep,
+            dgfvm,
+            Q,
+            Q,
+            model,
+            "advection_diffusion",
+        )
+
+        # Setup the output callback
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dgfvm, gettime(solver))
+            do_output(
+                mpicomm,
+                vtkdir,
+                vtkstep,
+                dgfvm,
+                Q,
+                Qe,
+                model,
+                "advection_diffusion",
+            )
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    solve!(Q, solver; timeend = timeend, callbacks = callbacks)
+
+    # Reference solution
+    engf = norm(Q, dims = (1, 3))
+    Q_ref = init_ode_state(dgfvm, FT(timeend))
+
+    engfe = norm(Q_ref, dims = (1, 3))
+    errf = norm(Q_ref .- Q, dims = (1, 3))
+
+    metrics = @. (engf, engf / eng0, engf - eng0, errf, errf / engfe)
+
+    @info @sprintf """Finished
+    Horizontal field:
+      norm(Q)                 = %.16e
+      norm(Q) / norm(Q₀)      = %.16e
+      norm(Q) - norm(Q₀)      = %.16e
+      norm(Q - Qe)            = %.16e
+      norm(Q - Qe) / norm(Qe) = %.16e
+    Vertical field:
+      norm(Q)                 = %.16e
+      norm(Q) / norm(Q₀)      = %.16e
+      norm(Q) - norm(Q₀)      = %.16e
+      norm(Q - Qe)            = %.16e
+      norm(Q - Qe) / norm(Qe) = %.16e
+    Diagonal field:
+      norm(Q)                 = %.16e
+      norm(Q) / norm(Q₀)      = %.16e
+      norm(Q) - norm(Q₀)      = %.16e
+      norm(Q - Qe)            = %.16e
+      norm(Q - Qe) / norm(Qe) = %.16e
+      """ first.(metrics)... ntuple(f -> metrics[f][2], 5)... last.(metrics)...
+
+    return Tuple(errf)
+end
+
+"""
+    main()
+
+Run this test problem
+"""
+function main()
+
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+    mpicomm = MPI.COMM_WORLD
+
+    # Dictionary keys: dim, level, and FT
+    expected_result = Dict()
+    expected_result[2, 1, Float32, FVConstant()] =
+        (2.3391991853713989e-02, 5.0738707184791565e-02, 4.1857458651065826e-02)
+    expected_result[2, 2, Float32, FVConstant()] =
+        (2.0331495907157660e-03, 3.3669386059045792e-02, 2.3904174566268921e-02)
+    expected_result[2, 3, Float32, FVConstant()] =
+        (2.6557327146292664e-05, 2.0002065226435661e-02, 1.2790882028639317e-02)
+
+    expected_result[2, 1, Float32, FVLinear()] =
+        (2.3391995579004288e-02, 4.9536284059286118e-02, 3.5911198705434799e-02)
+    expected_result[2, 2, Float32, FVLinear()] =
+        (2.0331430714577436e-03, 2.2621221840381622e-02, 1.5531544573605061e-02)
+    expected_result[2, 3, Float32, FVLinear()] =
+        (2.6568108296487480e-05, 7.5304862111806870e-03, 6.4526572823524475e-03)
+
+    expected_result[3, 1, Float32, FVConstant()] =
+        (8.7377587333321571e-03, 7.1755334734916687e-02, 4.3733172118663788e-02)
+    expected_result[3, 2, Float32, FVConstant()] =
+        (6.2517996411770582e-04, 4.7615684568881989e-02, 2.3986011743545532e-02)
+    expected_result[3, 3, Float32, FVConstant()] =
+        (3.5004395613214001e-05, 2.8287241235375404e-02, 1.2639496475458145e-02)
+
+    expected_result[3, 1, Float32, FVLinear()] =
+        (8.7377615272998810e-03, 7.0054858922958374e-02, 3.7571556866168976e-02)
+    expected_result[3, 2, Float32, FVLinear()] =
+        (6.2518107006326318e-04, 3.1991228461265564e-02, 1.6405479982495308e-02)
+    expected_result[3, 3, Float32, FVLinear()] =
+        (3.5004966775886714e-05, 1.0649790056049824e-02, 7.1499347686767578e-03)
+
+    expected_result[2, 1, Float64, FVConstant()] =
+        (2.3391871809628567e-02, 5.0738761087541523e-02, 4.1857480220018319e-02)
+    expected_result[2, 2, Float64, FVConstant()] =
+        (2.0332783913617892e-03, 3.3669399006499491e-02, 2.3904204301839819e-02)
+    expected_result[2, 3, Float64, FVConstant()] =
+        (2.6572168347086839e-05, 2.0002110124502395e-02, 1.2790993871268752e-02)
+    expected_result[2, 4, Float64, FVConstant()] =
+        (1.9890000550154039e-07, 1.0929144069594809e-02, 6.5110938897763263e-03)
+
+    expected_result[2, 1, Float64, FVLinear()] =
+        (2.3391871809628550e-02, 4.9536356061135857e-02, 3.5911213637569099e-02)
+    expected_result[2, 2, Float64, FVLinear()] =
+        (2.0332783913618278e-03, 2.2621252826152356e-02, 1.5531565558700888e-02)
+    expected_result[2, 3, Float64, FVLinear()] =
+        (2.6572168347111800e-05, 7.5305291439555161e-03, 6.4526740563561544e-03)
+    expected_result[2, 4, Float64, FVLinear()] =
+        (1.9890000549995218e-07, 2.5302226025389427e-03, 2.7792905025059711e-03)
+
+    expected_result[3, 1, Float64, FVConstant()] =
+        (8.7378337431297422e-03, 7.1755444068009461e-02, 4.3733196512722658e-02)
+    expected_result[3, 2, Float64, FVConstant()] =
+        (6.2510740807095622e-04, 4.7615720711942776e-02, 2.3986017606198881e-02)
+    expected_result[3, 3, Float64, FVConstant()] =
+        (3.4995405318038341e-05, 2.8287255414151377e-02, 1.2639742577376042e-02)
+    expected_result[3, 4, Float64, FVConstant()] =
+        (1.4362091045094841e-06, 1.5456143768350493e-02, 6.3677406803847331e-03)
+
+    expected_result[3, 1, Float64, FVLinear()] =
+        (8.7378337431297439e-03, 7.0054986572200995e-02, 3.7571599264936015e-02)
+    expected_result[3, 2, Float64, FVLinear()] =
+        (6.2510740807095286e-04, 3.1991282544615307e-02, 1.6405489038457288e-02)
+    expected_result[3, 3, Float64, FVLinear()] =
+        (3.4995405318035868e-05, 1.0649776447227678e-02, 7.1502921502446283e-03)
+    expected_result[3, 4, Float64, FVLinear()] =
+        (1.4362091045110612e-06, 3.5782751203335653e-03, 3.1186151510318319e-03)
+
+    @testset "Variable degree DG: advection diffusion model" begin
+        for FT in (Float32, Float64)
+            numlevels =
+                integration_testing ||
+                ClimateMachine.Settings.integration_testing ?
+                (FT == Float64 ? 4 : 3) : 1
+            for dim in 2:3
+                for fvmethod in (FVConstant(), FVLinear())
+                    polynomialorders = (4, 0)
+                    result = Dict()
+                    for level in 1:numlevels
+                        vtkdir =
+                            output ?
+                            "vtk_advection" *
+                            "_poly$(polynomialorders)" *
+                            "_dim$(dim)_$(ArrayType)_$(FT)" *
+                            "_fvmethod$(fvmethod)" *
+                            "_level$(level)" :
+                            nothing
+                        result[level] = test_run(
+                            mpicomm,
+                            dim,
+                            fvmethod,
+                            polynomialorders,
+                            level,
+                            ArrayType,
+                            FT,
+                            vtkdir,
+                        )
+                        @test all(
+                            result[level] .≈
+                            FT.(expected_result[dim, level, FT, fvmethod]),
+                        )
+                    end
+                    @info begin
+                        msg = ""
+                        for l in 1:(numlevels - 1)
+                            rate = @. log2(result[l]) - log2(result[l + 1])
+                            msg *= @sprintf(
+                                "\n  rates for level %d Horizontal = %e",
+                                l,
+                                rate[1]
+                            )
+                            msg *= @sprintf(", Vertical = %e", rate[2])
+                            msg *= @sprintf(", Diagonal = %e\n", rate[3])
+                        end
+                        msg
+                    end
+                end
+            end
+        end
+    end
+end
+
+main()

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_periodic.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_periodic.jl
@@ -335,7 +335,7 @@ function main()
     @testset "$(@__FILE__)" begin
         for FT in (Float64, Float32)
             result = Dict()
-            for fvmethod in (FVConstant(), FVLinear())
+            for fvmethod in (FVConstant(), FVLinear(), FVLinear{3}())
                 @info @sprintf """Test parameters:
                 ArrayType                   = %s
                 FloatType                   = %s
@@ -361,10 +361,11 @@ function main()
                     )
 
 
+                    fv_key = fvmethod isa FVLinear ? FVLinear() : fvmethod
                     @test result[level][1] ≈ FT(expected_result[
                         2,
                         polynomialorders[1],
-                        fvmethod,
+                        fv_key,
                         level,
                         FT,
                         1,
@@ -372,7 +373,7 @@ function main()
                     @test result[level][2] ≈ FT(expected_result[
                         2,
                         polynomialorders[1],
-                        fvmethod,
+                        fv_key,
                         level,
                         FT,
                         2,

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_periodic.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_periodic.jl
@@ -1,0 +1,404 @@
+using MPI
+using ClimateMachine
+using Logging
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+import ClimateMachine.DGMethods.FVReconstructions: FVConstant, FVLinear
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.ODESolvers
+using LinearAlgebra
+using Printf
+using Test
+using Dates
+using ClimateMachine.GenericCallbacks:
+    EveryXWallTimeSeconds, EveryXSimulationSteps
+using ClimateMachine.VTK: writevtk, writepvtu
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+
+const output = parse(Bool, lowercase(get(ENV, "JULIA_CLIMA_OUTPUT", "false")))
+
+include("advection_diffusion_model.jl")
+
+struct Pseudo1D{u, v, ν} <: AdvectionDiffusionProblem end
+
+# This test has two 2D equations : the first one is an advection equation with
+# the Gaussian initial condition the second one is an advection diffusion
+# equation with the Gaussian initial condition
+function init_velocity_diffusion!(
+    ::Pseudo1D{u, v, ν},
+    aux::Vars,
+    geom::LocalGeometry,
+) where {u, v, ν}
+    # Advection velocity of the flow is [u, v]
+    uvec = SVector(u, v, 0)
+    aux.advection.u = hcat(uvec, uvec)
+
+    # Diffusion of the flow is νI (isentropic diffusivity)
+    I3 = @SMatrix [1 0 0; 0 1 0; 0 0 1]
+    aux.diffusion.D = hcat(0 * I3, ν * I3)
+
+end
+
+function initial_condition!(
+    ::Pseudo1D{u, v, ν},
+    state,
+    aux,
+    localgeo,
+    t,
+) where {u, v, ν}
+    FT = typeof(u)
+    # The computational domain is [-1.5 1.5]×[-1.5 1.5]
+    Lx, Ly = 3, 3
+    x, y, _ = localgeo.coord
+
+    μx, μz, σ = 0, 0, Lx / 10
+    ρ1 = exp.(-(((x - μx) / σ)^2 + ((y - μz) / σ)^2) / 2) / (σ * sqrt(2 * pi))
+    ρ2 = exp.(-(((x - μx) / σ)^2 + ((y - μz) / σ)^2) / 2) / (σ * sqrt(2 * pi))
+
+    state.ρ = (ρ1, ρ2)
+end
+
+Dirichlet_data!(P::Pseudo1D, x...) = initial_condition!(P, x...)
+
+
+function do_output(mpicomm, vtkdir, vtkstep, dgfvm, Q, Qe, model, testname)
+    ## Name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+    exactnames = statenames .* "_exact"
+
+    writevtk(filename, Q, dgfvm, statenames, Qe, exactnames)
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## Name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## Name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+
+function test_run(
+    mpicomm,
+    vtkdir,
+    fvmethod,
+    polynomialorders,
+    level,
+    ArrayType,
+    FT,
+)
+
+    dim = 2
+    Lx, Ly = FT(3), FT(3)
+    u, v = FT(1), FT(1)
+    ν = FT(1 // 100)
+
+
+    # Grid/topology information
+    base_num_elem = 4
+    Ne = 2^(level - 1) * base_num_elem
+
+    # Match number of points
+    N_dg_point, N_fvm_point = Ne + 1, Ne * polynomialorders[1] + 1
+
+
+    brickrange = (
+        range(-Lx / 2; length = N_dg_point, stop = Lx / 2),
+        range(-Ly / 2; length = N_fvm_point, stop = Ly / 2),
+    )
+
+    periodicity = ntuple(j -> true, dim)
+    bc = ntuple(j -> (1, 2), dim)
+
+    topl = StackedBrickTopology(
+        mpicomm,
+        brickrange;
+        periodicity = periodicity,
+        boundary = bc,
+    )
+
+    # One period
+    timeend = Lx / u
+    # dt ≤ CFL (Δx / Np²)/u   u = √2  CFL = 1/√2
+    dt = Lx / (Ne * polynomialorders[1]^2)
+
+    Nt = (Ne * polynomialorders[1]^2)
+
+    outputtime = Ne * dt
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = polynomialorders,
+    )
+
+    # Model being tested
+    model = AdvectionDiffusion{dim}(Pseudo1D{u, v, ν}(), num_equations = 2)
+
+    # Main DG discretization
+    dgfvm = DGFVModel(
+        model,
+        grid,
+        fvmethod,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient();
+        direction = EveryDirection(),
+    )
+
+    # Initialize all relevant state arrays and create solvers
+    Q = init_ode_state(dgfvm, FT(0))
+
+    solver = LSRK54CarpenterKennedy(dgfvm, Q; dt = dt, t0 = 0)
+
+
+    # Set up the information callback
+    starttime = Ref(now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            @info @sprintf(
+                """Update
+                simtime = %.16e
+                runtime = %s
+                norm(Q) = %.16e""",
+                gettime(solver),
+                Dates.format(
+                    convert(Dates.DateTime, Dates.now() - starttime[]),
+                    Dates.dateformat"HH:MM:SS",
+                ),
+                energy
+            )
+        end
+    end
+    callbacks = (cbinfo,)
+    if ~isnothing(vtkdir)
+        # Create vtk dir
+        mkpath(vtkdir)
+
+        vtkstep = 0
+        # Output initial step
+        do_output(
+            mpicomm,
+            vtkdir,
+            vtkstep,
+            dgfvm,
+            Q,
+            Q,
+            model,
+            "advection_diffusion_periodic",
+        )
+
+        # Setup the output callback
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dgfvm, gettime(solver))
+            do_output(
+                mpicomm,
+                vtkdir,
+                vtkstep,
+                dgfvm,
+                Q,
+                Qe,
+                model,
+                "advection_diffusion_periodic",
+            )
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    numberofsteps = convert(Int64, cld(timeend, dt))
+    dt = timeend / numberofsteps
+
+    @info "time step" dt numberofsteps dt * numberofsteps timeend
+
+    solve!(Q, solver; timeend = timeend, callbacks = callbacks)
+
+    engf = norm(Q, dims = (1, 3))
+
+    # Reference solution
+    Q_ref = init_ode_state(dgfvm, FT(0))
+    engfe = norm(Q_ref, dims = (1, 3))
+
+    errf = norm(Q_ref .- Q, dims = (1, 3))
+
+    metrics = [engf; engfe; errf]
+
+    @info @sprintf """Finished
+    Advection equation:
+    norm(Q)                 = %.16e
+    norm(Qe)                = %.16e
+    norm(Q - Qe)            = %.16e
+    Advection diffusion equation:
+    norm(Q)                 = %.16e
+    norm(Qe)                = %.16e
+    norm(Q - Qe)            = %.16e
+    """ metrics[:]...
+
+    return errf
+end
+
+# Run this test problem
+function main()
+
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+    mpicomm = MPI.COMM_WORLD
+
+    # Dictionary keys: dim, level, polynomial order, FT, and direction
+    expected_result = Dict()
+
+    # Dim 2, degree 4 in the horizontal, FV order 1, refinement level, Float64, equation number
+    expected_result[2, 4, FVConstant(), 1, Float64, 1] = 4.5196354911392578e-01
+    expected_result[2, 4, FVConstant(), 1, Float64, 2] = 4.8622171647472179e-01
+    expected_result[2, 4, FVConstant(), 2, Float64, 1] = 3.5051983693457450e-01
+    expected_result[2, 4, FVConstant(), 2, Float64, 2] = 4.1168975732563706e-01
+    expected_result[2, 4, FVConstant(), 3, Float64, 1] = 2.5130141068332995e-01
+    expected_result[2, 4, FVConstant(), 3, Float64, 2] = 3.4635415661628755e-01
+    expected_result[2, 4, FVConstant(), 4, Float64, 1] = 1.6320856055402777e-01
+    expected_result[2, 4, FVConstant(), 4, Float64, 2] = 2.9647989774687805e-01
+    expected_result[2, 4, FVConstant(), 5, Float64, 1] = 9.6641259241910610e-02
+    expected_result[2, 4, FVConstant(), 5, Float64, 2] = 2.6372336617960646e-01
+
+    expected_result[2, 4, FVConstant(), 1, Float32, 1] = 4.5196333527565002e-01
+    expected_result[2, 4, FVConstant(), 1, Float32, 2] = 4.8622152209281921e-01
+    expected_result[2, 4, FVConstant(), 2, Float32, 1] = 3.5051953792572021e-01
+    expected_result[2, 4, FVConstant(), 2, Float32, 2] = 4.1168937087059021e-01
+    expected_result[2, 4, FVConstant(), 3, Float32, 1] = 2.5130018591880798e-01
+    expected_result[2, 4, FVConstant(), 3, Float32, 2] = 3.4635293483734131e-01
+    expected_result[2, 4, FVConstant(), 4, Float32, 1] = 1.6320574283599854e-01
+    expected_result[2, 4, FVConstant(), 4, Float32, 2] = 2.9647585749626160e-01
+    expected_result[2, 4, FVConstant(), 5, Float32, 1] = 9.6632070839405060e-02
+    expected_result[2, 4, FVConstant(), 5, Float32, 2] = 2.6370745897293091e-01
+
+
+    # Dim 2, degree 4 in the horizontal, FV order 1, refinement level, Float64, equation number
+
+    expected_result[2, 4, FVLinear(), 1, Float64, 1] = 2.2783152269907422e-01
+    expected_result[2, 4, FVLinear(), 1, Float64, 2] = 3.1823753821941969e-01
+    expected_result[2, 4, FVLinear(), 2, Float64, 1] = 9.2628269590376469e-02
+    expected_result[2, 4, FVLinear(), 2, Float64, 2] = 2.4517823755458742e-01
+    expected_result[2, 4, FVLinear(), 3, Float64, 1] = 3.1401247771425542e-02
+    expected_result[2, 4, FVLinear(), 3, Float64, 2] = 2.2608977452273774e-01
+    expected_result[2, 4, FVLinear(), 4, Float64, 1] = 9.8710350648653390e-03
+    expected_result[2, 4, FVLinear(), 4, Float64, 2] = 2.2377315397364847e-01
+    expected_result[2, 4, FVLinear(), 5, Float64, 1] = 2.9619222883137744e-03
+    expected_result[2, 4, FVLinear(), 5, Float64, 2] = 2.2359698753564772e-01
+
+
+    expected_result[2, 4, FVLinear(), 1, Float32, 1] = 2.2783152269907422e-01
+    expected_result[2, 4, FVLinear(), 1, Float32, 2] = 3.1823753821941969e-01
+    expected_result[2, 4, FVLinear(), 2, Float32, 1] = 9.2628269590376469e-02
+    expected_result[2, 4, FVLinear(), 2, Float32, 2] = 2.4517823755458742e-01
+    expected_result[2, 4, FVLinear(), 3, Float32, 1] = 3.1401247771425542e-02
+    expected_result[2, 4, FVLinear(), 3, Float32, 2] = 2.2608977452273774e-01
+    expected_result[2, 4, FVLinear(), 4, Float32, 1] = 9.8710350648653390e-03
+    expected_result[2, 4, FVLinear(), 4, Float32, 2] = 2.2377315397364847e-01
+    expected_result[2, 4, FVLinear(), 5, Float32, 1] = 2.9614968225359917e-03
+    expected_result[2, 4, FVLinear(), 5, Float32, 2] = 2.2358775138854980e-01
+
+    polynomialorders = (4, 0)
+    numlevels = integration_testing ? 5 : 1
+
+    # Dictionary keys: dim, level, polynomial order, FT, and direction
+    @testset "$(@__FILE__)" begin
+        for FT in (Float64, Float32)
+            result = Dict()
+            for fvmethod in (FVConstant(), FVLinear())
+                @info @sprintf """Test parameters:
+                ArrayType                   = %s
+                FloatType                   = %s
+                FV Reconstruction           = %s
+                Dimension                   = %s
+                Horizontal polynomial order = %s
+                Vertical polynomial order   = %s
+                """ ArrayType FT fvmethod 2 polynomialorders[1] polynomialorders[end]
+                for level in 1:numlevels
+                    result[level] = test_run(
+                        mpicomm,
+                        output ?
+                        "vtk_advection_diffusion_2d" *
+                        "_poly$(polynomialorders)" *
+                        "_$(ArrayType)_$(FT)" *
+                        "_level$(level)" :
+                        nothing,
+                        fvmethod,
+                        polynomialorders,
+                        level,
+                        ArrayType,
+                        FT,
+                    )
+
+
+                    @test result[level][1] ≈ FT(expected_result[
+                        2,
+                        polynomialorders[1],
+                        fvmethod,
+                        level,
+                        FT,
+                        1,
+                    ])
+                    @test result[level][2] ≈ FT(expected_result[
+                        2,
+                        polynomialorders[1],
+                        fvmethod,
+                        level,
+                        FT,
+                        2,
+                    ])
+                end
+
+                @info begin
+                    msg = "advection equation"
+                    for l in 1:(numlevels - 1)
+                        rate = log2(result[l][1]) - log2(result[l + 1][1])
+                        msg *= @sprintf("\n  rate for level %d = %e", l, rate)
+                    end
+                    msg
+                end
+                # Not an analytic solution, convergence doesn't make sense
+                # @info begin
+                #     msg = "advection-diffusion equation"
+                #     for l in 1:(numlevels - 1)
+                #         rate = log2(result[l][2]) - log2(result[l + 1][2])
+                #         msg *= @sprintf("\n  rate for level %d = %e", l, rate)
+                #     end
+                #     msg
+                # end
+            end
+        end
+    end
+end
+
+main()

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl
@@ -348,7 +348,7 @@ let
     expected_result[SolidBodyRotation, 1, FVConstant] = 1.6249678501611961e+07
     expected_result[SolidBodyRotation, 2, FVConstant] = 7.2020207047738554e+05
     expected_result[SolidBodyRotation, 3, FVConstant] = 5.2452627634607365e+04
-    expected_result[SolidBodyRotation, 4, FVConstant] = 3.1132401693922270e+03
+    expected_result[SolidBodyRotation, 4, FVConstant] = 3.1132403618328990e+03
 
     expected_result[SolidBodyRotation, 1, FVLinear] = 1.6650018586769039e+07
     expected_result[SolidBodyRotation, 2, FVLinear] = 7.2518593691652094e+05

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl
@@ -1,0 +1,454 @@
+using MPI
+using ClimateMachine
+using Logging
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.DGMethods
+using ClimateMachine.BalanceLaws: update_auxiliary_state!
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.DGMethods.FVReconstructions: FVConstant, FVLinear
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.ODESolvers
+using ClimateMachine.Atmos: SphericalOrientation, latitude, longitude
+using ClimateMachine.Orientations
+using LinearAlgebra
+using Printf
+using Dates
+using ClimateMachine.GenericCallbacks:
+    EveryXWallTimeSeconds, EveryXSimulationSteps
+using ClimateMachine.VTK: writevtk, writepvtu
+import ClimateMachine.BalanceLaws: boundary_state!
+using CLIMAParameters.Planet: planet_radius
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+
+const output = parse(Bool, lowercase(get(ENV, "JULIA_CLIMA_OUTPUT", "false")))
+
+include("advection_diffusion_model.jl")
+
+
+# This is a setup similar to the one presented in [Williamson1992](@cite)
+struct SolidBodyRotation <: AdvectionDiffusionProblem end
+function init_velocity_diffusion!(
+    ::SolidBodyRotation,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    FT = eltype(aux)
+    λ = longitude(SphericalOrientation(), aux)
+    φ = latitude(SphericalOrientation(), aux)
+    r = norm(geom.coord)
+
+    uλ = 2 * FT(π) * cos(φ) * r
+    uφ = 0
+    aux.advection.u = SVector(
+        -uλ * sin(λ) - uφ * cos(λ) * sin(φ),
+        +uλ * cos(λ) - uφ * sin(λ) * sin(φ),
+        +uφ * cos(φ),
+    )
+end
+function initial_condition!(::SolidBodyRotation, state, aux, localgeo, t)
+    λ = longitude(SphericalOrientation(), aux)
+    φ = latitude(SphericalOrientation(), aux)
+    state.ρ = exp(-((3λ)^2 + (3φ)^2))
+end
+finaltime(::SolidBodyRotation) = 1
+u_scale(::SolidBodyRotation) = 2π
+
+"""
+This is the Divergent flow with smooth initial condition test case, the Case 4 in
+
+@article{nair2010class,
+  title={A class of deformational flow test cases for linear transport problems on the sphere},
+  author={Nair, Ramachandran D and Lauritzen, Peter H},
+  journal={Journal of Computational Physics},
+  volume={229},
+  number={23},
+  pages={8868--8887},
+  year={2010},
+  publisher={Elsevier}
+}
+
+"""
+struct ReversingDeformationalFlow <: AdvectionDiffusionProblem end
+init_velocity_diffusion!(
+    ::ReversingDeformationalFlow,
+    aux::Vars,
+    geom::LocalGeometry,
+) = nothing
+function initial_condition!(::ReversingDeformationalFlow, state, aux, coord, t)
+    x, y, z = aux.coord
+    r = norm(aux.coord)
+    h_max = 0.95
+    b = 5
+    state.ρ = 0
+    for (λ, φ) in ((5π / 6, 0), (7π / 6, 0))
+        xi = r * cos(φ) * cos(λ)
+        yi = r * cos(φ) * sin(λ)
+        zi = r * sin(φ)
+        state.ρ +=
+            h_max * exp(-b * ((x - xi)^2 + (y - yi)^2 + (z - zi)^2) / r^2)
+    end
+end
+has_variable_coefficients(::ReversingDeformationalFlow) = true
+function update_velocity_diffusion!(
+    ::ReversingDeformationalFlow,
+    ::AdvectionDiffusion,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    FT = eltype(aux)
+    λ = longitude(SphericalOrientation(), aux)
+    φ = latitude(SphericalOrientation(), aux)
+    r = norm(aux.coord)
+    T = FT(5)
+    λp = λ - FT(2π) * t / T
+    uλ =
+        10 * r / T * sin(λp)^2 * sin(2φ) * cos(FT(π) * t / T) +
+        FT(2π) * r / T * cos(φ)
+    uφ = 10 * r / T * sin(2λp) * cos(φ) * cos(FT(π) * t / T)
+    aux.advection.u = SVector(
+        -uλ * sin(λ) - uφ * cos(λ) * sin(φ),
+        +uλ * cos(λ) - uφ * sin(λ) * sin(φ),
+        +uφ * cos(φ),
+    )
+end
+u_scale(::ReversingDeformationalFlow) = 2.9
+finaltime(::ReversingDeformationalFlow) = 5
+
+function advective_courant(
+    m::AdvectionDiffusion,
+    state::Vars,
+    aux::Vars,
+    diffusive::Vars,
+    Δx,
+    Δt,
+    direction,
+)
+    return Δt * norm(aux.advection.u) / Δx
+end
+
+function boundary_state!(
+    ::RusanovNumericalFlux,
+    bctype,
+    ::AdvectionDiffusion,
+    stateP::Vars,
+    auxP::Vars,
+    nM,
+    stateM::Vars,
+    auxM::Vars,
+    t,
+    _...,
+)
+    auxP.advection.u = -auxM.advection.u
+end
+
+function do_output(mpicomm, vtkdir, vtkstep, dgfvm, Q, Qe, model, testname)
+    ## Name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+    exactnames = statenames .* "_exact"
+
+    writevtk(filename, Q, dgfvm, statenames, Qe, exactnames)
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## Name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## Name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+function test_run(
+    mpicomm,
+    ArrayType,
+    vert_range,
+    topl,
+    problem,
+    explicit_method,
+    fvmethod,
+    cfl,
+    N,
+    timeend,
+    FT,
+    vtkdir,
+    outputtime,
+)
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = (N, 0),
+        meshwarp = cubedshellwarp,
+    )
+
+    dx = min_node_distance(grid, HorizontalDirection())
+    dt = FT(cfl * dx / (vert_range[2] * u_scale(problem())) / N)
+    dt = outputtime / ceil(Int64, outputtime / dt)
+
+    model = AdvectionDiffusion{3}(problem(), diffusion = false)
+    dgfvm = DGFVModel(
+        model,
+        grid,
+        fvmethod,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+
+    Q = init_ode_state(dgfvm, FT(0))
+
+    odesolver = explicit_method(dgfvm, Q; dt = dt, t0 = 0)
+
+    eng0 = norm(Q)
+    @info @sprintf """Starting
+    problem           = %s
+    ArrayType         = %s
+    FV Reconstruction = %s
+    method            = %s
+    time step         = %.16e
+    norm(Q₀)          = %.16e""" problem ArrayType fvmethod explicit_method dt eng0
+
+    # Set up the information callback
+    starttime = Ref(now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            @info @sprintf(
+                """Update
+                simtime = %.16e
+                runtime = %s
+                norm(Q) = %.16e""",
+                gettime(odesolver),
+                Dates.format(
+                    convert(Dates.DateTime, Dates.now() - starttime[]),
+                    Dates.dateformat"HH:MM:SS",
+                ),
+                energy
+            )
+        end
+    end
+    cbcfl = EveryXSimulationSteps(10) do
+        dt = ODESolvers.getdt(odesolver)
+        cfl = DGMethods.courant(
+            advective_courant,
+            dgfvm,
+            model,
+            Q,
+            dt,
+            HorizontalDirection(),
+        )
+        @info @sprintf(
+            """Courant number
+            simtime = %.16e
+            courant = %.16e""",
+            gettime(odesolver),
+            cfl
+        )
+    end
+    callbacks = (cbinfo,)
+    if ~isnothing(vtkdir)
+        # Create vtk dir
+        mkpath(vtkdir)
+
+        vtkstep = 0
+        # Output initial step
+        do_output(
+            mpicomm,
+            vtkdir,
+            vtkstep,
+            dgfvm,
+            Q,
+            Q,
+            model,
+            "fvm_advection_sphere",
+        )
+
+        # Setup the output callback
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dgfvm, gettime(odesolver))
+            do_output(
+                mpicomm,
+                vtkdir,
+                vtkstep,
+                dgfvm,
+                Q,
+                Qe,
+                model,
+                "fvm_advection_sphere",
+            )
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    solve!(Q, odesolver; timeend = timeend, callbacks = callbacks)
+
+    # Print some end of the simulation information
+    engf = norm(Q)
+    Qe = init_ode_state(dgfvm, FT(timeend))
+
+    engfe = norm(Qe)
+    errf = euclidean_distance(Q, Qe)
+    Δmass = abs(weightedsum(Q) - weightedsum(Qe)) / weightedsum(Qe)
+    @info @sprintf """Finished
+    Δmass                   = %.16e
+    norm(Q)                 = %.16e
+    norm(Q) / norm(Q₀)      = %.16e
+    norm(Q) - norm(Q₀)      = %.16e
+    norm(Q - Qe)            = %.16e
+    norm(Q - Qe) / norm(Qe) = %.16e
+    """ Δmass engf engf / eng0 engf - eng0 errf errf / engfe
+    return errf, Δmass
+end
+
+using Test
+let
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 4
+    base_num_elem = 3
+
+    max_cfl = Dict(LSRK144NiegemannDiehlBusch => 5.0)
+
+    expected_result = Dict()
+
+    expected_result[SolidBodyRotation, 1, FVConstant] = 1.6249678501611961e+07
+    expected_result[SolidBodyRotation, 2, FVConstant] = 7.2020207047738554e+05
+    expected_result[SolidBodyRotation, 3, FVConstant] = 5.2452627634607365e+04
+    expected_result[SolidBodyRotation, 4, FVConstant] = 3.1132401693922270e+03
+
+    expected_result[SolidBodyRotation, 1, FVLinear] = 1.6650018586769039e+07
+    expected_result[SolidBodyRotation, 2, FVLinear] = 7.2518593691652094e+05
+    expected_result[SolidBodyRotation, 3, FVLinear] = 5.2473203187596591e+04
+    expected_result[SolidBodyRotation, 4, FVLinear] = 3.1133127473480104e+03
+
+    expected_result[ReversingDeformationalFlow, 1, FVConstant] =
+        2.0097347028034222e+08
+    expected_result[ReversingDeformationalFlow, 2, FVConstant] =
+        7.0092390520693690e+07
+    expected_result[ReversingDeformationalFlow, 3, FVConstant] =
+        7.7527847763998993e+06
+    expected_result[ReversingDeformationalFlow, 4, FVConstant] =
+        1.4209138735343830e+05
+
+    expected_result[ReversingDeformationalFlow, 1, FVLinear] =
+        2.0156862801802599e+08
+    expected_result[ReversingDeformationalFlow, 2, FVLinear] =
+        7.0092714938572392e+07
+    expected_result[ReversingDeformationalFlow, 3, FVLinear] =
+        7.7527849036761308e+06
+    expected_result[ReversingDeformationalFlow, 4, FVLinear] =
+        1.4209138776027536e+05
+
+    numlevels =
+        integration_testing || ClimateMachine.Settings.integration_testing ? 4 :
+        1
+    explicit_method = LSRK144NiegemannDiehlBusch
+    @testset "$(@__FILE__)" begin
+        for FT in (Float64,)
+            for problem in (SolidBodyRotation, ReversingDeformationalFlow)
+                for fvmethod in (FVConstant, FVLinear)
+                    cfl = max_cfl[explicit_method]
+                    result = zeros(FT, numlevels)
+                    for l in 1:numlevels
+                        numelems_horizontal = 2^(l - 1) * base_num_elem
+                        numelems_vertical = 3
+
+                        _planet_radius = FT(planet_radius(param_set))
+                        domain_height = FT(10e3)
+                        vert_range =
+                            (_planet_radius, _planet_radius + domain_height)
+
+                        topl = StackedCubedSphereTopology(
+                            mpicomm,
+                            numelems_horizontal,
+                            range(
+                                vert_range[1],
+                                stop = vert_range[2],
+                                length = numelems_vertical + 1,
+                            ),
+                        )
+
+                        timeend = finaltime(problem())
+                        outputtime = timeend
+
+                        @info (ArrayType, FT)
+                        vtkdir =
+                            output ?
+                            "vtk_fvm_advection_sphere" *
+                            "_$problem" *
+                            "_$explicit_method" *
+                            "_poly$(polynomialorder)" *
+                            "_$(ArrayType)_$(FT)" *
+                            "_level$(l)" :
+                            nothing
+
+                        result[l], Δmass = test_run(
+                            mpicomm,
+                            ArrayType,
+                            vert_range,
+                            topl,
+                            problem,
+                            explicit_method,
+                            fvmethod(),
+                            cfl,
+                            polynomialorder,
+                            timeend,
+                            FT,
+                            vtkdir,
+                            outputtime,
+                        )
+                        @test result[l] ≈
+                              FT(expected_result[problem, l, fvmethod])
+                        @test Δmass <= FT(1e-12)
+                    end
+                    @info begin
+                        msg = ""
+                        for l in 1:(numlevels - 1)
+                            rate = log2(result[l]) - log2(result[l + 1])
+                            msg *= @sprintf(
+                                "\n  rate for level %d = %e\n",
+                                l,
+                                rate
+                            )
+                        end
+                        msg
+                    end
+                end
+            end
+        end
+    end
+end

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_swirl.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_swirl.jl
@@ -1,0 +1,330 @@
+# This tutorial uses the TMAR Filter from [Light2016](@cite)
+#
+# to reproduce the tutorial in section 4b.  It is a shear swirling
+# flow deformation of a transported quantity from LeVeque 1996.  The exact
+# solution at the final time is the same as the initial condition.
+
+using MPI
+using Test
+using ClimateMachine
+ClimateMachine.init()
+using Logging
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.Mesh.Filters
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.DGMethods.FVReconstructions: FVConstant, FVLinear
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.ODESolvers
+using LinearAlgebra
+using Printf
+using Dates
+using ClimateMachine.GenericCallbacks:
+    EveryXWallTimeSeconds, EveryXSimulationSteps
+using ClimateMachine.VTK: writevtk, writepvtu
+
+using ClimateMachine
+const clima_dir = dirname(dirname(pathof(ClimateMachine)))
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+const output = parse(Bool, lowercase(get(ENV, "JULIA_CLIMA_OUTPUT", "false")))
+
+include("advection_diffusion_model.jl")
+
+Base.@kwdef struct SwirlingFlow{FT} <: AdvectionDiffusionProblem
+    period::FT = 5
+end
+
+init_velocity_diffusion!(::SwirlingFlow, aux::Vars, geom::LocalGeometry) =
+    nothing
+
+function initial_condition!(::SwirlingFlow, state, aux, localgeo, t)
+    FT = eltype(state)
+    x, y, _ = aux.coord
+    x0, y0 = FT(1 // 3), FT(1 // 3)
+    τ = 6hypot(x - x0, y - y0)
+    state.ρ = exp(-τ^2)
+end
+
+has_variable_coefficients(::SwirlingFlow) = true
+function update_velocity_diffusion!(
+    problem::SwirlingFlow,
+    ::AdvectionDiffusion,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    x, y, _ = aux.coord
+    sx, cx = sinpi(x), cospi(x)
+    sy, cy = sinpi(y), cospi(y)
+    ct = cospi(t / problem.period)
+
+    u = 2 * sx^2 * sy * cy * ct
+    v = -2 * sy^2 * sx * cx * ct
+    aux.advection.u = SVector(u, v, 0)
+end
+
+function do_output(
+    mpicomm,
+    vtkdir,
+    vtkstep,
+    dg,
+    Q,
+    model,
+    testname;
+    number_sample_points = 0,
+)
+    ## Name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+
+    writevtk(
+        filename,
+        Q,
+        dg,
+        statenames;
+        number_sample_points = number_sample_points,
+    )
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## Name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## Name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(pvtuprefix, prefixes, (statenames...,), eltype(Q))
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+function test_run(
+    mpicomm,
+    ArrayType,
+    fvmethod,
+    topl,
+    problem,
+    dt,
+    N,
+    timeend,
+    FT,
+    vtkdir,
+    outputtime,
+)
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = N,
+    )
+
+    model = AdvectionDiffusion{2}(problem, diffusion = false)
+
+    dg = DGFVModel(
+        model,
+        grid,
+        fvmethod,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+
+    Q = init_ode_state(dg, FT(0))
+
+    ## We integrate so that the final solution is equal to the initial solution
+    Qe = copy(Q)
+    odesolver = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
+
+    # Set up the information callback
+    starttime = Ref(Dates.now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = Dates.now()
+        else
+            energy = norm(Q)
+            @info @sprintf(
+                """Update
+                simtime = %.16e
+                runtime = %s
+                norm(Q) = %.16e""",
+                gettime(odesolver),
+                Dates.format(
+                    convert(Dates.DateTime, Dates.now() - starttime[]),
+                    Dates.dateformat"HH:MM:SS",
+                ),
+                energy
+            )
+        end
+    end
+    callbacks = (cbinfo,)
+    if ~isnothing(vtkdir)
+        # Create vtk dir
+        if MPI.Comm_rank(mpicomm) == 0
+            mkpath(vtkdir)
+        end
+        MPI.Barrier(mpicomm)
+
+        vtkstep = 0
+        # Output initial step
+        do_output(
+            mpicomm,
+            vtkdir,
+            vtkstep,
+            dg,
+            Q,
+            model,
+            "swirling_flow";
+            number_sample_points = N[1] + 1,
+        )
+
+        # Setup the output callback
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dg, gettime(odesolver))
+            do_output(
+                mpicomm,
+                vtkdir,
+                vtkstep,
+                dg,
+                Q,
+                model,
+                "swirling_flow";
+                number_sample_points = N[1] + 1,
+            )
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    solve!(Q, odesolver; timeend = timeend, callbacks = callbacks)
+
+    error = euclidean_distance(Q, Qe)
+
+    # Print some end of the simulation information
+    eng0 = norm(Qe)
+    engf = norm(Q)
+
+    engfe = norm(Qe)
+    errf = euclidean_distance(Q, Qe)
+    @info @sprintf """Finished
+    norm(Q)                 = %.16e
+    norm(Q) / norm(Q₀)      = %.16e
+    norm(Q) - norm(Q₀)      = %.16e
+    norm(Q - Qe)            = %.16e
+    norm(Q - Qe) / norm(Qe) = %.16e
+    """ engf engf / eng0 engf - eng0 errf errf / engfe
+    errf
+end
+
+let
+    ArrayType = ClimateMachine.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    expected_result = Dict()
+    expected_result[1, FVConstant()] = 1.2437314516997458e-01
+    expected_result[2, FVConstant()] = 9.8829388561567838e-02
+    expected_result[3, FVConstant()] = 7.2096312912198937e-02
+    expected_result[4, FVConstant()] = 4.7720226730379636e-02
+    expected_result[1, FVLinear()] = 4.3807967239640234e-02
+    expected_result[2, FVLinear()] = 1.4913083518239653e-02
+    expected_result[3, FVLinear()] = 4.3666055848495802e-03
+    expected_result[4, FVLinear()] = 1.2749240022458719e-03
+
+    @testset "$(@__FILE__)" begin
+        numlevels =
+            integration_testing || ClimateMachine.Settings.integration_testing ?
+            4 : 1
+        FT = Float64
+        for fvmethod in (FVConstant(), FVLinear())
+            result = zeros(FT, numlevels)
+            for l in 1:numlevels
+                Ne = 20 * 2^(l - 1)
+                polynomialorder = (4, 0)
+
+                problem = SwirlingFlow()
+
+                brickrange = (
+                    range(FT(0); length = Ne + 1, stop = 1),
+                    range(
+                        FT(0);
+                        length = polynomialorder[1] * Ne + 1,
+                        stop = 1,
+                    ),
+                )
+
+                topology = StackedBrickTopology(
+                    mpicomm,
+                    brickrange,
+                    boundary = ((3, 3), (3, 3)),
+                )
+
+                maxvelocity = 2
+                elementsize = 1 / Ne
+                dx = elementsize / polynomialorder[1]^2
+                CFL = 1
+                dt = CFL * dx / maxvelocity
+
+                vtkdir = abspath(joinpath(
+                    ClimateMachine.Settings.output_dir,
+                    "fvm_swirl_lvl_$l",
+                ))
+
+                timeend = problem.period
+
+                outputtime = timeend / 10
+                dt = outputtime / ceil(Int64, outputtime / dt)
+
+                @info @sprintf """Starting
+                FT               = %s
+                ArrayType        = %s
+                FV Reconstuction = %s
+                dim              = %d
+                Ne               = %d
+                polynomial order = %d
+                final time       = %.16e
+                time step        = %.16e
+                """ FT ArrayType fvmethod 2 Ne polynomialorder[1] timeend dt
+
+                result[l] = test_run(
+                    mpicomm,
+                    ArrayType,
+                    fvmethod,
+                    topology,
+                    problem,
+                    dt,
+                    polynomialorder,
+                    timeend,
+                    FT,
+                    output ? vtkdir : nothing,
+                    outputtime,
+                )
+                @test result[l] ≈ FT(expected_result[l, fvmethod])
+            end
+            @info begin
+                msg = ""
+                for l in 1:(numlevels - 1)
+                    rate = log2(result[l]) - log2(result[l + 1])
+                    msg *= @sprintf("\n  rate for level %d = %e\n", l, rate)
+                end
+                msg
+            end
+        end
+    end
+end


### PR DESCRIPTION
Creates a `DGFVModel` for the using spectral element DG in the horizontal and finite volume in the vertical.

The dimensional splitting used implies that the method will be at most (formally) 2nd order accurate.

The finite volume reconstructions are handled with the newly introduced `FVReconstructions` module. Currently the following reconstruction types are supported:

- Constant reconstructions
- Linear reconstructions with limiters
- Linear reconstructions with limiters with a wider stencil (to test the interface for WENO without actually having weno implemented)

WENO should be supported and work once the WENO types are added to the `FVReconstructions` module.

Some things left to do after this PR:

- Add back in hyperdiffusion on with DG
- Hydrostatic balance
- WENO schemes 

Co-authored-by: Daniel Z. Huang <hzyhzy2014@gmail.com>
Co-authored-by: Thomas Gibson <gibsonthomas1120@hotmail.com>
Co-authored-by: Maciej Waruszewski <mwarusz@igf.fuw.edu.pl>