### PR TITLE
fixes to squall line experiment for QA-Microphysics

### DIFF
--- a/experiments/AtmosLES/squall_line.jl
+++ b/experiments/AtmosLES/squall_line.jl
@@ -241,7 +241,7 @@ function config_squall_line(
 
     # moisture model and its sources
     if moisture_model == "equilibrium"
-        moisture = EquilMoist{FT}(; maxiter = 4, tolerance = FT(1))
+        moisture = EquilMoist{FT}(; maxiter = 20, tolerance = FT(1))
     elseif moisture_model == "nonequilibrium"
         source = (source..., CreateClouds()...)
         moisture = NonEquilMoist()
@@ -333,10 +333,17 @@ function config_diagnostics(driver_config, boundaries, resolution)
         driver_config.name,
         interpol = interpol,
     )
+    dgngrp_aux = setup_dump_aux_diagnostics(
+        AtmosLESConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
 
     return ClimateMachine.DiagnosticsConfiguration([
         dgngrp_profiles,
         dgngrp_state,
+        dgngrp_aux,
     ])
 end
 


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->

Two fixes to squall line setup:
 - increase the maxiter for equilibrium runs with removed precipitation
 - add forgotten AuxState output for QA plots

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
