### PR TITLE
Move hyperdiffusion fluxes to new tend spec

### DIFF
--- a/docs/src/APIs/Common/TurbulenceClosures.md
+++ b/docs/src/APIs/Common/TurbulenceClosures.md
@@ -12,6 +12,8 @@ TurbulenceClosures
 
 ```@docs
 TurbulenceClosureModel
+hyperdiff_enthalpy_and_momentum_flux
+hyperdiff_momentum_flux
 WithDivergence
 WithoutDivergence
 ConstantViscosity

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -665,7 +665,6 @@ function. Contributions from subcomponents are then assembled (pointwise).
 
     flux_second_order!(atmos.moisture, flux, atmos, args)
     flux_second_order!(atmos.precipitation, flux, atmos, args)
-    flux_second_order!(atmos.hyperdiffusion, flux, args)
     flux_second_order!(atmos.tracers, flux, atmos, args)
     flux_second_order!(atmos.turbconv, flux, atmos, args)
 end

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -125,15 +125,25 @@ eq_tends(pv::PV, m::AtmosModel, tt::Flux{SecondOrder}) where {PV <: Mass} =
 
 # Momentum
 eq_tends(pv::PV, m::AtmosModel, tt::Flux{SecondOrder}) where {PV <: Momentum} =
-    (ViscousStress{PV}(), eq_tends(pv, m.moisture, tt)...)
+    (
+        ViscousStress{PV}(),
+        eq_tends(pv, m.moisture, tt)...,
+        hyperdiff_momentum_flux(pv, m.hyperdiffusion, tt)...,
+    )
 
 # Energy
-eq_tends(pv::PV, ::AtmosModel, ::Flux{SecondOrder}) where {PV <: Energy} =
-    (ViscousFlux{PV}(), DiffEnthalpyFlux{PV}())
+eq_tends(pv::PV, m::AtmosModel, tt::Flux{SecondOrder}) where {PV <: Energy} = (
+    ViscousFlux{PV}(),
+    DiffEnthalpyFlux{PV}(),
+    hyperdiff_enthalpy_and_momentum_flux(pv, m.hyperdiffusion, tt)...,
+)
 
 # Moisture
 eq_tends(pv::PV, m::AtmosModel, tt::Flux{SecondOrder}) where {PV <: Moisture} =
-    (eq_tends(pv, m.moisture, tt)...,)
+    (
+        eq_tends(pv, m.moisture, tt)...,
+        hyperdiff_momentum_flux(pv, m.hyperdiffusion, tt)...,
+    )
 
 # Precipitation
 eq_tends(

--- a/src/Atmos/Model/tendencies_energy.jl
+++ b/src/Atmos/Model/tendencies_energy.jl
@@ -26,6 +26,16 @@ function flux(::ViscousFlux{Energy}, atmos, args)
     return τ * state.ρu
 end
 
+function flux(::HyperdiffViscousFlux{Energy}, atmos, args)
+    @unpack state, hyperdiffusive = args
+    return hyperdiffusive.hyperdiffusion.ν∇³u_h * state.ρu
+end
+
+function flux(::HyperdiffEnthalpyFlux{Energy}, atmos, args)
+    @unpack state, hyperdiffusive = args
+    return hyperdiffusive.hyperdiffusion.ν∇³h_tot * state.ρ
+end
+
 struct DiffEnthalpyFlux{PV <: Energy} <: TendencyDef{Flux{SecondOrder}, PV} end
 function flux(::DiffEnthalpyFlux{Energy}, atmos, args)
     @unpack state, aux, t, diffusive = args

--- a/src/Atmos/Model/tendencies_moisture.jl
+++ b/src/Atmos/Model/tendencies_moisture.jl
@@ -47,6 +47,11 @@ function flux(::MoistureDiffusion{IceMoisture}, atmos, args)
     return d_q_ice * state.ρ
 end
 
+function flux(::HyperdiffViscousFlux{TotalMoisture}, atmos, args)
+    @unpack state, hyperdiffusive = args
+    return hyperdiffusive.hyperdiffusion.ν∇³q_tot * state.ρ
+end
+
 #####
 ##### Sources
 #####

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -41,6 +41,11 @@ function flux(::MoistureDiffusion{Momentum}, atmos, args)
     return d_q_tot .* state.ρu'
 end
 
+function flux(::HyperdiffViscousFlux{Momentum}, atmos, args)
+    @unpack state, hyperdiffusive = args
+    return state.ρ * hyperdiffusive.hyperdiffusion.ν∇³u_h
+end
+
 #####
 ##### Sources
 #####


### PR DESCRIPTION
### Description

The PR moves hyperdiffusion to the new tendency specification.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
