### PR TITLE
Add prim<->prog conversion

### DIFF
--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -38,6 +38,7 @@ source
 ```@docs
 AbstractStateType
 Prognostic
+Primitive
 Auxiliary
 Gradient
 GradientFlux

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -318,6 +318,15 @@ function vars_state(m::AtmosModel, st::Prognostic, FT)
     end
 end
 
+function vars_state(m::AtmosModel, st::Primitive, FT)
+    @vars begin
+        ρ::FT
+        u::SVector{3, FT}
+        p::FT
+        moisture::vars_state(m.moisture, st, FT)
+    end
+end
+
 """
     vars_state(m::AtmosModel, ::Gradient, FT)
 
@@ -463,6 +472,7 @@ include("lsforcing.jl")
 include("linear.jl")
 include("courant.jl")
 include("filters.jl")
+include("prog_prim_conversion.jl")   # prognostic<->primitive conversion
 
 include("atmos_tendencies.jl")        # specify atmos tendencies
 include("get_prognostic_vars.jl")     # get tuple of prognostic variables

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -104,6 +104,7 @@ EquilMoist{FT}(;
 
 
 vars_state(::EquilMoist, ::Prognostic, FT) = @vars(ρq_tot::FT)
+vars_state(::EquilMoist, ::Primitive, FT) = @vars(q_tot::FT)
 vars_state(::EquilMoist, ::Gradient, FT) = @vars(q_tot::FT)
 vars_state(::EquilMoist, ::GradientFlux, FT) = @vars(∇q_tot::SVector{3, FT})
 vars_state(::EquilMoist, ::Auxiliary, FT) =
@@ -207,6 +208,8 @@ struct NonEquilMoist <: MoistureModel end
 
 vars_state(::NonEquilMoist, ::Prognostic, FT) =
     @vars(ρq_tot::FT, ρq_liq::FT, ρq_ice::FT)
+vars_state(::NonEquilMoist, ::Primitive, FT) =
+    @vars(q_tot::FT, q_liq::FT, q_ice::FT)
 vars_state(::NonEquilMoist, ::Gradient, FT) =
     @vars(q_tot::FT, q_liq::FT, q_ice::FT)
 vars_state(::NonEquilMoist, ::GradientFlux, FT) = @vars(

--- a/src/Atmos/Model/prog_prim_conversion.jl
+++ b/src/Atmos/Model/prog_prim_conversion.jl
@@ -1,0 +1,174 @@
+####
+#### prognostic_to_primitive! and primitive_to_prognostic!
+####
+
+####
+#### Wrappers (entry point)
+####
+
+"""
+    prognostic_to_primitive!(atmos::AtmosModel, prim::Vars, prog::Vars, aux::Vars)
+
+Convert prognostic variables `prog` to primitive
+variables `prim` for the atmos model `atmos`.
+
+!!! note
+    The only field in `aux` required for this
+    method is the geo-potential.
+"""
+prognostic_to_primitive!(atmos::AtmosModel, prim::Vars, prog::Vars, aux) =
+    prognostic_to_primitive!(
+        atmos,
+        atmos.moisture,
+        prim,
+        prog,
+        Thermodynamics.internal_energy(
+            prog.ρ,
+            prog.ρe,
+            prog.ρu,
+            gravitational_potential(atmos.orientation, aux),
+        ),
+    )
+
+"""
+    primitive_to_prognostic!(atmos::AtmosModel, prog::Vars, prim::Vars, aux::Vars)
+
+Convert primitive variables `prim` to prognostic
+variables `prog` for the atmos model `atmos`.
+
+!!! note
+    The only field in `aux` required for this
+    method is the geo-potential.
+"""
+primitive_to_prognostic!(atmos::AtmosModel, prog::Vars, prim::Vars, aux) =
+    primitive_to_prognostic!(
+        atmos,
+        atmos.moisture,
+        prog,
+        prim,
+        gravitational_potential(atmos.orientation, aux),
+    )
+
+####
+#### prognostic to primitive
+####
+
+function prognostic_to_primitive!(
+    atmos,
+    moist::DryModel,
+    prim::Vars,
+    prog::Vars,
+    e_int::AbstractFloat,
+)
+    ts = PhaseDry(atmos.param_set, e_int, prog.ρ)
+    prim.ρ = prog.ρ
+    prim.u = prog.ρu ./ prog.ρ
+    prim.p = air_pressure(ts)
+end
+
+function prognostic_to_primitive!(
+    atmos,
+    moist::EquilMoist,
+    prim::Vars,
+    prog::Vars,
+    e_int::AbstractFloat,
+)
+    FT = eltype(prim)
+    ts = PhaseEquil(
+        atmos.param_set,
+        e_int,
+        prog.ρ,
+        prog.moisture.ρq_tot / prog.ρ,
+        # 20,       # can improve test error with better convergence
+        # FT(1e-3), # can improve test error with better convergence
+    )
+    prim.ρ = prog.ρ
+    prim.u = prog.ρu ./ prog.ρ
+    prim.p = air_pressure(ts)
+    prim.moisture.q_tot = PhasePartition(ts).tot
+end
+
+function prognostic_to_primitive!(
+    atmos,
+    moist::NonEquilMoist,
+    prim::Vars,
+    prog::Vars,
+    e_int::AbstractFloat,
+)
+    q_pt = PhasePartition(
+        prog.moisture.ρq_tot / prog.ρ,
+        prog.moisture.ρq_liq / prog.ρ,
+        prog.moisture.ρq_ice / prog.ρ,
+    )
+    ts = PhaseNonEquil(atmos.param_set, e_int, prog.ρ, q_pt)
+    prim.ρ = prog.ρ
+    prim.u = prog.ρu ./ prog.ρ
+    prim.p = air_pressure(ts)
+    prim.moisture.q_tot = PhasePartition(ts).tot
+    prim.moisture.q_liq = PhasePartition(ts).liq
+    prim.moisture.q_ice = PhasePartition(ts).ice
+end
+
+####
+#### primitive to prognostic
+####
+
+function primitive_to_prognostic!(
+    atmos,
+    moist::DryModel,
+    prog::Vars,
+    prim::Vars,
+    e_pot::AbstractFloat,
+)
+    ts = PhaseDry_ρp(atmos.param_set, prim.ρ, prim.p)
+    e_kin = prim.u' * prim.u / 2
+
+    prog.ρ = prim.ρ
+    prog.ρu = prim.ρ .* prim.u
+    prog.ρe = prim.ρ * total_energy(e_kin, e_pot, ts)
+end
+
+function primitive_to_prognostic!(
+    atmos,
+    moist::EquilMoist,
+    prog::Vars,
+    prim::Vars,
+    e_pot::AbstractFloat,
+)
+    ts = PhaseEquil_ρpq(
+        atmos.param_set,
+        prim.ρ,
+        prim.p,
+        prim.moisture.q_tot,
+        true,
+    )
+    e_kin = prim.u' * prim.u / 2
+
+    prog.ρ = prim.ρ
+    prog.ρu = prim.ρ .* prim.u
+    prog.ρe = prim.ρ * total_energy(e_kin, e_pot, ts)
+    prog.moisture.ρq_tot = prim.ρ * PhasePartition(ts).tot
+end
+
+function primitive_to_prognostic!(
+    atmos,
+    moist::NonEquilMoist,
+    prog::Vars,
+    prim::Vars,
+    e_pot::AbstractFloat,
+)
+    q_pt = PhasePartition(
+        prim.moisture.q_tot,
+        prim.moisture.q_liq,
+        prim.moisture.q_ice,
+    )
+    ts = PhaseNonEquil_ρpq(atmos.param_set, prim.ρ, prim.p, q_pt)
+    e_kin = prim.u' * prim.u / 2
+
+    prog.ρ = prim.ρ
+    prog.ρu = prim.ρ .* prim.u
+    prog.ρe = prim.ρ * total_energy(e_kin, e_pot, ts)
+    prog.moisture.ρq_tot = prim.ρ * PhasePartition(ts).tot
+    prog.moisture.ρq_liq = prim.ρ * PhasePartition(ts).liq
+    prog.moisture.ρq_ice = prim.ρ * PhasePartition(ts).ice
+end

--- a/src/BalanceLaws/BalanceLaws.jl
+++ b/src/BalanceLaws/BalanceLaws.jl
@@ -32,5 +32,6 @@ include("boundaryconditions.jl")
 include("tendency_types.jl")
 include("show_tendencies.jl")
 include("sum_tendencies.jl")
+include("prog_prim_conversion.jl")
 
 end

--- a/src/BalanceLaws/prog_prim_conversion.jl
+++ b/src/BalanceLaws/prog_prim_conversion.jl
@@ -1,0 +1,45 @@
+# Add `Primitive` type to BalanceLaws, AtmosModel
+
+# Vars wrapper
+function prognostic_to_primitive!(
+    bl::BalanceLaw,
+    prim::AbstractArray,
+    prog::AbstractArray,
+    aux::AbstractArray,
+)
+    FT = eltype(prim)
+    prognostic_to_primitive!(
+        bl,
+        Vars{vars_state(bl, Primitive(), FT)}(prim),
+        Vars{vars_state(bl, Prognostic(), FT)}(prog),
+        Vars{vars_state(bl, Auxiliary(), FT)}(aux),
+    )
+end
+function primitive_to_prognostic!(
+    bl::BalanceLaw,
+    prog::AbstractArray,
+    prim::AbstractArray,
+    aux::AbstractArray,
+)
+    FT = eltype(prog)
+    primitive_to_prognostic!(
+        bl,
+        Vars{vars_state(bl, Prognostic(), FT)}(prog),
+        Vars{vars_state(bl, Primitive(), FT)}(prim),
+        Vars{vars_state(bl, Auxiliary(), FT)}(aux),
+    )
+end
+
+# By default the primitive is the prognostic
+vars_state(bl::BalanceLaw, ::Primitive, FT) = vars_state(bl, Prognostic(), FT)
+
+function prognostic_to_primitive!(bl, prim::Vars, prog::Vars, aux)
+    prim_arr = parent(prim)
+    prog_arr = parent(prog)
+    prim_arr .= prog_arr
+end
+function primitive_to_prognostic!(bl, prog::Vars, prim::Vars, aux)
+    prim_arr = parent(prim)
+    prog_arr = parent(prog)
+    prog_arr .= prim_arr
+end

--- a/src/BalanceLaws/state_types.jl
+++ b/src/BalanceLaws/state_types.jl
@@ -2,6 +2,7 @@
 
 export AbstractStateType,
     Prognostic,
+    Primitive,
     Auxiliary,
     Gradient,
     GradientFlux,
@@ -15,6 +16,7 @@ export AbstractStateType,
 
 Subtypes of this describe the variables used by different parts of a [`BalanceLaw`](@ref):
 - [`Prognostic`](@ref)
+- [`Primitive`](@ref)
 - [`Auxiliary`](@ref)
 - [`Gradient`](@ref)
 - [`GradientFlux`](@ref)
@@ -35,6 +37,14 @@ which are specified by the [`BalanceLaw`](@ref), and
 solved for by the ODE solver.
 """
 struct Prognostic <: AbstractStateType end
+
+"""
+    Primitive <: AbstractStateType
+
+Primitive variables, which are specified
+by the [`BalanceLaw`](@ref).
+"""
+struct Primitive <: AbstractStateType end
 
 """
     Auxiliary <: AbstractStateType

--- a/test/Atmos/prog_prim_conversion/runtests.jl
+++ b/test/Atmos/prog_prim_conversion/runtests.jl
@@ -1,0 +1,226 @@
+module TestPrimitivePrognosticConversion
+
+using CLIMAParameters
+using CLIMAParameters.Planet
+using Test
+using StaticArrays
+using UnPack
+
+using ClimateMachine
+ClimateMachine.init()
+const ArrayType = ClimateMachine.array_type()
+
+const clima_dir = dirname(dirname(pathof(ClimateMachine)))
+
+include(joinpath(clima_dir, "test", "Common", "Thermodynamics", "profiles.jl"))
+using ClimateMachine.BalanceLaws
+using ClimateMachine.ConfigTypes
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Thermodynamics
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.Atmos: AtmosModel, DryModel, EquilMoist, NonEquilMoist
+using ClimateMachine.Atmos: prognostic_to_primitive!, primitive_to_prognostic!
+const BL = BalanceLaws
+
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+atol_temperature = 5e-1
+atol_energy = cv_d(param_set) * atol_temperature
+
+import ClimateMachine.BalanceLaws: vars_state
+
+struct TestBL{PS, M} <: BalanceLaw
+    param_set::PS
+    moisture::M
+end
+
+vars_state(bl::TestBL, st::Prognostic, FT) = @vars begin
+    ρ::FT
+    ρu::SVector{3, FT}
+    ρe::FT
+    moisture::vars_state(bl.moisture, st, FT)
+end
+
+vars_state(bl::TestBL, st::Primitive, FT) = @vars begin
+    ρ::FT
+    u::SVector{3, FT}
+    p::FT
+    moisture::vars_state(bl.moisture, st, FT)
+end
+
+function assign!(state, bl, nt, st::Prognostic)
+    @unpack u, v, w, ρ, e_kin, e_pot, T, q_pt = nt
+    state.ρ = ρ
+    state.ρu = SVector(ρ * u, ρ * v, ρ * w)
+    state.ρe = state.ρ * total_energy(bl.param_set, e_kin, e_pot, T, q_pt)
+    assign!(state, bl, bl.moisture, nt, st)
+end
+assign!(state, bl, moisture::DryModel, nt, ::Prognostic) = nothing
+assign!(state, bl, moisture::EquilMoist, nt, ::Prognostic) =
+    (state.moisture.ρq_tot = nt.ρ * nt.q_pt.tot)
+function assign!(state, bl, moisture::NonEquilMoist, nt, ::Prognostic)
+    state.moisture.ρq_tot = nt.ρ * nt.q_pt.tot
+    state.moisture.ρq_liq = nt.ρ * nt.q_pt.liq
+    state.moisture.ρq_ice = nt.ρ * nt.q_pt.ice
+end
+
+function assign!(state, bl, nt, st::Primitive)
+    @unpack u, v, w, ρ, p = nt
+    state.ρ = ρ
+    state.u = SVector(u, v, w)
+    state.p = p
+    assign!(state, bl, bl.moisture, nt, st)
+end
+assign!(state, bl, moisture::DryModel, nt, ::Primitive) = nothing
+assign!(state, bl, moisture::EquilMoist, nt, ::Primitive) =
+    (state.moisture.q_tot = nt.q_pt.tot)
+function assign!(state, bl, moisture::NonEquilMoist, nt, ::Primitive)
+    state.moisture.q_tot = nt.q_pt.tot
+    state.moisture.q_liq = nt.q_pt.liq
+    state.moisture.q_ice = nt.q_pt.ice
+end
+
+
+@testset "Prognostic-Primitive conversion (dry)" begin
+    FT = Float64
+    bl = TestBL(param_set, DryModel())
+    vs_prog = vars_state(bl, Prognostic(), FT)
+    vs_prim = vars_state(bl, Primitive(), FT)
+    prog_arr = zeros(varsize(vs_prog))
+    prim_arr = zeros(varsize(vs_prim))
+    prog = Vars{vs_prog}(prog_arr)
+    prim = Vars{vs_prim}(prim_arr)
+    for nt in PhaseDryProfiles(param_set, ArrayType)
+        @unpack e_int, e_pot = nt
+
+        # Test prognostic_to_primitive! identity
+        assign!(prog, bl, nt, Prognostic())
+        prog_0 = deepcopy(parent(prog))
+        prim_arr .= 0
+        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
+        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
+        @test all(parent(prog) .≈ prog_0)
+
+        # Test primitive_to_prognostic! identity
+        assign!(prim, bl, nt, Primitive())
+        prim_0 = deepcopy(parent(prim))
+        prog_arr .= 0
+        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
+        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
+        @test all(parent(prim) .≈ prim_0)
+    end
+end
+
+@testset "Prognostic-Primitive conversion (EquilMoist)" begin
+    FT = Float64
+    bl = TestBL(param_set, EquilMoist{FT}())
+    vs_prog = vars_state(bl, Prognostic(), FT)
+    vs_prim = vars_state(bl, Primitive(), FT)
+    prog_arr = zeros(varsize(vs_prog))
+    prim_arr = zeros(varsize(vs_prim))
+    prog = Vars{vs_prog}(prog_arr)
+    prim = Vars{vs_prim}(prim_arr)
+    err_max_fwd = 0
+    err_max_bwd = 0
+    for nt in PhaseEquilProfiles(param_set, ArrayType)
+        @unpack e_int, e_pot, q_tot = nt
+
+        # Test prognostic_to_primitive! identity
+        assign!(prog, bl, nt, Prognostic())
+        prog_0 = deepcopy(parent(prog))
+        prim_arr .= 0
+        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
+        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
+        @test all(parent(prog)[1:4] .≈ prog_0[1:4])
+        @test isapprox(parent(prog)[5], prog_0[5]; atol = atol_energy)
+        # @test all(parent(prog)[5] .≈ prog_0[5]) # fails
+        @test all(parent(prog)[6] .≈ prog_0[6])
+        err_max_fwd = max(abs(parent(prog)[5] .- prog_0[5]), err_max_fwd)
+
+        # Test primitive_to_prognostic! identity
+        assign!(prim, bl, nt, Primitive())
+        prim_0 = deepcopy(parent(prim))
+        prog_arr .= 0
+        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
+        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
+        @test all(parent(prim)[1:4] .≈ prim_0[1:4])
+        # @test all(parent(prim)[5] .≈ prim_0[5]) # fails
+        @test isapprox(parent(prim)[5], prim_0[5]; atol = atol_energy)
+        @test all(parent(prim)[6] .≈ prim_0[6])
+        err_max_bwd = max(abs(parent(prim)[5] .- prim_0[5]), err_max_bwd)
+    end
+    # We may want/need to improve this later, so leaving debug info:
+    # @show err_max_fwd
+    # @show err_max_bwd
+end
+
+@testset "Prognostic-Primitive conversion (NonEquilMoist)" begin
+    FT = Float64
+    bl = TestBL(param_set, NonEquilMoist())
+    vs_prog = vars_state(bl, Prognostic(), FT)
+    vs_prim = vars_state(bl, Primitive(), FT)
+    prog_arr = zeros(varsize(vs_prog))
+    prim_arr = zeros(varsize(vs_prim))
+    prog = Vars{vs_prog}(prog_arr)
+    prim = Vars{vs_prim}(prim_arr)
+    for nt in PhaseEquilProfiles(param_set, ArrayType)
+        @unpack e_int, e_pot = nt
+        # Test prognostic_to_primitive! identity
+        assign!(prog, bl, nt, Prognostic())
+        prog_0 = deepcopy(parent(prog))
+        prim_arr .= 0
+        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
+        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
+        @test all(parent(prog) .≈ prog_0)
+
+        # Test primitive_to_prognostic! identity
+        assign!(prim, bl, nt, Primitive())
+        prim_0 = deepcopy(parent(prim))
+        prog_arr .= 0
+        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
+        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
+        @test all(parent(prim) .≈ prim_0)
+    end
+end
+
+@testset "Prognostic-Primitive conversion (array interface)" begin
+    FT = Float64
+    bl = AtmosModel{FT}(
+        AtmosLESConfigType,
+        param_set;
+        moisture = DryModel(),
+        init_state_prognostic = x -> x,
+    )
+    vs_prog = vars_state(bl, Prognostic(), FT)
+    vs_prim = vars_state(bl, Primitive(), FT)
+    vs_aux = vars_state(bl, Auxiliary(), FT)
+    prog_arr = zeros(varsize(vs_prog))
+    prim_arr = zeros(varsize(vs_prim))
+    aux_arr = zeros(varsize(vs_aux))
+    prog = Vars{vs_prog}(prog_arr)
+    prim = Vars{vs_prim}(prim_arr)
+    aux = Vars{vs_aux}(aux_arr)
+    for nt in PhaseDryProfiles(param_set, ArrayType)
+        @unpack e_pot = nt
+
+        # Test prognostic_to_primitive! identity
+        assign!(prog, bl, nt, Prognostic())
+        aux.orientation.Φ = e_pot
+        prog_0 = deepcopy(parent(prog))
+        prim_arr .= 0
+        BL.prognostic_to_primitive!(bl, prim_arr, prog_arr, aux_arr)
+        BL.primitive_to_prognostic!(bl, prog_arr, prim_arr, aux_arr)
+        @test all(parent(prog) .≈ prog_0)
+
+        # Test primitive_to_prognostic! identity
+        assign!(prim, bl, nt, Primitive())
+        prim_0 = deepcopy(parent(prim))
+        prog_arr .= 0
+        BL.primitive_to_prognostic!(bl, prog_arr, prim_arr, aux_arr)
+        BL.prognostic_to_primitive!(bl, prim_arr, prog_arr, aux_arr)
+        @test all(parent(prim) .≈ prim_0)
+    end
+end
+
+end

--- a/test/Atmos/runtests.jl
+++ b/test/Atmos/runtests.jl
@@ -2,7 +2,12 @@ using Test, Pkg
 
 @testset "Atmos" begin
     all_tests = isempty(ARGS) || "all" in ARGS ? true : false
-    for submodule in ["Parameterizations", "TemperatureProfiles", "Model"]
+    for submodule in [
+        "Parameterizations",
+        "TemperatureProfiles",
+        "Model",
+        "prog_prim_conversion",
+    ]
         if all_tests ||
            "$submodule" in ARGS ||
            "Atmos/$submodule" in ARGS ||

--- a/test/BalanceLaws/runtests.jl
+++ b/test/BalanceLaws/runtests.jl
@@ -1,7 +1,12 @@
 using Test
-using ClimateMachine.BalanceLaws
+using Random
+using StaticArrays: SVector
+Random.seed!(1234)
 
-import ClimateMachine.BalanceLaws: eq_tends, prognostic_vars
+using ClimateMachine.VariableTemplates: @vars, varsize, Vars
+using ClimateMachine.BalanceLaws
+const BL = BalanceLaws
+import ClimateMachine.BalanceLaws: vars_state, eq_tends, prognostic_vars
 
 struct TestBL <: BalanceLaw end
 struct X <: PrognosticVariable end
@@ -26,4 +31,38 @@ eq_tends(::Y, ::TestBL, ::Source) = (S{Y}(),)
     @test sources(bl) == (S{X}(), S{Y}())
     show_tendencies(bl)
     show_tendencies(bl; include_params = true)
+end
+
+vars_state(bl::TestBL, st::Prognostic, FT) = @vars begin
+    ρ::FT
+    ρu::SVector{3, FT}
+end
+
+vars_state(bl::TestBL, st::Auxiliary, FT) = @vars()
+
+@testset "Prognostic-Primitive conversion (identity)" begin
+    FT = Float64
+    bl = TestBL()
+    vs_prog = vars_state(bl, Prognostic(), FT)
+    vs_prim = vars_state(bl, Primitive(), FT)
+    vs_aux = vars_state(bl, Auxiliary(), FT)
+    prim_arr = zeros(varsize(vs_prim))
+    prog_arr = zeros(varsize(vs_prog))
+    aux_arr = zeros(varsize(vs_aux))
+
+    # Test prognostic_to_primitive! identity
+    prog_arr .= rand(varsize(vs_prog))
+    prog_0 = deepcopy(prog_arr)
+    prim_arr .= 0
+    BL.prognostic_to_primitive!(bl, prim_arr, prog_arr, aux_arr)
+    BL.primitive_to_prognostic!(bl, prog_arr, prim_arr, aux_arr)
+    @test all(prog_arr .≈ prog_0)
+
+    # Test primitive_to_prognostic! identity
+    prim_arr .= rand(varsize(vs_prim))
+    prim_0 = deepcopy(prim_arr)
+    prog_arr .= 0
+    BL.primitive_to_prognostic!(bl, prog_arr, prim_arr, aux_arr)
+    BL.prognostic_to_primitive!(bl, prim_arr, prog_arr, aux_arr)
+    @test all(prim_arr .≈ prim_0)
 end


### PR DESCRIPTION
### Description

This adds `primitive_to_prognostic!` and `prognostic_to_primitive!` methods to `BalanceLaws`, as well as an `AtmosModel` implementation for all moisture models.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
