### PR TITLE
Cache some computations in turbconv

### DIFF
--- a/docs/src/Theory/Atmos/EDMF_plots.md
+++ b/docs/src/Theory/Atmos/EDMF_plots.md
@@ -18,6 +18,7 @@ to one of the EDMF profile constructors.
 ### TurbulentPrantlNumberProfile
 
 ```@example
+using UnPack
 using ClimateMachine
 const clima_dir = dirname(dirname(pathof(ClimateMachine)));
 using ClimateMachine.Atmos: AtmosModel

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -480,8 +480,11 @@ include("prog_prim_conversion.jl")   # prognostic<->primitive conversion
 include("atmos_tendencies.jl")        # specify atmos tendencies
 include("get_prognostic_vars.jl")     # get tuple of prognostic variables
 
-precompute(atmos::AtmosModel, args, tt::Flux{FirstOrder}) =
-    (ts = recover_thermo_state(atmos, args.state, args.aux),)
+function precompute(atmos::AtmosModel, args, tt::Flux{FirstOrder})
+    ts = recover_thermo_state(atmos, args.state, args.aux)
+    turbconv = precompute(atmos.turbconv, atmos, args, ts, tt)
+    return (; ts, turbconv)
+end
 
 """
     flux_first_order!(
@@ -618,8 +621,11 @@ function transform_post_gradient_laplacian!(
     )
 end
 
-precompute(atmos::AtmosModel, args, ::Flux{SecondOrder}) =
-    (ts = recover_thermo_state(atmos, args.state, args.aux),)
+function precompute(atmos::AtmosModel, args, tt::Flux{SecondOrder})
+    ts = recover_thermo_state(atmos, args.state, args.aux)
+    turbconv = precompute(atmos.turbconv, atmos, args, ts, tt)
+    return (; ts, turbconv)
+end
 
 """
     flux_second_order!(
@@ -820,8 +826,11 @@ function init_state_auxiliary!(
     )
 end
 
-precompute(atmos::AtmosModel, args, tt::Source) =
-    (ts = recover_thermo_state(atmos, args.state, args.aux),)
+function precompute(atmos::AtmosModel, args, tt::Source)
+    ts = recover_thermo_state(atmos, args.state, args.aux)
+    turbconv = precompute(atmos.turbconv, atmos, args, ts, tt)
+    return (; ts, turbconv)
+end
 
 """
     source!(

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -17,6 +17,7 @@ export init_state_prognostic!,
 import ..BalanceLaws:
     vars_state,
     source!,
+    precompute,
     prognostic_vars,
     init_state_prognostic!,
     init_state_auxiliary!,
@@ -43,6 +44,8 @@ pass through and do nothing.
 struct NoTurbConv <: TurbulenceConvectionModel end
 
 prognostic_vars(::NoTurbConv) = ()
+
+precompute(::NoTurbConv, bl, args, ts, tend_type) = NamedTuple()
 
 vars_state(m::TurbulenceConvectionModel, ::AbstractStateType, FT) = @vars()
 

--- a/test/Atmos/EDMF/bomex_edmf.jl
+++ b/test/Atmos/EDMF/bomex_edmf.jl
@@ -247,4 +247,4 @@ end
 
 solver_config, dons_arr, time_data, state_types = main(Float64)
 
-include(joinpath(@__DIR__, "report_mse.jl"))
+include(joinpath(@__DIR__, "report_mse_bomex.jl"))

--- a/test/Atmos/EDMF/closures/mixing_length.jl
+++ b/test/Atmos/EDMF/closures/mixing_length.jl
@@ -3,41 +3,35 @@
     mixing_length(
         m::AtmosModel{FT},
         ml::MixingLengthModel,
-        state::Vars,
-        diffusive::Vars,
-        aux::Vars,
-        t::Real,
+        args,
         Δ::Tuple,
         Et::Tuple,
-        ts,
+        ts_gm,
+        ts_en,
         env,
     ) where {FT}
 
 Returns the mixing length used in the diffusive turbulence closure, given:
  - `m`, an `AtmosModel`
  - `ml`, a `MixingLengthModel`
- - `state`, state variables
- - `diffusive`, additional variables
- - `aux`, auxiliary variables
- - `t`, the time
+ - `args`, the top-level arguments
  - `Δ`, the detrainment rate
  - `Et`, the turbulent entrainment rate
- - `ts`, NamedTuple of thermodynamic states
+ - `ts_gm`, grid-mean thermodynamic states
+ - `ts_en`, environment thermodynamic states
  - `env`, NamedTuple of environment variables
 """
 function mixing_length(
     m::AtmosModel{FT},
     ml::MixingLengthModel,
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
+    args,
     Δ::Tuple,
     Et::Tuple,
-    ts,
+    ts_gm,
+    ts_en,
     env,
 ) where {FT}
-
+    @unpack state, aux, diffusive, t = args
     # TODO: use functions: obukhov_length, ustar, ϕ_m
 
     # Alias convention:
@@ -59,7 +53,7 @@ function mixing_length(
     ustar = m.turbconv.surface.ustar
     obukhov_length = m.turbconv.surface.obukhov_length
 
-    ∂b∂z, Nˢ_eff = compute_buoyancy_gradients(m, state, diffusive, aux, t, ts)
+    ∂b∂z, Nˢ_eff = compute_buoyancy_gradients(m, args, ts_gm, ts_en)
     Grad_Ri = ∇Richardson_number(∂b∂z, Shear², 1 / ml.max_length, ml.Ri_c)
     Pr_t = turbulent_Prandtl_number(ml.Pr_n, Grad_Ri, ml.ω_pr)
 

--- a/test/Atmos/EDMF/closures/pressure.jl
+++ b/test/Atmos/EDMF/closures/pressure.jl
@@ -1,46 +1,44 @@
 #### Pressure model kernels
 
+function perturbation_pressure(bl::AtmosModel{FT}, args, env) where {FT}
+    dpdz = ntuple(n_updrafts(bl.turbconv)) do i
+        perturbation_pressure(bl, bl.turbconv.pressure, args, env, i)
+    end
+    return dpdz
+end
+
 """
     perturbation_pressure(
         m::AtmosModel{FT},
         press::PressureModel,
-        state::Vars,
-        diffusive::Vars,
-        aux::Vars,
-        t::Real,
+        args,
         env,
         i,
     ) where {FT}
+
 Returns the value of perturbation pressure gradient
 for updraft i following He et al. (JAMES, 2020), given:
+
  - `m`, an `AtmosModel`
  - `press`, a `PressureModel`
- - `state`, state variables
- - `diffusive`, additional variables
- - `aux`, auxiliary variables
- - `t`, the time
+ - `args`, top-level arguments
  - `env`, NamedTuple of environment variables
  - `i`, index of the updraft
 """
 function perturbation_pressure(
     m::AtmosModel{FT},
     press::PressureModel,
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
+    args,
     env,
     i,
 ) where {FT}
+    @unpack state, diffusive, aux = args
 
     # Alias convention:
-    gm = state
-    en = state.turbconv.environment
     up = state.turbconv.updraft
     up_aux = aux.turbconv.updraft
     up_dif = diffusive.turbconv.updraft
 
-    N_up = n_updrafts(m.turbconv)
     w_up_i = up[i].ρaw / up[i].ρa
 
     nh_press_buoy = press.α_b * up_aux[i].buoyancy

--- a/test/Atmos/EDMF/closures/turbulence_functions.jl
+++ b/test/Atmos/EDMF/closures/turbulence_functions.jl
@@ -22,29 +22,25 @@ end
 """
     compute_buoyancy_gradients(
         m::AtmosModel{FT},
-        state::Vars,
-        diffusive::Vars,
-        aux::Vars,
-        t::Real,
-        ts
+        args,
+        ts_gm,
+        ts_en
     ) where {FT}
 Returns the environmental buoyancy gradient following Tan et al. (JAMES, 2018)
 and the effective environmental static stability following
 Lopez-Gomez et al. (JAMES, 2020), given:
  - `m`, an `AtmosModel`
- - `state`, state variables
- - `diffusive`, additional variables
- - `aux`, auxiliary variables
- - `t`, the time
+ - `args`, top-level arguments
+ - `ts_gm`, grid-mean thermodynamic state
+ - `ts_en`, environment thermodynamic state
 """
 function compute_buoyancy_gradients(
     m::AtmosModel{FT},
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
-    ts,
+    args,
+    ts_gm,
+    ts_en,
 ) where {FT}
+    @unpack state, aux, diffusive = args
     # Alias convention:
     gm = state
     en_dif = diffusive.turbconv.environment
@@ -54,19 +50,19 @@ function compute_buoyancy_gradients(
     _R_d::FT = R_d(m.param_set)
     _R_v::FT = R_v(m.param_set)
     ε_v::FT = 1 / molmass_ratio(m.param_set)
-    p = air_pressure(ts.gm)
+    p = air_pressure(ts_gm)
 
-    q_tot_en = total_specific_humidity(ts.en)
-    θ_liq_en = liquid_ice_pottemp(ts.en)
-    lv = latent_heat_vapor(ts.en)
-    T = air_temperature(ts.en)
-    Π = exner(ts.en)
-    q_liq = liquid_specific_humidity(ts.en)
-    _cp_m = cp_m(ts.en)
-    θ_virt = virtual_pottemp(ts.en)
+    q_tot_en = total_specific_humidity(ts_en)
+    θ_liq_en = liquid_ice_pottemp(ts_en)
+    lv = latent_heat_vapor(ts_en)
+    T = air_temperature(ts_en)
+    Π = exner(ts_en)
+    q_liq = liquid_specific_humidity(ts_en)
+    _cp_m = cp_m(ts_en)
+    θ_virt = virtual_pottemp(ts_en)
 
     (ts_dry, ts_cloudy, cloud_frac) =
-        compute_subdomain_statistics(m, state, aux, t)
+        compute_subdomain_statistics(m, args, ts_gm, ts_en)
     cloudy = thermo_variables(ts_cloudy)
     dry = thermo_variables(ts_dry)
 

--- a/test/Atmos/EDMF/helper_funcs/nondimensional_exchange_functions.jl
+++ b/test/Atmos/EDMF/helper_funcs/nondimensional_exchange_functions.jl
@@ -5,7 +5,8 @@
         state::Vars,
         aux::Vars,
         t::Real,
-        ts,
+        ts_up,
+        ts_en,
         env,
         i,
     ) where {FT}
@@ -16,8 +17,8 @@ functions following Cohen et al. (JAMES, 2020), given:
  - `entr`, an `EntrainmentDetrainment` model
  - `state`, state variables
  - `aux`, auxiliary variables
- - `t`, the time
- - `ts`, NamedTuple of thermodynamic states
+ - `ts_up`, updraft thermodynamic states
+ - `ts_en`, environment thermodynamic states
  - `env`, NamedTuple of environment variables
  - `i`, the updraft index
 """
@@ -26,8 +27,8 @@ function nondimensional_exchange_functions(
     entr::EntrainmentDetrainment,
     state::Vars,
     aux::Vars,
-    t::Real,
-    ts,
+    ts_up,
+    ts_en,
     env,
     i,
 ) where {FT}
@@ -46,13 +47,13 @@ function nondimensional_exchange_functions(
     w_up_i = up[i].ρaw / up[i].ρa
 
     # thermodynamic variables
-    RH_up = relative_humidity(ts.up[i])
-    RH_en = relative_humidity(ts.en)
+    RH_up = relative_humidity(ts_up[i])
+    RH_en = relative_humidity(ts_en)
 
     Δw = filter_w(w_up_i - env.w, w_min)
     Δb = up_aux[i].buoyancy - en_aux.buoyancy
 
-    c_δ = sign(condensate(ts.en) + condensate(ts.up[i])) * entr.c_δ
+    c_δ = sign(condensate(ts_en) + condensate(ts_up[i])) * entr.c_δ
 
     # compute dry and moist aux functions
     μ_ij = (entr.χ - a_up_i / (a_up_i + env.a)) * Δb / Δw

--- a/test/Atmos/EDMF/helper_funcs/subdomain_statistics.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_statistics.jl
@@ -1,34 +1,33 @@
 #### Subdomain statistics
 
-compute_subdomain_statistics(m::AtmosModel, state, aux, t) =
+compute_subdomain_statistics(m::AtmosModel, args, ts_gm, ts_en) =
     compute_subdomain_statistics(
-        m,
-        state,
-        aux,
-        t,
         m.turbconv.micro_phys.statistical_model,
+        m,
+        args,
+        ts_gm,
+        ts_en,
     )
 
 """
     compute_subdomain_statistics(
-        m::AtmosModel{FT},
-        state::Vars,
-        aux::Vars,
-        t::Real,
         statistical_model::SubdomainMean,
+        m::AtmosModel{FT},
+        args,
+        ts_gm,
+        ts_en,
     ) where {FT}
 
 Returns a cloud fraction and cloudy and dry thermodynamic
 states in the subdomain.
 """
 function compute_subdomain_statistics(
-    m::AtmosModel{FT},
-    state::Vars,
-    aux::Vars,
-    t::Real,
     statistical_model::SubdomainMean,
+    m::AtmosModel{FT},
+    args,
+    ts_gm,
+    ts_en,
 ) where {FT}
-    ts_en = recover_thermo_state_en(m, state, aux)
     cloud_frac = has_condensate(ts_en) ? FT(1) : FT(0)
     dry = ts_en
     cloudy = ts_en

--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -16,13 +16,13 @@ best_mse[:Bomex]["ρ"] = 3.4943021267397123e-02
 best_mse[:Bomex]["ρu[1]"] = 3.0714039084256679e+03
 best_mse[:Bomex]["ρu[2]"] = 1.3375796498101822e-03
 best_mse[:Bomex]["moisture.ρq_tot"] = 4.8463531712319707e-02
-best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.1572840530432791e+02
-best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5666903275495429e+01
-best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6436084624021990e+02
-best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 8.0001172663166514e+01
-best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4920000488063571e-02
-best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0208723977237693e+00
-best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0782418080492549e+01
+best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.1572840542744723e+02
+best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5666903275489148e+01
+best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6436084624018417e+02
+best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 8.0001172665454277e+01
+best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4920000479795602e-02
+best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0208723977710275e+00
+best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0782418080549389e+01
 #! format: on
 
 sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + eps()


### PR DESCRIPTION
### Description

This PR adds some computations to the cache in `turbconv`, in preparation to adding the tendency specification layer.

We get hit a bit hard with the formatter here, I may try to see if we can alleviate this.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
