### PR TITLE
Jmc/split explicit cleaning

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1286,6 +1286,16 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "gpu_simple_dbl_gyre"
+    key: "gpu_simple_dbl_gyre"
+    command:
+      - "mpiexec julia --color=yes --project test/Ocean/SplitExplicit/simple_dbl_gyre.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
   - label: "gpu_discrete_hydrostatic_balance"
     key: "gpu_discrete_hydrostatic_balance"
     command:

--- a/src/Ocean/SplitExplicit01/BarotropicModel.jl
+++ b/src/Ocean/SplitExplicit01/BarotropicModel.jl
@@ -85,7 +85,7 @@ end
     t,
 )
     ν = viscosity_tensor(m)
-    D.ν∇U = ν * G.U
+    D.ν∇U = -ν * G.U
 
     return nothing
 end
@@ -132,7 +132,7 @@ end
     t::Real,
 )
     # numerical diffusivity for stability
-    F.U -= D.ν∇U
+    F.U += D.ν∇U
 
     return nothing
 end

--- a/src/Ocean/SplitExplicit01/IVDCModel.jl
+++ b/src/Ocean/SplitExplicit01/IVDCModel.jl
@@ -3,9 +3,6 @@
 #
 # In this version the operator is tweked to be the indentity for testing
 
-using ClimateMachine.DGMethods.NumericalFluxes:
-    NumericalFluxFirstOrder, NumericalFluxSecondOrder, NumericalFluxGradient
-
 """
  IVDCModel{M} <: BalanceLaw
 

--- a/src/Ocean/SplitExplicit01/OceanBoundaryConditions.jl
+++ b/src/Ocean/SplitExplicit01/OceanBoundaryConditions.jl
@@ -7,6 +7,7 @@ struct CoastlineFreeSlip <: OceanBoundaryCondition end
 struct CoastlineNoSlip <: OceanBoundaryCondition end
 struct OceanFloorFreeSlip <: OceanBoundaryCondition end
 struct OceanFloorNoSlip <: OceanBoundaryCondition end
+struct OceanFloorLinearDrag <: OceanBoundaryCondition end
 struct OceanSurfaceNoStressNoForcing <: OceanBoundaryCondition end
 struct OceanSurfaceStressNoForcing <: OceanBoundaryCondition end
 struct OceanSurfaceNoStressForcing <: OceanBoundaryCondition end
@@ -52,7 +53,7 @@ applies boundary condition ∇u = 0 and ∇θ = 0
 """
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder})
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::NumericalFluxFirstOrder)
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
@@ -60,7 +61,7 @@ apply no penetration boundary for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::CoastlineFreeSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::NumericalFluxFirstOrder,
     Q⁺,
     A⁺,
     n⁻,
@@ -80,7 +81,7 @@ end
 @inline function ocean_boundary_state!(
     ::BarotropicModel,
     ::CoastlineFreeSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::NumericalFluxFirstOrder,
     Q⁺,
     A⁺,
     n⁻,
@@ -98,7 +99,7 @@ end
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::CentralNumericalFluxGradient)
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::NumericalFluxGradient)
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
@@ -106,7 +107,7 @@ apply no penetration boundary for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::CoastlineFreeSlip,
-    ::CentralNumericalFluxGradient,
+    ::NumericalFluxGradient,
     Q⁺,
     A⁺,
     n⁻,
@@ -128,7 +129,7 @@ end
 @inline function ocean_boundary_state!(
     ::BarotropicModel,
     ::CoastlineFreeSlip,
-    ::CentralNumericalFluxGradient,
+    ::NumericalFluxGradient,
     Q⁺,
     A⁺,
     n⁻,
@@ -146,7 +147,7 @@ end
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineFreeSlip, ::NumericalFluxSecondOrder)
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
@@ -154,7 +155,7 @@ apply no penetration boundary for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::CoastlineFreeSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::NumericalFluxSecondOrder,
     Q⁺,
     D⁺,
     A⁺,
@@ -164,13 +165,6 @@ apply no penetration boundary for temperature
     A⁻,
     t,
 )
-    #   D⁺.ν∇u = -D⁻.ν∇u
-    #   D⁺.κ∇θ = -D⁻.κ∇θ
-    #-  new diffusive flux BC:
-    Q⁺.u = Q⁻.u
-    A⁺.u_d = A⁻.u_d
-    A⁺.w = A⁻.w
-    Q⁺.θ = Q⁻.θ
     D⁺.ν∇u = n⁻ * (@SVector [-0, -0])'
     D⁺.κ∇θ = n⁻ * -0
 
