### PR TITLE
Add thermo ProfileSet Iterator

### DIFF
--- a/test/Common/Thermodynamics/profiles.jl
+++ b/test/Common/Thermodynamics/profiles.jl
@@ -34,6 +34,33 @@ struct ProfileSet{AFT, QPT, PT}
     phase_type::PT  # Phase type (e.g., `PhaseDry`, `PhaseEquil`)
 end
 
+function Base.iterate(ps::ProfileSet, state = 1)
+    state > length(ps.z) && return nothing
+    nt = (
+        z = ps.z[state],
+        T = ps.T[state],
+        p = ps.p[state],
+        RS = ps.RS[state],
+        e_int = ps.e_int[state],
+        ρ = ps.ρ[state],
+        θ_liq_ice = ps.θ_liq_ice[state],
+        q_tot = ps.q_tot[state],
+        q_liq = ps.q_liq[state],
+        q_ice = ps.q_ice[state],
+        q_pt = ps.q_pt[state],
+        RH = ps.RH[state],
+        e_pot = ps.e_pot[state],
+        u = ps.u[state],
+        v = ps.v[state],
+        w = ps.w[state],
+        e_kin = ps.e_kin[state],
+        phase_type = ps.phase_type,
+    )
+    return (nt, state + 1)
+end
+Base.IteratorSize(::ProfileSet) = Base.HasLength()
+Base.length(ps::ProfileSet) = length(ps.z)
+
 """
     input_config(
         ArrayType;

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -1171,3 +1171,14 @@ end
     @test all(last.(gas_constants.(ts_eq)) ≈ last.(gas_constants.(ts_dry)))
 
 end
+
+@testset "Thermodynamics - ProfileSet Iterator" begin
+    ArrayType = Array{Float64}
+    FT = eltype(ArrayType)
+    profiles = PhaseEquilProfiles(param_set, ArrayType)
+    @unpack T, q_pt, z, phase_type = profiles
+    @test all(z .≈ (nt.z for nt in profiles))
+    @test all(T .≈ (nt.T for nt in profiles))
+    @test all(getproperty.(q_pt, :tot) .≈ (nt.q_pt.tot for nt in profiles))
+    @test all(phase_type .== (nt.phase_type for nt in profiles))
+end


### PR DESCRIPTION
### Description

Working on #1830, I realized that it would be really helpful to iterate, pointwise, through the set of thermo profiles. This way we can test the primitive-prognostic conversion across the same set of profiles that thermodynamics is tested. This PR adds and tests this iterator.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
