### PR TITLE
Detect CI environments and download Artifacts to unique path prefixes

### DIFF
--- a/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
+++ b/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
@@ -40,6 +40,13 @@ const param_set = EarthParameterSet()
 using ClimateMachine.Atmos: altitude, recover_thermo_state
 import ClimateMachine.BalanceLaws: source, eq_tends
 
+# path to download artifacts
+const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
+    @__DIR__
+else
+    mktempdir(@__DIR__; prefix = "artifact_")
+end
+
 # Citation for problem setup
 ## CMIP6 Test Dataset - cfsites
 ## [Webb2017](@cite)
@@ -271,7 +278,7 @@ function get_gcm_info(group_id)
     @printf("--------------------------------------------------\n")
 
     lsforcing_dataset = ArtifactWrapper(
-        joinpath(@__DIR__, "Artifacts.toml"),
+        joinpath(ARTIFACT_DIR, "Artifacts.toml"),
         "lsforcing",
         ArtifactFile[ArtifactFile(
             url = "https://caltech.box.com/shared/static/dszfbqzwgc9a55vhxd43yenvebcb6bcj.nc",

--- a/experiments/AtmosLES/squall_line.jl
+++ b/experiments/AtmosLES/squall_line.jl
@@ -51,6 +51,13 @@ const microphys = MicropysicsParameterSet(
 )
 const param_set = EarthParameterSet(microphys)
 
+# path to download artifacts
+const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
+    @__DIR__
+else
+    mktempdir(@__DIR__; prefix = "artifact_")
+end
+
 """
   Define initial conditions based on sounding data
 """
@@ -129,10 +136,8 @@ function read_sounding()
     # driver at the same time, we must store artifacts in a
     # separate folder.
 
-    artifact_folder = mktempdir(@__DIR__; prefix = "artifacts_")
-
     soundings_dataset = ArtifactWrapper(
-        joinpath(artifact_folder, "Artifacts.toml"),
+        joinpath(ARTIFACT_DIR, "Artifacts.toml"),
         "soundings",
         ArtifactFile[ArtifactFile(
             url = "https://caltech.box.com/shared/static/rjnvt2dlw7etm1c7mmdfrkw5gnfds5lx.nc",

--- a/test/Atmos/EDMF/compute_mse.jl
+++ b/test/Atmos/EDMF/compute_mse.jl
@@ -1,5 +1,11 @@
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+
+# path to download artifacts
+const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
+    @__DIR__
+else
+    mktempdir(@__DIR__; prefix = "artifact_")
+end
 
 if parse(Bool, get(ENV, "CLIMATEMACHINE_PLOT_EDMF_COMPARISON", "false"))
     using Plots
@@ -15,7 +21,7 @@ using ClimateMachine.ArtifactWrappers
 # Get PyCLES_output dataset folder:
 #! format: off
 PyCLES_output_dataset = ArtifactWrapper(
-    joinpath(clima_dir, "test", "Atmos", "EDMF", "Artifacts.toml"),
+    joinpath(ARTIFACT_DIR, "Artifacts.toml"),
     "PyCLES_output",
     ArtifactFile[
     # ArtifactFile(url = "https://caltech.box.com/shared/static/johlutwhohvr66wn38cdo7a6rluvz708.nc", filename = "Rico.nc",),

--- a/test/Atmos/Model/ref_state.jl
+++ b/test/Atmos/Model/ref_state.jl
@@ -5,9 +5,16 @@ using ClimateMachine.ArtifactWrappers
 using ClimateMachine.Thermodynamics
 const TD = Thermodynamics
 
+# path to download artifacts
+const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
+    @__DIR__
+else
+    mktempdir(@__DIR__; prefix = "artifact_")
+end
+
 @testset "Hydrostatic reference states - regression test" begin
     ref_state_dataset = ArtifactWrapper(
-        joinpath(@__DIR__, "Artifacts.toml"),
+        joinpath(ARTIFACT_DIR, "Artifacts.toml"),
         "ref_state",
         ArtifactFile[ArtifactFile(
             url = "https://caltech.box.com/shared/static/gyq292ns79wm9xpmy1sse3qtnpcxw54q.jld2",

--- a/test/Common/Thermodynamics/data_tests.jl
+++ b/test/Common/Thermodynamics/data_tests.jl
@@ -2,9 +2,16 @@ using Pkg.Artifacts
 
 using ClimateMachine.ArtifactWrappers
 
+# path to download artifacts
+const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
+    @__DIR__
+else
+    mktempdir(@__DIR__; prefix = "artifact_")
+end
+
 # Get dycoms dataset folder:
 dycoms_dataset = ArtifactWrapper(
-    joinpath(@__DIR__, "Artifacts.toml"),
+    joinpath(ARTIFACT_DIR, "Artifacts.toml"),
     "dycoms",
     ArtifactFile[ArtifactFile(
         url = "https://caltech.box.com/shared/static/bxau6i46y6ikxn2sy9krgz0sw5vuptfo.nc",

--- a/test/Land/Model/haverkamp_implicit_test.jl
+++ b/test/Land/Model/haverkamp_implicit_test.jl
@@ -31,8 +31,15 @@ using ClimateMachine.BalanceLaws:
     BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, vars_state
 using ClimateMachine.ArtifactWrappers
 
+# path to download artifacts
+const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
+    @__DIR__
+else
+    mktempdir(@__DIR__; prefix = "artifact_")
+end
+
 haverkamp_dataset = ArtifactWrapper(
-    joinpath("test", "Land", "Model", "Artifacts_implicit.toml"),
+    joinpath(ARTIFACT_DIR, "Artifacts.toml"),
     "richards",
     ArtifactFile[ArtifactFile(
         url = "https://caltech.box.com/shared/static/dfijf07io7h5dk1k87saaewgsg9apq8d.csv",

--- a/test/Land/Model/haverkamp_test.jl
+++ b/test/Land/Model/haverkamp_test.jl
@@ -30,8 +30,15 @@ using ClimateMachine.BalanceLaws:
     BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, vars_state
 using ClimateMachine.ArtifactWrappers
 
+# path to download artifacts
+const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
+    @__DIR__
+else
+    mktempdir(@__DIR__; prefix = "artifact_")
+end
+
 haverkamp_dataset = ArtifactWrapper(
-    joinpath("test", "Land", "Model", "Artifacts.toml"),
+    joinpath(ARTIFACT_DIR, "Artifacts.toml"),
     "richards",
     ArtifactFile[ArtifactFile(
         url = "https://caltech.box.com/shared/static/dfijf07io7h5dk1k87saaewgsg9apq8d.csv",

--- a/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
+++ b/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
@@ -107,8 +107,14 @@ using ClimateMachine.BalanceLaws:
 import ClimateMachine.DGMethods: calculate_dt
 using ClimateMachine.ArtifactWrappers
 
-# # Preliminary set-up
+# path to download artifacts
+const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
+    @__DIR__
+else
+    mktempdir(@__DIR__; prefix = "artifact_")
+end
 
+# # Preliminary set-up
 # Get the parameter set, which holds constants used across CliMA models.
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet();
@@ -429,7 +435,7 @@ plot(
 plot!(T_init.(z), z, label = "Initial condition")
 filename = "bonan_heat_data.csv"
 bonan_dataset = ArtifactWrapper(
-    joinpath(clima_dir, "tutorials", "Land", "Soil", "Artifacts.toml"),
+    joinpath(ARTIFACT_DIR, "Artifacts.toml"),
     "bonan_soil_heat",
     ArtifactFile[ArtifactFile(
         url = "https://caltech.box.com/shared/static/99vm8q8tlyoulext6c35lnd3355tx6bu.csv",


### PR DESCRIPTION
Prevents race conditions with multiple tests using the same Artifact
name through ArtifactWrappers running in parallel.

### Description

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
