### PR TITLE
Add missing TKE buoyancy source and use prantl number for K-m and K_h ratio

### DIFF
--- a/test/Atmos/EDMF/closures/turbulence_functions.jl
+++ b/test/Atmos/EDMF/closures/turbulence_functions.jl
@@ -145,6 +145,12 @@ Returns the turbulent Prandtl number, given:
  - `Grad_Ri`, the gradient Richardson number
 """
 function turbulent_Prandtl_number(Pr_n::FT, Grad_Ri::FT, ω_pr::FT) where {FT}
-    denom = 1 + ω_pr * Grad_Ri - sqrt((1 + ω_pr * Grad_Ri)^2 - 4 * Grad_Ri)
-    return Pr_n * 2 * Grad_Ri / denom
+    if Grad_Ri > FT(0)
+        factor =
+            2 * Grad_Ri /
+            (1 + ω_pr * Grad_Ri - sqrt((1 + ω_pr * Grad_Ri)^2 - 4 * Grad_Ri))
+    else
+        factor = FT(1)
+    end
+    return Pr_n * factor
 end;

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -527,7 +527,7 @@ function atmos_source!(
         # pressure tke source from the i'th updraft
         en_src.ρatke += ρa_up_i * (w_up_i - env.w) * dpdz
     end
-    l_mix = mixing_length(
+    l_mix, ∂b∂z_env, Pr_t = mixing_length(
         m,
         m.turbconv.mix_len,
         state,
@@ -539,22 +539,27 @@ function atmos_source!(
         ts,
         env,
     )
-    K_eddy = m.turbconv.mix_len.c_m * l_mix * sqrt(tke_en)
+
+    K_m = m.turbconv.mix_len.c_m * l_mix * sqrt(tke_en)
+    K_h = K_m / Pr_t
     Shear² = diffusive.turbconv.S²
     ρa₀ = gm.ρ * env.a
     Diss₀ = m.turbconv.mix_len.c_d * sqrt(tke_en) / l_mix
 
     # production from mean gradient and Dissipation
-    en_src.ρatke += ρa₀ * (K_eddy * Shear² - Diss₀ * tke_en)
+    en_src.ρatke += ρa₀ * K_m * Shear² # tke Shear source
+    en_src.ρatke += -ρa₀ * K_h * ∂b∂z_env   # tke Bouyancy source
+    en_src.ρatke += -ρa₀ * Diss₀ * tke_en  # tke Dissipation
+
     en_src.ρaθ_liq_cv +=
         ρa₀ *
-        (K_eddy * en_dif.∇θ_liq[3] * en_dif.∇θ_liq[3] - Diss₀ * en.ρaθ_liq_cv)
+        (K_h * en_dif.∇θ_liq[3] * en_dif.∇θ_liq[3] - Diss₀ * en.ρaθ_liq_cv)
     en_src.ρaq_tot_cv +=
         ρa₀ *
-        (K_eddy * en_dif.∇q_tot[3] * en_dif.∇q_tot[3] - Diss₀ * en.ρaq_tot_cv)
+        (K_h * en_dif.∇q_tot[3] * en_dif.∇q_tot[3] - Diss₀ * en.ρaq_tot_cv)
     en_src.ρaθ_liq_q_tot_cv +=
         ρa₀ * (
-            K_eddy * en_dif.∇θ_liq[3] * en_dif.∇q_tot[3] -
+            K_h * en_dif.∇θ_liq[3] * en_dif.∇q_tot[3] -
             Diss₀ * en.ρaθ_liq_q_tot_cv
         )
     # covariance microphysics sources should be applied here
@@ -711,7 +716,7 @@ function flux_second_order!(
 
     E_dyn, Δ_dyn, E_trb = ntuple(i -> map(x -> x[i], EΔ_up), 3)
 
-    l_mix = mixing_length(
+    l_mix, _, Pr_t = mixing_length(
         m,
         turbconv.mix_len,
         state,
@@ -724,7 +729,8 @@ function flux_second_order!(
         env,
     )
     tke_en = enforce_positivity(en.ρatke) / env.a * ρ_inv
-    K_eddy = m.turbconv.mix_len.c_m * l_mix * sqrt(tke_en)
+    K_m = m.turbconv.mix_len.c_m * l_mix * sqrt(tke_en)
+    K_h = K_m / Pr_t
 
     #TotalFlux(ϕ) = Eddy_Diffusivity(ϕ) + MassFlux(ϕ)
     e_int = internal_energy(m, state, aux)
@@ -769,9 +775,9 @@ function flux_second_order!(
     )
 
     # update grid mean flux_second_order
-    ρe_sgs_flux = -gm.ρ * env.a * K_eddy * en_dif.∇e[3] + massflux_e
-    ρq_tot_sgs_flux = -gm.ρ * env.a * K_eddy * en_dif.∇q_tot[3] + massflux_q_tot
-    ρu_sgs_flux = -gm.ρ * env.a * K_eddy * en_dif.∇w[3] + massflux_w
+    ρe_sgs_flux = -gm.ρ * env.a * K_h * en_dif.∇e[3] + massflux_e
+    ρq_tot_sgs_flux = -gm.ρ * env.a * K_h * en_dif.∇q_tot[3] + massflux_q_tot
+    ρu_sgs_flux = -gm.ρ * env.a * K_m * en_dif.∇w[3] + massflux_w
 
     # for now the coupling to the dycore is commented out
 
@@ -785,11 +791,11 @@ function flux_second_order!(
 
     ẑ = vertical_unit_vector(m, aux)
     # env second moment flux_second_order
-    en_flx.ρatke = -gm.ρ * env.a * K_eddy * en_dif.∇tke[3] * ẑ
-    en_flx.ρaθ_liq_cv = -gm.ρ * env.a * K_eddy * en_dif.∇θ_liq_cv[3] * ẑ
-    en_flx.ρaq_tot_cv = -gm.ρ * env.a * K_eddy * en_dif.∇q_tot_cv[3] * ẑ
+    en_flx.ρatke = -gm.ρ * env.a * K_m * en_dif.∇tke[3] * ẑ
+    en_flx.ρaθ_liq_cv = -gm.ρ * env.a * K_h * en_dif.∇θ_liq_cv[3] * ẑ
+    en_flx.ρaq_tot_cv = -gm.ρ * env.a * K_h * en_dif.∇q_tot_cv[3] * ẑ
     en_flx.ρaθ_liq_q_tot_cv =
-        -gm.ρ * env.a * K_eddy * en_dif.∇θ_liq_q_tot_cv[3] * ẑ
+        -gm.ρ * env.a * K_h * en_dif.∇θ_liq_q_tot_cv[3] * ẑ
 end;
 
 # First order boundary conditions

--- a/test/Atmos/EDMF/edmf_model.jl
+++ b/test/Atmos/EDMF/edmf_model.jl
@@ -179,7 +179,7 @@ Base.@kwdef struct MixingLengthModel{FT <: AbstractFloat}
     "Prandtl number empirical coefficient"
     ω_pr::FT = 53.0 / 13.0
     "Prandtl number scale"
-    Pr_n::FT = 1 #0.74
+    Pr_n::FT = 0.74
     "Critical Richardson number"
     Ri_c::FT = 0.25
     "Random small number variable that should be addressed"

--- a/test/Atmos/EDMF/report_mse.jl
+++ b/test/Atmos/EDMF/report_mse.jl
@@ -13,16 +13,16 @@ include(joinpath(@__DIR__, "compute_mse.jl"))
 best_mse = Dict()
 best_mse[:Bomex] = Dict()
 best_mse[:Bomex]["ρ"] = 3.4943021267397123e-02
-best_mse[:Bomex]["ρu[1]"] = 3.0714039084256697e+03
+best_mse[:Bomex]["ρu[1]"] = 3.0714039084256679e+03
 best_mse[:Bomex]["ρu[2]"] = 1.3375796498101822e-03
 best_mse[:Bomex]["moisture.ρq_tot"] = 4.8463531712319707e-02
-best_mse[:Bomex]["turbconv.environment.ρatke"] = 4.7760529270257848e+03
-best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5663972945756413e+01
-best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6260195840899604e+02
-best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9888809513438588e+01
-best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.5229392101997301e-02
-best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0175083910345997e+00
-best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0777046662295460e+01
+best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.7458994186482869e+02
+best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5667200477293633e+01
+best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6455670738880309e+02
+best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9547300082766554e+01
+best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4294492216319045e-02
+best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0095767705492662e+00
+best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0767427989197111e+01
 #! format: on
 
 sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + eps()


### PR DESCRIPTION
### Description
This code adds missing TKE buoyancy source in the edmf_kernels.jl, and makes use of Prantl number to compute Eddy diffusivities for tracers and momentum. I also added an if condition to the computation Prantl number that avoid zero division neutral and unstable conditions. 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
