### PR TITLE
Expose parameters for SBL calibration.

### DIFF
--- a/experiments/AtmosLES/stable_bl_les.jl
+++ b/experiments/AtmosLES/stable_bl_les.jl
@@ -1,4 +1,5 @@
 using Random
+
 include("stable_bl_model.jl")
 
 function add_perturbations!(state, localgeo)
@@ -9,26 +10,16 @@ function add_perturbations!(state, localgeo)
     end
 end
 
-function main()
+function set_clima_parameters(filename)
+    eval(:(include($filename)))
+end
 
-    # TODO: this will move to the future namelist functionality
-    sbl_args = ArgParseSettings(autofix_names = true)
-    add_arg_group!(sbl_args, "StableBoundaryLayer")
-    @add_arg_table! sbl_args begin
-        "--surface-flux"
-        help = "specify surface flux for energy and moisture"
-        metavar = "prescribed|bulk"
-        arg_type = String
-        default = "bulk"
-    end
-
-    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
+function main(cl_args)
 
     surface_flux = cl_args["surface_flux"]
 
     FT = Float64
     config_type = AtmosLESConfigType
-
     # DG polynomial order
     N = 4
     # Domain resolution and size
@@ -51,14 +42,14 @@ function main()
     # Choose default IMEX solver
     ode_solver_type = ClimateMachine.ExplicitSolverType()
 
-    C_smag = FT(0.23)
+    C_smag_ = C_smag(param_set) #FT(0.23)
 
     model = stable_bl_model(
         FT,
         config_type,
         zmax,
         surface_flux;
-        turbulence = SmagorinskyLilly{FT}(C_smag),
+        turbulence = SmagorinskyLilly{FT}(C_smag_),
     )
 
     ics = model.problem.init_state_prognostic
@@ -99,4 +90,26 @@ function main()
     )
 end
 
-main()
+# ArgParse in global scope to modify Clima Parameters
+sbl_args = ArgParseSettings(autofix_names = true)
+add_arg_group!(sbl_args, "StableBoundaryLayer")
+@add_arg_table! sbl_args begin
+    "--cparam-file"
+    help = "specify CLIMAParameters file"
+    arg_type = Union{String, Nothing}
+    default = nothing
+
+    "--surface-flux"
+    help = "specify surface flux for energy and moisture"
+    metavar = "prescribed|bulk"
+    arg_type = String
+    default = "bulk"
+end
+
+cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
+if !isnothing(cl_args["cparam_file"])
+    filename = cl_args["cparam_file"]
+    set_clima_parameters(filename)
+end
+
+main(cl_args)

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -39,8 +39,10 @@ import ClimateMachine.BalanceLaws: source
 
 using CLIMAParameters
 using CLIMAParameters.Planet: R_d, cp_d, cv_d, MSLP, grav, day
+using CLIMAParameters.Atmos.SubgridScale: C_smag, C_drag
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
+import CLIMAParameters
 
 using ClimateMachine.Atmos: altitude, recover_thermo_state
 
@@ -192,7 +194,7 @@ function stable_bl_model(
 
     ics = init_problem!     # Initial conditions
 
-    C_drag = FT(0.001)    # Momentum exchange coefficient
+    C_drag_::FT = C_drag(param_set) # FT(0.001)    # Momentum exchange coefficient
     u_star = FT(0.30)
 
     z_sponge = FT(300)     # Start of sponge layer
@@ -251,12 +253,12 @@ function stable_bl_model(
         moisture_bc = PrescribedMoistureFlux((state, aux, t) -> moisture_flux)
     elseif surface_flux == "bulk"
         energy_bc = BulkFormulaEnergy(
-            (bl, state, aux, t, normPu_int) -> C_drag,
+            (bl, state, aux, t, normPu_int) -> C_drag_,
             (bl, state, aux, t) ->
                 (surface_temperature_variation(bl, state, t), q_sfc),
         )
         moisture_bc = BulkFormulaMoisture(
-            (state, aux, t, normPu_int) -> C_drag,
+            (state, aux, t, normPu_int) -> C_drag_,
             (state, aux, t) -> q_sfc,
         )
     else


### PR DESCRIPTION
### Description

This PR makes the following changes, necessary for a first proof of concept of CalibrateEmulateSample-CLIMAParameters-ClimateMachine joint use:

- Adds a new ArgParse argument option to `stable_bl_les.jl` that allows ClimateMachine to read a certain set of parameters, identified by the path to the parameter definition file.
- Takes two turbulent parameters, `C_smag` and `C_drag`, from CLIMAParameters. Before, they were hardcoded in the example.

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
