### PR TITLE
Better pad to avoid `NaN * 0 = NaN`

### DIFF
--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -14,7 +14,8 @@ end
 function flux(::PressureGradient{Momentum}, atmos, args)
     @unpack state, aux = args
     @unpack ts = args.precomputed
-    pad = (state.ρu .* (state.ρu / state.ρ)') * 0
+    s = state.ρu * state.ρu'
+    pad = SArray{Tuple{size(s)...}}(ntuple(i -> 0, length(s)))
     if atmos.ref_state isa HydrostaticState
         return pad + (air_pressure(ts) - aux.ref_state.p) * I
     else
@@ -29,7 +30,8 @@ end
 struct ViscousStress{PV <: Momentum} <: TendencyDef{Flux{SecondOrder}, PV} end
 function flux(::ViscousStress{Momentum}, atmos, args)
     @unpack state, aux, t, diffusive = args
-    pad = (state.ρu .* (state.ρu / state.ρ)') * 0
+    s = state.ρu * state.ρu'
+    pad = SArray{Tuple{size(s)...}}(ntuple(i -> 0, length(s)))
     ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
     return pad + τ * state.ρ
 end


### PR DESCRIPTION
### Description

This PR changes `pad` in some fluxes to avoid unwanted behavior. For example `NaN * 0 = NaN`.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
