### PR TITLE
Vorticity from Atmos DGModel output by Diagnostics

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -999,7 +999,7 @@ steps:
   - label: "gpu_solid_body_rotation"
     key: "gpu_solid_body_rotation"
     command:
-      - "mpiexec julia --color=yes --project experiments/TestCase/solid_body_rotation.jl "
+      - "mpiexec julia --color=yes --project experiments/TestCase/solid_body_rotation.jl --diagnostics=default "
     agents:
       config: gpu
       queue: central
@@ -1029,7 +1029,7 @@ steps:
   - label: "gpu_heldsuarez"
     key: "gpu_heldsuarez"
     command:
-      - "mpiexec julia --color=yes --project experiments/AtmosGCM/heldsuarez.jl --diagnostics=default --fix-rng-seed"
+      - "mpiexec julia --color=yes --project experiments/AtmosGCM/heldsuarez.jl --fix-rng-seed "
     agents:
       config: gpu
       queue: central

--- a/docs/src/DevDocs/DiagnosticVariableList.md
+++ b/docs/src/DevDocs/DiagnosticVariableList.md
@@ -125,6 +125,7 @@ averaged density.
 | hi         | specific enthalpy from internal energy                                     |
 |                                                                                         |
 | vort       | relative vorticity                                                         |
+| vort2      | relative vorticity from DGmodel kernels                                    |
 
 
 #### 1D spectral decomposition using the Fourier transform (time, level, latitude, zonal wavenumber)

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -24,7 +24,20 @@ using Statistics
 
 using ..Atmos
 using ..Atmos: recover_thermo_state
+using ..DGMethods.NumericalFluxes
 using ..TurbulenceClosures: turbulence_tensors
+
+include("diagnostic_fields.jl")
+include("vorticity_balancelaw.jl")
+
+mutable struct VorticityBLState <: DiagnosticsGroupParams
+    bl::Union{Nothing, VorticityModel}
+    dg::Union{Nothing, DGModel}
+    state::Union{Nothing, MPIStateArray}
+    dQ::Union{Nothing, MPIStateArray}
+
+    VorticityBLState() = new(nothing, nothing, nothing, nothing)
+end
 
 """
     setup_atmos_default_diagnostics(
@@ -48,7 +61,8 @@ diagnostic variables:
 - ei: specific internal energy
 - ht: specific enthalpy based on total energy
 - hi: specific enthalpy based on internal energy
-- vort: vertical component of relative velocity
+- vort: vertical component of relative vorticity
+- vort2: vertical component of relative vorticity from DGModel kernels via a mini balance law
 
 When an `EquilMoist` moisture model is used, the following diagnostic
 variables are also output:
@@ -83,12 +97,11 @@ function setup_atmos_default_diagnostics(
         out_prefix,
         writer,
         interpol,
+        VorticityBLState(),
     )
 end
 
-include("diagnostic_fields.jl")
-
-# 3D variables
+# Declare all (3D) variables for this diagnostics group
 function vars_atmos_gcm_default_simple_3d(atmos::AtmosModel, FT)
     @vars begin
         u::FT
@@ -103,6 +116,7 @@ function vars_atmos_gcm_default_simple_3d(atmos::AtmosModel, FT)
         ht::FT
         hi::FT
         vort::FT                # Ω₃
+        vort2::FT               # Ω_bl₃
 
         moisture::vars_atmos_gcm_default_simple_3d(atmos.moisture, FT)
     end
@@ -124,26 +138,31 @@ num_atmos_gcm_default_simple_3d_vars(m, FT) =
 atmos_gcm_default_simple_3d_vars(m, array) =
     Vars{vars_atmos_gcm_default_simple_3d(m, eltype(array))}(array)
 
+# Collect all (3D) variables for this diagnostics group
 function atmos_gcm_default_simple_3d_vars!(
     atmos::AtmosModel,
     state_prognostic,
     thermo,
     dyni,
+    dyn_bli,
     vars,
 )
     vars.u = state_prognostic.ρu[1] / state_prognostic.ρ
     vars.v = state_prognostic.ρu[2] / state_prognostic.ρ
     vars.w = state_prognostic.ρu[3] / state_prognostic.ρ
     vars.rho = state_prognostic.ρ
+    vars.et = state_prognostic.ρe / state_prognostic.ρ
+
     vars.temp = thermo.temp
     vars.pres = thermo.pres
     vars.thd = thermo.θ_dry
-    vars.et = state_prognostic.ρe / state_prognostic.ρ
     vars.ei = thermo.e_int
     vars.ht = thermo.h_tot
     vars.hi = thermo.h_int
 
     vars.vort = dyni.Ω₃
+
+    vars.vort2 = dyn_bli.Ω_bl₃
 
     atmos_gcm_default_simple_3d_vars!(
         atmos.moisture,
@@ -188,6 +207,16 @@ function vars_dyn(FT)
 end
 dyn_vars(array) = Vars{vars_dyn(eltype(array))}(array)
 
+function vars_dyn_bl(FT)
+    @vars begin
+        Ω_bl₁::FT
+        Ω_bl₂::FT
+        Ω_bl₃::FT
+    end
+end
+dyn_bl_vars(array) = Vars{vars_dyn_bl(eltype(array))}(array)
+
+
 """
     atmos_gcm_default_init(dgngrp, currtime)
 
