### PR TITLE
Move precompute method to balance law

### DIFF
--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -19,6 +19,7 @@ AbstractTendencyType
 TendencyDef
 eq_tends
 prognostic_vars
+precompute
 fluxes
 sources
 show_tendencies

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -52,6 +52,7 @@ import ..BalanceLaws:
     source!,
     eq_tends,
     flux,
+    precompute,
     source,
     wavespeed,
     boundary_conditions,

--- a/src/BalanceLaws/BalanceLaws.jl
+++ b/src/BalanceLaws/BalanceLaws.jl
@@ -5,6 +5,7 @@ using ..VariableTemplates
 export BalanceLaw,
     vars_state,
     number_states,
+    precompute,
     init_state_prognostic!,
     init_state_auxiliary!,
     compute_gradient_flux!,

--- a/src/BalanceLaws/tendency_types.jl
+++ b/src/BalanceLaws/tendency_types.jl
@@ -17,7 +17,7 @@
 
 export PrognosticVariable
 export FirstOrder, SecondOrder
-export Flux, Source
+export AbstractTendencyType, Flux, Source
 export TendencyDef
 
 """
@@ -121,3 +121,14 @@ function fluxes(bl::BalanceLaw, order::O) where {O <: AbstractOrder}
     tend = filter(x -> x ≠ nothing, tend)
     return Tuple(Iterators.flatten(tend))
 end
+
+"""
+    precompute(bl, args, ::AbstractTendencyType)
+
+A nested NamedTuple of precomputed (cached) values
+and or objects. This is useful for "expensive"
+point-wise quantities that are used in multiple
+tendency terms. For example, computing a quantity
+that requires iteration.
+"""
+precompute(bl, args, ::AbstractTendencyType) = NamedTuple()


### PR DESCRIPTION
### Description

This should have been incorporated in #1850, we want `precompute` to be a `BalanceLaw` method, so that we can inherit/modularize its use across different models.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
