### PR TITLE
Import prim-prog in AtmosModel

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -60,6 +60,8 @@ import ..BalanceLaws:
     compute_gradient_argument!,
     compute_gradient_flux!,
     transform_post_gradient_laplacian!,
+    prognostic_to_primitive!,
+    primitive_to_prognostic!,
     init_state_auxiliary!,
     init_state_prognostic!,
     update_auxiliary_state!,

--- a/test/Atmos/prog_prim_conversion/runtests.jl
+++ b/test/Atmos/prog_prim_conversion/runtests.jl
@@ -19,7 +19,8 @@ using ClimateMachine.VariableTemplates
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Atmos: AtmosModel, DryModel, EquilMoist, NonEquilMoist
-using ClimateMachine.Atmos: prognostic_to_primitive!, primitive_to_prognostic!
+using ClimateMachine.BalanceLaws:
+    prognostic_to_primitive!, primitive_to_prognostic!
 const BL = BalanceLaws
 
 struct EarthParameterSet <: AbstractEarthParameterSet end
@@ -99,6 +100,7 @@ end
         prog_0 = deepcopy(parent(prog))
         prim_arr .= 0
         prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
+        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
         primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
         @test all(parent(prog) .≈ prog_0)
 
@@ -107,6 +109,7 @@ end
         prim_0 = deepcopy(parent(prim))
         prog_arr .= 0
         primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
+        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
         prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
         @test all(parent(prim) .≈ prim_0)
     end
@@ -131,6 +134,7 @@ end
         prog_0 = deepcopy(parent(prog))
         prim_arr .= 0
         prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
+        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
         primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
         @test all(parent(prog)[1:4] .≈ prog_0[1:4])
         @test isapprox(parent(prog)[5], prog_0[5]; atol = atol_energy)
@@ -143,6 +147,7 @@ end
         prim_0 = deepcopy(parent(prim))
         prog_arr .= 0
         primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
+        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
         prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
         @test all(parent(prim)[1:4] .≈ prim_0[1:4])
         # @test all(parent(prim)[5] .≈ prim_0[5]) # fails
@@ -171,6 +176,7 @@ end
         prog_0 = deepcopy(parent(prog))
         prim_arr .= 0
         prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
+        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
         primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
         @test all(parent(prog) .≈ prog_0)
 
@@ -179,6 +185,7 @@ end
         prim_0 = deepcopy(parent(prim))
         prog_arr .= 0
         primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
+        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
         prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
         @test all(parent(prim) .≈ prim_0)
     end
@@ -210,6 +217,7 @@ end
         prog_0 = deepcopy(parent(prog))
         prim_arr .= 0
         BL.prognostic_to_primitive!(bl, prim_arr, prog_arr, aux_arr)
+        @test !all(prog_arr .≈ prim_arr) # ensure not calling fallback
         BL.primitive_to_prognostic!(bl, prog_arr, prim_arr, aux_arr)
         @test all(parent(prog) .≈ prog_0)
 
@@ -218,6 +226,7 @@ end
         prim_0 = deepcopy(parent(prim))
         prog_arr .= 0
         BL.primitive_to_prognostic!(bl, prog_arr, prim_arr, aux_arr)
+        @test !all(prog_arr .≈ prim_arr) # ensure not calling fallback
         BL.prognostic_to_primitive!(bl, prim_arr, prog_arr, aux_arr)
         @test all(parent(prim) .≈ prim_0)
     end


### PR DESCRIPTION
### Description

This PR `import`s `prognostic_to_primitive!, primitive_to_prognostic!` into the `Atmos` module, so that it's called with `AtmosModel`s. This was missed in #1830.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
