### PR TITLE
Reformulate second order flux arguments, add precomputed NamedTuple

### DIFF
--- a/docs/src/APIs/Common/TurbulenceClosures.md
+++ b/docs/src/APIs/Common/TurbulenceClosures.md
@@ -34,7 +34,6 @@ UpperAtmosSponge
 ```@docs
 turbulence_tensors
 init_aux_turbulence!
-turbulence_nodal_update_auxiliary_state!
 principal_invariants
 symmetrize
 norm2

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -25,12 +25,7 @@ function flux_second_order!(
     ::MoistureModel,
     flux::Grad,
     atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
+    args,
 ) end
 
 function compute_gradient_argument!(
@@ -156,17 +151,11 @@ function flux_second_order!(
     moist::EquilMoist,
     flux::Grad,
     atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
+    args,
 )
     tend = Flux{SecondOrder}()
-    args = (atmos, state, aux, t, ts, diffusive, hyperdiffusive)
     flux.moisture.ρq_tot =
-        Σfluxes(eq_tends(TotalMoisture(), atmos, tend), args...)
+        Σfluxes(eq_tends(TotalMoisture(), atmos, tend), atmos, args)
 end
 
 function source!(m::EquilMoist, source::Vars, atmos::AtmosModel, args)
@@ -254,21 +243,15 @@ function flux_second_order!(
     ::NonEquilMoist,
     flux::Grad,
     atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
+    args,
 )
     tend = Flux{SecondOrder}()
-    args = (atmos, state, aux, t, ts, diffusive, hyperdiffusive)
     flux.moisture.ρq_tot =
-        Σfluxes(eq_tends(TotalMoisture(), atmos, tend), args...)
+        Σfluxes(eq_tends(TotalMoisture(), atmos, tend), atmos, args)
     flux.moisture.ρq_liq =
-        Σfluxes(eq_tends(LiquidMoisture(), atmos, tend), args...)
+        Σfluxes(eq_tends(LiquidMoisture(), atmos, tend), atmos, args)
     flux.moisture.ρq_ice =
-        Σfluxes(eq_tends(IceMoisture(), atmos, tend), args...)
+        Σfluxes(eq_tends(IceMoisture(), atmos, tend), atmos, args)
 end
 
 function source!(m::NonEquilMoist, source::Vars, atmos::AtmosModel, args)

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -34,12 +34,7 @@ function flux_second_order!(
     ::PrecipitationModel,
     flux::Grad,
     ::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
+    args,
 ) end
 function flux_first_order!(::PrecipitationModel, _...) end
 function compute_gradient_argument!(
@@ -115,16 +110,11 @@ function flux_second_order!(
     precip::RainModel,
     flux::Grad,
     atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
+    args,
 )
     tend = Flux{SecondOrder}()
-    args = (atmos, state, aux, t, ts, diffusive, hyperdiffusive)
-    flux.precipitation.ρq_rai = Σfluxes(eq_tends(Rain(), atmos, tend), args...)
+    flux.precipitation.ρq_rai =
+        Σfluxes(eq_tends(Rain(), atmos, tend), atmos, args)
 end
 
 function source!(m::RainModel, source::Vars, atmos::AtmosModel, args)
@@ -194,17 +184,13 @@ function flux_second_order!(
     precip::RainSnowModel,
     flux::Grad,
     atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
+    args,
 )
     tend = Flux{SecondOrder}()
-    args = (atmos, state, aux, t, ts, diffusive, hyperdiffusive)
-    flux.precipitation.ρq_rai = Σfluxes(eq_tends(Rain(), atmos, tend), args...)
-    flux.precipitation.ρq_sno = Σfluxes(eq_tends(Snow(), atmos, tend), args...)
+    flux.precipitation.ρq_rai =
+        Σfluxes(eq_tends(Rain(), atmos, tend), atmos, args)
+    flux.precipitation.ρq_sno =
+        Σfluxes(eq_tends(Snow(), atmos, tend), atmos, args)
 end
 
 function source!(m::RainSnowModel, source::Vars, atmos::AtmosModel, args)

--- a/src/Atmos/Model/tendencies_energy.jl
+++ b/src/Atmos/Model/tendencies_energy.jl
@@ -20,23 +20,16 @@ end
 #####
 
 struct ViscousFlux{PV <: Energy} <: TendencyDef{Flux{SecondOrder}, PV} end
-function flux(::ViscousFlux{Energy}, m, state, aux, t, ts, diffusive, hyperdiff)
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+function flux(::ViscousFlux{Energy}, atmos, args)
+    @unpack state, aux, t, diffusive = args
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     return τ * state.ρu
 end
 
 struct DiffEnthalpyFlux{PV <: Energy} <: TendencyDef{Flux{SecondOrder}, PV} end
-function flux(
-    ::DiffEnthalpyFlux{Energy},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    diffusive,
-    hyperdiff,
-)
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+function flux(::DiffEnthalpyFlux{Energy}, atmos, args)
+    @unpack state, aux, t, diffusive = args
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     d_h_tot = -D_t .* diffusive.∇h_tot
     return d_h_tot * state.ρ
 end

--- a/src/Atmos/Model/tendencies_mass.jl
+++ b/src/Atmos/Model/tendencies_mass.jl
@@ -12,17 +12,9 @@ end
 ##### Second order fluxes
 #####
 
-function flux(
-    ::MoistureDiffusion{Mass},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    diffusive,
-    hyperdiff,
-)
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+function flux(::MoistureDiffusion{Mass}, atmos, args)
+    @unpack state, aux, t, diffusive = args
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     d_q_tot = (-D_t) .* diffusive.moisture.∇q_tot
     return d_q_tot * state.ρ
 end

--- a/src/Atmos/Model/tendencies_moisture.jl
+++ b/src/Atmos/Model/tendencies_moisture.jl
@@ -26,47 +26,23 @@ end
 ##### Second order fluxes
 #####
 
-function flux(
-    ::MoistureDiffusion{TotalMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    diffusive,
-    hyperdiff,
-)
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+function flux(::MoistureDiffusion{TotalMoisture}, atmos, args)
+    @unpack state, aux, t, diffusive = args
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     d_q_tot = (-D_t) .* diffusive.moisture.∇q_tot
     return d_q_tot * state.ρ
 end
 
-function flux(
-    ::MoistureDiffusion{LiquidMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    diffusive,
-    hyperdiff,
-)
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+function flux(::MoistureDiffusion{LiquidMoisture}, atmos, args)
+    @unpack state, aux, t, diffusive = args
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     d_q_liq = (-D_t) .* diffusive.moisture.∇q_liq
     return d_q_liq * state.ρ
 end
 
-function flux(
-    ::MoistureDiffusion{IceMoisture},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    diffusive,
-    hyperdiff,
-)
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+function flux(::MoistureDiffusion{IceMoisture}, atmos, args)
+    @unpack state, aux, t, diffusive = args
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     d_q_ice = (-D_t) .* diffusive.moisture.∇q_ice
     return d_q_ice * state.ρ
 end

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -27,32 +27,16 @@ end
 #####
 
 struct ViscousStress{PV <: Momentum} <: TendencyDef{Flux{SecondOrder}, PV} end
-function flux(
-    ::ViscousStress{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    diffusive,
-    hyperdiff,
-)
+function flux(::ViscousStress{Momentum}, atmos, args)
+    @unpack state, aux, t, diffusive = args
     pad = (state.ρu .* (state.ρu / state.ρ)') * 0
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     return pad + τ * state.ρ
 end
 
-function flux(
-    ::MoistureDiffusion{Momentum},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    diffusive,
-    hyperdiff,
-)
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+function flux(::MoistureDiffusion{Momentum}, atmos, args)
+    @unpack state, aux, t, diffusive = args
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     d_q_tot = (-D_t) .* diffusive.moisture.∇q_tot
     return d_q_tot .* state.ρu'
 end

--- a/src/Atmos/Model/tendencies_precipitation.jl
+++ b/src/Atmos/Model/tendencies_precipitation.jl
@@ -49,14 +49,16 @@ end
 ##### Second order fluxes
 #####
 
-function flux(::Diffusion{Rain}, m, state, aux, t, ts, diffusive, hyperdiff)
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+function flux(::Diffusion{Rain}, atmos, args)
+    @unpack state, aux, t, diffusive = args
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     d_q_rai = (-D_t) .* diffusive.precipitation.∇q_rai
     return d_q_rai * state.ρ
 end
 
-function flux(::Diffusion{Snow}, m, state, aux, t, ts, diffusive, hyperdiff)
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+function flux(::Diffusion{Snow}, atmos, args)
+    @unpack state, aux, t, diffusive = args
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     d_q_sno = (-D_t) .* diffusive.precipitation.∇q_sno
     return d_q_sno * state.ρ
 end

--- a/src/Atmos/Model/tendencies_tracers.jl
+++ b/src/Atmos/Model/tendencies_tracers.jl
@@ -14,17 +14,9 @@ end
 ##### Second order fluxes
 #####
 
-function flux(
-    ::Diffusion{Tracers{N}},
-    m,
-    state,
-    aux,
-    t,
-    ts,
-    diffusive,
-    hyperdiff,
-) where {N}
-    ν, D_t, τ = turbulence_tensors(m, state, diffusive, aux, t)
+function flux(::Diffusion{Tracers{N}}, atmos, args) where {N}
+    @unpack state, aux, t, diffusive = args
+    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     d_χ = (-D_t) * aux.tracers.δ_χ' .* diffusive.tracers.∇χ
     return d_χ * state.ρ
 end

--- a/src/Atmos/Model/tracers.jl
+++ b/src/Atmos/Model/tracers.jl
@@ -69,17 +69,7 @@ function compute_gradient_flux!(
 )
     nothing
 end
-function flux_second_order!(
-    ::TracerModel,
-    flux::Grad,
-    atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
-)
+function flux_second_order!(::TracerModel, flux::Grad, atmos::AtmosModel, args)
     nothing
 end
 function compute_gradient_argument!(
@@ -189,16 +179,10 @@ function flux_second_order!(
     tr::NTracers{N},
     flux::Grad,
     atmos::AtmosModel,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
+    args,
 ) where {N}
     tend = Flux{SecondOrder}()
-    args = (atmos, state, aux, t, ts, diffusive, hyperdiffusive)
-    flux.tracers.ρχ = Σfluxes(eq_tends(Tracers{N}(), atmos, tend), args...)
+    flux.tracers.ρχ = Σfluxes(eq_tends(Tracers{N}(), atmos, tend), atmos, args)
 end
 
 function wavespeed_tracers!(

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -1,7 +1,7 @@
 """
     TurbulenceClosures
 
-Functions for turbulence, sub-grid scale modelling. These include
+Functions for turbulence, sub-grid scale modeling. These include
 viscosity terms, diffusivity and stress tensors.
 
 - [`ConstantViscosity`](@ref)
@@ -35,38 +35,27 @@ module TurbulenceClosures
 #md #     `turbulence=Vreman(C_smag)`\
 #md #     `turbulence=AnisoMinDiss(C_poincare)`
 
-using ClimateMachine
 using DocStringExtensions
 using LinearAlgebra
 using StaticArrays
-
+using UnPack
 import CLIMAParameters: AbstractParameterSet
-import ClimateMachine.Mesh.Geometry:
-    LocalGeometry, resolutionmetric, lengthscale
-
-using ClimateMachine.Orientations
-using ClimateMachine.VariableTemplates
-using ClimateMachine.BalanceLaws
 using CLIMAParameters.Atmos.SubgridScale: inv_Pr_turb
 
+using ClimateMachine
 
-import ClimateMachine.BalanceLaws:
+import ..Mesh.Geometry: LocalGeometry, resolutionmetric, lengthscale
+
+using ..Orientations
+using ..VariableTemplates
+using ..BalanceLaws
+
+import ..BalanceLaws:
     vars_state,
-    flux_first_order!,
     flux_second_order!,
-    source!,
     compute_gradient_argument!,
     compute_gradient_flux!,
-    transform_post_gradient_laplacian!,
-    init_state_prognostic!,
-    update_auxiliary_state!,
-    indefinite_stack_integral!,
-    reverse_indefinite_stack_integral!,
-    integral_load_auxiliary_state!,
-    integral_set_auxiliary_state!,
-    reverse_integral_load_auxiliary_state!,
-    reverse_integral_set_auxiliary_state!
-
+    transform_post_gradient_laplacian!
 
 export TurbulenceClosureModel,
     ConstantViscosity,
@@ -84,7 +73,6 @@ export TurbulenceClosureModel,
     turbulence_tensors,
     init_aux_turbulence!,
     init_aux_hyperdiffusion!,
-    turbulence_nodal_update_auxiliary_state!,
     sponge_viscosity_modifier
 
 # ### Abstract Type
@@ -113,7 +101,7 @@ abstract type ConstantViscosity <: TurbulenceClosureModel end
 abstract type HyperDiffusion end
 
 """
-    Abstract type for viscous sponge layers. 
+    Abstract type for viscous sponge layers.
 Modifier for viscosity computed from existing turbulence closures.
 """
 abstract type ViscousSponge end
@@ -129,19 +117,6 @@ function init_aux_turbulence!(
     ::BalanceLaw,
     aux::Vars,
     geom::LocalGeometry,
-) end
-
-"""
-    turbulence_nodal_update_auxiliary_state!
-Update auxiliary variables for turbulence models.
-Overload for specific turbulence closure type.
-"""
-function turbulence_nodal_update_auxiliary_state!(
-    ::TurbulenceClosureModel,
-    ::BalanceLaw,
-    state::Vars,
-    aux::Vars,
-    t::Real,
 ) end
 
 """
@@ -178,13 +153,6 @@ function init_aux_hyperdiffusion!(
     aux::Vars,
     geom::LocalGeometry,
 ) end
-function hyperdiffusion_nodal_update_auxiliary_state!(
-    ::HyperDiffusion,
-    ::BalanceLaw,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-) end
 function compute_gradient_argument!(
     ::HyperDiffusion,
     ::BalanceLaw,
@@ -202,15 +170,7 @@ function transform_post_gradient_laplacian!(
     aux::Vars,
     t::Real,
 ) end
-function flux_second_order!(
-    h::HyperDiffusion,
-    flux::Grad,
-    state::Vars,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
-    aux::Vars,
-    t::Real,
-) end
+function flux_second_order!(h::HyperDiffusion, flux::Grad, args) end
 function compute_gradient_flux!(
     h::HyperDiffusion,
     diffusive::Vars,
@@ -378,10 +338,10 @@ export WithoutDivergence
 # and appropriately computes the turbulent stress tensor based on this term. Diffusivity can be
 # computed using the turbulent Prandtl number for the appropriate problem regime.
 # ```math