@@ -180,7 +174,7 @@ end
 @inline function ocean_boundary_state!(
     ::BarotropicModel,
     ::CoastlineFreeSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::NumericalFluxSecondOrder,
     Q⁺,
     D⁺,
     A⁺,
@@ -190,9 +184,6 @@ end
     A⁻,
     t,
 )
-    #   D⁺.ν∇U = -D⁻.ν∇U
-    #-  new diffusive flux BC:
-    Q⁺.U = Q⁻.U
     D⁺.ν∇U = n⁻ * (@SVector [-0, -0])'
 
     return nothing
@@ -205,7 +196,7 @@ applies boundary condition u = 0 and ∇θ = 0
 """
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineNoSlip, ::RusanovNumericalFlux)
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineNoSlip, ::NumericalFluxFirstOrder)
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
@@ -213,7 +204,7 @@ apply no penetration boundary for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::CoastlineNoSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::NumericalFluxFirstOrder,
     Q⁺,
     A⁺,
     n⁻,
@@ -229,7 +220,7 @@ end
 @inline function ocean_boundary_state!(
     ::BarotropicModel,
     ::CoastlineNoSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::NumericalFluxFirstOrder,
     Q⁺,
     A⁺,
     n⁻,
@@ -243,7 +234,7 @@ end
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineNoSlip, ::CentralNumericalFluxGradient)
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineNoSlip, ::NumericalFluxGradient)
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
@@ -251,7 +242,7 @@ apply no penetration boundary for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::CoastlineNoSlip,
-    ::CentralNumericalFluxGradient,
+    ::NumericalFluxGradient,
     Q⁺,
     A⁺,
     n⁻,
@@ -269,7 +260,7 @@ end
 @inline function ocean_boundary_state!(
     ::BarotropicModel,
     ::CoastlineNoSlip,
-    ::CentralNumericalFluxGradient,
+    ::NumericalFluxGradient,
     Q⁺,
     A⁺,
     n⁻,
@@ -284,7 +275,7 @@ end
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineNoSlip, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::CoastlineNoSlip, ::NumericalFluxSecondOrder)
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
@@ -292,7 +283,7 @@ apply no penetration boundary for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::CoastlineNoSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::NumericalFluxSecondOrder,
     Q⁺,
     D⁺,
     A⁺,
@@ -302,15 +293,6 @@ apply no penetration boundary for temperature
     A⁻,
     t,
 )
-    Q⁺.u = -Q⁻.u
-    A⁺.u_d = -A⁻.u_d
-
-    #   D⁺.κ∇θ = -D⁻.κ∇θ
-
-    #-  new diffusive flux BC:
-    #   Q⁺.u = -Q⁻.u
-    #   A⁺.w = -A⁻.w
-    Q⁺.θ = Q⁻.θ
     D⁺.ν∇u = D⁻.ν∇u
     D⁺.κ∇θ = n⁻ * -0
 
@@ -320,7 +302,7 @@ end
 @inline function ocean_boundary_state!(
     ::BarotropicModel,
     ::CoastlineNoSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::NumericalFluxSecondOrder,
     Q⁺,
     D⁺,
     A⁺,
@@ -330,8 +312,6 @@ end
     A⁻,
     t,
 )
-    Q⁺.U = -Q⁻.U
-    #-  new diffusive flux BC:
     D⁺.ν∇U = D⁻.ν∇U
 
     return nothing
@@ -344,7 +324,7 @@ applies boundary condition ∇u = 0 and ∇θ = 0
 """
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorFreeSlip, ::RusanovNumericalFlux)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorFreeSlip, ::NumericalFluxFirstOrder)
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
@@ -352,7 +332,7 @@ apply no penetration boundary for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::OceanFloorFreeSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::NumericalFluxFirstOrder,
     Q⁺,
     A⁺,
     n⁻,
@@ -366,7 +346,7 @@ apply no penetration boundary for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorFreeSlip, ::CentralNumericalFluxGradient)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorFreeSlip, ::NumericalFluxGradient)
 
 apply free slip boundary condition for velocity
 apply no penetration boundary for temperature
@@ -374,7 +354,7 @@ apply no penetration boundary for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::OceanFloorFreeSlip,
-    ::CentralNumericalFluxGradient,
+    ::NumericalFluxGradient,
     Q⁺,
     A⁺,
     n⁻,
@@ -389,7 +369,7 @@ apply no penetration boundary for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorFreeSlip, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorFreeSlip, ::NumericalFluxSecondOrder)
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
@@ -397,7 +377,7 @@ apply no penetration boundary for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::OceanFloorFreeSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::NumericalFluxSecondOrder,
     Q⁺,
     D⁺,
     A⁺,
@@ -407,16 +387,6 @@ apply no penetration boundary for temperature
     A⁻,
     t,
 )
