### PR TITLE
add solid body rotation test with topography (DCMIP 2-0-0)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1148,6 +1148,16 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "gpu_solid_body_rotation_mountain"
+    key: "gpu_solid_body_rotation_mountain"
+    command:
+      - "mpiexec julia --color=yes --project experiments/TestCase/solid_body_rotation_mountain.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
   - label: "gpu_dry_baroclinic_wave"
     key: "gpu_dry_baroclinic_wave"
     command:

--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -17,6 +17,9 @@ Topologies.BoxElementTopology
 Topologies.BrickTopology
 Topologies.StackedBrickTopology
 Topologies.CubedShellTopology
+Topologies.AnalyticalTopography
+Topologies.NoTopography
+Topologies.DCMIPMountain
 Topologies.StackedCubedSphereTopology
 Topologies.SingleExponentialStretching
 ```
@@ -37,6 +40,8 @@ Topologies.cubedshellmesh
 Topologies.cubedshellwarp
 Topologies.hasboundary
 Topologies.cubedshellunwarp
+Topologies.compute_lat_long
+Topologies.cubedshelltopowarp
 Topologies.grid1d
 ```
 

--- a/experiments/TestCase/solid_body_rotation_mountain.jl
+++ b/experiments/TestCase/solid_body_rotation_mountain.jl
@@ -1,0 +1,225 @@
+#!/usr/bin/env julia --project
+using ClimateMachine
+ClimateMachine.init(parse_clargs = true)
+
+using ClimateMachine.Atmos
+using ClimateMachine.Orientations
+using ClimateMachine.ConfigTypes
+using ClimateMachine.NumericalFluxes
+using ClimateMachine.Diagnostics
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.ODESolvers
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.SystemSolvers: ManyColumnLU
+using ClimateMachine.Mesh.Filters
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Interpolation
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Thermodynamics: air_density, total_energy
+
+using LinearAlgebra
+using StaticArrays
+
+using CLIMAParameters
+using CLIMAParameters.Planet: day, planet_radius
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+function set_topofun(f, r_inner, r_outer, topography)
+    function wrapper_topo(a, b, c)
+        return f(
+            a,
+            b,
+            c,
+            max(abs(a), abs(b), abs(c));
+            r_inner = r_inner,
+            r_outer = r_outer,
+            topography = topography,
+        )
+    end
+    return wrapper_topo
+end
+
+function init_solid_body_rotation!(problem, bl, state, aux, localgeo, t)
+    FT = eltype(state)
+
+    # initial velocity profile (we need to transform the vector into the Cartesian
+    # coordinate system)
+    u_0::FT = 0
+    u_sphere = SVector{3, FT}(u_0, 0, 0)
+    u_init = sphr_to_cart_vec(bl.orientation, u_sphere, aux)
+    e_kin::FT = 0.5 * sum(abs2.(u_init))
+
+    # Assign state variables
+    state.ρ = aux.ref_state.ρ
+    state.ρu = u_init
+    state.ρe = aux.ref_state.ρe + state.ρ * e_kin
+
+    nothing
+end
+
+function config_solid_body_rotation(FT, poly_order, resolution, ref_state)
+
+    # Set up the atmosphere model
+    exp_name = "SolidBodyRotation"
+    domain_height::FT = 30e3 # distance between surface and top of atmosphere (m)
+
+    _planet_radius = FT(planet_radius(param_set))
+
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        param_set;
+        init_state_prognostic = init_solid_body_rotation!,
+        ref_state = ref_state,
+        turbulence = ConstantKinematicViscosity(FT(0)),
+        #hyperdiffusion = DryBiharmonic(FT(8 * 3600)),
+        moisture = DryModel(),
+        source = (Gravity(), Coriolis()),
+    )
+
+    config = ClimateMachine.AtmosGCMConfiguration(
+        exp_name,
+        poly_order,
+        resolution,
+        domain_height,
+        param_set,
+        init_solid_body_rotation!;
+        model = model,
+        numerical_flux_first_order = RoeNumericalFlux(),
+        meshwarp = set_topofun(
+            cubedshelltopowarp,                   ## Topography warp function 
+            _planet_radius,                       ## Domain inner radius
+            _planet_radius + domain_height,       ## Domain outer radius
+            DCMIPMountain(),                      ## Problem specific dispatch
+        ),
+    )
+
+    return config
+end
+
+function main()
+    # Driver configuration parameters
+    FT = Float64                             # floating type precision
+    poly_order = 5                           # discontinuous Galerkin polynomial order
+    n_horz = 8                               # horizontal element number
+    n_vert = 4                               # vertical element number
+    timestart::FT = 0                        # start time (s)
+    timeend::FT = 7200
+
+    # Set up a reference state for linearization of equations
+    temp_profile_ref =
+        DecayingTemperatureProfile{FT}(param_set, FT(290), FT(220), FT(8e3))
+    ref_state = HydrostaticState(temp_profile_ref)
+
+    # Set up driver configuration
+    driver_config =
+        config_solid_body_rotation(FT, poly_order, (n_horz, n_vert), ref_state)
+
+    # Set up experiment
+    ode_solver_type = ClimateMachine.IMEXSolverType(
+        implicit_model = AtmosAcousticGravityLinearModel,
+        implicit_solver = ManyColumnLU,
+        solver_method = ARK2GiraldoKellyConstantinescu,
+        split_explicit_implicit = false,
+        discrete_splitting = true,
+    )
+
+    CFL = FT(0.2) # target acoustic CFL number
+
+    # time step is computed such that the horizontal acoustic Courant number is CFL
+    solver_config = ClimateMachine.SolverConfiguration(
+        timestart,
+        timeend,
+        driver_config,
+        Courant_number = CFL,
+        ode_solver_type = ode_solver_type,
+        CFL_direction = HorizontalDirection(),
+        diffdir = HorizontalDirection(),
+    )
+
+    # initialize using a different ref state (mega-hack)
+    temp_profile_init =
+        DecayingTemperatureProfile{FT}(param_set, FT(280), FT(230), FT(9e3))
+    init_ref_state = HydrostaticState(temp_profile_init)
+
+    init_driver_config = config_solid_body_rotation(
+        FT,
+        poly_order,
+        (n_horz, n_vert),
+        init_ref_state,
+    )
+    init_solver_config = ClimateMachine.SolverConfiguration(
+        timestart,
+        timeend,
+        init_driver_config,
+        Courant_number = CFL,
+        ode_solver_type = ode_solver_type,
+        CFL_direction = HorizontalDirection(),
+        diffdir = HorizontalDirection(),
+    )
+
+    # initialization
+    solver_config.Q .= init_solver_config.Q
+
+    # Set up diagnostics
+    dgn_config = config_diagnostics(FT, driver_config)
+
+    # Set up user-defined callbacks
+    filterorder = 20
+    filter = ExponentialFilter(solver_config.dg.grid, 0, filterorder)
+    cbfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            AtmosFilterPerturbations(driver_config.bl),
+            solver_config.dg.grid,
+            filter,
+            # filter perturbations from the initial state
+            state_auxiliary = init_solver_config.dg.state_auxiliary,
+        )
+        nothing
+    end
+
+    # Run the model
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (cbfilter,),
+        check_euclidean_distance = false,
+    )
+
+    relative_error =
+        norm(solver_config.Q .- init_solver_config.Q) /
+        norm(init_solver_config.Q)
+    @info "Relative error = $relative_error"
+end
+
+function config_diagnostics(FT, driver_config)
+    interval = "0.5shours" # chosen to allow diagnostics every 30 simulated minutes
+
+    _planet_radius = FT(planet_radius(param_set))
+
+    info = driver_config.config_info
+    boundaries = [
+        FT(-90.0) FT(-180.0) _planet_radius
+        FT(90.0) FT(180.0) FT(_planet_radius + info.domain_height)
+    ]
+    resolution = (FT(2), FT(2), FT(1000)) # in (deg, deg, m)
+    interpol = ClimateMachine.InterpolationConfiguration(
+        driver_config,
+        boundaries,
+        resolution,
+    )
+
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosGCMConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+
+    return ClimateMachine.DiagnosticsConfiguration([dgngrp])
+end
+
+main()

