### PR TITLE
Reformulate source arguments, add precomputed NamedTuple

### DIFF
--- a/experiments/AtmosGCM/GCMDriver/gcm_sources.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_sources.jl
@@ -21,15 +21,9 @@ import ClimateMachine.Atmos: filter_source, atmos_source!
 filter_source(pv::PV, m, s::HeldSuarezForcing{PV}) where {PV} = s
 atmos_source!(::HeldSuarezForcing, args...) = nothing
 
-function held_suarez_forcing_coefficients(
-    bl,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function held_suarez_forcing_coefficients(bl, args)
+    @unpack state, aux = args
+    @unpack ts = args.precomputed
     FT = eltype(state)
 
     # Parameters
@@ -68,25 +62,10 @@ function held_suarez_forcing_coefficients(
     return (k_v = k_v, k_T = k_T, T_equil = T_equil)
 end
 
-function source(
-    s::HeldSuarezForcing{Energy},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = held_suarez_forcing_coefficients(
-        m,
-        state,
-        aux,
-        t,
-        ts,
-        direction,
-        diffusive,
-    )
+function source(s::HeldSuarezForcing{Energy}, m, args)
+    @unpack state = args
+    @unpack ts = args.precomputed
+    nt = held_suarez_forcing_coefficients(m, args)
     FT = eltype(state)
     _cv_d = FT(cv_d(m.param_set))
     @unpack k_T, T_equil = nt
@@ -94,24 +73,7 @@ function source(
     return -k_T * state.ρ * _cv_d * (T - T_equil)
 end
 
-function source(
-    s::HeldSuarezForcing{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = held_suarez_forcing_coefficients(
-        m,
-        state,
-        aux,
-        t,
-        ts,
-        direction,
-        diffusive,
-    )
-    return -nt.k_v * projection_tangential(m, aux, state.ρu)
+function source(s::HeldSuarezForcing{Momentum}, m, args)
+    nt = held_suarez_forcing_coefficients(m, args)
+    return -nt.k_v * projection_tangential(m, args.aux, args.state.ρu)
 end

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -92,16 +92,8 @@ end
 BomexGeostrophic(::Type{FT}, args...) where {FT} =
     BomexGeostrophic{Momentum, FT}(args...)
 
-function source(
-    s::BomexGeostrophic{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::BomexGeostrophic{Momentum}, m, args)
+    @unpack state, aux = args
     @unpack f_coriolis, u_geostrophic, u_slope, v_geostrophic = s
 
     z = altitude(m, aux)
@@ -135,16 +127,8 @@ end
 
 BomexSponge(::Type{FT}, args...) where {FT} = BomexSponge{Momentum, FT}(args...)
 
-function source(
-    s::BomexSponge{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::BomexSponge{Momentum}, m, args)
+    @unpack state, aux = args
     @unpack z_max, z_sponge, α_max, γ = s
     @unpack u_geostrophic, u_slope, v_geostrophic = s
 
@@ -193,16 +177,8 @@ BomexTendencies(::Type{FT}, args...) where {FT} = (
     BomexTendencies{TotalMoisture, FT}(args...),
 )
 
-function compute_bomex_tend_params(
-    s,
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function compute_bomex_tend_params(s, m, args)
+    @unpack state, aux = args
     FT = eltype(state)
     ρ = state.ρ
     z = altitude(m, aux)
@@ -249,34 +225,17 @@ function compute_bomex_tend_params(
     return (w_s = w_s, ρ∂qt∂t = ρ∂qt∂t, ρ∂θ∂t = ρ∂θ∂t, k̂ = k̂)
 end
 
-function source(
-    s::BomexTendencies{Mass},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    params =
-        compute_bomex_tend_params(s, m, state, aux, t, ts, direction, diffusive)
+function source(s::BomexTendencies{Mass}, m, args)
+    @unpack state, diffusive = args
+    params = compute_bomex_tend_params(s, m, args)
     @unpack ρ∂qt∂t, w_s, k̂ = params
     ρ = state.ρ
     return ρ∂qt∂t - state.ρ * w_s * dot(k̂, diffusive.moisture.∇q_tot)
 end
-function source(
-    s::BomexTendencies{Energy},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    params =
-        compute_bomex_tend_params(s, m, state, aux, t, ts, direction, diffusive)
+function source(s::BomexTendencies{Energy}, m, args)
+    @unpack state, diffusive = args
+    @unpack ts = args.precomputed
+    params = compute_bomex_tend_params(s, m, args)
     FT = eltype(state)
     @unpack ρ∂qt∂t, ρ∂θ∂t, w_s, k̂ = params
     cvm = cv_m(ts)
@@ -285,18 +244,9 @@ function source(
     term2 = state.ρ * w_s * dot(k̂, diffusive.∇h_tot)
     return term1 - term2
 end
-function source(
-    s::BomexTendencies{TotalMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    params =
-        compute_bomex_tend_params(s, m, state, aux, t, ts, direction, diffusive)
+function source(s::BomexTendencies{TotalMoisture}, m, args)
+    @unpack state, diffusive = args
+    params = compute_bomex_tend_params(s, m, args)
     @unpack ρ∂qt∂t, w_s, k̂ = params
     return ρ∂qt∂t - state.ρ * w_s * dot(k̂, diffusive.moisture.∇q_tot)
 end

--- a/experiments/AtmosLES/convective_bl_model.jl
+++ b/experiments/AtmosLES/convective_bl_model.jl
@@ -63,16 +63,8 @@ end
 ConvectiveBLGeostrophic(::Type{FT}, args...) where {FT} =
     ConvectiveBLGeostrophic{Momentum, FT}(args...)
 
-function source(
-    s::ConvectiveBLGeostrophic{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::ConvectiveBLGeostrophic{Momentum}, m, args)
+    @unpack state, aux = args
     @unpack f_coriolis, u_geostrophic, u_slope, v_geostrophic = s
 
     z = altitude(m, aux)
@@ -106,16 +98,9 @@ end
 ConvectiveBLSponge(::Type{FT}, args...) where {FT} =
     ConvectiveBLSponge{Momentum, FT}(args...)
 
-function source(
-    s::ConvectiveBLSponge{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::ConvectiveBLSponge{Momentum}, m, args)
+    @unpack state, aux = args
+
     @unpack z_max, z_sponge, α_max, γ = s
     @unpack u_geostrophic, u_slope, v_geostrophic = s
 

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -62,16 +62,8 @@ end
 StableBLGeostrophic(::Type{FT}, args...) where {FT} =
     StableBLGeostrophic{Momentum, FT}(args...)
 
-function source(
-    s::StableBLGeostrophic{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::StableBLGeostrophic{Momentum}, m, args)
+    @unpack state, aux = args
     @unpack f_coriolis, u_geostrophic, u_slope, v_geostrophic = s
 
     z = altitude(m, aux)
@@ -106,16 +98,9 @@ end
 StableBLSponge(::Type{FT}, args...) where {FT} =
     StableBLSponge{Momentum, FT}(args...)
 
-function source(
-    s::StableBLSponge{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::StableBLSponge{Momentum}, m, args)
+    @unpack state, aux = args
+
     @unpack z_max, z_sponge, α_max, γ = s
     @unpack u_geostrophic, u_slope, v_geostrophic = s
 

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -181,21 +181,10 @@ function flux_second_order!(moist::EquilMoist, flux::Grad, state::Vars, d_q_tot)
     flux.moisture.ρq_tot += d_q_tot * state.ρ
 end
 
-function source!(
-    m::EquilMoist,
-    source::Vars,
-    atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    direction,
-    diffusive::Vars,
-)
+function source!(m::EquilMoist, source::Vars, atmos::AtmosModel, args)
     tend = Source()
-    args = (atmos, state, aux, t, ts, direction, diffusive)
     source.moisture.ρq_tot =
-        Σsources(eq_tends(TotalMoisture(), atmos, tend), args...)
+        Σsources(eq_tends(TotalMoisture(), atmos, tend), atmos, args)
 end
 
 """
@@ -306,23 +295,12 @@ function flux_second_order!(
     flux.moisture.ρq_ice += d_q_ice * state.ρ
 end
 
-function source!(
-    m::NonEquilMoist,
-    source::Vars,
-    atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    direction,
-    diffusive::Vars,
-)
+function source!(m::NonEquilMoist, source::Vars, atmos::AtmosModel, args)
     tend = Source()
-    args = (atmos, state, aux, t, ts, direction, diffusive)
     source.moisture.ρq_tot =
-        Σsources(eq_tends(TotalMoisture(), atmos, tend), args...)
+        Σsources(eq_tends(TotalMoisture(), atmos, tend), atmos, args)
     source.moisture.ρq_liq =
-        Σsources(eq_tends(LiquidMoisture(), atmos, tend), args...)
+        Σsources(eq_tends(LiquidMoisture(), atmos, tend), atmos, args)
     source.moisture.ρq_ice =
-        Σsources(eq_tends(IceMoisture(), atmos, tend), args...)
+        Σsources(eq_tends(IceMoisture(), atmos, tend), atmos, args)
 end

--- a/src/Atmos/Model/multiphysics_types.jl
+++ b/src/Atmos/Model/multiphysics_types.jl
@@ -51,10 +51,10 @@ RemovePrecipitation(b::Bool) = (
 function remove_precipitation_sources(
     s::RemovePrecipitation{PV},
     atmos,
-    state,
-    aux,
-    ts,
+    args,
 ) where {PV <: Union{Mass, Energy, TotalMoisture}}
+    @unpack state, aux = args
+    @unpack ts = args.precomputed
 
     FT = eltype(state)
 
@@ -94,7 +94,9 @@ WarmRain_1M() = (
     WarmRain_1M{Rain}(),
 )
 
-function warm_rain_sources(atmos, state, aux, ts)
+function warm_rain_sources(atmos, args)
+    @unpack state, aux = args
+    @unpack ts = args.precomputed
 
     FT = eltype(state)
 
@@ -156,7 +158,9 @@ RainSnow_1M() = (
     RainSnow_1M{Snow}(),
 )
 
-function rain_snow_sources(atmos, state, aux, ts)
+function rain_snow_sources(atmos, args)
+    @unpack state, aux = args
+    @unpack ts = args.precomputed
 
     FT = eltype(state)
 

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -184,21 +184,10 @@ function flux_second_order!(precip::RainModel, flux::Grad, state::Vars, d_q_rai)
     flux.precipitation.ρq_rai += d_q_rai * state.ρ
 end
 
-function source!(
-    m::RainModel,
-    source::Vars,
-    atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    direction,
-    diffusive::Vars,
-)
+function source!(m::RainModel, source::Vars, atmos::AtmosModel, args)
     tend = Source()
-    args = (atmos, state, aux, t, ts, direction, diffusive)
     source.precipitation.ρq_rai =
-        Σsources(eq_tends(Rain(), atmos, tend), args...)
+        Σsources(eq_tends(Rain(), atmos, tend), atmos, args)
 end
 
 """
@@ -278,23 +267,12 @@ function flux_second_order!(
     flux.precipitation.ρq_sno = Σfluxes(eq_tends(Snow(), atmos, tend), args...)
 end
 
-function source!(
-    m::RainSnowModel,
-    source::Vars,
-    atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    direction,
-    diffusive::Vars,
-)
+function source!(m::RainSnowModel, source::Vars, atmos::AtmosModel, args)
     tend = Source()
-    args = (atmos, state, aux, t, ts, direction, diffusive)
     source.precipitation.ρq_rai =
-        Σsources(eq_tends(Rain(), atmos, tend), args...)
+        Σsources(eq_tends(Rain(), atmos, tend), atmos, args)
     source.precipitation.ρq_sno =
-        Σsources(eq_tends(Snow(), atmos, tend), args...)
+        Σsources(eq_tends(Snow(), atmos, tend), atmos, args)
 end
 
 #####

--- a/src/Atmos/Model/tendencies_energy.jl
+++ b/src/Atmos/Model/tendencies_energy.jl
@@ -42,34 +42,19 @@ end
 ##### Sources
 #####
 
-function source(
-    s::Subsidence{Energy},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::Subsidence{Energy}, m, args)
+    @unpack state, aux, diffusive = args
     z = altitude(m, aux)
     w_sub = subsidence_velocity(s, z)
     k̂ = vertical_unit_vector(m, aux)
     return -state.ρ * w_sub * dot(k̂, diffusive.∇h_tot)
 end
 
-function source(
-    s::RemovePrecipitation{Energy},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::RemovePrecipitation{Energy}, m, args)
+    @unpack state = args
+    @unpack ts = args.precomputed
     if has_condensate(ts)
-        nt = remove_precipitation_sources(s, m, state, aux, ts)
+        nt = remove_precipitation_sources(s, m, args)
         return nt.S_ρ_e
     else
         FT = eltype(state)
@@ -77,30 +62,12 @@ function source(
     end
 end
 
-function source(
-    s::WarmRain_1M{Energy},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = warm_rain_sources(m, state, aux, ts)
+function source(s::WarmRain_1M{Energy}, m, args)
+    nt = warm_rain_sources(m, args)
     return nt.S_ρ_e
 end
 
-function source(
-    s::RainSnow_1M{Energy},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = rain_snow_sources(m, state, aux, ts)
+function source(s::RainSnow_1M{Energy}, m, args)
+    nt = rain_snow_sources(m, args)
     return nt.S_ρ_e
 end

--- a/src/Atmos/Model/tendencies_mass.jl
+++ b/src/Atmos/Model/tendencies_mass.jl
@@ -32,25 +32,19 @@ end
 ##### Sources
 #####
 
-function source(s::Subsidence{Mass}, m, state, aux, t, ts, direction, diffusive)
+function source(s::Subsidence{Mass}, m, args)
+    @unpack state, aux, diffusive = args
     z = altitude(m, aux)
     w_sub = subsidence_velocity(s, z)
     k̂ = vertical_unit_vector(m, aux)
     return -state.ρ * w_sub * dot(k̂, diffusive.moisture.∇q_tot)
 end
 
-function source(
-    s::RemovePrecipitation{Mass},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::RemovePrecipitation{Mass}, m, args)
+    @unpack state = args
+    @unpack ts = args.precomputed
     if has_condensate(ts)
-        nt = remove_precipitation_sources(s, m, state, aux, ts)
+        nt = remove_precipitation_sources(s, m, args)
         return nt.S_ρ_qt
     else
         FT = eltype(state)
@@ -58,30 +52,12 @@ function source(
     end
 end
 
-function source(
-    s::WarmRain_1M{Mass},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = warm_rain_sources(m, state, aux, ts)
+function source(s::WarmRain_1M{Mass}, m, args)
+    nt = warm_rain_sources(m, args)
     return nt.S_ρ_qt
 end
 
-function source(
-    s::RainSnow_1M{Mass},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = rain_snow_sources(m, state, aux, ts)
+function source(s::RainSnow_1M{Mass}, m, args)
+    nt = rain_snow_sources(m, args)
     return nt.S_ρ_qt
 end

--- a/src/Atmos/Model/tendencies_moisture.jl
+++ b/src/Atmos/Model/tendencies_moisture.jl
@@ -23,16 +23,8 @@ end
 ##### Sources
 #####
 
-function source(
-    s::Subsidence{TotalMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::Subsidence{TotalMoisture}, m, args)
+    @unpack state, aux, diffusive = args
     z = altitude(m, aux)
     w_sub = subsidence_velocity(s, z)
     k̂ = vertical_unit_vector(m, aux)
@@ -52,16 +44,9 @@ struct CreateClouds{PV <: Union{LiquidMoisture, IceMoisture}} <:
 
 CreateClouds() = (CreateClouds{LiquidMoisture}(), CreateClouds{IceMoisture}())
 
-function source(
-    s::CreateClouds{LiquidMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::CreateClouds{LiquidMoisture}, m, args)
+    @unpack state = args
+    @unpack ts = args.precomputed
     # get current temperature and phase partition
     FT = eltype(state)
     q = PhasePartition(ts)
@@ -78,16 +63,9 @@ function source(
     return state.ρ * S_q_liq
 end
 
-function source(
-    s::CreateClouds{IceMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::CreateClouds{IceMoisture}, m, args)
+    @unpack state = args
+    @unpack ts = args.precomputed
     # get current temperature and phase partition
     FT = eltype(state)
     q = PhasePartition(ts)
@@ -104,18 +82,11 @@ function source(
     return state.ρ * S_q_ice
 end
 
-function source(
-    s::RemovePrecipitation{TotalMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::RemovePrecipitation{TotalMoisture}, m, args)
+    @unpack state = args
+    @unpack ts = args.precomputed
     if has_condensate(ts)
-        nt = remove_precipitation_sources(s, m, state, aux, ts)
+        nt = remove_precipitation_sources(s, m, args)
         return nt.S_ρ_qt
     else
         FT = eltype(state)
@@ -123,72 +94,27 @@ function source(
     end
 end
 
-function source(
-    s::WarmRain_1M{TotalMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = warm_rain_sources(m, state, aux, ts)
+function source(s::WarmRain_1M{TotalMoisture}, m, args)
+    nt = warm_rain_sources(m, args)
     return nt.S_ρ_qt
 end
 
-function source(
-    s::WarmRain_1M{LiquidMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = warm_rain_sources(m, state, aux, ts)
+function source(s::WarmRain_1M{LiquidMoisture}, m, args)
+    nt = warm_rain_sources(m, args)
     return nt.S_ρ_ql
 end
 
-function source(
-    s::RainSnow_1M{TotalMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = rain_snow_sources(m, state, aux, ts)
+function source(s::RainSnow_1M{TotalMoisture}, m, args)
+    nt = rain_snow_sources(m, args)
     return nt.S_ρ_qt
 end
 
-function source(
-    s::RainSnow_1M{LiquidMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = rain_snow_sources(m, state, aux, ts)
+function source(s::RainSnow_1M{LiquidMoisture}, m, args)
+    nt = rain_snow_sources(m, args)
     return nt.S_ρ_ql
 end
 
-function source(
-    s::RainSnow_1M{IceMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = rain_snow_sources(m, state, aux, ts)
+function source(s::RainSnow_1M{IceMoisture}, m, args)
+    nt = rain_snow_sources(m, args)
     return nt.S_ρ_qi
 end

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -45,16 +45,8 @@ end
 export Gravity
 struct Gravity{PV <: Momentum} <: TendencyDef{Source, PV} end
 Gravity() = Gravity{Momentum}()
-function source(
-    s::Gravity{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::Gravity{Momentum}, m, args)
+    @unpack state, aux = args
     if m.ref_state isa HydrostaticState
         return -(state.ρ - aux.ref_state.ρ) * aux.orientation.∇Φ
     else
@@ -65,16 +57,8 @@ end
 export Coriolis
 struct Coriolis{PV <: Momentum} <: TendencyDef{Source, PV} end
 Coriolis() = Coriolis{Momentum}()
-function source(
-    s::Coriolis{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::Coriolis{Momentum}, m, args)
+    @unpack state = args
     FT = eltype(state)
     _Omega::FT = Omega(m.param_set)
     # note: this assumes a SphericalOrientation
@@ -89,16 +73,8 @@ struct GeostrophicForcing{PV <: Momentum, FT} <: TendencyDef{Source, PV}
 end
 GeostrophicForcing(::Type{FT}, args...) where {FT} =
     GeostrophicForcing{Momentum, FT}(args...)
-function source(
-    s::GeostrophicForcing{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::GeostrophicForcing{Momentum}, m, args)
+    @unpack state, aux = args
     u_geo = SVector(s.u_geostrophic, s.v_geostrophic, 0)
     ẑ = vertical_unit_vector(m, aux)
     fkvector = s.f_coriolis * ẑ
@@ -128,16 +104,8 @@ struct RayleighSponge{PV <: Momentum, FT} <: TendencyDef{Source, PV}
 end
 RayleighSponge(::Type{FT}, args...) where {FT} =
     RayleighSponge{Momentum, FT}(args...)
-function source(
-    s::RayleighSponge{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function source(s::RayleighSponge{Momentum}, m, args)
+    @unpack state, aux = args
     z = altitude(m, aux)
     if z >= s.z_sponge
         r = (z - s.z_sponge) / (s.z_max - s.z_sponge)

--- a/src/Atmos/Model/tendencies_precipitation.jl
+++ b/src/Atmos/Model/tendencies_precipitation.jl
@@ -25,44 +25,17 @@ end
 ##### Sources
 #####
 
-function source(
-    s::WarmRain_1M{Rain},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = warm_rain_sources(m, state, aux, ts)
+function source(s::WarmRain_1M{Rain}, m, args)
+    nt = warm_rain_sources(m, args)
     return nt.S_ρ_qr
 end
 
-function source(
-    s::RainSnow_1M{Rain},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = rain_snow_sources(m, state, aux, ts)
+function source(s::RainSnow_1M{Rain}, m, args)
+    nt = rain_snow_sources(m, args)
     return nt.S_ρ_qr
 end
 
-function source(
-    s::RainSnow_1M{Snow},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = rain_snow_sources(m, state, aux, ts)
+function source(s::RainSnow_1M{Snow}, m, args)
+    nt = rain_snow_sources(m, args)
     return nt.S_ρ_qs
 end

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -30,6 +30,7 @@ using LinearAlgebra
 using MPI
 using StaticArrays
 using Test
+using UnPack
 
 const clima_dir = dirname(dirname(pathof(ClimateMachine)));
 include(joinpath(
@@ -65,29 +66,13 @@ MMSSource(N::Int) =
     (MMSSource{Mass, N}(), MMSSource{Momentum, N}(), MMSSource{Energy, N}())
 
 
-function source(
-    s::MMSSource{Mass, N},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-) where {N}
+function source(s::MMSSource{Mass, N}, m, args) where {N}
+    @unpack aux, t = args
     x1, x2, x3 = aux.coord
     return Sρ_g(t, x1, x2, x3, Val(N))
 end
-function source(
-    s::MMSSource{Momentum, N},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-) where {N}
+function source(s::MMSSource{Momentum, N}, m, args) where {N}
+    @unpack aux, t = args
     x1, x2, x3 = aux.coord
     return SVector(
         SU_g(t, x1, x2, x3, Val(N)),
@@ -95,16 +80,8 @@ function source(
         SW_g(t, x1, x2, x3, Val(N)),
     )
 end
-function source(
-    s::MMSSource{Energy, N},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-) where {N}
+function source(s::MMSSource{Energy, N}, m, args) where {N}
+    @unpack aux, t = args
     x1, x2, x3 = aux.coord
     return SE_g(t, x1, x2, x3, Val(N))
 end

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -4,6 +4,7 @@ using LinearAlgebra
 using MPI
 using Printf
 using StaticArrays
+using UnPack
 
 using ClimateMachine
 using ClimateMachine.ConfigTypes
@@ -69,29 +70,13 @@ MMSSource(N::Int) =
     (MMSSource{Mass, N}(), MMSSource{Momentum, N}(), MMSSource{Energy, N}())
 
 
-function source(
-    s::MMSSource{Mass, N},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-) where {N}
+function source(s::MMSSource{Mass, N}, m, args) where {N}
+    @unpack aux, t = args
     x1, x2, x3 = aux.coord
     return Sρ_g(t, x1, x2, x3, Val(N))
 end
-function source(
-    s::MMSSource{Momentum, N},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-) where {N}
+function source(s::MMSSource{Momentum, N}, m, args) where {N}
+    @unpack aux, t = args
     x1, x2, x3 = aux.coord
     return SVector(
         SU_g(t, x1, x2, x3, Val(N)),
@@ -99,16 +84,8 @@ function source(
         SW_g(t, x1, x2, x3, Val(N)),
     )
 end
-function source(
-    s::MMSSource{Energy, N},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-) where {N}
+function source(s::MMSSource{Energy, N}, m, args) where {N}
+    @unpack aux, t = args
     x1, x2, x3 = aux.coord
     return SE_g(t, x1, x2, x3, Val(N))
 end

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -61,15 +61,9 @@ HeldSuarezForcingTutorial() =
 filter_source(pv::PV, m, s::HeldSuarezForcingTutorial{PV}) where {PV} = s
 atmos_source!(::HeldSuarezForcingTutorial, args...) = nothing
 
-function held_suarez_forcing_coefficients(
-    bl,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
+function held_suarez_forcing_coefficients(bl, args)
+    @unpack state, aux = args
+    @unpack ts = args.precomputed
     FT = eltype(state)
 
     ## Parameters
@@ -108,50 +102,19 @@ function held_suarez_forcing_coefficients(
     return (k_v = k_v, k_T = k_T, T_equil = T_equil)
 end
 
-function source(
-    s::HeldSuarezForcingTutorial{Energy},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = held_suarez_forcing_coefficients(
-        m,
-        state,
-        aux,
-        t,
-        ts,
-        direction,
-        diffusive,
-    )
+function source(s::HeldSuarezForcingTutorial{Energy}, m, args)
+    @unpack state = args
+    @unpack ts = args.precomputed
+    nt = held_suarez_forcing_coefficients(m, args)
     _cv_d = FT(cv_d(m.param_set))
     @unpack k_T, T_equil = nt
     T = air_temperature(ts)
     return -k_T * state.ρ * _cv_d * (T - T_equil)
 end
 
-function source(
-    s::HeldSuarezForcingTutorial{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    direction,
-    diffusive,
-)
-    nt = held_suarez_forcing_coefficients(
-        m,
-        state,
-        aux,
-        t,
-        ts,
-        direction,
-        diffusive,
-    )
+function source(s::HeldSuarezForcingTutorial{Momentum}, m, args)
+    @unpack state, aux = args
+    nt = held_suarez_forcing_coefficients(m, args)
     return -nt.k_v * projection_tangential(m, aux, state.ρu)
 end
 


### PR DESCRIPTION
### Description

This is a tracer bullet for my [proposed solution](https://github.com/CliMA/ClimateMachine.jl/issues/1832#issuecomment-742168958) to #1832 specifically for `source` in the AtmosModel--but we can extend this to `flux` as well. The basic idea is that the argument list is:

```julia
source(::S, ::BalanceLaw, args::NamedTuple, precomputed::NamedTuple) where {S <: TendencyDef{Source, PrognosticVariable}}
```

`precomputed` is computed in `source!` as
```julia
precompute(atmos::AtmosModel, args, ::Source) =
    (ts = recover_thermo_state(atmos, args.state, args.aux),)

function source!(m::AtmosModel, ...)
    tend = Source()
    args = (
        state = state,
        aux = aux,
        t = t,
        direction = direction,
        diffusive = diffusive,
    )
    precomputed = precompute(m, args, tend)

    source.ρ = Σsources(eq_tends(Mass(), m, tend), m, args, precomputed)
...
end
```

We can compute `precomputed` in a nested, model-dependent, way so that we only precompute things when needed:

```julia
precompute(atmos::AtmosModel, args, tt::Flux{SecondOrder}) =
    (
     ts = recover_thermo_state(atmos, args.state, args.aux),
     turbulence = precompute(atmos.turbulence, atmos, args, tt),
     )
function precompute(m::TurbulenceClosureModel, atmos::AtmosModel, args, ::Flux{SecondOrder})
     ν, D_t, τ = turbulence_tensors(atmos, args.state, args.diffusive, args.aux, args.t)
    return (ν = ν, D_t = D_t, τ = τ)
end
```

That way, in the `flux` kernels, we'll have access to, for example, `precomputed.turbulence.D_t`. This should be easy to extend and inject nearly anything we want from the top-level `source!` into any nested submodel. Finally, `args` can be treated as effectively the same args that are available at the top-level `source!`. Thoughts?

Some solution, that allows us to optionally precompute things, is really needed to convert the remaining (EDMF) sources to the new tendency specification. Once we've converted all of the sources, we'll be able to cut out a bunch of unnecessary boilerplate (e.g., removing `atmos_source!`).

## Update

I've incorporated @simonbyrne's suggestion and used `merge` so that `precomputed` is stored in `args` as `args.precomputed`, so that we only need a single argument 🎉.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