-    #   A⁺.w = -A⁻.w
-    #   D⁺.ν∇u = -D⁻.ν∇u
-
-    #   D⁺.κ∇θ = -D⁻.κ∇θ
-
-    #-  new diffusive flux BC:
-    Q⁺.u = Q⁻.u
-    A⁺.u_d = A⁻.u_d
-    A⁺.w = A⁻.w
-    Q⁺.θ = Q⁻.θ
     D⁺.ν∇u = n⁻ * (@SVector [-0, -0])'
     D⁺.κ∇θ = n⁻ * -0
 
@@ -430,15 +400,15 @@ applies boundary condition u = 0 and ∇θ = 0
 """
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorNoSlip, ::RusanovNumericalFlux)
+    ocean_boundary_state!(::AbstractOceanModel, ::Union{OceanFloorNoSlip, OceanFloorLinearDrag}, ::NumericalFluxFirstOrder)
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
-    ::OceanFloorNoSlip,
-    ::Union{RusanovNumericalFlux, CentralNumericalFluxFirstOrder},
+    ::Union{OceanFloorNoSlip, OceanFloorLinearDrag},
+    ::NumericalFluxFirstOrder,
     Q⁺,
     A⁺,
     n⁻,
@@ -453,15 +423,15 @@ apply no penetration boundary for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorNoSlip, ::CentralNumericalFluxGradient)
+    ocean_boundary_state!(::AbstractOceanModel, ::Union{OceanFloorNoSlip, OceanFloorLinearDrag}, ::NumericalFluxGradient)
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
 """
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
-    ::OceanFloorNoSlip,
-    ::CentralNumericalFluxGradient,
+    ::Union{OceanFloorNoSlip, OceanFloorLinearDrag},
+    ::NumericalFluxGradient,
     Q⁺,
     A⁺,
     n⁻,
@@ -477,7 +447,7 @@ apply no penetration boundary for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorNoSlip, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorNoSlip, ::NumericalFluxSecondOrder)
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
@@ -485,7 +455,7 @@ apply no penetration boundary for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::OceanFloorNoSlip,
-    ::CentralNumericalFluxSecondOrder,
+    ::NumericalFluxSecondOrder,
     Q⁺,
     D⁺,
     A⁺,
@@ -495,16 +465,6 @@ apply no penetration boundary for temperature
     A⁻,
     t,
 )
-
-    Q⁺.u = -Q⁻.u
-    A⁺.w = -A⁻.w
-
-    #   D⁺.κ∇θ = -D⁻.κ∇θ
-
-    #-  new diffusive flux BC:
-    #   Q⁺.u = -Q⁻.u
-    #   A⁺.w = -A⁻.w
-    Q⁺.θ = Q⁻.θ
     D⁺.ν∇u = D⁻.ν∇u
     D⁺.κ∇θ = n⁻ * -0
 
@@ -512,8 +472,40 @@ apply no penetration boundary for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::Union{OceanSurface*}, ::Union{RusanovNumericalFlux, CentralNumericalFluxGradient})
+    OceanFloorLinearDrag
 
