### PR TITLE
Move second order rain flux to new tend spec

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -625,7 +625,7 @@ function. Contributions from subcomponents are then assembled (pointwise).
     ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
 
     flux_second_order!(atmos.moisture, flux, state, diffusive, aux, t, D_t)
-    flux_second_order!(atmos.precipitation, flux, state, diffusive, aux, t, D_t)
+    flux_second_order!(atmos.precipitation, flux, args...)
     flux_second_order!(
         atmos.hyperdiffusion,
         flux,

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -129,9 +129,9 @@ eq_tends(pv::PV, ::AtmosModel, ::Flux{SecondOrder}) where {PV <: Moisture} = ()
 # Precipitation
 eq_tends(
     pv::PV,
-    ::AtmosModel,
-    ::Flux{SecondOrder},
-) where {PV <: Precipitation} = ()
+    m::AtmosModel,
+    tt::Flux{SecondOrder},
+) where {PV <: Precipitation} = (eq_tends(pv, m.precipitation, tt)...,)
 
 # Tracers
 eq_tends(

--- a/src/Atmos/Model/multiphysics_types.jl
+++ b/src/Atmos/Model/multiphysics_types.jl
@@ -24,6 +24,7 @@ struct PressureGradient{PV <: Momentum} <: TendencyDef{Flux{FirstOrder}, PV} end
 struct Pressure{PV <: Energy} <: TendencyDef{Flux{FirstOrder}, PV} end
 
 struct Advect{PV} <: TendencyDef{Flux{FirstOrder}, PV} end
+struct Diffusion{PV} <: TendencyDef{Flux{SecondOrder}, PV} end
 
 
 export RemovePrecipitation

--- a/src/Atmos/Model/tendencies_precipitation.jl
+++ b/src/Atmos/Model/tendencies_precipitation.jl
@@ -8,6 +8,19 @@
 ##### Second order fluxes
 #####
 
+function flux(::Diffusion{Rain}, m, state, aux, t, ts, diffusive, hyperdiff)
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    d_q_rai = (-D_t) .* diffusive.precipitation.∇q_rai
+    return d_q_rai * state.ρ
+end
+
+function flux(::Diffusion{Snow}, m, state, aux, t, ts, diffusive, hyperdiff)
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    d_q_sno = (-D_t) .* diffusive.precipitation.∇q_sno
+    return d_q_sno * state.ρ
+end
+
+
 #####
 ##### Sources
 #####


### PR DESCRIPTION
### Description

This PR
 - Adds 2nd order rain fluxes to the new tendency specification

Not sure if `Diffusion` is a good name here. 

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
