### PR TITLE
Comput and use correct face auxiliary in FV vert_interface_tendency

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -62,6 +62,7 @@ import ..BalanceLaws:
     transform_post_gradient_laplacian!,
     prognostic_to_primitive!,
     primitive_to_prognostic!,
+    construct_face_auxiliary_state!,
     init_state_auxiliary!,
     init_state_prognostic!,
     update_auxiliary_state!,

--- a/src/BalanceLaws/prog_prim_conversion.jl
+++ b/src/BalanceLaws/prog_prim_conversion.jl
@@ -43,3 +43,22 @@ function primitive_to_prognostic!(bl, prog::Vars, prim::Vars, aux)
     prog_arr = parent(prog)
     prog_arr .= prim_arr
 end
+
+"""
+    construct_face_auxiliary_state!(bl::AtmosModel, aux_face::AbstractArray, aux_cell::AbstractArray, Δz::FT)
+
+Default constructor
+
+ - `bl` balance law
+ - `aux_face` face auxiliary variables to be constructed 
+ - `aux_cell` cell center auxiliary variable
+ - `Δz` cell vertical size 
+"""
+function construct_face_auxiliary_state!(
+    bl,
+    aux_face::AbstractArray,
+    aux_cell::AbstractArray,
+    Δz::FT,
+) where {FT}
+    aux_face .= aux_cell
+end


### PR DESCRIPTION
This PR updates face auxiliary variables in FV kernel

In the present FV  implementation, we do not have nodal points at the top/bottom cell faces, 
but we need to compute flux at the top/bottom cell faces, therefore, we need to construct the face auxiliary variables.

The geopotential is constructed as 
```
Φᵢ₊₀.₅ =  Φᵢ + gΔzᵢ/2
```
The `aux.moisture.temperature`  is updated in `primitive_to_prognostic!`, which is called at the cell faces

The `prognostic_to_primitive!`, which is only called at the cell centers is updated, which uses the auxiliary variables computed from `update_auxiliary_state!`

This PR also requires using ```Δzᵢ```  as cell weights (same modification in  #1881 )

### Description

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
