### PR TITLE
Update DG-FV driver and test diagnostics

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1127,6 +1127,16 @@ steps:
       queue: central
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
+  
+  - label: "gpu_dry_risingbubble_fvm"
+    key: "gpu_dry_risingbubble_fvm"
+    command:
+      - "mpiexec julia --color=yes --project experiments/TestCase/risingbubble_fvm.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
 
   - label: "gpu_moist_risingbubble"
     key: "gpu_moist_risingbubble"
@@ -1147,11 +1157,31 @@ steps:
       queue: central
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
+  
+  - label: "gpu_solid_body_rotation_fvm"
+    key: "gpu_solid_body_rotation_fvm"
+    command:
+      - "mpiexec julia --color=yes --project experiments/TestCase/solid_body_rotation_fvm.jl --diagnostics=default "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
 
   - label: "gpu_dry_baroclinic_wave"
     key: "gpu_dry_baroclinic_wave"
     command:
       - "mpiexec julia --color=yes --project experiments/TestCase/baroclinic_wave.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+  
+  - label: "gpu_dry_baroclinic_wave_fvm"
+    key: "gpu_dry_baroclinic_wave_fvm"
+    command:
+      - "mpiexec julia --color=yes --project experiments/TestCase/baroclinic_wave_fvm.jl "
     agents:
       config: gpu
       queue: central

--- a/experiments/OceanSplitExplicit/simple_box.jl
+++ b/experiments/OceanSplitExplicit/simple_box.jl
@@ -48,6 +48,7 @@ function OceanSplitExplicitConfiguration(
     numerical_flux_first_order = RusanovNumericalFlux(),
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
     numerical_flux_gradient = CentralNumericalFluxGradient(),
+    fv_reconstruction = nothing,
     periodicity = (false, false, false),
     boundary = ((1, 1), (1, 1), (2, 3)),
 )
@@ -185,6 +186,7 @@ function OceanSplitExplicitConfiguration(
         numerical_flux_first_order,
         numerical_flux_second_order,
         numerical_flux_gradient,
+        fv_reconstruction,
         OceanSplitExplicitSpecificInfo(model_2D, grid_2D, dg_3D),
     )
 end