+applies boundary condition u = 0 with linear drag on viscous-flux and ∇θ = 0
+"""
+
+"""
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanFloorLinearDrag, ::NumericalFluxSecondOrder)
+
+apply linear drag boundary condition for velocity
+apply no penetration boundary for temperature
+"""
+@inline function ocean_boundary_state!(
+    m::AbstractOceanModel,
+    ::OceanFloorLinearDrag,
+    ::NumericalFluxSecondOrder,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
+    u, v = Q⁻.u
+
+    D⁺.ν∇u = -m.problem.Cd_lin * @SMatrix [-0 -0; -0 -0; u v]
+    D⁺.κ∇θ = n⁻ * -0
+
+    return nothing
+end
+
+"""
+    ocean_boundary_state!(::AbstractOceanModel, ::Union{OceanSurface*}, ::Union{NumericalFluxFirstOrder, NumericalFluxGradient})
 applying neumann boundary conditions, so don't need to do anything for these numerical fluxes
 """
 @inline function ocean_boundary_state!(
@@ -524,11 +516,7 @@ applying neumann boundary conditions, so don't need to do anything for these num
         OceanSurfaceNoStressForcing,
         OceanSurfaceStressForcing,
     },
-    ::Union{
-        RusanovNumericalFlux,
-        CentralNumericalFluxFirstOrder,
-        CentralNumericalFluxGradient,
-    },
+    ::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
     Q⁺,
     A⁺,
     n⁻,
@@ -540,7 +528,7 @@ applying neumann boundary conditions, so don't need to do anything for these num
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceNoStressNoForcing, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceNoStressNoForcing, ::NumericalFluxSecondOrder)
 
 apply no flux boundary condition for velocity
 apply no flux boundary condition for temperature
@@ -548,7 +536,7 @@ apply no flux boundary condition for temperature
 @inline function ocean_boundary_state!(
     ::AbstractOceanModel,
     ::OceanSurfaceNoStressNoForcing,
-    ::CentralNumericalFluxSecondOrder,
+    ::NumericalFluxSecondOrder,
     Q⁺,
     D⁺,
     A⁺,
@@ -558,15 +546,6 @@ apply no flux boundary condition for temperature
     A⁻,
     t,
 )
-    #   D⁺.ν∇u = -D⁻.ν∇u
-
-    #   D⁺.κ∇θ = -D⁻.κ∇θ
-
-    #-  new diffusive flux BC:
-    Q⁺.u = Q⁻.u
-    A⁺.u_d = A⁻.u_d
-    A⁺.w = A⁻.w
-    Q⁺.θ = Q⁻.θ
     D⁺.ν∇u = n⁻ * (@SVector [-0, -0])'
     D⁺.κ∇θ = n⁻ * -0
 
@@ -574,7 +553,7 @@ apply no flux boundary condition for temperature
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceStressNoForcing, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceStressNoForcing, ::NumericalFluxSecondOrder)
 
 apply wind-stress boundary condition for velocity
 apply no flux boundary condition for temperature
@@ -582,7 +561,7 @@ apply no flux boundary condition for temperature
 @inline function ocean_boundary_state!(
     m::AbstractOceanModel,
     ::OceanSurfaceStressNoForcing,
-    ::CentralNumericalFluxSecondOrder,
+    ::NumericalFluxSecondOrder,
     Q⁺,
     D⁺,
     A⁺,
@@ -593,24 +572,14 @@ apply no flux boundary condition for temperature
     t,
 )
     τᶻ = velocity_flux(m.problem, A⁻.y, m.ρₒ)
-    #   τ = @SMatrix [-0 -0; -0 -0; τᶻ -0]
-    #   D⁺.ν∇u = -D⁻.ν∇u + 2 * τ
-
-    #   D⁺.κ∇θ = -D⁻.κ∇θ
-
-    #-  new diffusive flux BC:
-    Q⁺.u = Q⁻.u
-    A⁺.u_d = A⁻.u_d
-    A⁺.w = A⁻.w
-    Q⁺.θ = Q⁻.θ
-    D⁺.ν∇u = n⁻ * (@SVector [τᶻ, -0])'
+    D⁺.ν∇u = n⁻ * (@SVector [-τᶻ, -0])'
     D⁺.κ∇θ = n⁻ * -0
 
     return nothing
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceNoStressForcing, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceNoStressForcing, ::NumericalFluxSecondOrder)
 
 apply no flux boundary condition for velocity
 apply forcing boundary condition for temperature
@@ -618,7 +587,7 @@ apply forcing boundary condition for temperature
 @inline function ocean_boundary_state!(
     m::AbstractOceanModel,
     ::OceanSurfaceNoStressForcing,
-    ::CentralNumericalFluxSecondOrder,
+    ::NumericalFluxSecondOrder,
     Q⁺,
     D⁺,
     A⁺,
@@ -628,25 +597,15 @@ apply forcing boundary condition for temperature
     A⁻,
     t,
 )
-    #   D⁺.ν∇u = -D⁻.ν∇u
-
     σᶻ = temperature_flux(m.problem, A⁻.y, Q⁻.θ)
-    #   σ = @SVector [-0, -0, σᶻ]
-    #   D⁺.κ∇θ = -D⁻.κ∇θ + 2 * σ
-
-    #-  new diffusive flux BC:
-    Q⁺.u = Q⁻.u
-    A⁺.u_d = A⁻.u_d
-    A⁺.w = A⁻.w
-    Q⁺.θ = Q⁻.θ
     D⁺.ν∇u = n⁻ * (@SVector [-0, -0])'
-    D⁺.κ∇θ = n⁻ * σᶻ
+    D⁺.κ∇θ = -n⁻ * σᶻ
 
     return nothing
 end
 
 """
-    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceStressForcing, ::CentralNumericalFluxSecondOrder)
+    ocean_boundary_state!(::AbstractOceanModel, ::OceanSurfaceStressForcing, ::NumericalFluxSecondOrder)
 
 apply wind-stress boundary condition for velocity
 apply forcing boundary condition for temperature
