### PR TITLE
fix BC state used in the edmf_kernels BC implementation

### DIFF
--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -815,10 +815,10 @@ function turbconv_boundary_state!(
 
     turbconv = m.turbconv
     N_up = n_updrafts(turbconv)
-    up = state⁺.turbconv.updraft
-    en = state⁺.turbconv.environment
-    gm = state⁺
-    gm_a = aux⁺
+    up⁺ = state⁺.turbconv.updraft
+    en⁺ = state⁺.turbconv.environment
+    gm⁻ = state⁻
+    gm_a⁻ = aux⁻
 
     zLL = altitude(m, aux_int)
     a_up_surf,
@@ -827,19 +827,20 @@ function turbconv_boundary_state!(
     θ_liq_cv,
     q_tot_cv,
     θ_liq_q_tot_cv,
-    tke = subdomain_surface_values(turbconv.surface, turbconv, m, gm, gm_a, zLL)
+    tke =
+        subdomain_surface_values(turbconv.surface, turbconv, m, gm⁻, gm_a⁻, zLL)
 
     @unroll_map(N_up) do i
-        up[i].ρaw = FT(0)
-        up[i].ρa = a_up_surf[i] * gm.ρ
-        up[i].ρaθ_liq = up[i].ρa * θ_liq_up_surf[i]
-        up[i].ρaq_tot = up[i].ρa * q_tot_up_surf[i]
+        up⁺[i].ρaw = FT(0)
+        up⁺[i].ρa = gm⁻.ρ * a_up_surf[i]
+        up⁺[i].ρaθ_liq = gm⁻.ρ * a_up_surf[i] * θ_liq_up_surf[i]
+        up⁺[i].ρaq_tot = gm⁻.ρ * a_up_surf[i] * q_tot_up_surf[i]
     end
-    a_en = environment_area(gm, gm_a, N_up)
-    en.ρatke = gm.ρ * a_en * tke
-    en.ρaθ_liq_cv = gm.ρ * a_en * θ_liq_cv
-    en.ρaq_tot_cv = gm.ρ * a_en * q_tot_cv
-    en.ρaθ_liq_q_tot_cv = gm.ρ * a_en * θ_liq_q_tot_cv
+    a_en = environment_area(gm⁻, gm_a⁻, N_up)
+    en⁺.ρatke = gm⁻.ρ * a_en * tke
+    en⁺.ρaθ_liq_cv = gm⁻.ρ * a_en * θ_liq_cv
+    en⁺.ρaq_tot_cv = gm⁻.ρ * a_en * q_tot_cv
+    en⁺.ρaθ_liq_q_tot_cv = gm⁻.ρ * a_en * θ_liq_q_tot_cv
 end;
 function turbconv_boundary_state!(
     nf,

--- a/test/Atmos/EDMF/report_mse.jl
+++ b/test/Atmos/EDMF/report_mse.jl
@@ -16,13 +16,13 @@ best_mse[:Bomex]["ρ"] = 3.4943021267397123e-02
 best_mse[:Bomex]["ρu[1]"] = 3.0714039084256679e+03
 best_mse[:Bomex]["ρu[2]"] = 1.3375796498101822e-03
 best_mse[:Bomex]["moisture.ρq_tot"] = 4.8463531712319707e-02
-best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.7458994186482869e+02
-best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5667200477293633e+01
-best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6455670738880309e+02
-best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9547300082766554e+01
-best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4294492216319045e-02
-best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0095767705492662e+00
-best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0767427989197111e+01
+best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.6626829120765967e+02
+best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5667200586224638e+01
+best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6455724508026515e+02
+best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9577347148736081e+01
+best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4352020356445540e-02
+best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0101465706333848e+00
+best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0768121066483779e+01
 #! format: on
 
 sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + eps()


### PR DESCRIPTION
### Description
This PR fixes the state ('+' or '-') used in the BC implementation for the EDMF. 
Results improved in the TKE and use errors in the table have been updated 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