-# \tau = 
+# \tau =
 #     \begin{cases}
 #     - 2 \nu \mathrm{S} & \mathrm{WithoutDivergence},\\
-#     - 2 \nu \mathrm{S} + \frac{2}{3} \nu \mathrm{tr(S)} I_3 & \mathrm{WithDivergence}. 
+#     - 2 \nu \mathrm{S} + \frac{2}{3} \nu \mathrm{tr(S)} I_3 & \mathrm{WithDivergence}.
 #     \end{cases}
 # ```
 
@@ -920,15 +880,8 @@ function transform_post_gradient_laplacian!(
     hyperdiffusive.hyperdiffusion.ν∇³q_tot = ν₄_q_tot * ∇Δq_tot
 end
 
-function flux_second_order!(
-    h::EquilMoistBiharmonic,
-    flux::Grad,
-    state::Vars,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
-    aux::Vars,
-    t::Real,
-)
+function flux_second_order!(h::EquilMoistBiharmonic, flux::Grad, args)
+    @unpack state, hyperdiffusive = args
     flux.ρu += state.ρ * hyperdiffusive.hyperdiffusion.ν∇³u_h
     flux.ρe += hyperdiffusive.hyperdiffusion.ν∇³u_h * state.ρu
     flux.ρe += hyperdiffusive.hyperdiffusion.ν∇³h_tot * state.ρ
@@ -938,7 +891,7 @@ end
 """
   DryBiharmonic{FT} <: HyperDiffusion
 
-Assumes dry compressible flow. 
+Assumes dry compressible flow.
 Horizontal hyperdiffusion methods for application in GCM and LES settings
 Timescales are prescribed by the user while the diffusion coefficient is
 computed as a function of the grid lengthscale.
@@ -1002,34 +955,27 @@ function transform_post_gradient_laplacian!(
     hyperdiffusive.hyperdiffusion.ν∇³h_tot = ν₄ * ∇Δh_tot
 end
 
-function flux_second_order!(
-    h::DryBiharmonic,
-    flux::Grad,
-    state::Vars,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
-    aux::Vars,
-    t::Real,
-)
+function flux_second_order!(h::DryBiharmonic, flux::Grad, args)
+    @unpack state, hyperdiffusive = args
     flux.ρu += state.ρ * hyperdiffusive.hyperdiffusion.ν∇³u_h
     flux.ρe += hyperdiffusive.hyperdiffusion.ν∇³u_h * state.ρu
     flux.ρe += hyperdiffusive.hyperdiffusion.ν∇³h_tot * state.ρ
 end
 
 # ### [Viscous Sponge](@id viscous-sponge)
-# `ViscousSponge` requires a user to specify a constant viscosity (kinematic), 
+# `ViscousSponge` requires a user to specify a constant viscosity (kinematic),
 # a sponge start height, the domain height, a sponge strength, and a sponge
 # exponent.
-# Given viscosity, diffusivity and stresses from arbitrary turbulence models, 
+# Given viscosity, diffusivity and stresses from arbitrary turbulence models,
 # the viscous sponge enhances diffusive terms within a user-specified layer,
 # typically used at the top of the domain to absorb waves. A smooth onset is
 # ensured through a weight function that increases weight height from the sponge
 # onset height.
 # ```
 """
-    NoViscousSponge 
+    NoViscousSponge
 No modifiers applied to viscosity/diffusivity in sponge layer
-# Fields 
+# Fields
 #
 $(DocStringExtensions.FIELDS)
 """
@@ -1045,11 +991,11 @@ function sponge_viscosity_modifier(
     return (ν, D_t, τ)
 end
 
-""" 
-    Upper domain viscous relaxation 
+"""
+    Upper domain viscous relaxation
 Applies modifier to viscosity and diffusivity terms
 in a user-specified upper domain sponge region
-# Fields 
+# Fields
 #
 $(DocStringExtensions.FIELDS)
 """

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -109,12 +109,9 @@ end
 
 function flux_second_order!(
     m::TurbulenceConvectionModel,
-    bl::BalanceLaw,
     flux::Grad,
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
+    bl::BalanceLaw,
+    args,
 )
     return nothing
 end


### PR DESCRIPTION
### Description

This is the second-order flux counter-part to #1850.

I think we'll be able to remove the call to `thermo_state` in second-order fluxes, but it will be more clear that we can once we've moved all second-order fluxes to the new specification.

I also removed a few unused pieces in `TurbulenceClosures.jl`

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