@@ -654,7 +613,7 @@ apply forcing boundary condition for temperature
 @inline function ocean_boundary_state!(
     m::AbstractOceanModel,
     ::OceanSurfaceStressForcing,
-    ::CentralNumericalFluxSecondOrder,
+    ::NumericalFluxSecondOrder,
     Q⁺,
     D⁺,
     A⁺,
@@ -665,20 +624,9 @@ apply forcing boundary condition for temperature
     t,
 )
     τᶻ = velocity_flux(m.problem, A⁻.y, m.ρₒ)
-    #   τ = @SMatrix [-0 -0; -0 -0; τᶻ -0]
-    #   D⁺.ν∇u = -D⁻.ν∇u + 2 * τ
-
     σᶻ = temperature_flux(m.problem, A⁻.y, Q⁻.θ)
-    #   σ = @SVector [-0, -0, σᶻ]
-    #   D⁺.κ∇θ = -D⁻.κ∇θ + 2 * σ
-
-    #-  new diffusive flux BC:
-    Q⁺.u = Q⁻.u
-    A⁺.u_d = A⁻.u_d
-    A⁺.w = A⁻.w
-    Q⁺.θ = Q⁻.θ
-    D⁺.ν∇u = n⁻ * (@SVector [τᶻ, -0])'
-    D⁺.κ∇θ = n⁻ * σᶻ
+    D⁺.ν∇u = n⁻ * (@SVector [-τᶻ, -0])'
+    D⁺.κ∇θ = -n⁻ * σᶻ
 
     return nothing
 end

--- a/src/Ocean/SplitExplicit01/OceanModel.jl
+++ b/src/Ocean/SplitExplicit01/OceanModel.jl
@@ -237,14 +237,15 @@ end
 )
     ν = viscosity_tensor(m)
     #  D.ν∇u = ν * G.u
-    D.ν∇u = @SMatrix [
-        m.νʰ*G.ud[1, 1] m.νʰ*G.ud[1, 2]
-        m.νʰ*G.ud[2, 1] m.νʰ*G.ud[2, 2]
-        m.νᶻ*G.u[3, 1] m.νᶻ*G.u[3, 2]
-    ]
+    D.ν∇u =
+        -@SMatrix [
+            m.νʰ*G.ud[1, 1] m.νʰ*G.ud[1, 2]
+            m.νʰ*G.ud[2, 1] m.νʰ*G.ud[2, 2]
+            m.νᶻ*G.u[3, 1] m.νᶻ*G.u[3, 2]
+        ]
 
     κ = diffusivity_tensor(m, G.θ[3])
-    D.κ∇θ = κ * G.θ
+    D.κ∇θ = -κ * G.θ
 
     return nothing
 end
@@ -426,9 +427,9 @@ end
     #- vertical viscosity only (horizontal fluxes in horizontal model)
     #  F.u -= @SVector([0, 0, 1]) * D.ν∇u[3, :]'
     #- all 3 direction viscous flux for horizontal momentum tendency
-    F.u -= D.ν∇u
+    F.u += D.ν∇u
 
-    F.θ -= D.κ∇θ
+    F.θ += D.κ∇θ
 
     return nothing
 end

--- a/src/Ocean/SplitExplicit01/SplitExplicitModel.jl
+++ b/src/Ocean/SplitExplicit01/SplitExplicitModel.jl
@@ -31,9 +31,9 @@ using ...DGMethods.NumericalFluxes:
     NumericalFluxGradient,
     NumericalFluxSecondOrder,
     RusanovNumericalFlux,
+    CentralNumericalFluxFirstOrder,
     CentralNumericalFluxGradient,
-    CentralNumericalFluxSecondOrder,
-    CentralNumericalFluxFirstOrder
+    CentralNumericalFluxSecondOrder
 
 using ..Ocean: AbstractOceanProblem
 

--- a/test/Ocean/SplitExplicit/simple_box_ivd.jl
+++ b/test/Ocean/SplitExplicit/simple_box_ivd.jl
@@ -16,6 +16,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.VTK
 using ClimateMachine.Checkpoint
 
+using Test
 using MPI
 using LinearAlgebra
 using StaticArrays
@@ -209,22 +210,17 @@ function main(; restart = 0)
 
     if restart > 0
         direction = EveryDirection()
-        Q_3D, A_3D, t0 =
+        Q_3D, _, t0 =
             read_checkpoint(vtkpath, "baroclinic", ArrayType, mpicomm, restart)
-        Q_2D, A_2D, _ =
+        Q_2D, _, _ =
             read_checkpoint(vtkpath, "barotropic", ArrayType, mpicomm, restart)
