### PR TITLE
Fix race condition in Squal line artifact

### DIFF
--- a/experiments/AtmosLES/squall_line.jl
+++ b/experiments/AtmosLES/squall_line.jl
@@ -122,8 +122,17 @@ end
   Read the original squall sounding
 """
 function read_sounding()
+
+    # Artifact creation is not thread-safe
+    #      https://github.com/JuliaLang/Pkg.jl/issues/1219
+    # To avoid race conditions from multiple jobs running this
+    # driver at the same time, we must store artifacts in a
+    # separate folder.
+
+    artifact_folder = mktempdir(@__DIR__; prefix = "artifacts_")
+
     soundings_dataset = ArtifactWrapper(
-        joinpath(@__DIR__, "Artifacts.toml"),
+        joinpath(artifact_folder, "Artifacts.toml"),
         "soundings",
         ArtifactFile[ArtifactFile(
             url = "https://caltech.box.com/shared/static/rjnvt2dlw7etm1c7mmdfrkw5gnfds5lx.nc",


### PR DESCRIPTION
### Description

This PR should hopefully fix the race condition we're seeing with the squal line experiment in #1678. I'm not sure if this is the best way to grab the job ID.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