--- a/experiments/TestCase/baroclinic_wave_fvm.jl
+++ b/experiments/TestCase/baroclinic_wave_fvm.jl
@@ -1,0 +1,333 @@
+#!/usr/bin/env julia --project
+
+using ArgParse
+using LinearAlgebra
+using StaticArrays
+using Test
+
+using ClimateMachine
+using ClimateMachine.Atmos
+using ClimateMachine.Orientations
+using ClimateMachine.ConfigTypes
+using ClimateMachine.Diagnostics
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.ODESolvers
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.SystemSolvers: ManyColumnLU
+using ClimateMachine.Mesh.Filters
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.Thermodynamics:
+    air_density, air_temperature, total_energy, internal_energy, PhasePartition
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.VariableTemplates
+import ClimateMachine.DGMethods.FVReconstructions: FVLinear
+
+using CLIMAParameters
+using CLIMAParameters.Planet: MSLP, R_d, day, grav, Omega, planet_radius
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
+    FT = eltype(state)
+
+    # parameters
+    _grav::FT = grav(bl.param_set)
+    _R_d::FT = R_d(bl.param_set)
+    _Ω::FT = Omega(bl.param_set)
+    _a::FT = planet_radius(bl.param_set)
+    _p_0::FT = MSLP(bl.param_set)
+
+    k::FT = 3
+    T_E::FT = 310
+    T_P::FT = 240
+    T_0::FT = 0.5 * (T_E + T_P)
+    Γ::FT = 0.005
+    A::FT = 1 / Γ
+    B::FT = (T_0 - T_P) / T_0 / T_P
+    C::FT = 0.5 * (k + 2) * (T_E - T_P) / T_E / T_P
+    b::FT = 2
+    H::FT = _R_d * T_0 / _grav
+    z_t::FT = 15e3
+    λ_c::FT = π / 9
+    φ_c::FT = 2 * π / 9
+    d_0::FT = _a / 6
+    V_p::FT = 1
+    M_v::FT = 0.608
+    p_w::FT = 34e3                 # Pressure width parameter for specific humidity
+    η_crit::FT = p_w / _p_0        # Critical pressure coordinate
+    q_0::FT = 0.018                # Maximum specific humidity (default: 0.018)
+    q_t::FT = 1e-12                # Specific humidity above artificial tropopause
+    φ_w::FT = 2π / 9               # Specific humidity latitude wind parameter
+
+    # grid
+    φ = latitude(bl.orientation, aux)
+    λ = longitude(bl.orientation, aux)
+    z = altitude(bl.orientation, bl.param_set, aux)
+    r::FT = z + _a
+    γ::FT = 1 # set to 0 for shallow-atmosphere case and to 1 for deep atmosphere case
+
+    # convenience functions for temperature and pressure
+    τ_z_1::FT = exp(Γ * z / T_0)
+    τ_z_2::FT = 1 - 2 * (z / b / H)^2
+    τ_z_3::FT = exp(-(z / b / H)^2)
+    τ_1::FT = 1 / T_0 * τ_z_1 + B * τ_z_2 * τ_z_3
+    τ_2::FT = C * τ_z_2 * τ_z_3
+    τ_int_1::FT = A * (τ_z_1 - 1) + B * z * τ_z_3
+    τ_int_2::FT = C * z * τ_z_3
+    I_T::FT =
+        (cos(φ) * (1 + γ * z / _a))^k -
+        k / (k + 2) * (cos(φ) * (1 + γ * z / _a))^(k + 2)
+
+    # base state virtual temperature, pressure, specific humidity, density
+    T_v::FT = (τ_1 - τ_2 * I_T)^(-1)
+    p::FT = _p_0 * exp(-_grav / _R_d * (τ_int_1 - τ_int_2 * I_T))
+
+    # base state velocity
+    U::FT =
+        _grav * k / _a *
+        τ_int_2 *
+        T_v *
+        (
+            (cos(φ) * (1 + γ * z / _a))^(k - 1) -
+            (cos(φ) * (1 + γ * z / _a))^(k + 1)
+        )
+    u_ref::FT =
+        -_Ω * (_a + γ * z) * cos(φ) +
+        sqrt((_Ω * (_a + γ * z) * cos(φ))^2 + (_a + γ * z) * cos(φ) * U)
+    v_ref::FT = 0
+    w_ref::FT = 0
+
+    # velocity perturbations
+    F_z::FT = 1 - 3 * (z / z_t)^2 + 2 * (z / z_t)^3
+    if z > z_t
+        F_z = FT(0)
+    end
+    d::FT = _a * acos(sin(φ) * sin(φ_c) + cos(φ) * cos(φ_c) * cos(λ - λ_c))
+    c3::FT = cos(π * d / 2 / d_0)^3
+    s1::FT = sin(π * d / 2 / d_0)
+    if 0 < d < d_0 && d != FT(_a * π)
+        u′::FT =
+            -16 * V_p / 3 / sqrt(3) *
+            F_z *
+            c3 *
+            s1 *
+            (-sin(φ_c) * cos(φ) + cos(φ_c) * sin(φ) * cos(λ - λ_c)) /
+            sin(d / _a)
+        v′::FT =
+            16 * V_p / 3 / sqrt(3) * F_z * c3 * s1 * cos(φ_c) * sin(λ - λ_c) /
+            sin(d / _a)
+    else
+        u′ = FT(0)
+        v′ = FT(0)
+    end
+    w′::FT = 0
+    u_sphere = SVector{3, FT}(u_ref + u′, v_ref + v′, w_ref + w′)
+    u_cart = sphr_to_cart_vec(bl.orientation, u_sphere, aux)
+
+    if bl.moisture isa DryModel
+        q_tot = FT(0)
+    else
+        ## Compute moisture profile
+        ## Pressure coordinate η
+        ## η_crit = p_t / p_w ; p_t = 10000 hPa, p_w = 340 hPa
+        η = p / _p_0
+        if η > η_crit
+            q_tot = q_0 * exp(-(φ / φ_w)^4) * exp(-((η - 1) * _p_0 / p_w)^2)
+        else
+            q_tot = q_t
+        end
+    end
+    phase_partition = PhasePartition(q_tot)
+
+    ## temperature & density
+    T::FT = T_v / (1 + M_v * q_tot)
+    ρ::FT = air_density(bl.param_set, T, p, phase_partition)
+
+    ## potential & kinetic energy
+    e_pot::FT = gravitational_potential(bl.orientation, aux)
+    e_kin::FT = 0.5 * u_cart' * u_cart
+    e_tot::FT = total_energy(bl.param_set, e_kin, e_pot, T, phase_partition)
+
+    ## Assign state variables
+    state.ρ = ρ
+    state.ρu = ρ * u_cart
+    state.ρe = ρ * e_tot
+
+    if !(bl.moisture isa DryModel)
+        state.moisture.ρq_tot = ρ * q_tot
+    end
+
+    nothing
+end
+
+function config_baroclinic_wave(
+    FT,
+    poly_order,
+    fv_reconstruction,
+    resolution,
+    with_moisture,
+)
+    # Set up a reference state for linearization of equations
+    temp_profile_ref =
+        DecayingTemperatureProfile{FT}(param_set, FT(290), FT(220), FT(8e3))
+    ref_state = HydrostaticState(temp_profile_ref; subtract_off = false)
+
+    # Set up the atmosphere model
+    exp_name = "BaroclinicWave"
+    domain_height::FT = 30e3 # distance between surface and top of atmosphere (m)
+    if with_moisture
+        # hyperdiffusion = EquilMoistBiharmonic(FT(8 * 3600))
+        moisture = EquilMoist{FT}()
+        source = (Gravity(), Coriolis())
+    else
+        # hyperdiffusion = DryBiharmonic(FT(8 * 3600))
+        moisture = DryModel()
+        source = (Gravity(), Coriolis())
+    end
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        param_set;
+        init_state_prognostic = init_baroclinic_wave!,
+        ref_state = ref_state,
+        turbulence = ConstantKinematicViscosity(FT(0)),
+        # hyperdiffusion = hyperdiffusion,
+        moisture = moisture,
+        source = source,
+    )
+
+    config = ClimateMachine.AtmosGCMConfiguration(
+        exp_name,
+        poly_order,
+        resolution,
+        domain_height,
+        param_set,
+        init_baroclinic_wave!;
+        model = model,
+        numerical_flux_first_order = RoeNumericalFlux(),
+        fv_reconstruction = HBFVReconstruction(model, fv_reconstruction),
+    )
+
+    return config
+end
+
+function main()
+    # add a command line argument to specify whether to use a moist setup
+    # TODO: this will move to the future namelist functionality
+    bw_args = ArgParseSettings(autofix_names = true)
+    add_arg_group!(bw_args, "BaroclinicWave")
+    @add_arg_table! bw_args begin
+        "--with-moisture"
+        help = "use a moist setup"
+        action = :store_const
+        constant = true
+        default = false
+    end
+
+    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = bw_args)
+    with_moisture = cl_args["with_moisture"]
+
+    # Driver configuration parameters
+    FT = Float64                             # floating type precision
+    poly_order = (5, 0)                      # discontinuous Galerkin polynomial order
+    fv_reconstruction = FVLinear()           # finite volume reconstruction scheme
+    n_horz = 8                               # horizontal element number
+    n_vert = 20                              # vertical element number
+    timestart::FT = 0                        # start time (s)
+    timeend::FT = 3600                       # end time (s)
+
+    # Set up driver configuration
+    driver_config = config_baroclinic_wave(
+        FT,
+        poly_order,
+        fv_reconstruction,
+        (n_horz, n_vert),
+        with_moisture,
+    )
+
+    # Set up experiment
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK54CarpenterKennedy,
+    )
+
+    CFL = FT(0.2) # target acoustic CFL number
+
+    # time step is computed such that the horizontal acoustic Courant number is CFL
+    solver_config = ClimateMachine.SolverConfiguration(
+        timestart,
+        timeend,
+        driver_config,
+        Courant_number = CFL,
+        ode_solver_type = ode_solver_type,
+        CFL_direction = EveryDirection(),
+        diffdir = HorizontalDirection(),
+    )
+
+    # Set up diagnostics
+    dgn_config = config_diagnostics(FT, driver_config)
+
+    #TODO enable filter
+    # # Set up user-defined callbacks
+    filterorder = 20
+    filter = ExponentialFilter(solver_config.dg.grid, 0, filterorder)
+    cbfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            AtmosFilterPerturbations(driver_config.bl),
+            solver_config.dg.grid,
+            filter,
+            state_auxiliary = solver_config.dg.state_auxiliary,
+            direction = HorizontalDirection(),
+        )
+        nothing
+    end
+
+    # cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+    #     Filters.apply!(
+    #         solver_config.Q,
+    #         ("moisture.ρq_tot",),
+    #         solver_config.dg.grid,
+    #         TMARFilter(),
+    #     )
+    #     nothing
+    # end
+
+    # Run the model
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (cbfilter,),
+        #user_callbacks = (cbtmarfilter, cbfilter),
+        check_euclidean_distance = true,
+    )
+end
+
+function config_diagnostics(FT, driver_config)
+    interval = "12shours" # chosen to allow diagnostics every 12 simulated hours
+
+    _planet_radius = FT(planet_radius(param_set))
+
+    info = driver_config.config_info
+    boundaries = [
+        FT(-90.0) FT(-180.0) _planet_radius
+        FT(90.0) FT(180.0) FT(_planet_radius + info.domain_height)
+    ]
+    resolution = (FT(2), FT(2), FT(1000)) # in (deg, deg, m)
+    interpol = ClimateMachine.InterpolationConfiguration(
+        driver_config,
+        boundaries,
+        resolution,
+    )
+
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosGCMConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+
+    return ClimateMachine.DiagnosticsConfiguration([dgngrp])
+end
+
+main()