-
-        A_3D = restart_auxiliary_state(model, grid_3D, A_3D, direction)
-        A_2D =
-            restart_auxiliary_state(barotropicmodel, grid_2D, A_2D, direction)
 
         dg = OceanDGModel(
             model,
             grid_3D,
             RusanovNumericalFlux(),
             CentralNumericalFluxSecondOrder(),
-            CentralNumericalFluxGradient();
-            state_auxiliary = A_3D,
+            CentralNumericalFluxGradient(),
         )
         barotropic_dg = DGModel(
             barotropicmodel,
@@ -232,7 +228,6 @@ function main(; restart = 0)
             RusanovNumericalFlux(),
             CentralNumericalFluxSecondOrder(),
             CentralNumericalFluxGradient(),
-            state_auxiliary = A_2D,
         )
 
         Q_3D = restart_ode_state(dg, Q_3D; init_on_cpu = true)
@@ -258,9 +253,6 @@ function main(; restart = 0)
         )
 
         Q_3D = init_ode_state(dg, FT(0); init_on_cpu = true)
-        # update_auxiliary_state!(dg, model, Q_3D, FT(0))
-        # update_auxiliary_state_gradient!(dg, model, Q_3D, FT(0))
-
         Q_2D = init_ode_state(barotropic_dg, FT(0); init_on_cpu = true)
 
     end
@@ -344,6 +336,7 @@ function main(; restart = 0)
         checkPass = ClimateMachine.StateCheck.scdocheck(cbcs_dg, refDat)
         checkPass ? checkRep = "Pass" : checkRep = "Fail"
         @info @sprintf("""Compare vs RefVals: %s""", checkRep)
+        @test checkPass
     end
 
     return nothing
