### PR TITLE
Move second order moisture flux to new tend spec

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -498,13 +498,13 @@ equations.
     t::Real,
     direction,
 )
-    ρu_pad = SVector(1, 1, 1)
+    flux_pad = SVector(1, 1, 1)
     ts = recover_thermo_state(m, state, aux)
     tend = Flux{FirstOrder}()
     args = (m, state, aux, t, ts, direction)
-    flux.ρ = Σfluxes(eq_tends(Mass(), m, tend), args...)
-    flux.ρu = Σfluxes(eq_tends(Momentum(), m, tend), args...) .* ρu_pad
-    flux.ρe = Σfluxes(eq_tends(Energy(), m, tend), args...)
+    flux.ρ = Σfluxes(eq_tends(Mass(), m, tend), args...) .* flux_pad
+    flux.ρu = Σfluxes(eq_tends(Momentum(), m, tend), args...) .* flux_pad
+    flux.ρe = Σfluxes(eq_tends(Energy(), m, tend), args...) .* flux_pad
 
     flux_first_order!(m.moisture, m, flux, state, aux, t, ts, direction)
     flux_first_order!(m.precipitation, m, flux, state, aux, t, ts, direction)
@@ -633,17 +633,17 @@ function. Contributions from subcomponents are then assembled (pointwise).
     aux::Vars,
     t::Real,
 )
-    ρu_pad = SVector(1, 1, 1)
+    flux_pad = SVector(1, 1, 1)
     ts = recover_thermo_state(atmos, state, aux)
     tend = Flux{SecondOrder}()
     args = (atmos, state, aux, t, ts, diffusive, hyperdiffusive)
-    flux.ρ = Σfluxes(eq_tends(Mass(), atmos, tend), args...) .* ρu_pad
-    flux.ρu = Σfluxes(eq_tends(Momentum(), atmos, tend), args...) .* ρu_pad
-    flux.ρe = Σfluxes(eq_tends(Energy(), atmos, tend), args...)
+    flux.ρ = Σfluxes(eq_tends(Mass(), atmos, tend), args...) .* flux_pad
+    flux.ρu = Σfluxes(eq_tends(Momentum(), atmos, tend), args...) .* flux_pad
+    flux.ρe = Σfluxes(eq_tends(Energy(), atmos, tend), args...) .* flux_pad
 
     ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
 