--- a/experiments/TestCase/risingbubble_fvm.jl
+++ b/experiments/TestCase/risingbubble_fvm.jl
@@ -1,0 +1,243 @@
+#!/usr/bin/env julia --project
+using ArgParse
+
+using ClimateMachine
+using ClimateMachine.Atmos
+using ClimateMachine.Orientations
+using ClimateMachine.ConfigTypes
+using ClimateMachine.Diagnostics
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.ODESolvers
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.VariableTemplates
+import ClimateMachine.DGMethods.FVReconstructions: FVLinear
+
+using StaticArrays
+using Test
+using CLIMAParameters
+using CLIMAParameters.Atmos.SubgridScale: C_smag
+using CLIMAParameters.Planet: R_d, cp_d, cv_d, MSLP, grav
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet();
+
+function init_risingbubble!(problem, bl, state, aux, localgeo, t)
+    ## Problem float-type
+    FT = eltype(state)
+
+    (x, y, z) = localgeo.coord
+
+    ## Unpack constant parameters
+    R_gas::FT = R_d(bl.param_set)
+    c_p::FT = cp_d(bl.param_set)
+    c_v::FT = cv_d(bl.param_set)
+    p0::FT = MSLP(bl.param_set)
+    _grav::FT = grav(bl.param_set)
+    γ::FT = c_p / c_v
+
+    ## Define bubble center and background potential temperature
+    xc::FT = 5000
+    yc::FT = 1000
+    zc::FT = 2000
+    r = sqrt((x - xc)^2 + (z - zc)^2)
+    rc::FT = 2000
+    θamplitude::FT = 2
+    q_tot_amplitude::FT = 1e-3
+
+    ## TODO: clean this up, or add convenience function:
+    ## This is configured in the reference hydrostatic state
+    θ_ref::FT = bl.ref_state.virtual_temperature_profile.T_surface
+
+    ## Add the thermal perturbation:
+    Δθ::FT = 0
+    Δq_tot::FT = 0
+    if r <= rc
+        Δθ = θamplitude * (1.0 - r / rc)
+        Δq_tot = q_tot_amplitude * (1.0 - r / rc)
+    end
+
+    ## Compute perturbed thermodynamic state:
+    θ = θ_ref + Δθ                                      # potential temperature
+    q_pt = PhasePartition(Δq_tot)
+    R_m = gas_constant_air(bl.param_set, q_pt)
+    _cp_m = cp_m(bl.param_set, q_pt)
+    _cv_m = cv_m(bl.param_set, q_pt)
+    π_exner = FT(1) - _grav / (_cp_m * θ) * z           # exner pressure
+    ρ = p0 / (R_gas * θ) * (π_exner)^(_cv_m / R_m)      # density
+    T = θ * π_exner
+
+    if bl.moisture isa EquilMoist
+        e_int = internal_energy(bl.param_set, T, q_pt)
+        ts = PhaseEquil(bl.param_set, e_int, ρ, Δq_tot)
+    else
+        e_int = internal_energy(bl.param_set, T)
+        ts = PhaseDry(bl.param_set, e_int, ρ)
+    end
+    ρu = SVector(FT(0), FT(0), FT(0))                   # momentum
+    ## State (prognostic) variable assignment
+    e_kin = FT(0)                                       # kinetic energy
+    e_pot = gravitational_potential(bl, aux)            # potential energy
+    ρe_tot = ρ * total_energy(e_kin, e_pot, ts)         # total energy
+    ρq_tot = ρ * Δq_tot                                 # total water specific humidity
+
+    ## Assign State Variables
+    state.ρ = ρ
+    state.ρu = ρu
+    state.ρe = ρe_tot
+    if !(bl.moisture isa DryModel)
+        state.moisture.ρq_tot = ρq_tot
+    end
+end
+
+function config_risingbubble(
+    FT,
+    N,
+    fv_reconstruction,
+    resolution,
+    xmax,
+    ymax,
+    zmax,
+    with_moisture,
+)
+
+    ode_solver = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK54CarpenterKennedy,
+    )
+
+    T_surface = FT(300)
+    T_min_ref = FT(0)
+    T_profile = DryAdiabaticProfile{FT}(param_set, T_surface, T_min_ref)
+    ref_state = HydrostaticState(T_profile)
+
+    _C_smag = FT(C_smag(param_set))
+
+    if with_moisture
+        moisture = EquilMoist{FT}()
+    else
+        moisture = DryModel()
+    end
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        param_set;
+        init_state_prognostic = init_risingbubble!,
+        ref_state = ref_state,
+        turbulence = ConstantKinematicViscosity(FT(0)),
+        moisture = moisture,
+        source = (Gravity(),),
+        tracers = NoTracers(),
+    )
+
+    config = ClimateMachine.AtmosLESConfiguration(
+        "RisingBubble",
+        (N, 0),
+        resolution,
+        xmax,
+        ymax,
+        zmax,
+        param_set,
+        init_risingbubble!,
+        solver_type = ode_solver,
+        model = model,
+        numerical_flux_first_order = RoeNumericalFlux(),
+        fv_reconstruction = HBFVReconstruction(model, fv_reconstruction),
+    )
+    return config
+end
+
+function config_diagnostics(driver_config)
+    FT = Float64
+    interval = "50ssecs"
+    boundaries = [
+        FT(0.0) FT(0.0) FT(0.0)
+        FT(10000) FT(500) FT(10000)
+    ]
+    resolution = (FT(100), FT(100), FT(100))
+    interpol = ClimateMachine.InterpolationConfiguration(
+        driver_config,
+        boundaries,
+        resolution,
+    )
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
+        interval,
+        driver_config.name,
+    )
+    state_dgngrp = setup_dump_state_diagnostics(
+        AtmosLESConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+    aux_dgngrp = setup_dump_aux_diagnostics(
+        AtmosLESConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+    return ClimateMachine.DiagnosticsConfiguration([
+        dgngrp,
+        state_dgngrp,
+        aux_dgngrp,
+    ])
+end
+
+function main()
+    # add a command line argument to specify whether to use a moist setup
+    rb_args = ArgParseSettings(autofix_names = true)
+    add_arg_group!(rb_args, "RisingBubble")
+    @add_arg_table! rb_args begin
+        "--with-moisture"
+        help = "use a moist setup"
+        action = :store_const
+        constant = true
+        default = false
+    end
+    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = rb_args)
+    with_moisture = cl_args["with_moisture"]
+
+    FT = Float64
+    N = 4
+    # effective mesh size
+    Δh = FT(125)
+    Δv = FT(125)
+    resolution = (Δh, Δh, Δv)
+    xmax = FT(10000)
+    ymax = FT(500)
+    zmax = FT(10000)
+    t0 = FT(0)
+    timeend = FT(1000)
+    fv_reconstruction = FVLinear()         # finite volume reconstruction scheme
+
+    CFL = FT(0.2)
+
+    driver_config = config_risingbubble(
+        FT,
+        N,
+        fv_reconstruction,
+        resolution,
+        xmax,
+        ymax,
+        zmax,
+        with_moisture,
+    )
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFL,
+    )
+    dgn_config = config_diagnostics(driver_config)
+
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (),
+        check_euclidean_distance = true,
+    )
+
+    @test isapprox(result, FT(1); atol = 1.5e-3)
+end
+
+main()

