### PR TITLE
Add flux_first_order for environment covariances and update the mse report values so that Bomex test is passing

### DIFF
--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -533,7 +533,9 @@ function flux_first_order!(
     # Aliases:
     gm = state
     up = state.turbconv.updraft
+    en = state.turbconv.environment
     up_flx = flux.turbconv.updraft
+    en_flx = flux.turbconv.environment
     N_up = n_updrafts(turbconv)
 
     ρ_inv = 1 / gm.ρ
@@ -554,6 +556,11 @@ function flux_first_order!(
         up_flx[i].ρaθ_liq = w_up_i * up[i].ρaθ_liq * ẑ
         up_flx[i].ρaq_tot = w_up_i * up[i].ρaq_tot * ẑ
     end
+    env = environment_vars(state, aux, N_up)
+    en_flx.ρatke = en.ρatke * env.w * ẑ
+    en_flx.ρaθ_liq_cv = en.ρaθ_liq_cv * env.w * ẑ
+    en_flx.ρaq_tot_cv = en.ρaq_tot_cv * env.w * ẑ
+    en_flx.ρaθ_liq_q_tot_cv = en.ρaθ_liq_q_tot_cv * env.w * ẑ
 end;
 
 # in the EDMF second order (diffusive) fluxes

--- a/test/Atmos/EDMF/report_mse.jl
+++ b/test/Atmos/EDMF/report_mse.jl
@@ -13,11 +13,11 @@ include(joinpath(@__DIR__, "compute_mse.jl"))
 best_mse = Dict()
 best_mse[:Bomex] = Dict()
 best_mse[:Bomex]["ρ"] = 3.4943021267397123e-02
-best_mse[:Bomex]["ρu[1]"] = 3.0714039084256679e+03
+best_mse[:Bomex]["ρu[1]"] = 3.0714039084256697e+03
 best_mse[:Bomex]["ρu[2]"] = 1.3375796498101822e-03
 best_mse[:Bomex]["moisture.ρq_tot"] = 4.8463531712319707e-02
 best_mse[:Bomex]["turbconv.environment.ρatke"] = 4.7760529270257848e+03
-best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5663969066126555e+01
+best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5663972837809141e+01
 best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6260195840899604e+02
 best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9888809513438588e+01
 best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.5229392101997301e-02


### PR DESCRIPTION
### Description

This branch adds the first order flux for environment covariances of then EDMF equations.
The values of mse for ρu[1] and turbconv.environment.ρaθ_liq_cv where updated to allow then Bomex test to pass. 


- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.