### PR TITLE
Move tracers first order flux to new tendency specification

### DIFF
--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -75,6 +75,10 @@ eq_tends(
     tt::Flux{FirstOrder},
 ) where {PV <: Precipitation} = (eq_tends(pv, m.precipitation, tt)...,)
 
+# Tracers
+eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {N, PV <: Tracers{N}} =
+    (Advect{PV}(),)
+
 #####
 ##### Second order fluxes
 #####
@@ -103,3 +107,10 @@ eq_tends(
     ::AtmosModel,
     ::Flux{SecondOrder},
 ) where {PV <: Precipitation} = ()
+
+# Tracers
+eq_tends(
+    pv::PV,
+    ::AtmosModel,
+    ::Flux{SecondOrder},
+) where {N, PV <: Tracers{N}} = ()

--- a/src/Atmos/Model/declare_prognostic_vars.jl
+++ b/src/Atmos/Model/declare_prognostic_vars.jl
@@ -18,4 +18,4 @@ abstract type Precipitation <: PrognosticVariable end
 struct Rain <: Precipitation end
 struct Snow <: Precipitation end
 
-struct Tracers <: PrognosticVariable end
+struct Tracers{N} <: PrognosticVariable end

--- a/src/Atmos/Model/get_prognostic_vars.jl
+++ b/src/Atmos/Model/get_prognostic_vars.jl
@@ -9,6 +9,8 @@ prognostic_vars(::NonEquilMoist) =
 
 prognostic_vars(::NoPrecipitation) = ()
 prognostic_vars(::RainModel) = (Rain(),)
+prognostic_vars(::NoTracers) = ()
+prognostic_vars(::NTracers{N}) where {N} = (Tracers{N}(),)
 
 prognostic_vars(m::AtmosModel) = (
     Mass(),
@@ -16,4 +18,5 @@ prognostic_vars(m::AtmosModel) = (
     Energy(),
     prognostic_vars(m.moisture)...,
     prognostic_vars(m.precipitation)...,
+    prognostic_vars(m.tracers)...,
 )

--- a/src/BalanceLaws/show_tendencies.jl
+++ b/src/BalanceLaws/show_tendencies.jl
@@ -37,7 +37,7 @@ function show_tendencies(bl; include_params = false)
             "Equation" "Flux{FirstOrder}" "Flux{SecondOrder}" "Source"
             "(Y_i)" "(F_1)" "(F_2)" "(S)"
         ]
-        eqs = collect(string.(nameof.(typeof.(prog_vars))))
+        eqs = collect(string.(typeof.(prog_vars)))
         fmt_tends(tt) = map(prog_vars) do pv
             format_tends(eq_tends(pv, bl, tt), ip)
         end |> collect


### PR DESCRIPTION
### Description

This PR moves tracers first order flux to the new tendency specification.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
