### PR TITLE
Move second order tracer flux to new tend spec

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -443,6 +443,7 @@ include("tendencies_momentum.jl")     # specify momentum tendencies
 include("tendencies_energy.jl")       # specify energy tendencies
 include("tendencies_moisture.jl")     # specify moisture tendencies
 include("tendencies_precipitation.jl")# specify precipitation tendencies
+include("tendencies_tracers.jl")      # specify tracer tendencies
 
 include("problem.jl")
 include("ref_state.jl")
@@ -636,7 +637,7 @@ function. Contributions from subcomponents are then assembled (pointwise).
         aux,
         t,
     )
-    flux_second_order!(atmos.tracers, flux, state, diffusive, aux, t, D_t)
+    flux_second_order!(atmos.tracers, flux, args...)
     flux_second_order!(atmos.turbconv, atmos, flux, state, diffusive, aux, t)
 end
 

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -111,6 +111,6 @@ eq_tends(
 # Tracers
 eq_tends(
     pv::PV,
-    ::AtmosModel,
-    ::Flux{SecondOrder},
-) where {N, PV <: Tracers{N}} = ()
+    m::AtmosModel,
+    tt::Flux{SecondOrder},
+) where {N, PV <: Tracers{N}} = (eq_tends(pv, m.tracers, tt)...,)

--- a/src/Atmos/Model/multiphysics_types.jl
+++ b/src/Atmos/Model/multiphysics_types.jl
@@ -22,6 +22,7 @@ struct PressureGradient{PV <: Momentum} <: TendencyDef{Flux{FirstOrder}, PV} end
 struct Pressure{PV <: Energy} <: TendencyDef{Flux{FirstOrder}, PV} end
 
 struct Advect{PV} <: TendencyDef{Flux{FirstOrder}, PV} end
+struct Diffusion{PV} <: TendencyDef{Flux{SecondOrder}, PV} end
 
 
 export RemovePrecipitation

--- a/src/Atmos/Model/tendencies_tracers.jl
+++ b/src/Atmos/Model/tendencies_tracers.jl
@@ -1,0 +1,29 @@
+##### Moisture tendencies
+
+#####
+##### First order fluxes
+#####
+
+function flux(::Advect{Tracers{N}}, m, state, aux, t, ts, direction) where {N}
+    u = state.ρu / state.ρ
+    return (state.tracers.ρχ .* u')'
+end
+
+#####
+##### Second order fluxes
+#####
+
+function flux(
+    ::Diffusion{Tracers{N}},
+    m,
+    state,
+    aux,
+    t,
+    ts,
+    diffusive,
+    hyperdiff,
+) where {N}
+    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    d_χ = (-D_t) * aux.tracers.δ_χ' .* diffusive.tracers.∇χ
+    return d_χ * state.ρ
+end


### PR DESCRIPTION
### Description

This PR
 - Moves the second order tracer fluxes to the new tendency specification
 - Adds `tendencies_tracer.jl` to `src/Atmos/Model/`
 - Moves the first order flux definition to `tendencies_tracer.jl` (I think I missed following this pattern in the first order tracer flux PR)

I'm not 100% sure about the name `Diffusion` here. cc @akshaysridhar?

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
