### PR TITLE
Fix and test the LU solver for FV

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,6 +48,15 @@ steps:
       queue: central
       slurm_ntasks: 1
 
+  - label: "cpu_fvm_advection_diffusion_model_1dimex_bjfnks"
+    key: "cpu_fvm_advection_diffusion_model_1dimex_bjfnks"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_model_1dimex_bjfnks.jl "
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: "cpu_pseudo1D_advection_diffusion"
     key: "cpu_pseudo1D_advection_diffusion"
     command:

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -1096,7 +1096,7 @@ function courant(
     MPI.Allreduce(rank_courant_max, max, topology.mpicomm)
 end
 
-function MPIStateArrays.MPIStateArray(dg::DGModel)
+function MPIStateArrays.MPIStateArray(dg::SpaceDiscretization)
     balance_law = dg.balance_law
     grid = dg.grid
 

--- a/src/Numerics/SystemSolvers/SystemSolvers.jl
+++ b/src/Numerics/SystemSolvers/SystemSolvers.jl
@@ -7,7 +7,8 @@ using ..Mesh.Grids
 import ..Mesh.Grids: polynomialorders, dimensionality
 using ..Mesh.Topologies
 using ..DGMethods
-using ..DGMethods: DGModel
+using ..DGMethods: DGModel, DGFVModel, SpaceDiscretization
+import ..DGMethods.FVReconstructions: width
 using ..BalanceLaws
 
 using Adapt

--- a/src/Numerics/SystemSolvers/batched_generalized_minimal_residual_solver.jl
+++ b/src/Numerics/SystemSolvers/batched_generalized_minimal_residual_solver.jl
@@ -193,7 +193,7 @@ end
 
 """
     BatchedGeneralizedMinimalResidual(
-        dg::DGModel,
+        dg::SpaceDiscretization,
         Q::MPIStateArray;
         atol = sqrt(eps(eltype(Q))),
         rtol = sqrt(eps(eltype(Q))),
@@ -203,11 +203,11 @@ end
 
 # Description
 Specialized constructor for `BatchedGeneralizedMinimalResidual` struct, using
-a `DGModel` to infer state-information and determine appropriate reshaping
+a `SpaceDiscretization` to infer state-information and determine appropriate reshaping
 and permutations.
 
 # Arguments
-- `dg`: (DGModel) A `DGModel` containing all relevant grid and topology
+- `dg`: (SpaceDiscretization) A `SpaceDiscretization` containing all relevant grid and topology
         information.
 - `Q` : (MPIStateArray) An `MPIStateArray` containing field information.
 
@@ -224,7 +224,7 @@ and permutations.
 instance of `BatchedGeneralizedMinimalResidual` struct
 """
 function BatchedGeneralizedMinimalResidual(
-    dg::DGModel,
+    dg::SpaceDiscretization,
     Q::MPIStateArray;
     atol = sqrt(eps(eltype(Q))),
     rtol = sqrt(eps(eltype(Q))),

--- a/src/Numerics/SystemSolvers/columnwise_lu_solver.jl
+++ b/src/Numerics/SystemSolvers/columnwise_lu_solver.jl
@@ -54,15 +54,15 @@ single_column(
 ) where {D, P, NS, EH, EV, EB, SC} = SC
 
 # DG: lower_bandwidth is Nq_v*nstate * eband - 1, (does not include itself) 
-# eband = 1 for inviscid, since nodal point at the face communicates to the overlaping point to its neighbor
-# and other points only communicates to points in the same element
+# eband = 1 for inviscid, since nodal point at the face communicate to the overlaping point to its neighbor
+# and other points only communicate to points in the same element
 # eband = 2 for visous
 #
 # FV: lower_bandwidth is nstate * (stencil_width + 1 + 1) - 1,  
 # since the reconstruction states depend on stencil_width points on each side, 
 # and the flux depends on stencil_width + 1 points on each side
 # eband = (stencil_width + 2) for inviscid
-# eband = max{ (stencil_width + 2), 3} for viscid, 
+# eband = max{ (stencil_width + 2), 3} for viscous, 
 # since the viscous flux is computed by applying first order FD twice
 #  
 # The lower_bandwidth ls formulated as Nq_v*nstate * eband - 1

--- a/src/Numerics/SystemSolvers/columnwise_lu_solver.jl
+++ b/src/Numerics/SystemSolvers/columnwise_lu_solver.jl
@@ -68,7 +68,7 @@ single_column(
 # The lower_bandwidth ls formulated as Nq_v*nstate * eband - 1
 lower_bandwidth(N, nstate, eband) = (N + 1) * nstate * eband - 1
 lower_bandwidth(A::DGColumnBandedMatrix) =
-    (vertical_polynomialorder(A) + 1) * num_state(A) * elem_band(A) - 1
+    lower_bandwidth(vertical_polynomialorder(A), num_state(A), elem_band(A))
 upper_bandwidth(N, nstate, eband) = lower_bandwidth(N, nstate, eband)
 upper_bandwidth(A::DGColumnBandedMatrix) =
     upper_bandwidth(vertical_polynomialorder(A), num_state(A), elem_band(A))
@@ -343,9 +343,10 @@ function empty_banded_matrix(
             number_states(bl, GradientFlux()) == 0 ?
             width(dg.fv_reconstruction) + 2 :
             max(width(dg.fv_reconstruction) + 2, 3)
-        )
+        ) # else: DGFVModel
 
-    p = q = nstate * Nq_v * eband - 1
+    p = lower_bandwidth(N[dim], nstate, eband)
+    q = upper_bandwidth(N[dim], nstate, eband)
 
     nrealelem = length(topology.realelems)
     nvertelem = topology.stacksize

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_model_1dimex_bjfnks.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_model_1dimex_bjfnks.jl
@@ -1,0 +1,419 @@
+using MPI
+using ClimateMachine
+using Logging
+using Test
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.DGMethods.FVReconstructions: FVConstant, FVLinear
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.SystemSolvers
+using ClimateMachine.ODESolvers
+using LinearAlgebra
+using Printf
+using Dates
+using ClimateMachine.GenericCallbacks:
+    EveryXWallTimeSeconds, EveryXSimulationSteps
+using ClimateMachine.VTK: writevtk, writepvtu
+
+if !@isdefined integration_testing
+    if length(ARGS) > 0
+        const integration_testing = parse(Bool, ARGS[1])
+    else
+        const integration_testing = parse(
+            Bool,
+            lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+        )
+    end
+end
+
+const output = parse(Bool, lowercase(get(ENV, "JULIA_CLIMA_OUTPUT", "false")))
+
+include("advection_diffusion_model.jl")
+
+struct Pseudo1D{n, α, β, μ, δ} <: AdvectionDiffusionProblem end
+
+function init_velocity_diffusion!(
+    ::Pseudo1D{n, α, β},
+    aux::Vars,
+    geom::LocalGeometry,
+) where {n, α, β}
+    # Direction of flow is n with magnitude α
+    aux.advection.u = α * n
+
+    # Diffusion of strength β in the n direction
+    aux.diffusion.D = β * n * n'
+end
+
+function initial_condition!(
+    ::Pseudo1D{n, α, β, μ, δ},
+    state,
+    aux,
+    localgeo,
+    t,
+) where {n, α, β, μ, δ}
+    ξn = dot(n, localgeo.coord)
+    # ξT = SVector(localgeo.coord) - ξn * n
+    state.ρ = exp(-(ξn - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
+end
+Dirichlet_data!(P::Pseudo1D, x...) = initial_condition!(P, x...)
+function Neumann_data!(
+    ::Pseudo1D{n, α, β, μ, δ},
+    ∇state,
+    aux,
+    x,
+    t,
+) where {n, α, β, μ, δ}
+    ξn = dot(n, x)
+    ∇state.ρ =
+        -(
+            2n * (ξn - μ - α * t) / (4 * β * (δ + t)) *
+            exp(-(ξn - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
+        )
+end
+
+function do_output(mpicomm, vtkdir, vtkstep, dgfvm, Q, Qe, model, testname)
+    ## Name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state(model, Prognostic(), eltype(Q)))
+    exactnames = statenames .* "_exact"
+
+    writevtk(filename, Q, dgfvm, statenames, Qe, exactnames)
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## Name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## Name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(
+            pvtuprefix,
+            prefixes,
+            (statenames..., exactnames...),
+            eltype(Q),
+        )
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+
+function test_run(
+    mpicomm,
+    ArrayType,
+    dim,
+    topl,
+    N,
+    fvmethod,
+    timeend,
+    FT,
+    dt,
+    n,
+    α,
+    β,
+    μ,
+    δ,
+    vtkdir,
+    outputtime,
+    fluxBC,
+)
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = (N, 0),
+    )
+    model = AdvectionDiffusion{dim}(Pseudo1D{n, α, β, μ, δ}(), flux_bc = fluxBC)
+    dgfvm = DGFVModel(
+        model,
+        grid,
+        fvmethod,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+        direction = EveryDirection(),
+    )
+
+    vdgfvm = DGFVModel(
+        model,
+        grid,
+        fvmethod,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+        state_auxiliary = dgfvm.state_auxiliary,
+        direction = VerticalDirection(),
+    )
+
+
+    Q = init_ode_state(dgfvm, FT(0))
+
+    linearsolver = BatchedGeneralizedMinimalResidual(
+        dgfvm,
+        Q;
+        max_subspace_size = 5,
+        atol = sqrt(eps(FT)) * 0.01,
+        rtol = sqrt(eps(FT)) * 0.01,
+    )
+
+    nonlinearsolver =
+        JacobianFreeNewtonKrylovSolver(Q, linearsolver; tol = 1e-4)
+
+    ode_solver = ARK2ImplicitExplicitMidpoint(
+        dgfvm,
+        vdgfvm,
+        NonLinearBackwardEulerSolver(
+            nonlinearsolver;
+            isadjustable = true,
+            preconditioner_update_freq = 1000,
+        ),
+        Q;
+        dt = dt,
+        t0 = 0,
+        split_explicit_implicit = false,
+    )
+
+    eng0 = norm(Q)
+    @info @sprintf """Starting
+    norm(Q₀) = %.16e""" eng0
+
+    # Set up the information callback
+    starttime = Ref(now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            @info @sprintf(
+                """Update
+                simtime = %.16e
+                runtime = %s
+                norm(Q) = %.16e""",
+                gettime(ode_solver),
+                Dates.format(
+                    convert(Dates.DateTime, Dates.now() - starttime[]),
+                    Dates.dateformat"HH:MM:SS",
+                ),
+                energy
+            )
+        end
+    end
+    callbacks = (cbinfo,)
+    if ~isnothing(vtkdir)
+        # Create vtk dir
+        mkpath(vtkdir)
+
+        vtkstep = 0
+        # Output initial step
+        do_output(
+            mpicomm,
+            vtkdir,
+            vtkstep,
+            dgfvm,
+            Q,
+            Q,
+            model,
+            "advection_diffusion",
+        )
+
+        # Setup the output callback
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dgfvm, gettime(ode_solver))
+            do_output(
+                mpicomm,
+                vtkdir,
+                vtkstep,
+                dgfvm,
+                Q,
+                Qe,
+                model,
+                "advection_diffusion",
+            )
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    numberofsteps = convert(Int64, cld(timeend, dt))
+    dt = timeend / numberofsteps
+
+    @info "time step" dt numberofsteps dt * numberofsteps timeend
+
+    solve!(
+        Q,
+        ode_solver;
+        numberofsteps = numberofsteps,
+        callbacks = callbacks,
+        adjustfinalstep = false,
+    )
+
+    # Print some end of the simulation information
+    engf = norm(Q)
+    Qe = init_ode_state(dgfvm, FT(timeend))
+
+    engfe = norm(Qe)
+    errf = euclidean_distance(Q, Qe)
+    @info @sprintf """Finished
+    norm(Q)                 = %.16e
+    norm(Q) / norm(Q₀)      = %.16e
+    norm(Q) - norm(Q₀)      = %.16e
+    norm(Q - Qe)            = %.16e
+    norm(Q - Qe) / norm(Qe) = %.16e
+    """ engf engf / eng0 engf - eng0 errf errf / engfe
+    errf
+end
+
+let
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 4
+    base_num_elem = 4
+
+    expected_result = Dict()
+    # dim, refinement level, FT, vertical scheme
+    expected_result[2, 1, Float64, FVConstant()] = 1.4890228213182394e-01
+    expected_result[2, 2, Float64, FVConstant()] = 1.1396608915201276e-01
+    expected_result[2, 3, Float64, FVConstant()] = 7.9360293305962212e-02
+
+    expected_result[2, 1, Float64, FVLinear()] = 1.0755278583097065e-01
+    expected_result[2, 2, Float64, FVLinear()] = 4.5924219102504410e-02
+    expected_result[2, 3, Float64, FVLinear()] = 1.0775256661783415e-02
+
+    expected_result[3, 1, Float64, FVConstant()] = 2.1167998484526718e-01
+    expected_result[3, 2, Float64, FVConstant()] = 1.5936623436529485e-01
+    expected_result[3, 3, Float64, FVConstant()] = 1.1069147173311458e-01
+
+    expected_result[3, 1, Float64, FVLinear()] = 1.5361757743888277e-01
+    expected_result[3, 2, Float64, FVLinear()] = 6.3622331921472902e-02
+    expected_result[3, 3, Float64, FVLinear()] = 1.4836612761110498e-02
+
+
+    numlevels = integration_testing ? 3 : 1
+
+    @testset "$(@__FILE__)" begin
+        for FT in (Float64,)
+            result = zeros(FT, numlevels)
+            for dim in 2:3
+                for fvmethod in (FVConstant(), FVLinear())
+
+
+                    for fluxBC in (true, false)
+                        d = dim == 2 ? FT[1, 10, 0] : FT[1, 1, 10]
+                        n = SVector{3, FT}(d ./ norm(d))
+
+                        α = FT(1)
+                        β = FT(1 // 100)
+                        μ = FT(-1 // 2)
+                        δ = FT(1 // 10)
+
+                        solvertype = "HEVI_Nolinearsolver"
+                        for l in 1:numlevels
+                            Ne = 2^(l - 1) * base_num_elem
+                            brickrange = (
+                                ntuple(
+                                    j -> range(
+                                        FT(-1);
+                                        length = Ne + 1,
+                                        stop = 1,
+                                    ),
+                                    dim - 1,
+                                )...,
+                                range(
+                                    FT(-5);
+                                    length = 5Ne * polynomialorder + 1,
+                                    stop = 5,
+                                ),
+                            )
+
+                            periodicity = ntuple(j -> false, dim)
+                            topl = StackedBrickTopology(
+                                mpicomm,
+                                brickrange;
+                                periodicity = periodicity,
+                                boundary = (
+                                    ntuple(j -> (1, 2), dim - 1)...,
+                                    (3, 4),
+                                ),
+                            )
+                            dt = 2 * (α / 4) / (Ne * polynomialorder^2)
+
+                            outputtime = 0.01
+                            timeend = 0.5
+
+                            @info (
+                                ArrayType,
+                                FT,
+                                dim,
+                                solvertype,
+                                l,
+                                polynomialorder,
+                                fvmethod,
+                                fluxBC,
+                            )
+                            vtkdir =
+                                output ?
+                                "vtk_fvm_advection" *
+                                "_poly$(polynomialorder)" *
+                                "_dim$(dim)_$(ArrayType)_$(FT)" *
+                                "_fvmethod$(fvmethod)" *
+                                "_$(solvertype)_level$(l)" :
+                                nothing
+                            result[l] = test_run(
+                                mpicomm,
+                                ArrayType,
+                                dim,
+                                topl,
+                                polynomialorder,
+                                fvmethod,
+                                timeend,
+                                FT,
+                                dt,
+                                n,
+                                α,
+                                β,
+                                μ,
+                                δ,
+                                vtkdir,
+                                outputtime,
+                                fluxBC,
+                            )
+                            # Test the errors significantly larger than floating point epsilon
+                            if !(dim == 2 && l == 4 && FT == Float32)
+                                @test result[l] ≈
+                                      FT(expected_result[dim, l, FT, fvmethod])
+                            end
+                        end
+                        @info begin
+                            msg = ""
+                            for l in 1:(numlevels - 1)
+                                rate = log2(result[l]) - log2(result[l + 1])
+                                msg *= @sprintf(
+                                    "\n  rate for level %d = %e\n",
+                                    l,
+                                    rate
+                                )
+                            end
+                            msg
+                        end
+                    end
+                end
+            end
+        end
+    end
+end

--- a/test/Numerics/SystemSolvers/bandedsystem.jl
+++ b/test/Numerics/SystemSolvers/bandedsystem.jl
@@ -66,194 +66,216 @@ let
     Random.seed!(777 + MPI.Comm_rank(mpicomm))
 
     # Mesh generation parameters
-    N = 4
-    Nq = N + 1
     Neh = 10
     Nev = 4
 
     @testset "$(@__FILE__) DGModel matrix" begin
         for FT in (Float64, Float32)
             for dim in (2, 3)
-                for single_column in (false, true)
-                    # Setup the topology
-                    if dim == 2
-                        brickrange = (
-                            range(FT(0); length = Neh + 1, stop = 1),
-                            range(FT(1); length = Nev + 1, stop = 2),
-                        )
-                    elseif dim == 3
-                        brickrange = (
-                            range(FT(0); length = Neh + 1, stop = 1),
-                            range(FT(0); length = Neh + 1, stop = 1),
-                            range(FT(1); length = Nev + 1, stop = 2),
-                        )
-                    end
-                    topl = StackedBrickTopology(mpicomm, brickrange)
-
-                    # Warp mesh
-                    function warpfun(ξ1, ξ2, ξ3)
-                        # single column currently requires no geometry warping
-
-                        # Even if the warping is in only the horizontal, the way we
-                        # compute metrics causes problems for the single column approach
-                        # (possibly need to not use curl-invariant computation)
-                        if !single_column
-                            ξ1 = ξ1 + sin(2 * FT(π) * ξ1 * ξ2) / 10
-                            ξ2 = ξ2 + sin(2 * FT(π) * ξ1) / 5
-                            if dim == 3
-                                ξ3 = ξ3 + sin(8 * FT(π) * ξ1 * ξ2) / 10
-                            end
+                for N in (0, 4)
+                    for single_column in (false, true)
+                        # Setup the topology
+                        if dim == 2
+                            brickrange = (
+                                range(FT(0); length = Neh + 1, stop = 1),
+                                range(FT(1); length = Nev + 1, stop = 2),
+                            )
+                        elseif dim == 3
+                            brickrange = (
+                                range(FT(0); length = Neh + 1, stop = 1),
+                                range(FT(0); length = Neh + 1, stop = 1),
+                                range(FT(1); length = Nev + 1, stop = 2),
+                            )
                         end
-                        (ξ1, ξ2, ξ3)
+                        topl = StackedBrickTopology(mpicomm, brickrange)
+
+                        # Warp mesh
+                        function warpfun(ξ1, ξ2, ξ3)
+                            # single column currently requires no geometry warping
+
+                            # Even if the warping is in only the horizontal, the way we
+                            # compute metrics causes problems for the single column approach
+                            # (possibly need to not use curl-invariant computation)
+                            if !single_column
+                                ξ1 = ξ1 + sin(2 * FT(π) * ξ1 * ξ2) / 10
+                                ξ2 = ξ2 + sin(2 * FT(π) * ξ1) / 5
+                                if dim == 3
+                                    ξ3 = ξ3 + sin(8 * FT(π) * ξ1 * ξ2) / 10
+                                end
+                            end
+                            (ξ1, ξ2, ξ3)
+                        end
+
+                        # create the actual grid
+                        grid = DiscontinuousSpectralElementGrid(
+                            topl,
+                            FloatType = FT,
+                            DeviceArray = ArrayType,
+                            polynomialorder = N,
+                            meshwarp = warpfun,
+                        )
+                        d = dim == 2 ? FT[1, 10, 0] : FT[1, 1, 10]
+                        n = SVector{3, FT}(d ./ norm(d))
+
+                        α = FT(1)
+                        β = FT(1 // 100)
+                        μ = FT(-1 // 2)
+                        δ = FT(1 // 10)
+                        model =
+                            AdvectionDiffusion{dim}(Pseudo1D{n, α, β, μ, δ}())
+
+                        # the nonlinear model is needed so we can grab the state_auxiliary below
+                        dg = DGModel(
+                            model,
+                            grid,
+                            RusanovNumericalFlux(),
+                            CentralNumericalFluxSecondOrder(),
+                            CentralNumericalFluxGradient(),
+                        )
+
+                        vdg = DGModel(
+                            model,
+                            grid,
+                            RusanovNumericalFlux(),
+                            CentralNumericalFluxSecondOrder(),
+                            CentralNumericalFluxGradient();
+                            direction = VerticalDirection(),
+                            state_auxiliary = dg.state_auxiliary,
+                        )
+
+                        A_banded = banded_matrix(
+                            vdg,
+                            MPIStateArray(dg),
+                            MPIStateArray(dg);
+                            single_column = single_column,
+                        )
+
+                        Q = init_ode_state(dg, FT(0))
+                        dQ1 = MPIStateArray(dg)
+                        dQ2 = MPIStateArray(dg)
+
+                        vdg(dQ1, Q, nothing, 0; increment = false)
+                        Q.data .= dQ1.data
+
+                        vdg(dQ1, Q, nothing, 0; increment = false)
+                        banded_matrix_vector_product!(A_banded, dQ2, Q)
+                        @test all(isapprox.(
+                            Array(dQ1.realdata),
+                            Array(dQ2.realdata),
+                            atol = 100 * eps(FT),
+                        ))
+
+                        big_Q = create_state(
+                            BigAdvectionDiffusion(),
+                            grid,
+                            Prognostic(),
+                        )
+                        big_dQ = create_state(
+                            BigAdvectionDiffusion(),
+                            grid,
+                            Prognostic(),
+                        )
+
+                        big_Q .= NaN
+                        big_dQ .= NaN
+
+                        big_Q.data[:, 1:size(Q, 2), :] .= Q.data
+
+                        vdg(big_dQ, big_Q, nothing, 0; increment = false)
+
+                        @test all(isapprox.(
+                            Array(big_dQ.realdata[:, 1:size(Q, 2), :]),
+                            Array(dQ1.realdata),
+                            atol = 100 * eps(FT),
+                        ))
+
+                        @test all(big_dQ[:, (size(Q, 2) + 1):end, :] .== 0)
+
+                        big_dQ.data[:, (size(Q, 2) + 1):end, :] .= -7
+
+                        vdg(big_dQ, big_Q, nothing, 0; increment = true)
+
+                        @test all(big_dQ[:, (size(Q, 2) + 1):end, :] .== -7)
+
+                        @test all(isapprox.(
+                            Array(big_dQ.realdata[:, 1:size(Q, 2), :]),
+                            Array(dQ1.realdata),
+                            atol = 100 * eps(FT),
+                        ))
+
+                        big_A = banded_matrix(
+                            vdg,
+                            similar(big_Q),
+                            similar(big_dQ);
+                            single_column = single_column,
+                        )
+                        @test all(isapprox.(
+                            Array(big_A.data),
+                            Array(A_banded.data),
+                            atol = 100 * eps(FT),
+                        ))
+
+                        α = FT(1 // 10)
+                        function op!(LQ, Q)
+                            vdg(LQ, Q, nothing, 0; increment = false)
+                            @. LQ = Q + α * LQ
+                        end
+
+                        A_banded = banded_matrix(
+                            op!,
+                            vdg,
+                            MPIStateArray(dg),
+                            MPIStateArray(dg);
+                            single_column = single_column,
+                        )
+
+                        Q = init_ode_state(dg, FT(0))
+                        dQ1 = MPIStateArray(vdg)
+                        dQ2 = MPIStateArray(vdg)
+
+                        op!(dQ1, Q)
+                        Q.data .= dQ1.data
+
+                        op!(dQ1, Q)
+                        banded_matrix_vector_product!(A_banded, dQ2, Q)
+                        @test all(isapprox.(
+                            Array(dQ1.realdata),
+                            Array(dQ2.realdata),
+                            atol = 100 * eps(FT),
+                        ))
+
+                        big_Q .= NaN
+                        big_Q.data[:, 1:size(Q, 2), :] .= Q.data
+
+                        big_dQ .= NaN
+                        op!(big_dQ, big_Q)
+                        big_dQ.data[:, (size(Q, 2) + 1):end, :] .= -7
+
+                        big_A = banded_matrix(
+                            op!,
+                            vdg,
+                            similar(big_Q),
+                            similar(big_dQ);
+                            single_column = single_column,
+                        )
+
+                        @test all(isapprox.(
+                            Array(big_A.data),
+                            Array(A_banded.data),
+                            atol = 100 * eps(FT),
+                        ))
+
+                        band_lu!(big_A)
+                        band_forward!(big_dQ, big_A)
+                        band_back!(big_dQ, big_A)
+
+                        @test all(isapprox.(
+                            Array(big_dQ.realdata[:, 1:size(Q, 2), :]),
+                            Array(Q.realdata),
+                            atol = 100 * eps(FT),
+                        ))
+                        @test all(big_dQ[:, (size(Q, 2) + 1):end, :] .== -7)
                     end
-
-                    # create the actual grid
-                    grid = DiscontinuousSpectralElementGrid(
-                        topl,
-                        FloatType = FT,
-                        DeviceArray = ArrayType,
-                        polynomialorder = N,
-                        meshwarp = warpfun,
-                    )
-                    d = dim == 2 ? FT[1, 10, 0] : FT[1, 1, 10]
-                    n = SVector{3, FT}(d ./ norm(d))
-
-                    α = FT(1)
-                    β = FT(1 // 100)
-                    μ = FT(-1 // 2)
-                    δ = FT(1 // 10)
-                    model = AdvectionDiffusion{dim}(Pseudo1D{n, α, β, μ, δ}())
-
-                    # the nonlinear model is needed so we can grab the state_auxiliary below
-                    dg = DGModel(
-                        model,
-                        grid,
-                        RusanovNumericalFlux(),
-                        CentralNumericalFluxSecondOrder(),
-                        CentralNumericalFluxGradient(),
-                    )
-
-                    vdg = DGModel(
-                        model,
-                        grid,
-                        RusanovNumericalFlux(),
-                        CentralNumericalFluxSecondOrder(),
-                        CentralNumericalFluxGradient();
-                        direction = VerticalDirection(),
-                        state_auxiliary = dg.state_auxiliary,
-                    )
-
-                    A_banded = banded_matrix(
-                        vdg,
-                        MPIStateArray(dg),
-                        MPIStateArray(dg);
-                        single_column = single_column,
-                    )
-
-                    Q = init_ode_state(dg, FT(0))
-                    dQ1 = MPIStateArray(dg)
-                    dQ2 = MPIStateArray(dg)
-
-                    vdg(dQ1, Q, nothing, 0; increment = false)
-                    Q.data .= dQ1.data
-
-                    vdg(dQ1, Q, nothing, 0; increment = false)
-                    banded_matrix_vector_product!(A_banded, dQ2, Q)
-                    @test all(isapprox.(
-                        Array(dQ1.realdata),
-                        Array(dQ2.realdata),
-                        atol = 100 * eps(FT),
-                    ))
-
-                    big_Q = create_state(
-                        BigAdvectionDiffusion(),
-                        grid,
-                        Prognostic(),
-                    )
-                    big_dQ = create_state(
-                        BigAdvectionDiffusion(),
-                        grid,
-                        Prognostic(),
-                    )
-
-                    big_Q .= NaN
-                    big_dQ .= NaN
-
-                    big_Q.data[:, 1:size(Q, 2), :] .= Q.data
-
-                    vdg(big_dQ, big_Q, nothing, 0; increment = false)
-
-                    @test all(isapprox.(
-                        Array(big_dQ.realdata[:, 1:size(Q, 2), :]),
-                        Array(dQ1.realdata),
-                        atol = 100 * eps(FT),
-                    ))
-
-                    @test all(big_dQ[:, (size(Q, 2) + 1):end, :] .== 0)
-
-                    big_dQ.data[:, (size(Q, 2) + 1):end, :] .= -7
-
-                    vdg(big_dQ, big_Q, nothing, 0; increment = true)
-
-                    @test all(big_dQ[:, (size(Q, 2) + 1):end, :] .== -7)
-
-                    @test all(isapprox.(
-                        Array(big_dQ.realdata[:, 1:size(Q, 2), :]),
-                        Array(dQ1.realdata),
-                        atol = 100 * eps(FT),
-                    ))
-
-                    big_A = banded_matrix(
-                        vdg,
-                        similar(big_Q),
-                        similar(big_dQ);
-                        single_column = single_column,
-                    )
-                    @test all(isapprox.(
-                        Array(big_A.data),
-                        Array(A_banded.data),
-                        atol = 100 * eps(FT),
-                    ))
-
-                    band_lu!(big_A)
-                    band_forward!(big_dQ, big_A)
-                    band_back!(big_dQ, big_A)
-
-                    @test all(isapprox.(
-                        Array(big_dQ.realdata[:, 1:size(Q, 2), :]),
-                        Array(Q.realdata),
-                        atol = 100 * eps(FT),
-                    ))
-                    @test all(big_dQ[:, (size(Q, 2) + 1):end, :] .== -7)
-
-                    α = FT(1 // 10)
-                    function op!(LQ, Q)
-                        vdg(LQ, Q, nothing, 0; increment = false)
-                        @. LQ = Q + α * LQ
-                    end
-
-                    A_banded = banded_matrix(
-                        op!,
-                        vdg,
-                        MPIStateArray(dg),
-                        MPIStateArray(dg);
-                        single_column = single_column,
-                    )
-
-                    Q = init_ode_state(dg, FT(0))
-                    dQ1 = MPIStateArray(vdg)
-                    dQ2 = MPIStateArray(vdg)
-
-                    op!(dQ1, Q)
-                    Q.data .= dQ1.data
-
-                    op!(dQ1, Q)
-                    banded_matrix_vector_product!(A_banded, dQ2, Q)
-                    @test all(isapprox.(
-                        Array(dQ1.realdata),
-                        Array(dQ2.realdata),
-                        atol = 100 * eps(FT),
-                    ))
                 end
             end
         end

--- a/test/Numerics/SystemSolvers/columnwiselu.jl
+++ b/test/Numerics/SystemSolvers/columnwiselu.jl
@@ -10,7 +10,9 @@ using ClimateMachine.SystemSolvers:
     band_lu_kernel!,
     band_forward_kernel!,
     band_back_kernel!,
-    DGColumnBandedMatrix
+    DGColumnBandedMatrix,
+    lower_bandwidth,
+    upper_bandwidth
 
 import ClimateMachine.MPIStateArrays: array_device
 
@@ -40,7 +42,8 @@ function run_columnwiselu_test(FT, N)
     eband = 2
 
     m = n = Nqv * nstate * nvertelem
-    p = q = Nqv * nstate * eband - 1
+    p = lower_bandwidth(N[end], nstate, eband)
+    q = upper_bandwidth(N[end], nstate, eband)
 
     Random.seed!(1234)
     AB = rand(FT, Nq1, Nq2, p + q + 1, n, nhorzelem)

--- a/test/Numerics/SystemSolvers/columnwiselu.jl
+++ b/test/Numerics/SystemSolvers/columnwiselu.jl
@@ -10,7 +10,8 @@ using ClimateMachine.SystemSolvers:
     band_lu_kernel!,
     band_forward_kernel!,
     band_back_kernel!,
-    DGColumnBandedMatrix
+    DGColumnBandedMatrix,
+    lower_bandwidth
 
 import ClimateMachine.MPIStateArrays: array_device
 
@@ -28,99 +29,91 @@ function band_to_full(B, p, q)
     A
 end
 
-function run_columnwiselu_test(FT, N)
+let
 
-    Nq = N .+ 1
-    Nq1 = Nq[1]
-    Nq2 = Nq[2]
-    Nqv = Nq[3]
-    nstate = 3
-    nvertelem = 5
-    nhorzelem = 4
-    eband = 2
+    @testset "$(@__FILE__) Columnwise LU" begin
+        for N in (0, 1)
+            Nq = N + 1
+            nstate = 3
+            nvertelem = 5
+            nhorzelem = 4
+            eband = 2
 
-    m = n = Nqv * nstate * nvertelem
-    p = q = Nqv * nstate * eband - 1
+            FT = Float64
+            m = n = Nq * nstate * nvertelem
+            p = q = lower_bandwidth(N, nstate, eband)
 
-    Random.seed!(1234)
-    AB = rand(FT, Nq1, Nq2, p + q + 1, n, nhorzelem)
+            Random.seed!(1234)
+            AB = rand(FT, Nq, Nq, p + q + 1, n, nhorzelem)
 
-    AB[:, :, q + 1, :, :] .+= 10 # Make A's diagonally dominate
+            AB[:, :, q + 1, :, :] .+= 10 # Make A's diagonally dominate
 
-    Random.seed!(5678)
-    b = rand(FT, Nq1, Nq2, Nqv, nstate, nvertelem, nhorzelem)
-    x = similar(b)
+            Random.seed!(5678)
+            b = rand(FT, Nq, Nq, Nq, nstate, nvertelem, nhorzelem)
+            x = similar(b)
 
-    perm = (4, 3, 5, 1, 2, 6)
-    bp = reshape(PermutedDimsArray(b, perm), n, Nq1, Nq2, nhorzelem)
-    xp = reshape(PermutedDimsArray(x, perm), n, Nq1, Nq2, nhorzelem)
+            perm = (4, 3, 5, 1, 2, 6)
+            bp = reshape(PermutedDimsArray(b, perm), n, Nq, Nq, nhorzelem)
+            xp = reshape(PermutedDimsArray(x, perm), n, Nq, Nq, nhorzelem)
 
-    d_F = ArrayType(AB)
-    d_F = DGColumnBandedMatrix{
-        3,
-        N,
-        nstate,
-        nhorzelem,
-        nvertelem,
-        eband,
-        false,
-        typeof(d_F),
-    }(
-        d_F,
-    )
+            d_F = ArrayType(AB)
+            d_F = DGColumnBandedMatrix{
+                3,
+                N,
+                nstate,
+                nhorzelem,
+                nvertelem,
+                eband,
+                false,
+                typeof(d_F),
+            }(
+                d_F,
+            )
 
-    groupsize = (Nq1, Nq2)
-    ndrange = (Nq1, Nq2, nhorzelem)
+            groupsize = (Nq, Nq)
+            ndrange = (Nq, Nq, nhorzelem)
 
-    event = Event(array_device(d_F.data))
-    event = band_lu_kernel!(array_device(d_F.data), groupsize, ndrange)(
-        d_F,
-        dependencies = (event,),
-    )
-    wait(array_device(d_F.data), event)
+            event = Event(array_device(d_F.data))
+            event = band_lu_kernel!(array_device(d_F.data), groupsize, ndrange)(
+                d_F,
+                dependencies = (event,),
+            )
+            wait(array_device(d_F.data), event)
 
-    F = Array(d_F.data)
+            F = Array(d_F.data)
 
-    for h in 1:nhorzelem, j in 1:Nq2, i in 1:Nq1
-        B = AB[i, j, :, :, h]
-        G = band_to_full(B, p, q)
-        GLU = lu!(G, Val(false))
+            for h in 1:nhorzelem, j in 1:Nq, i in 1:Nq
+                B = AB[i, j, :, :, h]
+                G = band_to_full(B, p, q)
+                GLU = lu!(G, Val(false))
 
-        H = band_to_full(F[i, j, :, :, h], p, q)
+                H = band_to_full(F[i, j, :, :, h], p, q)
 
-        @assert H ≈ G
+                @test H ≈ G
 
-        xp[:, i, j, h] .= GLU \ bp[:, i, j, h]
-    end
+                xp[:, i, j, h] .= GLU \ bp[:, i, j, h]
+            end
 
-    b = reshape(b, Nq1 * Nq2 * Nqv, nstate, nvertelem * nhorzelem)
-    x = reshape(x, Nq1 * Nq2 * Nqv, nstate, nvertelem * nhorzelem)
+            b = reshape(b, Nq * Nq * Nq, nstate, nvertelem * nhorzelem)
+            x = reshape(x, Nq * Nq * Nq, nstate, nvertelem * nhorzelem)
 
-    d_x = ArrayType(b)
+            d_x = ArrayType(b)
 
-    event = Event(array_device(d_x))
-    event = band_forward_kernel!(array_device(d_x), groupsize, ndrange)(
-        d_x,
-        d_F,
-        dependencies = (event,),
-    )
+            event = Event(array_device(d_x))
+            event = band_forward_kernel!(array_device(d_x), groupsize, ndrange)(
+                d_x,
+                d_F,
+                dependencies = (event,),
+            )
 
-    event = band_back_kernel!(array_device(d_x), groupsize, ndrange)(
-        d_x,
-        d_F,
-        dependencies = (event,),
-    )
-    wait(array_device(d_x), event)
+            event = band_back_kernel!(array_device(d_x), groupsize, ndrange)(
+                d_x,
+                d_F,
+                dependencies = (event,),
+            )
+            wait(array_device(d_x), event)
 
-    result = x ≈ Array(d_x)
-    return result
-end
-
-@testset "Columnwise LU test" begin
-    for FT in (Float64, Float32)
-        for N in ((1, 1, 1), (1, 1, 2), (2, 2, 1))
-            result = run_columnwiselu_test(FT, N)
-            @test result
+            @test x ≈ Array(d_x)
         end
     end
 end


### PR DESCRIPTION
This PR update the LU solver to support both DG and DGFV system

- DG: lower_bandwidth is Nq_v*nstate * eband - 1, (does not include itself) 
    - eband = 1 for inviscid, since nodal point at the face communicates to the overlaping point to its neighbor
       and other points only communicates to points in the same element
    - eband = 2 for visous

- FV: lower_bandwidth is nstate * (stencil_width + 1 + 1) - 1,  
   - since the reconstruction states depend on stencil_width points on each side, 
      and the flux depends on stencil_width + 1 points on each side
   - eband = (stencil_width + 2) for inviscid
   - eband = max{ (stencil_width + 2), 3} for viscid, 
   - since the viscous flux is computed by applying first order FD twice

Tests are added:

- The fully implicit solver with Jacobian free Newton Krylov method and LU precondition is add in test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_model_1dimex_bjfnks.jl
- Unit tests are added in test/Numerics/SystemSolvers/columnwiselu.jl
- Unit tests are added in test/Numerics/SystemSolvers/bandedsystem.jl

Some findings:

- For linear problem (fvm_advection_diffusion_model_1dimex_bjfnks.jl), since we have preconditioner
  - with constant reconstruction, it converges in 1 iteration to machine accuracy
  - with Linear reconstruction, turning off the limiter, it converges in 1 iteration  to machine accuracy
  - with Linear reconstruction, turning on the limiter, it converges in 5 iteration  to machine accuracy. The limiter makes it a nonlinear problems
   
<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
