### PR TITLE
Adaptive timestepping callback

### DIFF
--- a/docs/src/APIs/Driver/index.md
+++ b/docs/src/APIs/Driver/index.md
@@ -4,7 +4,7 @@
 CurrentModule = ClimateMachine
 ```
 
-## Solver types
+## Solver types and functions
 
 ```@docs
 HEVISplitting
@@ -17,6 +17,7 @@ ImplicitSolverType
 SplitExplicitSolverType
 ConfigTypes
 IMEXSolverType
+getdtmodel
 ```
 
 ## Configurations

--- a/docs/src/GettingStarted/RunningClimateMachine.md
+++ b/docs/src/GettingStarted/RunningClimateMachine.md
@@ -85,6 +85,7 @@ usage: experiments/AtmosGCM/heldsuarez.jl [--disable-gpu]
                         [--vtk-number-sample-points <number>]
                         [--monitor-timestep-duration <interval>]
                         [--monitor-courant-numbers <interval>]
+                        [--adapt-timestep <interval>]
                         [--checkpoint <interval>]
                         [--checkpoint-keep-all] [--checkpoint-at-end]
                         [--checkpoint-dir <path>]
@@ -124,6 +125,10 @@ ClimateMachine:
   --monitor-courant-numbers <interval>
                         interval at which to output acoustic,
                         advective, and diffusive Courant numbers
+                        (default: "never")
+  --adapt-timestep <interval>
+                        interval at which to adjust timestep to correspond
+                        to desired courant number
                         (default: "never")
   --checkpoint <interval>
                         interval at which to create a checkpoint

--- a/src/Driver/SolverTypes/SolverTypes.jl
+++ b/src/Driver/SolverTypes/SolverTypes.jl
@@ -1,6 +1,7 @@
 
 export AbstractSolverType
 export DiscreteSplittingType, HEVISplitting
+export getdtmodel
 
 """
     AbstractSolverType

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -21,6 +21,9 @@ mutable struct SolverConfiguration{FT}
     numberofsteps::Int
     init_args::Any
     solver::Any
+    ode_solver_type::Any
+    diffdir::Any
+    CFL::FT
 end
 
 """
@@ -244,6 +247,9 @@ function SolverConfiguration(
         numberofsteps,
         init_args,
         solver,
+        ode_solver_type,
+        diffdir,
+        Courant_number,
     )
 end
 


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
A simple callback to adapt the timestep to stay consistent with the user-specified initial Courant number. 
Useful for accelerating flows.
<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
