### PR TITLE
FV kernel_min_neighbor_distance! update to support  vertical CFL based dt computation

### DIFF
--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -1038,7 +1038,7 @@ model.
 """
 function courant(
     local_courant::Function,
-    dg::DGModel,
+    dg::SpaceDiscretization,
     m::BalanceLaw,
     state_prognostic::MPIStateArray,
     Δt,


### PR DESCRIPTION
This PR updates the kernel_min_neighbor_distance! for FV 
The neighbor_distance in the vertical direction for FV is approximated as the cell vertical size, 2vgeo[ijk, _JcV, e]

This enables CFL computation for FV vertical direction


### Description

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