@@ -195,7 +224,9 @@ Initialize the GCM default diagnostics group, establishing the output file's
 dimensions and variables.
 """
 function atmos_gcm_default_init(dgngrp::DiagnosticsGroup, currtime)
-    atmos = Settings.dg.balance_law
+    dg = Settings.dg
+    grid = dg.grid
+    atmos = dg.balance_law
     FT = eltype(Settings.Q)
     mpicomm = Settings.mpicomm
     mpirank = MPI.Comm_rank(mpicomm)
@@ -206,6 +237,23 @@ function atmos_gcm_default_init(dgngrp::DiagnosticsGroup, currtime)
             """
         return nothing
     end
+
+    # set up the vorticity mini balance law
+    vort_state = dgngrp.params
+    vort_state.bl = VorticityModel()
+    vort_state.dg = DGModel(
+        vort_state.bl,
+        grid,
+        CentralNumericalFluxFirstOrder(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+    vort_state.state = init_ode_state(vort_state.dg, FT(0))
+    vort_state.dQ = similar(
+        vort_state.state;
+        vars = @vars(Ω_bl::SVector{3, FT}),
+        nstate = 3,
+    )
 
     if mpirank == 0
         # get dimensions for the interpolated grid
@@ -237,6 +285,7 @@ function atmos_gcm_default_init(dgngrp::DiagnosticsGroup, currtime)
             Settings.starttime,
         )
         dfilename = joinpath(Settings.output_dir, dprefix)
+
         init_data(dgngrp.writer, dfilename, dims, vars)
     end
 
@@ -257,6 +306,7 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
             """
         return nothing
     end
+    vort_state = dgngrp.params
 
     mpicomm = Settings.mpicomm
     dg = Settings.dg
@@ -292,7 +342,16 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
     vgrad = VectorGradients(dg, Q)
     vort = Vorticity(dg, vgrad)
 
-    # Compute thermo variables
+    # run the vorticity mini balance law
+    ix_ρu = varsindex(vars(Q), :ρu)
+    ix_ρ = varsindex(vars(Q), :ρ)
+    ρ = Q.data[:, ix_ρ, :]
+    u = Q.data[:, ix_ρu, :] ./ ρ
+
+    vort_state.dg.state_auxiliary.data .= u
+    vort_state.dg(vort_state.dQ, vort_state.state, nothing, FT(0))
+
+    # Compute thermo variables element-wise
     thermo_array = Array{FT}(undef, npoints, num_thermo(atmos, FT), nrealelem)
     @traverse_dg_grid grid_info topl_info begin
         state = extract_state(dg, state_data, ijk, e, Prognostic())
@@ -302,7 +361,7 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
         compute_thermo!(atmos, state, aux, thermo)
     end
 
-    # Interpolate the state, thermo and dyn vars to sphere (u and vorticity
+    # Interpolate the state, thermo, dgdiags and dyn vars to sphere (u and vorticity
     # need projection to zonal, merid). All this may happen on the GPU.
     istate =
         ArrayType{FT}(undef, interpol.Npl, number_states(atmos, Prognostic()))
@@ -314,16 +373,22 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
     idyn = ArrayType{FT}(undef, interpol.Npl, size(vort.data, 2))
     interpolate_local!(interpol, vort.data, idyn)
 
+    idyn_bl = ArrayType{FT}(undef, interpol.Npl, size(vort_state.dQ.data, 2))
+    interpolate_local!(interpol, vort_state.dQ.data, idyn_bl)
+
     # TODO: get indices here without hard-coding them
     _ρu, _ρv, _ρw = 2, 3, 4
     project_cubed_sphere!(interpol, istate, (_ρu, _ρv, _ρw))
     _Ω₁, _Ω₂, _Ω₃ = 1, 2, 3
     project_cubed_sphere!(interpol, idyn, (_Ω₁, _Ω₂, _Ω₃))
+    project_cubed_sphere!(interpol, idyn_bl, (_Ω₁, _Ω₂, _Ω₃))
+
 
     # FIXME: accumulating to rank 0 is not scalable
     all_state_data = accumulate_interpolated_data(mpicomm, interpol, istate)
     all_thermo_data = accumulate_interpolated_data(mpicomm, interpol, ithermo)
     all_dyn_data = accumulate_interpolated_data(mpicomm, interpol, idyn)
+    all_dyn_bl_data = accumulate_interpolated_data(mpicomm, interpol, idyn_bl)
 
     if mpirank == 0
         # get dimensions for the interpolated grid
@@ -352,6 +417,7 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
             ))
             thermoi = thermo_vars(atmos, view(all_thermo_data, lo, la, le, :))
             dyni = dyn_vars(view(all_dyn_data, lo, la, le, :))
+            dyn_bli = dyn_bl_vars(view(all_dyn_bl_data, lo, la, le, :))
             simple_3d_vars = atmos_gcm_default_simple_3d_vars(
                 atmos,
                 view(simple_3d_vars_array, lo, la, le, :),
@@ -362,6 +428,7 @@ function atmos_gcm_default_collect(dgngrp::DiagnosticsGroup, currtime)
                 statei,
                 thermoi,
                 dyni,
+                dyn_bli,
                 simple_3d_vars,
             )
         end

--- a/src/Diagnostics/variables.jl
+++ b/src/Diagnostics/variables.jl
@@ -536,4 +536,9 @@ function setup_variables()
         DiagnosticVariable("mass_loss", var_attrib("", "", ""))
     Variables["energy_loss"] =
         DiagnosticVariable("energy_loss", var_attrib("", "", ""))
+
+    Variables["vort2"] = DiagnosticVariable(
+        "vort2",
+        var_attrib("s^-1", "vorticity from DG kernels", ""),
+    )
 end

--- a/src/Diagnostics/vorticity_balancelaw.jl
+++ b/src/Diagnostics/vorticity_balancelaw.jl
@@ -1,0 +1,93 @@
+# A mini balance law for computing vorticity using the DG kernels.
+#
+
+using StaticArrays
+
+using ..BalanceLaws
+using ..VariableTemplates
+using ..MPIStateArrays
+
+import ..BalanceLaws:
+    vars_state,
+    flux_first_order!,
+    flux_second_order!,
+    source!,
+    eq_tends,
+    flux,
+    source,
+    wavespeed,
+    boundary_conditions,
+    boundary_state!,
+    compute_gradient_argument!,
+    compute_gradient_flux!,
+    transform_post_gradient_laplacian!,
+    init_state_auxiliary!,
+    init_state_prognostic!,
+    update_auxiliary_state!,
+    indefinite_stack_integral!,
+    reverse_indefinite_stack_integral!,
+    integral_load_auxiliary_state!,
+    integral_set_auxiliary_state!,
+    reverse_integral_load_auxiliary_state!,
+    reverse_integral_set_auxiliary_state!
+
+
+# A mini balance law that is used to take the gradient of u and v
+# to obtain vorticity.
+struct VorticityModel <: BalanceLaw end
+
+# output vorticity vector
+vars_state(::VorticityModel, ::Prognostic, FT) = @vars(Ω_bl::SVector{3, FT})
+# input velocity vector
+vars_state(::VorticityModel, ::Auxiliary, FT) = @vars(u::SVector{3, FT})
+vars_state(::VorticityModel, ::Gradient, FT) = @vars()
+vars_state(::VorticityModel, ::GradientFlux, FT) = @vars()
+
+# required for each balance law 
+function init_state_auxiliary!(
+    m::VorticityModel,
+    state_auxiliary::MPIStateArray,
+    grid,
+    direction,
+) end
+function init_state_prognostic!(
+    ::VorticityModel,
+    state::Vars,
+    aux::Vars,
+    localgeo,
+    t,
+) end
+function nodal_update_auxiliary_state!(
+    m::VorticityModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end;
+function flux_first_order!(
+    ::VorticityModel,
+    flux::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
+    u = aux.u
+    @inbounds begin
+        flux.Ω_bl = @SMatrix [
+            0 u[3] -u[2]
+            -u[3] 0 u[1]
+            u[2] -u[1] 0
+        ]
+    end
+end
+function compute_gradient_argument!(
+    ::VorticityModel,
+    transform::Vars,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end
+flux_second_order!(::VorticityModel, _...) = nothing
+source!(::VorticityModel, _...) = nothing
+boundary_conditions(::VorticityModel) = ntuple(i -> nothing, 6)
+boundary_state!(nf, ::Nothing, ::VorticityModel, _...) = nothing


### PR DESCRIPTION
### Description

Co-authored by @kpamnany and based on a branch by @thomasgibson .   

Allows plugging a mini balance law into the atmos_gcm_default diagnostics to compute diagnostics (e.g. gradients) using DGModel compute kernels at every diagnostic timestep.   

So far implemented for vorticity, which was previously calculated without surface numerical fluxes.

To do:
- Add a how to guide (separate PR)
- Add smoothing (e.g. discrete stiffness summation, DSS) for smoother plots (separate PR, low priority)

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
