### PR TITLE
Attempt to speed up Dycoms: Use `Type{FT}`, lower diagnostics freq, cache O2 fluxes

### DIFF
--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -247,7 +247,7 @@ function init_dycoms!(problem, bl, state, aux, localgeo, t)
 end
 
 function config_dycoms(
-    FT,
+    ::Type{FT},
     N,
     resolution,
     xmax,
@@ -255,7 +255,7 @@ function config_dycoms(
     zmax,
     moisture_model = "equilibrium",
     precipitation_model = "noprecipitation",
-)
+) where {FT}
     # Reference state
     T_profile = DecayingTemperatureProfile{FT}(param_set)
     ref_state = HydrostaticState(T_profile)
@@ -394,8 +394,9 @@ function config_dycoms(
     return config
 end
 
-function config_diagnostics(driver_config)
-    interval = "1000steps"
+function config_diagnostics(driver_config, timeend)
+    ssecs = cld(timeend, 2) + 10
+    interval = "$(ssecs)ssecs"
     dgngrp = setup_atmos_default_diagnostics(
         AtmosLESConfigType(),
         interval,
@@ -469,7 +470,7 @@ function main()
         init_on_cpu = true,
         Courant_number = Cmax,
     )
-    dgn_config = config_diagnostics(driver_config)
+    dgn_config = config_diagnostics(driver_config, timeend)
 
     if moisture_model == "equilibrium"
         filter_vars = ("moisture.ρq_tot",)

--- a/src/Atmos/Model/multiphysics_types.jl
+++ b/src/Atmos/Model/multiphysics_types.jl
@@ -107,9 +107,8 @@ WarmRain_1M() = (
     WarmRain_1M{Rain}(),
 )
 
-function warm_rain_sources(atmos, args)
+function warm_rain_sources(atmos, args, ts)
     @unpack state, aux = args
-    @unpack ts = args.precomputed
 
     FT = eltype(state)
 
@@ -171,9 +170,8 @@ RainSnow_1M() = (
     RainSnow_1M{Snow}(),
 )
 
-function rain_snow_sources(atmos, args)
+function rain_snow_sources(atmos, args, ts)
     @unpack state, aux = args
-    @unpack ts = args.precomputed
 
     FT = eltype(state)
 

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -54,6 +54,9 @@ No precipitation.
 """
 struct NoPrecipitation <: PrecipitationModel end
 
+precompute(::NoPrecipitation, atmos::AtmosModel, args, ts, ::Source) =
+    NamedTuple()
+
 """
     RainModel <: PrecipitationModel
 
@@ -64,6 +67,9 @@ struct RainModel <: PrecipitationModel end
 vars_state(::RainModel, ::Prognostic, FT) = @vars(ρq_rai::FT)
 vars_state(::RainModel, ::Gradient, FT) = @vars(q_rai::FT)
 vars_state(::RainModel, ::GradientFlux, FT) = @vars(∇q_rai::SVector{3, FT})
+
+precompute(::RainModel, atmos::AtmosModel, args, ts, ::Source) =
+    (cache = warm_rain_sources(atmos, args, ts),)
 
 function atmos_nodal_update_auxiliary_state!(
     precip::RainModel,
@@ -134,6 +140,9 @@ vars_state(::RainSnowModel, ::Prognostic, FT) = @vars(ρq_rai::FT, ρq_sno::FT)
 vars_state(::RainSnowModel, ::Gradient, FT) = @vars(q_rai::FT, q_sno::FT)
 vars_state(::RainSnowModel, ::GradientFlux, FT) =
     @vars(∇q_rai::SVector{3, FT}, ∇q_sno::SVector{3, FT})
+
+precompute(::RainSnowModel, atmos::AtmosModel, args, ts, ::Source) =
+    (cache = rain_snow_sources(atmos, args, ts),)
 
 function atmos_nodal_update_auxiliary_state!(
     precip::RainSnowModel,

--- a/src/Atmos/Model/tendencies_energy.jl
+++ b/src/Atmos/Model/tendencies_energy.jl
@@ -21,8 +21,8 @@ end
 
 struct ViscousFlux{PV <: Energy} <: TendencyDef{Flux{SecondOrder}, PV} end
 function flux(::ViscousFlux{Energy}, atmos, args)
-    @unpack state, aux, t, diffusive = args
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state = args
+    @unpack τ = args.precomputed.turbulence
     return τ * state.ρu
 end
 
@@ -38,8 +38,8 @@ end
 
 struct DiffEnthalpyFlux{PV <: Energy} <: TendencyDef{Flux{SecondOrder}, PV} end
 function flux(::DiffEnthalpyFlux{Energy}, atmos, args)
-    @unpack state, aux, t, diffusive = args
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state, diffusive = args
+    @unpack D_t = args.precomputed.turbulence
     d_h_tot = -D_t .* diffusive.∇h_tot
     return d_h_tot * state.ρ
 end
@@ -69,11 +69,11 @@ function source(s::RemovePrecipitation{Energy}, m, args)
 end
 
 function source(s::WarmRain_1M{Energy}, m, args)
-    nt = warm_rain_sources(m, args)
-    return nt.S_ρ_e
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_e
 end
 
 function source(s::RainSnow_1M{Energy}, m, args)
-    nt = rain_snow_sources(m, args)
-    return nt.S_ρ_e
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_e
 end

--- a/src/Atmos/Model/tendencies_mass.jl
+++ b/src/Atmos/Model/tendencies_mass.jl
@@ -13,8 +13,8 @@ end
 #####
 
 function flux(::MoistureDiffusion{Mass}, atmos, args)
-    @unpack state, aux, t, diffusive = args
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state, diffusive = args
+    @unpack D_t = args.precomputed.turbulence
     d_q_tot = (-D_t) .* diffusive.moisture.∇q_tot
     return d_q_tot * state.ρ
 end
@@ -44,11 +44,11 @@ function source(s::RemovePrecipitation{Mass}, m, args)
 end
 
 function source(s::WarmRain_1M{Mass}, m, args)
-    nt = warm_rain_sources(m, args)
-    return nt.S_ρ_qt
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_qt
 end
 
 function source(s::RainSnow_1M{Mass}, m, args)
-    nt = rain_snow_sources(m, args)
-    return nt.S_ρ_qt
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_qt
 end

--- a/src/Atmos/Model/tendencies_moisture.jl
+++ b/src/Atmos/Model/tendencies_moisture.jl
@@ -27,22 +27,22 @@ end
 #####
 
 function flux(::MoistureDiffusion{TotalMoisture}, atmos, args)
-    @unpack state, aux, t, diffusive = args
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state, diffusive = args
+    @unpack D_t = args.precomputed.turbulence
     d_q_tot = (-D_t) .* diffusive.moisture.∇q_tot
     return d_q_tot * state.ρ
 end
 
 function flux(::MoistureDiffusion{LiquidMoisture}, atmos, args)
-    @unpack state, aux, t, diffusive = args
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state, diffusive = args
+    @unpack D_t = args.precomputed.turbulence
     d_q_liq = (-D_t) .* diffusive.moisture.∇q_liq
     return d_q_liq * state.ρ
 end
 
 function flux(::MoistureDiffusion{IceMoisture}, atmos, args)
-    @unpack state, aux, t, diffusive = args
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state, diffusive = args
+    @unpack D_t = args.precomputed.turbulence
     d_q_ice = (-D_t) .* diffusive.moisture.∇q_ice
     return d_q_ice * state.ρ
 end
@@ -128,26 +128,26 @@ function source(s::RemovePrecipitation{TotalMoisture}, m, args)
 end
 
 function source(s::WarmRain_1M{TotalMoisture}, m, args)
-    nt = warm_rain_sources(m, args)
-    return nt.S_ρ_qt
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_qt
 end
 
 function source(s::WarmRain_1M{LiquidMoisture}, m, args)
-    nt = warm_rain_sources(m, args)
-    return nt.S_ρ_ql
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_ql
 end
 
 function source(s::RainSnow_1M{TotalMoisture}, m, args)
-    nt = rain_snow_sources(m, args)
-    return nt.S_ρ_qt
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_qt
 end
 
 function source(s::RainSnow_1M{LiquidMoisture}, m, args)
-    nt = rain_snow_sources(m, args)
-    return nt.S_ρ_ql
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_ql
 end
 
 function source(s::RainSnow_1M{IceMoisture}, m, args)
-    nt = rain_snow_sources(m, args)
-    return nt.S_ρ_qi
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_qi
 end

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -29,16 +29,15 @@ end
 
 struct ViscousStress{PV <: Momentum} <: TendencyDef{Flux{SecondOrder}, PV} end
 function flux(::ViscousStress{Momentum}, atmos, args)
-    @unpack state, aux, t, diffusive = args
-    s = state.ρu * state.ρu'
-    pad = SArray{Tuple{size(s)...}}(ntuple(i -> 0, length(s)))
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state = args
+    @unpack τ = args.precomputed.turbulence
+    pad = SArray{Tuple{size(τ)...}}(ntuple(i -> 0, length(τ)))
     return pad + τ * state.ρ
 end
 
 function flux(::MoistureDiffusion{Momentum}, atmos, args)
-    @unpack state, aux, t, diffusive = args
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state, diffusive = args
+    @unpack D_t = args.precomputed.turbulence
     d_q_tot = (-D_t) .* diffusive.moisture.∇q_tot
     return d_q_tot .* state.ρu'
 end

--- a/src/Atmos/Model/tendencies_precipitation.jl
+++ b/src/Atmos/Model/tendencies_precipitation.jl
@@ -50,15 +50,15 @@ end
 #####
 
 function flux(::Diffusion{Rain}, atmos, args)
-    @unpack state, aux, t, diffusive = args
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state, diffusive = args
+    @unpack D_t = args.precomputed.turbulence
     d_q_rai = (-D_t) .* diffusive.precipitation.∇q_rai
     return d_q_rai * state.ρ
 end
 
 function flux(::Diffusion{Snow}, atmos, args)
-    @unpack state, aux, t, diffusive = args
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state, diffusive = args
+    @unpack D_t = args.precomputed.turbulence
     d_q_sno = (-D_t) .* diffusive.precipitation.∇q_sno
     return d_q_sno * state.ρ
 end
@@ -69,16 +69,16 @@ end
 #####
 
 function source(s::WarmRain_1M{Rain}, m, args)
-    nt = warm_rain_sources(m, args)
-    return nt.S_ρ_qr
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_qr
 end
 
 function source(s::RainSnow_1M{Rain}, m, args)
-    nt = rain_snow_sources(m, args)
-    return nt.S_ρ_qr
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_qr
 end
 
 function source(s::RainSnow_1M{Snow}, m, args)
-    nt = rain_snow_sources(m, args)
-    return nt.S_ρ_qs
+    @unpack cache = args.precomputed.precipitation
+    return cache.S_ρ_qs
 end

--- a/src/Atmos/Model/tendencies_tracers.jl
+++ b/src/Atmos/Model/tendencies_tracers.jl
@@ -15,8 +15,8 @@ end
 #####
 
 function flux(::Diffusion{Tracers{N}}, atmos, args) where {N}
-    @unpack state, aux, t, diffusive = args
-    ν, D_t, τ = turbulence_tensors(atmos, state, diffusive, aux, t)
+    @unpack state, aux, diffusive = args
+    @unpack D_t = args.precomputed.turbulence
     d_χ = (-D_t) * aux.tracers.δ_χ' .* diffusive.tracers.∇χ
     return d_χ * state.ρ
 end


### PR DESCRIPTION
### Description

This PR is an attempt to speed up Dycoms a bit via:
 - Using `::Type{FT}` constraint in the driver, to ensure we avoid dynamic closures
 - Lower the diagnostics output frequency
 - Cache some of the 2nd order fluxes (both `turbulence_tensors` and some precipitation sources)

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
