### PR TITLE
Fix sources and fluxes in edmf_kernels.

### DIFF
--- a/test/Atmos/EDMF/closures/mixing_length.jl
+++ b/test/Atmos/EDMF/closures/mixing_length.jl
@@ -65,7 +65,7 @@ function mixing_length(
 
     # compute L1
     Nˢ_fact = (sign(Nˢ_eff - eps(FT)) + 1) / 2
-    coeff = min(sqrt(ml.c_b * tke_en) / Nˢ_eff, ml.max_length)
+    coeff = min(ml.c_b * sqrt(tke_en) / Nˢ_eff, ml.max_length)
     L_Nˢ = coeff * Nˢ_fact + ml.max_length * (FT(1) - Nˢ_fact)
 
     # compute L2 - law of the wall
@@ -80,7 +80,10 @@ function mixing_length(
     tke_surf = surf_vals.tke
     L_W = ml.κ * z / (sqrt(tke_surf) * ml.c_m / ustar / ustar)
     stab_fac = -(sign(obukhov_length) - 1) / 2
-    L_W *= stab_fac * min((FT(1) - ml.a2 * z / obukhov_length)^ml.a1, 1 / ml.κ)
+    L_W *= (
+        stab_fac * min((FT(1) - ml.a2 * z / obukhov_length)^ml.a1, 1 / ml.κ) +
+        (FT(1) - stab_fac)
+    )
 
     # compute L3 - entrainment detrainment sources
     # Production/destruction terms
@@ -97,7 +100,7 @@ function mixing_length(
         end,
     )
 
-    c_neg = ml.c_d * tke_en * sqrt(abs(tke_en))
+    c_neg = ml.c_d * tke_en * sqrt(tke_en)
     if abs(a) > ml.random_minval && 4 * a * c_neg > -b^2
         l_entdet =
             max(-b / FT(2) / a + sqrt(b^2 + 4 * a * c_neg) / 2 / a, FT(0))

--- a/test/Atmos/EDMF/report_mse.jl
+++ b/test/Atmos/EDMF/report_mse.jl
@@ -16,13 +16,13 @@ best_mse[:Bomex]["ρ"] = 3.4943021267397123e-02
 best_mse[:Bomex]["ρu[1]"] = 3.0714039084256679e+03
 best_mse[:Bomex]["ρu[2]"] = 1.3375796498101822e-03
 best_mse[:Bomex]["moisture.ρq_tot"] = 4.8463531712319707e-02
-best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.6626829120765967e+02
-best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5667200586224638e+01
-best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6455724508026515e+02
-best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9577347148736081e+01
-best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4352020356445540e-02
-best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0101465706333848e+00
-best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0768121066483779e+01
+best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.6626422991098286e+02
+best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5667099987715503e+01
+best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6439116552012851e+02
+best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9577348413012515e+01
+best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4352188057391225e-02
+best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0101464252959325e+00
+best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0768120864370509e+01
 #! format: on
 
 sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + eps()


### PR DESCRIPTION
### Description

This PR fixes the turbulent production sources for all second order moments in the environment, the stability function used in the mixing length l_w, and the mass flux components of the sgs fluxes.

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
