### PR TITLE
cleanup in multiphysics sources

### DIFF
--- a/src/Atmos/Model/tendencies_energy.jl
+++ b/src/Atmos/Model/tendencies_energy.jl
@@ -69,9 +69,8 @@ function source(
     diffusive,
 )
     if has_condensate(ts)
-        nt = compute_remove_precip_params(s, aux, ts)
-        @unpack S_qt, λ, I_l, I_i, Φ = nt
-        return (λ * I_l + (1 - λ) * I_i + Φ) * state.ρ * S_qt
+        nt = remove_precipitation_sources(s, m, state, aux, ts)
+        return nt.S_ρ_e
     else
         FT = eltype(state)
         return FT(0)
@@ -88,9 +87,8 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_warm_rain_params(m, state, aux, t, ts)
-    @unpack S_qt, Φ, I_l = nt
-    return state.ρ * S_qt * (Φ + I_l)
+    nt = warm_rain_sources(m, state, aux, ts)
+    return nt.S_ρ_e
 end
 
 function source(
@@ -103,6 +101,6 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_rain_snow_params(m, state, aux, t, ts)
-    return nt.S_ρe
+    nt = rain_snow_sources(m, state, aux, ts)
+    return nt.S_ρ_e
 end

--- a/src/Atmos/Model/tendencies_mass.jl
+++ b/src/Atmos/Model/tendencies_mass.jl
@@ -50,8 +50,8 @@ function source(
     diffusive,
 )
     if has_condensate(ts)
-        nt = compute_remove_precip_params(s, aux, ts)
-        return state.ρ * nt.S_qt
+        nt = remove_precipitation_sources(s, m, state, aux, ts)
+        return nt.S_ρ_qt
     else
         FT = eltype(state)
         return FT(0)
@@ -68,8 +68,8 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_warm_rain_params(m, state, aux, t, ts)
-    return state.ρ * nt.S_qt
+    nt = warm_rain_sources(m, state, aux, ts)
+    return nt.S_ρ_qt
 end
 
 function source(
@@ -82,6 +82,6 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_rain_snow_params(m, state, aux, t, ts)
-    return state.ρ * nt.S_qt
+    nt = rain_snow_sources(m, state, aux, ts)
+    return nt.S_ρ_qt
 end

--- a/src/Atmos/Model/tendencies_moisture.jl
+++ b/src/Atmos/Model/tendencies_moisture.jl
@@ -115,8 +115,8 @@ function source(
     diffusive,
 )
     if has_condensate(ts)
-        nt = compute_remove_precip_params(s, aux, ts)
-        return state.ρ * nt.S_qt
+        nt = remove_precipitation_sources(s, m, state, aux, ts)
+        return nt.S_ρ_qt
     else
         FT = eltype(state)
         return FT(0)
@@ -133,8 +133,8 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_warm_rain_params(m, state, aux, t, ts)
-    return state.ρ * nt.S_qt
+    nt = warm_rain_sources(m, state, aux, ts)
+    return nt.S_ρ_qt
 end
 
 function source(
@@ -147,8 +147,8 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_warm_rain_params(m, state, aux, t, ts)
-    return state.ρ * nt.S_ql
+    nt = warm_rain_sources(m, state, aux, ts)
+    return nt.S_ρ_ql
 end
 
 function source(
@@ -161,8 +161,8 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_rain_snow_params(m, state, aux, t, ts)
-    return state.ρ * nt.S_qt
+    nt = rain_snow_sources(m, state, aux, ts)
+    return nt.S_ρ_qt
 end
 
 function source(
@@ -175,8 +175,8 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_rain_snow_params(m, state, aux, t, ts)
-    return state.ρ * nt.S_ql
+    nt = rain_snow_sources(m, state, aux, ts)
+    return nt.S_ρ_ql
 end
 
 function source(
@@ -189,6 +189,6 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_rain_snow_params(m, state, aux, t, ts)
-    return state.ρ * nt.S_qi
+    nt = rain_snow_sources(m, state, aux, ts)
+    return nt.S_ρ_qi
 end

--- a/src/Atmos/Model/tendencies_precipitation.jl
+++ b/src/Atmos/Model/tendencies_precipitation.jl
@@ -22,8 +22,8 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_warm_rain_params(m, state, aux, t, ts)
-    return state.ρ * nt.S_qr
+    nt = warm_rain_sources(m, state, aux, ts)
+    return nt.S_ρ_qr
 end
 
 function source(
@@ -36,8 +36,8 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_rain_snow_params(m, state, aux, t, ts)
-    return state.ρ * nt.S_qr
+    nt = rain_snow_sources(m, state, aux, ts)
+    return nt.S_ρ_qr
 end
 
 function source(
@@ -50,6 +50,6 @@ function source(
     direction,
     diffusive,
 )
-    nt = compute_rain_snow_params(m, state, aux, t, ts)
-    return state.ρ * nt.S_qs
+    nt = rain_snow_sources(m, state, aux, ts)
+    return nt.S_ρ_qs
 end


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->

I unified the returned items in the named tuple. Now all the microphysics multiphysics functions return only the source terms to state variables

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