--- a/src/Numerics/Mesh/Topologies.jl
+++ b/src/Numerics/Mesh/Topologies.jl
@@ -8,8 +8,14 @@ export AbstractTopology,
     StackedBrickTopology,
     CubedShellTopology,
     StackedCubedSphereTopology,
+    AnalyticalTopography,
+    NoTopography,
+    DCMIPMountain,
     isstacked,
     cubedshellwarp,
+    cubedshelltopowarp,
+    compute_lat_long,
+    compute_analytical_topography,
     cubedshellunwarp
 
 export grid1d, SingleExponentialStretching, InteriorStretching
@@ -996,6 +1002,7 @@ function cubedshellwarp(a, b, c, R = max(abs(a), abs(b), abs(c)))
     return x1, x2, x3
 end
 
+
 """
     cubedshellunwarp(x1, x2, x3)
 
@@ -1351,6 +1358,170 @@ function basic_topology_info(topology::AbstractTopology)
         nelem = length(topology.elems),
         nrealelem = length(topology.realelems),
     )
+end
+
+
+### Helper Functions for Topography Calculations
+"""
+    compute_lat_long(X,Y,δ,faceid)
+Helper function to allow computation of latitute and longitude coordinates
+given the cubed sphere coordinates X, Y, δ, faceid 
+"""
+function compute_lat_long(X, Y, δ, faceid)
+    if faceid == 1
+        λ = atan(X)                     # longitude 
+        ϕ = atan(cos(λ) * Y)            # latitude
+    elseif faceid == 2
+        λ = atan(X) + π / 2
+        ϕ = atan(Y * cos(atan(X)))
+    elseif faceid == 3
+        λ = atan(X) + π
+        ϕ = atan(Y * cos(atan(X)))
+    elseif faceid == 4
+        λ = atan(X) + (3 / 2) * π
+        ϕ = atan(Y * cos(atan(X)))
+    elseif faceid == 5
+        λ = atan(X, -Y) + π
+        ϕ = atan(1 / sqrt(δ - 1))
+    elseif faceid == 6
+        λ = atan(X, Y)
+        ϕ = -atan(1 / sqrt(δ - 1))
+    end
+    return λ, ϕ
+end
+
+
+"""
+    AnalyticalTopography
+Abstract type to allow dispatch over different analytical topography prescriptions 
+in experiments. 
+"""
+abstract type AnalyticalTopography end
+
+function compute_analytical_topography(
+    ::AnalyticalTopography,
+    λ,
+    ϕ,
+    sR,
+    r_inner,
+    r_outer,
+)
+    return sR
+end
+
+"""
+    NoTopography <: AnalyticalTopography
+Allows definition of fallback methods in case cubedshelltopowarp is used with 
+no prescribed topography function. 
+"""
+struct NoTopography <: AnalyticalTopography end
+
+### DCMIP Mountain 
+"""
+    DCMIPMountain <: AnalyticalTopography
+Topography description based on standard DCMIP experiments. 
+"""
+struct DCMIPMountain <: AnalyticalTopography end
+function compute_analytical_topography(
+    ::DCMIPMountain,
+    λ,
+    ϕ,
+    sR,
+    r_inner,
+    r_outer,
+)
+    #User specified warp parameters
+    R_m = π * 3 / 4
+    h0 = 2000
+    ζ_m = π / 16
+    φ_m = 0
+    λ_m = π * 3 / 2
+    r_m = acos(sin(φ_m) * sin(ϕ) + cos(φ_m) * cos(ϕ) * cos(λ - λ_m))
+    # Define mesh decay profile 
+    Δ = (r_outer - abs(sR)) / (r_outer - r_inner)
+    if r_m < R_m
+        zs =
+            0.5 *
+            h0 *
+            (1 + cos(π * r_m / R_m)) *
+            cos(π * r_m / ζ_m) *
+            cos(π * r_m / ζ_m)
+    else
+        zs = 0.0
+    end
+    mR = sign(sR) * (abs(sR) + zs * Δ)
+    return mR
+end
+
+"""
+    cubedshelltopowarp(a, b, c, R = max(abs(a), abs(b), abs(c)); 
+                       r_inner = _planet_radius,
+                       r_outer = _planet_radius + domain_height,
+                       topography = NoTopography())
+
+Given points `(a, b, c)` on the surface of a cube, warp the points out to a
+spherical shell of radius `R` based on the equiangular gnomonic grid proposed by
+[Ronchi1996](@cite). Assumes a user specified modified radius using the 
+compute_analytical_topography function. Defaults to smooth cubed sphere unless otherwise specified 
+via the AnalyticalTopography type.
+"""
+function cubedshelltopowarp(
+    a,
+    b,
+    c,
+    R = max(abs(a), abs(b), abs(c));
+    r_inner = _planet_radius,
+    r_outer = _planet_radius + domain_height,
+    topography::AnalyticalTopography = NoTopography(),
+)
+
+    function f(sR, ξ, η, faceid)
+        X, Y = tan(π * ξ / 4), tan(π * η / 4)
+        δ = 1 + X^2 + Y^2
+        λ, ϕ = compute_lat_long(X, Y, δ, faceid)
+        mR = compute_analytical_topography(
+            topography,
+            λ,
+            ϕ,
+            sR,
+            r_inner,
+            r_outer,
+        )
+        x1 = mR / sqrt(δ)
+        x2, x3 = X * x1, Y * x1
+        x1, x2, x3
+    end
+    fdim = argmax(abs.((a, b, c)))
+
+    if fdim == 1 && a < 0
+        faceid = 1
+        # (-R, *, *) : Face I from Ronchi, Iacono, Paolucci (1996)
+        x1, x2, x3 = f(-R, b / a, c / a, faceid)
+    elseif fdim == 2 && b < 0
+        faceid = 2
+        # ( *,-R, *) : Face II from Ronchi, Iacono, Paolucci (1996)
+        x2, x1, x3 = f(-R, a / b, c / b, faceid)
+    elseif fdim == 1 && a > 0
+        faceid = 3
+        # ( R, *, *) : Face III from Ronchi, Iacono, Paolucci (1996)
+        x1, x2, x3 = f(R, b / a, c / a, faceid)
+    elseif fdim == 2 && b > 0
+        faceid = 4
+        # ( *, R, *) : Face IV from Ronchi, Iacono, Paolucci (1996)
+        x2, x1, x3 = f(R, a / b, c / b, faceid)
+    elseif fdim == 3 && c > 0
+        faceid = 5
+        # ( *, *, R) : Face V from Ronchi, Iacono, Paolucci (1996)
+        x3, x2, x1 = f(R, b / c, a / c, faceid)
+    elseif fdim == 3 && c < 0
+        faceid = 6
+        # ( *, *,-R) : Face VI from Ronchi, Iacono, Paolucci (1996)
+        x3, x2, x1 = f(-R, b / c, a / c, faceid)
+    else
+        error("invalid case for cubedshellwarp: $a, $b, $c")
+    end
+
+    return x1, x2, x3
 end
 
 end


### PR DESCRIPTION
### Description

co-authored with @akshaysridhar 

This PR enables enables users to define topography on the cubed sphere. It adds the following functionalities in `Topologies.jl`:
- `compute_lat_long` function to compute lat/long given cubed sphere coordinates and face id;
- `AnalyticalTopography` abstract type to hold topography function;
- `cubedshelltopowarp` function to compute the warp grid given topography function.

A `solid_body_rotation_mountain.jl` test case into the `TestCase` suite, to test the hydrostatic balance with topography. It follows the DCMIP2012 2-0-0 mountain set-up.

CI test on this case only makes sure the simulation can run but it does not check on the relative error. It will be later on added to the weekly test for visualization.

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