@@ -443,10 +436,12 @@ function make_callbacks(
     end
 
     if n_chkp > 0
+        # Note: write zeros instead of Aux vars (not needed to restart); would be
+        # better just to write state vars (once write_checkpoint() can handle it)
         cb_checkpoint = GenericCallbacks.EveryXSimulationSteps(n_chkp) do
             write_checkpoint(
                 Q_slow,
-                dg_slow.state_auxiliary,
+                zero(Q_slow),
                 odesolver,
                 vtkpath,
                 "baroclinic",
@@ -456,7 +451,7 @@ function make_callbacks(
 
             write_checkpoint(
                 Q_fast,
-                dg_fast.state_auxiliary,
+                zero(Q_fast),
                 odesolver,
                 vtkpath,
                 "barotropic",
@@ -464,14 +459,14 @@ function make_callbacks(
                 step[3],
             )
 
-            # rm_checkpoint(vtkpath, "baroclinic", mpicomm, step[3] - 1)
-            # rm_checkpoint(vtkpath, "barotropic", mpicomm, step[3] - 1)
             step[3] += 1
             nothing
         end
         return (cbvtk_slow, cbvtk_fast, cbinfo, cb_checkpoint)
+        # return (cbinfo, cb_checkpoint)
     else
         return (cbvtk_slow, cbvtk_fast, cbinfo)
+        # return (cbinfo)
     end
 
 end
@@ -522,4 +517,6 @@ const λʳ = 20 // 86400 # m/s
 #const λʳ = 10 // 86400
 const θᴱ = 10    # deg.C
 
-main(restart = 0)
+@testset "$(@__FILE__)" begin
+    main(restart = 0)
+end

--- a/test/Ocean/SplitExplicit/simple_box_rk3.jl
+++ b/test/Ocean/SplitExplicit/simple_box_rk3.jl
@@ -16,6 +16,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.VTK
 using ClimateMachine.Checkpoint
 
+using Test
 using MPI
 using LinearAlgebra
 using StaticArrays
@@ -209,22 +210,17 @@ function main(; restart = 0)
 
     if restart > 0
         direction = EveryDirection()
-        Q_3D, A_3D, t0 =
+        Q_3D, _, t0 =
             read_checkpoint(vtkpath, "baroclinic", ArrayType, mpicomm, restart)
-        Q_2D, A_2D, _ =
+        Q_2D, _, _ =
             read_checkpoint(vtkpath, "barotropic", ArrayType, mpicomm, restart)
-
-        A_3D = restart_auxiliary_state(model, grid_3D, A_3D, direction)
-        A_2D =
-            restart_auxiliary_state(barotropicmodel, grid_2D, A_2D, direction)
 
         dg = OceanDGModel(
             model,
             grid_3D,
             RusanovNumericalFlux(),
             CentralNumericalFluxSecondOrder(),
-            CentralNumericalFluxGradient();
-            state_auxiliary = A_3D,
+            CentralNumericalFluxGradient(),
         )
         barotropic_dg = DGModel(
             barotropicmodel,
@@ -232,7 +228,6 @@ function main(; restart = 0)
             RusanovNumericalFlux(),
             CentralNumericalFluxSecondOrder(),
             CentralNumericalFluxGradient(),
-            state_auxiliary = A_2D,
         )
 
         Q_3D = restart_ode_state(dg, Q_3D; init_on_cpu = true)
@@ -258,9 +253,6 @@ function main(; restart = 0)
         )
 
         Q_3D = init_ode_state(dg, FT(0); init_on_cpu = true)
-        # update_auxiliary_state!(dg, model, Q_3D, FT(0))
-        # update_auxiliary_state_gradient!(dg, model, Q_3D, FT(0))
-
         Q_2D = init_ode_state(barotropic_dg, FT(0); init_on_cpu = true)
 
     end
@@ -343,6 +335,7 @@ function main(; restart = 0)
         checkPass = ClimateMachine.StateCheck.scdocheck(cbcs_dg, refDat)
         checkPass ? checkRep = "Pass" : checkRep = "Fail"
         @info @sprintf("""Compare vs RefVals: %s""", checkRep)
+        @test checkPass
     end
 
     return nothing
@@ -442,10 +435,12 @@ function make_callbacks(
     end
 
     if n_chkp > 0
+        # Note: write zeros instead of Aux vars (not needed to restart); would be
+        # better just to write state vars (once write_checkpoint() can handle it)
         cb_checkpoint = GenericCallbacks.EveryXSimulationSteps(n_chkp) do
             write_checkpoint(
                 Q_slow,
-                dg_slow.state_auxiliary,
+                zero(Q_slow),
                 odesolver,
                 vtkpath,
                 "baroclinic",
@@ -455,7 +450,7 @@ function make_callbacks(
 
             write_checkpoint(
                 Q_fast,
-                dg_fast.state_auxiliary,
+                zero(Q_fast),
                 odesolver,
                 vtkpath,
                 "barotropic",
@@ -463,8 +458,6 @@ function make_callbacks(
                 step[3],
             )
 
-            # rm_checkpoint(vtkpath, "baroclinic", mpicomm, step[3] - 1)
-            # rm_checkpoint(vtkpath, "barotropic", mpicomm, step[3] - 1)
             step[3] += 1
             nothing
         end
@@ -521,4 +514,6 @@ const λʳ = 20 // 86400 # m/s
 #const λʳ = 10 // 86400
 const θᴱ = 10    # deg.C
 
-main(restart = 0)
+@testset "$(@__FILE__)" begin
+    main(restart = 0)
+end

--- a/test/Ocean/SplitExplicit/simple_dbl_gyre.jl
+++ b/test/Ocean/SplitExplicit/simple_dbl_gyre.jl
@@ -16,6 +16,7 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.VTK
 using ClimateMachine.Checkpoint
 
+using Test
 using MPI
 using LinearAlgebra
 using StaticArrays
@@ -221,22 +222,17 @@ function main(; restart = 0)
 
     if restart > 0
         direction = EveryDirection()
-        Q_3D, A_3D, t0 =
+        Q_3D, _, t0 =
             read_checkpoint(vtkpath, "baroclinic", ArrayType, mpicomm, restart)
-        Q_2D, A_2D, _ =
+        Q_2D, _, _ =
             read_checkpoint(vtkpath, "barotropic", ArrayType, mpicomm, restart)
-
-        A_3D = restart_auxiliary_state(model, grid_3D, A_3D, direction)
-        A_2D =
-            restart_auxiliary_state(barotropicmodel, grid_2D, A_2D, direction)
 
         dg = OceanDGModel(
             model,
             grid_3D,
             RusanovNumericalFlux(),
             CentralNumericalFluxSecondOrder(),
-            CentralNumericalFluxGradient();
-            state_auxiliary = A_3D,
+            CentralNumericalFluxGradient(),
         )
         barotropic_dg = DGModel(
             barotropicmodel,
@@ -244,7 +240,6 @@ function main(; restart = 0)
             RusanovNumericalFlux(),
             CentralNumericalFluxSecondOrder(),
             CentralNumericalFluxGradient(),
-            state_auxiliary = A_2D,
         )
 
         Q_3D = restart_ode_state(dg, Q_3D; init_on_cpu = true)
@@ -270,9 +265,6 @@ function main(; restart = 0)
         )
 
         Q_3D = init_ode_state(dg, FT(0); init_on_cpu = true)
-        # update_auxiliary_state!(dg, model, Q_3D, FT(0))
-        # update_auxiliary_state_gradient!(dg, model, Q_3D, FT(0))
-
         Q_2D = init_ode_state(barotropic_dg, FT(0); init_on_cpu = true)
 
     end
@@ -355,6 +347,7 @@ function main(; restart = 0)
         checkPass = ClimateMachine.StateCheck.scdocheck(cbcs_dg, refDat)
         checkPass ? checkRep = "Pass" : checkRep = "Fail"
         @info @sprintf("""Compare vs RefVals: %s""", checkRep)
+        @test checkPass
     end
 
     return nothing
@@ -454,10 +447,12 @@ function make_callbacks(
     end
 
     if n_chkp > 0
+        # Note: write zeros instead of Aux vars (not needed to restart); would be
+        # better just to write state vars (once write_checkpoint() can handle it)
         cb_checkpoint = GenericCallbacks.EveryXSimulationSteps(n_chkp) do
             write_checkpoint(
                 Q_slow,
-                dg_slow.state_auxiliary,
+                zero(Q_slow),
                 odesolver,
                 vtkpath,
                 "baroclinic",
@@ -467,7 +462,7 @@ function make_callbacks(
 
             write_checkpoint(
                 Q_fast,
-                dg_fast.state_auxiliary,
+                zero(Q_fast),
                 odesolver,
                 vtkpath,
                 "barotropic",
@@ -475,8 +470,6 @@ function make_callbacks(
                 step[3],
             )
 
-            # rm_checkpoint(vtkpath, "baroclinic", mpicomm, step[3] - 1)
-            # rm_checkpoint(vtkpath, "barotropic", mpicomm, step[3] - 1)
             step[3] += 1
             nothing
         end
@@ -537,4 +530,6 @@ const λʳ = 20 // 86400 # m/s
 #const λʳ = 10 // 86400
 const θᴱ = 25    # deg.C
 
-main(restart = 0)
+@testset "$(@__FILE__)" begin
+    main(restart = 0)
+end

--- a/test/Ocean/refvals/simple_box_2dt_refvals.jl
+++ b/test/Ocean/refvals/simple_box_2dt_refvals.jl
@@ -69,7 +69,7 @@ parr = [
  [  "baro aux",  "Δu[1]",    12,    12,    12,    12 ],
  [  "baro aux",  "Δu[2]",    12,    12,    12,    12 ],
  [  "baro aux",  :η_diag,    12,    12,     8,    12 ],
- [  "baro aux",      :Δη,    12,    12,     8,    12 ],
+ [  "baro aux",      :Δη,     9,     9,     6,    10 ],
  [  "baro aux",       :y,    12,    12,    12,    12 ],
 ]
 # END SCPRINT

--- a/test/Ocean/refvals/simple_box_ivd_refvals.jl
+++ b/test/Ocean/refvals/simple_box_ivd_refvals.jl
@@ -69,7 +69,7 @@ parr = [
  [  "baro aux",  "Δu[1]",    12,    12,    12,    12 ],
  [  "baro aux",  "Δu[2]",    12,    12,    12,    12 ],
  [  "baro aux",  :η_diag,    12,    12,     8,    12 ],
- [  "baro aux",      :Δη,    12,    12,     8,    12 ],
+ [  "baro aux",      :Δη,     9,     9,     6,    10 ],
  [  "baro aux",       :y,    12,    12,    12,    12 ],
 ]
 # END SCPRINT

--- a/test/Ocean/refvals/simple_box_rk3_refvals.jl
+++ b/test/Ocean/refvals/simple_box_rk3_refvals.jl
@@ -69,7 +69,7 @@ parr = [
  [  "baro aux",  "Δu[1]",    12,    12,    12,    12 ],
  [  "baro aux",  "Δu[2]",    12,    12,    12,    12 ],
  [  "baro aux",  :η_diag,    12,    12,     8,    12 ],
- [  "baro aux",      :Δη,    12,    12,     8,    12 ],
+ [  "baro aux",      :Δη,     9,     9,     6,    10 ],
  [  "baro aux",       :y,    12,    12,    12,    12 ],
 ]
 # END SCPRINT

--- a/test/Ocean/refvals/simple_dbl_gyre_refvals.jl
+++ b/test/Ocean/refvals/simple_dbl_gyre_refvals.jl
@@ -69,7 +69,7 @@ parr = [
  [  "baro aux",  "Δu[1]",    12,    12,    12,    12 ],
  [  "baro aux",  "Δu[2]",    12,    12,    12,    12 ],
  [  "baro aux",  :η_diag,    12,    12,     8,    12 ],
- [  "baro aux",      :Δη,    12,    12,     8,    12 ],
+ [  "baro aux",      :Δη,     9,     9,     6,    10 ],
  [  "baro aux",       :y,    12,    12,    12,    12 ],
 ]
 # END SCPRINT


### PR DESCRIPTION
### Description
Split-Explicit Ocean model:
 - simplify and clean BC ; change sign of second-order fluxes ;
 - simplify checkpoints ; add (back) bits for checking State-Check in test

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
