### PR TITLE
Move first order flux turbconv tendencies to new spec

### DIFF
--- a/src/Atmos/Model/get_prognostic_vars.jl
+++ b/src/Atmos/Model/get_prognostic_vars.jl
@@ -19,4 +19,5 @@ prognostic_vars(m::AtmosModel) = (
     prognostic_vars(m.moisture)...,
     prognostic_vars(m.precipitation)...,
     prognostic_vars(m.tracers)...,
+    prognostic_vars(m.turbconv)...,
 )

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -16,6 +16,7 @@ export init_state_prognostic!,
 
 import ..BalanceLaws:
     vars_state,
+    prognostic_vars,
     init_state_prognostic!,
     init_state_auxiliary!,
     update_auxiliary_state!,
@@ -39,6 +40,8 @@ A "no model" type, which results in kernels that
 pass through and do nothing.
 """
 struct NoTurbConv <: TurbulenceConvectionModel end
+
+prognostic_vars(::NoTurbConv) = ()
 
 vars_state(m::TurbulenceConvectionModel, ::AbstractStateType, FT) = @vars()
 

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -2,9 +2,9 @@
 
 using CLIMAParameters.Planet: e_int_v0, grav, day, R_d, R_v, molmass_ratio
 using Printf
-using ClimateMachine.Atmos: nodal_update_auxiliary_state!
+using ClimateMachine.Atmos: nodal_update_auxiliary_state!, Advect
 
-using ClimateMachine.BalanceLaws: number_states
+using ClimateMachine.BalanceLaws
 
 using ClimateMachine.MPIStateArrays: MPIStateArray
 using ClimateMachine.DGMethods: LocalGeometry, DGModel
@@ -13,6 +13,10 @@ import ClimateMachine.Atmos: atmos_source!
 
 import ClimateMachine.BalanceLaws:
     vars_state,
+    prognostic_vars,
+    flux,
+    source,
+    eq_tends,
     update_auxiliary_state!,
     init_state_prognostic!,
     flux_first_order!,
@@ -150,6 +154,61 @@ function vars_state(m::EDMF, st::GradientFlux, FT)
         updraft::vars_state(m.updraft, st, FT)
     )
 end
+
+abstract type EDMFPrognosticVariable <: PrognosticVariable end
+
+abstract type EnvironmentPrognosticVariable <: EDMFPrognosticVariable end
+struct en_ρatke <: EnvironmentPrognosticVariable end
+struct en_ρaθ_liq_cv <: EnvironmentPrognosticVariable end
+struct en_ρaq_tot_cv <: EnvironmentPrognosticVariable end
+struct en_ρaθ_liq_q_tot_cv <: EnvironmentPrognosticVariable end
+
+abstract type UpdraftPrognosticVariable{i} <: EDMFPrognosticVariable end
+struct up_ρa{i} <: UpdraftPrognosticVariable{i} end
+struct up_ρaw{i} <: UpdraftPrognosticVariable{i} end
+struct up_ρaθ_liq{i} <: UpdraftPrognosticVariable{i} end
+struct up_ρaq_tot{i} <: UpdraftPrognosticVariable{i} end
+
+prognostic_vars(m::EDMF) =
+    (prognostic_vars(m.environment)..., prognostic_vars(m.updraft)...)
+prognostic_vars(m::Environment) =
+    (en_ρatke(), en_ρaθ_liq_cv(), en_ρaq_tot_cv(), en_ρaθ_liq_q_tot_cv())
+
+function prognostic_vars(m::NTuple{N, Updraft}) where {N}
+    t_ρa = ntuple(i -> up_ρa{i}(), N)
+    t_ρaw = ntuple(i -> up_ρaw{i}(), N)
+    t_ρaθ_liq = ntuple(i -> up_ρaθ_liq{i}(), N)
+    t_ρaq_tot = ntuple(i -> up_ρaq_tot{i}(), N)
+    t = (t_ρa..., t_ρaw..., t_ρaθ_liq..., t_ρaq_tot...)
+    return t
+end
+
+# Dycore tendencies
+eq_tends(
+    pv::PV,
+    m::EDMF,
+    ::Flux{SecondOrder},
+) where {PV <: Union{Momentum, Energy, TotalMoisture}} = ()
+# (SGSFlux{PV}(),) # to add SGSFlux back to grid-mean
+
+# Turbconv tendencies
+eq_tends(
+    pv::PV,
+    m::AtmosModel,
+    tt::Flux{O},
+) where {O, PV <: EDMFPrognosticVariable} = eq_tends(pv, m.turbconv, tt)
+
+eq_tends(pv::PV, m::EDMF, ::Flux{O}) where {O, PV <: EDMFPrognosticVariable} =
+    ()
+
+eq_tends(
+    pv::PV,
+    m::EDMF,
+    ::Flux{FirstOrder},
+) where {PV <: EDMFPrognosticVariable} = (Advect{PV}(),)
+
+struct SGSFlux{PV <: Union{Momentum, Energy, TotalMoisture}} <:
+       TendencyDef{Flux{SecondOrder}, PV} end
 
 """
     init_aux_turbconv!(
@@ -501,6 +560,86 @@ function atmos_source!(
     # covariance microphysics sources should be applied here
 end;
 
+function compute_ρa_up(m, state, aux)
+    # Aliases:
+    turbconv = m.turbconv
+    gm = state
+    up = state.turbconv.updraft
+    N_up = n_updrafts(turbconv)
+    a_min = turbconv.subdomains.a_min
+    a_max = turbconv.subdomains.a_max
+    # in future GCM implementations we need to think about grid mean advection
+    ρa_up = vuntuple(N_up) do i
+        gm.ρ * enforce_unit_bounds(up[i].ρa / gm.ρ, a_min, a_max)
+    end
+    return ρa_up
+end
+
+function flux(::Advect{up_ρa{i}}, m, state, aux, t, ts, direction) where {i}
+    up = state.turbconv.updraft
+    ẑ = vertical_unit_vector(m, aux)
+    return up[i].ρaw * ẑ
+end
+function flux(::Advect{up_ρaw{i}}, m, state, aux, t, ts, direction) where {i}
+    up = state.turbconv.updraft
+    ẑ = vertical_unit_vector(m, aux)
+    ρa_up = compute_ρa_up(m, state, aux)
+    return up[i].ρaw * up[i].ρaw / ρa_up[i] * ẑ
+end
+function flux(
+    ::Advect{up_ρaθ_liq{i}},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+) where {i}
+    up = state.turbconv.updraft
+    ẑ = vertical_unit_vector(m, aux)
+    ρa_up = compute_ρa_up(m, state, aux)
+    return up[i].ρaw / ρa_up[i] * up[i].ρaθ_liq * ẑ
+end
+function flux(
+    ::Advect{up_ρaq_tot{i}},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    direction,
+) where {i}
+    up = state.turbconv.updraft
+    ẑ = vertical_unit_vector(m, aux)
+    ρa_up = compute_ρa_up(m, state, aux)
+    return up[i].ρaw / ρa_up[i] * up[i].ρaq_tot * ẑ
+end
+
+function flux(::Advect{en_ρatke}, m, state, aux, t, ts, direction)
+    en = state.turbconv.environment
+    env = environment_vars(state, aux, n_updrafts(m.turbconv))
+    ẑ = vertical_unit_vector(m, aux)
+    return en.ρatke * env.w * ẑ
+end
+function flux(::Advect{en_ρaθ_liq_cv}, m, state, aux, t, ts, direction)
+    en = state.turbconv.environment
+    env = environment_vars(state, aux, n_updrafts(m.turbconv))
+    ẑ = vertical_unit_vector(m, aux)
+    return en.ρaθ_liq_cv * env.w * ẑ
+end
+function flux(::Advect{en_ρaq_tot_cv}, m, state, aux, t, ts, direction)
+    en = state.turbconv.environment
+    env = environment_vars(state, aux, n_updrafts(m.turbconv))
+    ẑ = vertical_unit_vector(m, aux)
+    return en.ρaq_tot_cv * env.w * ẑ
+end
+function flux(::Advect{en_ρaθ_liq_q_tot_cv}, m, state, aux, t, ts, direction)
+    en = state.turbconv.environment
+    env = environment_vars(state, aux, n_updrafts(m.turbconv))
+    ẑ = vertical_unit_vector(m, aux)
+    return en.ρaθ_liq_q_tot_cv * env.w * ẑ
+end
+
 # # in the EDMF first order (advective) fluxes exist only in the grid mean (if <w> is nonzero) and the uprdafts
 function flux_first_order!(
     turbconv::EDMF{FT},
@@ -513,36 +652,24 @@ function flux_first_order!(
     direction,
 ) where {FT}
     # Aliases:
-    gm = state
-    up = state.turbconv.updraft
-    en = state.turbconv.environment
     up_flx = flux.turbconv.updraft
     en_flx = flux.turbconv.environment
     N_up = n_updrafts(turbconv)
-
-    ρ_inv = 1 / gm.ρ
-    ẑ = vertical_unit_vector(m, aux)
-    a_min = turbconv.subdomains.a_min
-    a_max = turbconv.subdomains.a_max
     # in future GCM implementations we need to think about grid mean advection
-
-    ρa_up = vuntuple(N_up) do i
-        gm.ρ * enforce_unit_bounds(up[i].ρa * ρ_inv, a_min, a_max)
-    end
+    tend = Flux{FirstOrder}()
+    args = (m, state, aux, t, ts, direction)
 
     @unroll_map(N_up) do i
-        ρa_i = ρa_up[i]
-        up_flx[i].ρa = up[i].ρaw * ẑ
-        w_up_i = up[i].ρaw / ρa_i
-        up_flx[i].ρaw = up[i].ρaw * w_up_i * ẑ
-        up_flx[i].ρaθ_liq = w_up_i * up[i].ρaθ_liq * ẑ
-        up_flx[i].ρaq_tot = w_up_i * up[i].ρaq_tot * ẑ
+        up_flx[i].ρa = Σfluxes(eq_tends(up_ρa{i}(), m, tend), args...)
+        up_flx[i].ρaw = Σfluxes(eq_tends(up_ρaw{i}(), m, tend), args...)
+        up_flx[i].ρaθ_liq = Σfluxes(eq_tends(up_ρaθ_liq{i}(), m, tend), args...)
+        up_flx[i].ρaq_tot = Σfluxes(eq_tends(up_ρaq_tot{i}(), m, tend), args...)
     end
-    env = environment_vars(state, aux, N_up)
-    en_flx.ρatke = en.ρatke * env.w * ẑ
-    en_flx.ρaθ_liq_cv = en.ρaθ_liq_cv * env.w * ẑ
-    en_flx.ρaq_tot_cv = en.ρaq_tot_cv * env.w * ẑ
-    en_flx.ρaθ_liq_q_tot_cv = en.ρaθ_liq_q_tot_cv * env.w * ẑ
+    en_flx.ρatke = Σfluxes(eq_tends(en_ρatke(), m, tend), args...)
+    en_flx.ρaθ_liq_cv = Σfluxes(eq_tends(en_ρaθ_liq_cv(), m, tend), args...)
+    en_flx.ρaq_tot_cv = Σfluxes(eq_tends(en_ρaq_tot_cv(), m, tend), args...)
+    en_flx.ρaθ_liq_q_tot_cv =
+        Σfluxes(eq_tends(en_ρaθ_liq_q_tot_cv(), m, tend), args...)
 end;
 
 # in the EDMF second order (diffusive) fluxes


### PR DESCRIPTION
### Description

This PR moves the `atmos.turbconv` first order fluxes to the new tendency specification.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