-    flux_second_order!(atmos.moisture, flux, state, diffusive, aux, t, D_t)
+    flux_second_order!(atmos.moisture, flux, args...)
     flux_second_order!(atmos.precipitation, flux, args...)
     flux_second_order!(
         atmos.hyperdiffusion,

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -108,23 +108,32 @@ eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {N, PV <: Tracers{N}} =
 ##### Second order fluxes
 #####
 
+eq_tends(
+    pv::PV,
+    ::DryModel,
+    ::Flux{SecondOrder},
+) where {PV <: Union{Mass, Momentum, Moisture}} = ()
+eq_tends(
+    pv::PV,
+    ::MoistureModel,
+    ::Flux{SecondOrder},
+) where {PV <: Union{Mass, Momentum, Moisture}} = (MoistureDiffusion{PV}(),)
+
 # Mass
-moist_diffusion(pv::PV, ::DryModel) where {PV <: Mass} = ()
-moist_diffusion(pv::PV, ::MoistureModel) where {PV <: Mass} =
-    (MoistureDiffusion{PV}(),)
-eq_tends(pv::PV, m::AtmosModel, ::Flux{SecondOrder}) where {PV <: Mass} =
-    (moist_diffusion(pv, m.moisture)...,)
+eq_tends(pv::PV, m::AtmosModel, tt::Flux{SecondOrder}) where {PV <: Mass} =
+    (eq_tends(pv, m.moisture, tt)...,)
 
 # Momentum
-eq_tends(pv::PV, ::AtmosModel, ::Flux{SecondOrder}) where {PV <: Momentum} =
-    (ViscousStress{PV}(),)
+eq_tends(pv::PV, m::AtmosModel, tt::Flux{SecondOrder}) where {PV <: Momentum} =
+    (ViscousStress{PV}(), eq_tends(pv, m.moisture, tt)...)
 
 # Energy
 eq_tends(pv::PV, ::AtmosModel, ::Flux{SecondOrder}) where {PV <: Energy} =
     (ViscousFlux{PV}(), DiffEnthalpyFlux{PV}())
 
 # Moisture
-eq_tends(pv::PV, ::AtmosModel, ::Flux{SecondOrder}) where {PV <: Moisture} = ()
+eq_tends(pv::PV, m::AtmosModel, tt::Flux{SecondOrder}) where {PV <: Moisture} =
+    (eq_tends(pv, m.moisture, tt)...,)
 
 # Precipitation
 eq_tends(

--- a/src/Atmos/Model/multiphysics_types.jl
+++ b/src/Atmos/Model/multiphysics_types.jl
@@ -26,6 +26,8 @@ struct Pressure{PV <: Energy} <: TendencyDef{Flux{FirstOrder}, PV} end
 struct Advect{PV} <: TendencyDef{Flux{FirstOrder}, PV} end
 struct Diffusion{PV} <: TendencyDef{Flux{SecondOrder}, PV} end
 
+struct MoistureDiffusion{PV <: Union{Mass, Momentum, Moisture}} <:
+       TendencyDef{Flux{SecondOrder}, PV} end
 
 export RemovePrecipitation
 """

--- a/src/Atmos/Model/tendencies_mass.jl
+++ b/src/Atmos/Model/tendencies_mass.jl
@@ -12,7 +12,6 @@ end
 ##### Second order fluxes
 #####
 
-struct MoistureDiffusion{PV <: Mass} <: TendencyDef{Flux{SecondOrder}, PV} end
 function flux(
     ::MoistureDiffusion{Mass},
     m,

--- a/src/Atmos/Model/tendencies_moisture.jl
+++ b/src/Atmos/Model/tendencies_moisture.jl
@@ -20,6 +20,55 @@ function flux(::Advect{IceMoisture}, m, state, aux, t, ts, direction)
 end
 
 #####
+##### Second order fluxes
+#####
+
+function flux(
+    ::MoistureDiffusion{TotalMoisture},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    diffusive,
+    hyperdiff,
+)
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    d_q_tot = (-D_t) .* diffusive.moisture.∇q_tot
+    return d_q_tot * state.ρ
+end
+
+function flux(
+    ::MoistureDiffusion{LiquidMoisture},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    diffusive,
+    hyperdiff,
+)
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    d_q_liq = (-D_t) .* diffusive.moisture.∇q_liq
+    return d_q_liq * state.ρ
+end
+
+function flux(
+    ::MoistureDiffusion{IceMoisture},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    diffusive,
+    hyperdiff,
+)
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    d_q_ice = (-D_t) .* diffusive.moisture.∇q_ice
+    return d_q_ice * state.ρ
+end
+
+#####
 ##### Sources
 #####
 

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -34,8 +34,24 @@ function flux(
     diffusive,
     hyperdiff,
 )
+    pad = (state.ρu .* (state.ρu / state.ρ)') * 0
     ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
-    return τ * state.ρ
+    return pad + τ * state.ρ
+end
+
+function flux(
+    ::MoistureDiffusion{Momentum},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    diffusive,
+    hyperdiff,
+)
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    d_q_tot = (-D_t) .* diffusive.moisture.∇q_tot
+    return d_q_tot .* state.ρu'
 end
 
 #####


### PR DESCRIPTION
### Description

This PR
 - moves second order moisture fluxes (`MoistureDiffusion`) to the new tendency specification.
 - Changes the argument order in `flux_second_order!(::MoistureModel, args...)` so that arguments can be easily passed through

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
