### PR TITLE
add EDMF plots with a first plot for turbulent Prantl number as function of gradient Richardson number 

### DIFF
--- a/docs/list_of_theory_docs.jl
+++ b/docs/list_of_theory_docs.jl
@@ -9,6 +9,7 @@ theory_docs = Any[
     ],
     "Atmos" => Any[
         "AtmosModel" => "Theory/Atmos/AtmosModel.md",
+        "EDMF Model" => "Theory/Atmos/EDMF_plots.md",
         "Microphysics_0M" => "Theory/Atmos/Microphysics_0M.md",
         "Microphysics" => "Theory/Atmos/Microphysics.md",
         "EDMF equations" => "Theory/Atmos/EDMFEquations.md",

--- a/docs/src/Theory/Atmos/EDMF_plots.md
+++ b/docs/src/Theory/Atmos/EDMF_plots.md
@@ -1,0 +1,39 @@
+# Atmospheric EDMF parameterization profiles
+
+```@meta
+CurrentModule = ClimateMachine
+```
+
+Several EDMF related profiles are to be plotted here
+
+## Usage
+
+Using a profile involves passing two arguments:
+
+ - `param_set` a parameter set, from [CLIMAParameters.jl](https://github.com/CliMA/CLIMAParameters.jl)
+ - `max_Grad_Ri` maximum gradient Richarson Number (indepndent, non-dimensional variable for the turbulent Prantl number)
+
+to one of the EDMF profile constructors.
+
+### TurbulentPrantlNumberProfile
+
+```@example
+using ClimateMachine
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+using ClimateMachine.Atmos: AtmosModel
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Thermodynamics
+using ClimateMachine.BalanceLaws
+using ClimateMachine.TurbulenceConvection
+include(joinpath(clima_dir, "test", "Atmos", "EDMF", "closures", "turbulence_functions.jl"))
+include(joinpath(clima_dir, "test", "Atmos", "EDMF", "edmf_model.jl"))
+using Plots
+FT = Float64;
+Grad_Ri = range(FT(-1), stop = 10 , length = 100);
+ml = MixingLengthModel{FT}();
+Pr_t = turbulent_Prandtl_number.(Ref(ml.Pr_n), Grad_Ri, Ref(ml.ω_pr))
+p1 = plot(Grad_Ri, Pr_t, xlabel=" gradient Richardson number");
+plot(p1, title="turbulent Prantl number")
+savefig("Pr_t.svg")
+```
+![](Pr_t.svg)


### PR DESCRIPTION
### Description
This PR adds a plot for the turbulent Prantl number as function of gradient Richardson number  for a range of values to verify its behavior offline.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