--- a/experiments/TestCase/solid_body_rotation_fvm.jl
+++ b/experiments/TestCase/solid_body_rotation_fvm.jl
@@ -1,0 +1,215 @@
+#!/usr/bin/env julia --project
+using ClimateMachine
+ClimateMachine.init(parse_clargs = true)
+
+using ClimateMachine.Atmos
+using ClimateMachine.Orientations
+using ClimateMachine.ConfigTypes
+using ClimateMachine.NumericalFluxes
+using ClimateMachine.Diagnostics
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.ODESolvers
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.SystemSolvers: ManyColumnLU
+using ClimateMachine.Mesh.Filters
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.Mesh.Interpolation
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Thermodynamics: air_density, total_energy
+import ClimateMachine.DGMethods.FVReconstructions: FVLinear
+
+using LinearAlgebra
+using StaticArrays
+using Test
+
+using CLIMAParameters
+using CLIMAParameters.Planet: day, planet_radius
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+function init_solid_body_rotation!(problem, bl, state, aux, localgeo, t)
+    FT = eltype(state)
+
+    # initial velocity profile (we need to transform the vector into the Cartesian
+    # coordinate system)
+    u_0::FT = 0
+    u_sphere = SVector{3, FT}(u_0, 0, 0)
+    u_init = sphr_to_cart_vec(bl.orientation, u_sphere, aux)
+    e_kin::FT = 0.5 * sum(abs2.(u_init))
+
+    # Assign state variables
+    state.ρ = aux.ref_state.ρ
+    state.ρu = u_init
+    state.ρe = aux.ref_state.ρe + state.ρ * e_kin
+
+    nothing
+end
+
+function config_solid_body_rotation(
+    FT,
+    poly_order,
+    fv_reconstruction,
+    resolution,
+    ref_state,
+)
+
+    # Set up the atmosphere model
+    exp_name = "SolidBodyRotation"
+    domain_height::FT = 30e3 # distance between surface and top of atmosphere (m)
+
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        param_set;
+        init_state_prognostic = init_solid_body_rotation!,
+        ref_state = ref_state,
+        turbulence = ConstantKinematicViscosity(FT(0)),
+        #hyperdiffusion = DryBiharmonic(FT(8 * 3600)),
+        moisture = DryModel(),
+        source = (Gravity(), Coriolis()),
+    )
+
+    config = ClimateMachine.AtmosGCMConfiguration(
+        exp_name,
+        poly_order,
+        resolution,
+        domain_height,
+        param_set,
+        init_solid_body_rotation!;
+        model = model,
+        numerical_flux_first_order = RoeNumericalFlux(),
+        fv_reconstruction = HBFVReconstruction(model, fv_reconstruction),
+    )
+
+    return config
+end
+
+function main()
+    # Driver configuration parameters
+    FT = Float64                             # floating type precision
+    poly_order = (5, 0)                     # discontinuous Galerkin polynomial order
+    n_horz = 8                              # horizontal element number
+    n_vert = 20                               # vertical element number
+    timestart::FT = 0                        # start time (s)
+    timeend::FT = 7200    # end time (s)
+    fv_reconstruction = FVLinear()
+
+    # Set up a reference state for linearization of equations
+    temp_profile_ref =
+        DecayingTemperatureProfile{FT}(param_set, FT(290), FT(220), FT(8e3))
+    ref_state = HydrostaticState(temp_profile_ref; subtract_off = false)
+
+    # Set up driver configuration
+    driver_config = config_solid_body_rotation(
+        FT,
+        poly_order,
+        fv_reconstruction,
+        (n_horz, n_vert),
+        ref_state,
+    )
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK54CarpenterKennedy,
+    )
+
+    CFL = FT(0.5) # target acoustic CFL number
+
+    # time step is computed such that the horizontal acoustic Courant number is CFL
+    solver_config = ClimateMachine.SolverConfiguration(
+        timestart,
+        timeend,
+        driver_config,
+        Courant_number = CFL,
+        ode_solver_type = ode_solver_type,
+        CFL_direction = EveryDirection(),
+        diffdir = HorizontalDirection(),
+    )
+
+    # initialize using a different ref state (mega-hack)
+    temp_profile_init =
+        DecayingTemperatureProfile{FT}(param_set, FT(280), FT(230), FT(9e3))
+    init_ref_state = HydrostaticState(temp_profile_init; subtract_off = false)
+
+    init_driver_config = config_solid_body_rotation(
+        FT,
+        poly_order,
+        fv_reconstruction,
+        (n_horz, n_vert),
+        init_ref_state,
+    )
+    init_solver_config = ClimateMachine.SolverConfiguration(
+        timestart,
+        timeend,
+        init_driver_config,
+        Courant_number = CFL,
+        ode_solver_type = ode_solver_type,
+        CFL_direction = EveryDirection(),
+        diffdir = HorizontalDirection(),
+    )
+
+    # initialization
+    solver_config.Q .= init_solver_config.Q
+
+    # Set up diagnostics
+    dgn_config = config_diagnostics(FT, driver_config)
+
+    # Set up user-defined callbacks
+    filterorder = 20
+    filter = ExponentialFilter(solver_config.dg.grid, 0, filterorder)
+    cbfilter = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            AtmosFilterPerturbations(driver_config.bl),
+            # driver_config.bl,
+            solver_config.dg.grid,
+            filter,
+            # filter perturbations from the initial state
+            state_auxiliary = init_solver_config.dg.state_auxiliary,
+            direction = HorizontalDirection(),
+        )
+        nothing
+    end
+
+    # Run the model
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        user_callbacks = (cbfilter,),
+        check_euclidean_distance = false,
+    )
+
+    relative_error =
+        norm(solver_config.Q .- init_solver_config.Q) /
+        norm(init_solver_config.Q)
+    @info "Relative error = $relative_error"
+    @test relative_error < 1e-9
+end
+
+function config_diagnostics(FT, driver_config)
+    interval = "0.5shours" # chosen to allow diagnostics every 30 simulated minutes
+
+    _planet_radius = FT(planet_radius(param_set))
+
+    info = driver_config.config_info
+    boundaries = [
+        FT(-90.0) FT(-180.0) _planet_radius
+        FT(90.0) FT(180.0) FT(_planet_radius + info.domain_height)
+    ]
+    resolution = (FT(2), FT(2), FT(1000)) # in (deg, deg, m)
+    interpol = ClimateMachine.InterpolationConfiguration(
+        driver_config,
+        boundaries,
+        resolution,
+    )
+
+    dgngrp = setup_atmos_default_diagnostics(
+        AtmosGCMConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+
+    return ClimateMachine.DiagnosticsConfiguration([dgngrp])
+end
+
+main()

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -105,7 +105,8 @@ end
 vars_state(lm::AtmosLinearModel, ::AbstractStateType, FT) = @vars()
 vars_state(lm::AtmosLinearModel, st::Auxiliary, FT) =
     vars_state(lm.atmos, st, FT)
-
+vars_state(lm::AtmosLinearModel, ::Primitive, FT) =
+    vars_state(lm, Prognostic(), FT)
 
 function update_auxiliary_state!(
     dg::DGModel,

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -257,15 +257,15 @@ end
 
 function fvm_balance_init!(
     m::AtmosModel,
-    aux_bot::Vars,
     aux::Vars,
+    aux_top::Vars,
     Δz::MArray{Tuple{2}, FT},
 ) where {FT}
-    # ρᵢ  = (pᵢ₋₁ - pᵢ - g ρᵢ₋₁ Δzᵢ₋₁/2) / (g  Δzᵢ/2)
+    # ρᵢ₋₁  = (pᵢ₋₁ - pᵢ - g ρᵢ Δzᵢ/2) / (g  Δzᵢ₋₁/2)
     _grav::FT = grav(m.param_set)
     aux.ref_state.ρ =
         (
-            aux_bot.ref_state.p - aux.ref_state.p -
-            _grav * aux_bot.ref_state.ρ * Δz[1] / 2
-        ) / (_grav * Δz[2] / 2)
+            aux.ref_state.p - aux_top.ref_state.p -
+            _grav * aux_top.ref_state.ρ * Δz[2] / 2
+        ) / (_grav * Δz[1] / 2)
 end

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -44,7 +44,7 @@ using CLIMAParameters.Planet: planet_radius
 Base.@kwdef mutable struct Diagnostic_Settings
     mpicomm::MPI.Comm = MPI.COMM_WORLD
     param_set::Union{Nothing, AbstractParameterSet} = nothing
-    dg::Union{Nothing, DGModel} = nothing
+    dg::Union{Nothing, SpaceDiscretization} = nothing
     Q::Union{Nothing, MPIStateArray} = nothing
     starttime::Union{Nothing, String} = nothing
     output_dir::Union{Nothing, String} = nothing
@@ -60,7 +60,7 @@ Initialize the diagnostics collection module -- save the parameters into
 function init(
     mpicomm::MPI.Comm,
     param_set::AbstractParameterSet,
-    dg::DGModel,
+    dg::SpaceDiscretization,
     Q::MPIStateArray,
     starttime::String,
     output_dir::String,

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -590,17 +590,15 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
         state_data = Q.realdata
         aux_data = dg.state_auxiliary.realdata
         vgeo = grid.vgeo
-        # Currently only support single polynomial order
-        # XXX: Needs updating for multiple polynomial orders
-        ω = grid.ω[1]
+        # ω is the weight vector for the vertical direction
+        ω = grid.ω[end]
         gradflux_data = dg.state_gradient_flux.realdata
     else
         state_data = Array(Q.realdata)
         aux_data = Array(dg.state_auxiliary.realdata)
         vgeo = Array(grid.vgeo)
-        # Currently only support single polynomial order
-        # XXX: Needs updating for multiple polynomial orders
-        ω = Array(grid.ω[1])
+        # ω is the weight vector for the vertical direction
+        ω = Array(grid.ω[end])
         gradflux_data = Array(dg.state_gradient_flux.realdata)
     end
     FT = eltype(state_data)

--- a/src/Diagnostics/diagnostic_fields.jl
+++ b/src/Diagnostics/diagnostic_fields.jl
@@ -81,15 +81,15 @@ struct VectorGradients{
 end
 
 """
-    VectorGradients(dg::DGModel, Q::MPIStateArray)
+    VectorGradients(dg::SpaceDiscretization, Q::MPIStateArray)
 
 This constructor computes the spatial gradients of the velocity field.
 
 # Arguments
- - `dg`: DGModel
+ - `dg`: SpaceDiscretization
  - `Q`: MPIStateArray containing the prognostic state variables
 """
-function VectorGradients(dg::DGModel, Q::MPIStateArray)
+function VectorGradients(dg::SpaceDiscretization, Q::MPIStateArray)
     bl = dg.balance_law
     FT = eltype(dg.grid)
     Nq = polynomialorders(dg.grid) .+ 1 #N + 1
@@ -343,17 +343,17 @@ end
 
 """
     Vorticity(
-        dg::DGModel,
+        dg::SpaceDiscretization,
         vgrad::VectorGradients,
     )
 
 This function computes the vorticity of the velocity field.
 
 # Arguments
- - `dg`: DGModel
+ - `dg`: SpaceDiscretization
  - `vgrad`: vector gradients
 """
-function Vorticity(dg::DGModel, vgrad::VectorGradients)
+function Vorticity(dg::SpaceDiscretization, vgrad::VectorGradients)
     bl = dg.balance_law
     FT = eltype(dg.grid)
     npoints = prod(polynomialorders(dg.grid) .+ 1)

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -19,8 +19,9 @@ using ..ConfigTypes
 using ..Diagnostics
 using ..DGMethods
 using ..BalanceLaws
-using ..DGMethods: remainder_DGModel
+using ..DGMethods: remainder_DGModel, SpaceDiscretization
 using ..DGMethods.NumericalFluxes
+using ..DGMethods.FVReconstructions
 
 using ..Mesh.Grids
 using ..Mesh.Topologies

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -86,6 +86,8 @@ struct DriverConfiguration{FT}
     numerical_flux_first_order::NumericalFluxFirstOrder
     numerical_flux_second_order::NumericalFluxSecondOrder
     numerical_flux_gradient::NumericalFluxGradient
+    # DGFVModel details, used when polyorder_vert = 0
+    fv_reconstruction::Union{Nothing, AbstractReconstruction}
     #
     # configuration-specific info
     config_info::ConfigSpecificInfo
@@ -104,6 +106,7 @@ struct DriverConfiguration{FT}
         numerical_flux_first_order::NumericalFluxFirstOrder,
         numerical_flux_second_order::NumericalFluxSecondOrder,
         numerical_flux_gradient::NumericalFluxGradient,
+        fv_reconstruction::Union{Nothing, AbstractReconstruction},
         config_info::ConfigSpecificInfo,
     )
         return new{FT}(
@@ -119,6 +122,7 @@ struct DriverConfiguration{FT}
             numerical_flux_first_order,
             numerical_flux_second_order,
             numerical_flux_gradient,
+            fv_reconstruction,
             config_info,
         )
     end
@@ -167,6 +171,7 @@ function AtmosLESConfiguration(
     numerical_flux_first_order = RusanovNumericalFlux(),
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
     numerical_flux_gradient = CentralNumericalFluxGradient(),
+    fv_reconstruction = nothing,
 ) where {FT <: AbstractFloat}
 
     (polyorder_horz, polyorder_vert) = get_polyorders(N)
@@ -174,9 +179,9 @@ function AtmosLESConfiguration(
     print_model_info(model)
 
     brickrange = (
-        grid1d(xmin, xmax, elemsize = Δx * polyorder_horz),
-        grid1d(ymin, ymax, elemsize = Δy * polyorder_horz),
-        grid1d(zmin, zmax, elemsize = Δz * polyorder_vert),
+        grid1d(xmin, xmax, elemsize = Δx * max(polyorder_horz, 1)),
+        grid1d(ymin, ymax, elemsize = Δy * max(polyorder_horz, 1)),
+        grid1d(zmin, zmax, elemsize = Δz * max(polyorder_vert, 1)),
     )
     topology = StackedBrickTopology(
         mpicomm,
@@ -233,6 +238,7 @@ Establishing Atmos LES configuration for %s
         numerical_flux_first_order,
         numerical_flux_second_order,
         numerical_flux_gradient,
+        fv_reconstruction,
         AtmosLESSpecificInfo(),
     )
 end
@@ -256,6 +262,7 @@ function AtmosGCMConfiguration(
     numerical_flux_first_order = RusanovNumericalFlux(),
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
     numerical_flux_gradient = CentralNumericalFluxGradient(),
+    fv_reconstruction = nothing,
 ) where {FT <: AbstractFloat}
 
     (polyorder_horz, polyorder_vert) = get_polyorders(N)
@@ -322,6 +329,7 @@ Establishing Atmos GCM configuration for %s
         numerical_flux_first_order,
         numerical_flux_second_order,
         numerical_flux_gradient,
+        fv_reconstruction,
         AtmosGCMSpecificInfo(domain_height, nelem_vert, nelem_horz),
     )
 end
@@ -341,6 +349,7 @@ function OceanBoxGCMConfiguration(
     numerical_flux_first_order = RusanovNumericalFlux(),
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
     numerical_flux_gradient = CentralNumericalFluxGradient(),
+    fv_reconstruction = nothing,
     periodicity = (false, false, false),
     boundary = ((1, 1), (1, 1), (2, 3)),
 )
@@ -381,6 +390,7 @@ function OceanBoxGCMConfiguration(
         numerical_flux_first_order,
         numerical_flux_second_order,
         numerical_flux_gradient,
+        fv_reconstruction,
         OceanBoxGCMSpecificInfo(),
     )
 end
@@ -403,6 +413,7 @@ function SingleStackConfiguration(
     numerical_flux_first_order = RusanovNumericalFlux(),
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
     numerical_flux_gradient = CentralNumericalFluxGradient(),
+    fv_reconstruction = nothing,
 ) where {FT <: AbstractFloat}
 
     (polyorder_horz, polyorder_vert) = get_polyorders(N)
@@ -473,6 +484,7 @@ Establishing single stack configuration for %s
         numerical_flux_first_order,
         numerical_flux_second_order,
         numerical_flux_gradient,
+        fv_reconstruction,
         SingleStackSpecificInfo(),
     )
 end
@@ -498,6 +510,7 @@ function MultiColumnLandModel(
     numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
     numerical_flux_gradient = CentralNumericalFluxGradient(),
+    fv_reconstruction = nothing,
 ) where {FT <: AbstractFloat}
 
     (polyorder_horz, polyorder_vert) = isa(N, Int) ? (N, N) : N
@@ -506,9 +519,9 @@ function MultiColumnLandModel(
     print_model_info(model)
 
     brickrange = (
-        grid1d(xmin, xmax, elemsize = Δx * polyorder_horz),
-        grid1d(ymin, ymax, elemsize = Δy * polyorder_horz),
-        grid1d(zmin, zmax, elemsize = Δz * polyorder_vert),
+        grid1d(xmin, xmax, elemsize = Δx * max(polyorder_horz, 1)),
+        grid1d(ymin, ymax, elemsize = Δy * max(polyorder_horz, 1)),
+        grid1d(zmin, zmax, elemsize = Δz * max(polyorder_vert, 1)),
     )
 
     topology = StackedBrickTopology(
@@ -566,6 +579,7 @@ Establishing MultiColumnLandModel configuration for %s
         numerical_flux_first_order,
         numerical_flux_second_order,
         numerical_flux_gradient,
+        fv_reconstruction,
         MultiColumnLandSpecificInfo(),
     )
 end
@@ -587,3 +601,30 @@ DGModel(driver_config; kwargs...) = DGModel(
     driver_config.numerical_flux_gradient;
     kwargs...,
 )
+
+"""
+-SpaceDiscretization(driver_config; kwargs...)
+-
+-Initialize a [`SpaceDiscretization`](@ref) given a
+-[`DriverConfiguration`](@ref) and keyword
+-arguments supported by [`SpaceDiscretization`](@ref).
+-"""
+SpaceDiscretization(driver_config; kwargs...) =
+    (driver_config.polyorders[2] == 0) ?
+    DGFVModel(
+        driver_config.bl,
+        driver_config.grid,
+        driver_config.fv_reconstruction,
+        driver_config.numerical_flux_first_order,
+        driver_config.numerical_flux_second_order,
+        driver_config.numerical_flux_gradient;
+        kwargs...,
+    ) :
+    DGModel(
+        driver_config.bl,
+        driver_config.grid,
+        driver_config.numerical_flux_first_order,
+        driver_config.numerical_flux_second_order,
+        driver_config.numerical_flux_gradient;
+        kwargs...,
+    )

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -12,7 +12,7 @@ mutable struct SolverConfiguration{FT}
     name::String
     mpicomm::MPI.Comm
     param_set::AbstractParameterSet
-    dg::DGModel
+    dg::SpaceDiscretization
     Q::MPIStateArray
     t0::FT
     timeend::FT
@@ -126,7 +126,7 @@ function SolverConfiguration(
 
             dg.state_auxiliary .= state_auxiliary
         else
-            dg = DGModel(
+            dg = SpaceDiscretization(
                 driver_config;
                 state_auxiliary = state_auxiliary,
                 direction = direction,
@@ -145,7 +145,7 @@ function SolverConfiguration(
         if hasproperty(driver_config.config_info, :dg)
             dg = driver_config.config_info.dg
         else
-            dg = DGModel(
+            dg = SpaceDiscretization(
                 driver_config;
                 fill_nan = Settings.debug_init,
                 direction = direction,

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -50,6 +50,7 @@ import ..BalanceLaws:
 
 export DGModel,
     DGFVModel,
+    SpaceDiscretization,
     init_ode_state,
     restart_ode_state,
     restart_auxiliary_state,

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -14,7 +14,7 @@ Must have the following properties:
 """
 abstract type SpaceDiscretization end
 
-struct DGFVModel{BL, G, FVR, NFND, NFD, GNF, AS, DS, D, DD, MD} <:
+struct DGFVModel{BL, G, FVR, NFND, NFD, GNF, AS, DS, HDS, D, DD, MD} <:
        SpaceDiscretization
     balance_law::BL
     grid::G
@@ -24,6 +24,7 @@ struct DGFVModel{BL, G, FVR, NFND, NFD, GNF, AS, DS, D, DD, MD} <:
     numerical_flux_gradient::GNF
     state_auxiliary::AS
     state_gradient_flux::DS
+    states_higher_order::HDS
     direction::D
     diffusion_direction::DD
     modeldata::MD
@@ -44,6 +45,10 @@ function DGFVModel(
         fill_nan = fill_nan,
     ),
     state_gradient_flux = create_state(balance_law, grid, GradientFlux()),
+    states_higher_order = (
+        create_state(balance_law, grid, GradientLaplacian()),
+        create_state(balance_law, grid, Hyperdiffusive()),
+    ),
     direction = EveryDirection(),
     diffusion_direction = direction,
     modeldata = nothing,
@@ -62,6 +67,7 @@ function DGFVModel(
         numerical_flux_gradient,
         state_auxiliary,
         state_gradient_flux,
+        states_higher_order,
         direction,
         diffusion_direction,
         modeldata,

--- a/src/Numerics/DGMethods/FVReconstructions.jl
+++ b/src/Numerics/DGMethods/FVReconstructions.jl
@@ -1,4 +1,5 @@
 module FVReconstructions
+export AbstractReconstruction
 using KernelAbstractions.Extras: @unroll
 import StaticArrays: SUnitRange, SVector
 
@@ -171,6 +172,23 @@ function (::VanLeer)(Δ_top, Δ_bot)
     else
         return FT(0)
     end
+end
+
+
+"""
+    NoLimiter <: AbstractSlopeLimiter
+
+No Limiter: 
+1) smooth case, no dissipation is added
+2) linear case, which guarantee the discreted equation is linear
+```
+   ϕ(r) = r
+```
+"""
+struct NoLimiter <: AbstractSlopeLimiter end
+
+function (::NoLimiter)(Δ_top, Δ_bot)
+    return (Δ_top + Δ_bot) / 2
 end
 
 end

--- a/src/Numerics/Mesh/Filters.jl
+++ b/src/Numerics/Mesh/Filters.jl
@@ -118,7 +118,7 @@ function spectral_filter_matrix(r, Nc, σ)
     @assert 0 <= Nc <= N
 
     a, b = GaussQuadrature.legendre_coefs(T, N)
-    V = GaussQuadrature.orthonormal_poly(r, a, b)
+    V = (N == 0 ? ones(T, 1, 1) : GaussQuadrature.orthonormal_poly(r, a, b))
 
     Σ = ones(T, N + 1)
     Σ[(Nc:N) .+ 1] .= σ.(((Nc:N) .- Nc) ./ (N - Nc))

--- a/src/Ocean/SuperModels.jl
+++ b/src/Ocean/SuperModels.jl
@@ -174,6 +174,7 @@ function HydrostaticBoussinesqSuperModel(;
         numerical_fluxes.first_order,
         numerical_fluxes.second_order,
         numerical_fluxes.gradient,
+        nothing,
         OceanBoxGCMSpecificInfo(),
     )
 

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -156,6 +156,7 @@ function main()
         RusanovNumericalFlux(),
         CentralNumericalFluxSecondOrder(),
         CentralNumericalFluxGradient(),
+        nothing,
         ClimateMachine.AtmosLESSpecificInfo(),
     )
 


### PR DESCRIPTION
### Description

This PR updates the driver of the DG-FV method and tests the diagnostics of DG-FV method

So far, DG-FV can not maintain hydrostatics balance (#1881), and does not support implicit solver(#1814), and this PR should wait for #1881 and #1814

The example is in the experiments/TestCase/baroclinic_wave_fvm.jl

Some plots at a very short simulation time indicate the basic diagnostics is correct



- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
