### PR TITLE
change poly order in baroclinic_wave.jl for QA purposes

### DIFF
--- a/experiments/TestCase/baroclinic_wave.jl
+++ b/experiments/TestCase/baroclinic_wave.jl
@@ -220,9 +220,9 @@ function main()
 
     # Driver configuration parameters
     FT = Float64                             # floating type precision
-    poly_order = 5                           # discontinuous Galerkin polynomial order
-    n_horz = 8                              # horizontal element number
-    n_vert = 4                               # vertical element number
+    poly_order = (5, 6)                      # discontinuous Galerkin polynomial order
+    n_horz = 8                               # horizontal element number
+    n_vert = 3                               # vertical element number
     n_days::FT = 1
     timestart::FT = 0                        # start time (s)
     timeend::FT = n_days * day(param_set)    # end time (s)


### PR DESCRIPTION
### Description

This PR changes the polynomial order in experiments/TestCase/baroclinic_wave.jl to (5, 6) for QA purposes.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
