### PR TITLE
Fix temp BCs for SBL.

### DIFF
--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -178,15 +178,7 @@ end
 
 function surface_temperature_variation(bl, state, t)
     FT = eltype(state)
-    ρ = state.ρ
-    θ_liq_sfc = FT(265) - FT(1 / 4) * (t / 3600)
-    if bl.moisture isa DryModel
-        TS = PhaseDry_ρθ(bl.param_set, ρ, θ_liq_sfc)
-    else
-        q_tot = state.moisture.ρq_tot / ρ
-        TS = PhaseEquil_ρθq(bl.param_set, ρ, θ_liq_sfc, q_tot)
-    end
-    return air_temperature(TS)
+    return FT(265) - FT(1 / 4) * (t / 3600)
 end
 
 function stable_bl_model(


### PR DESCRIPTION
### Description

This PR simplifies the `surface_temperature_variation` function in the `stable_bl_model`, making it consistent with the description of these conditions in the original publication (Beare et al, 2006). Although analytically theta_liq, theta and T should be equivalent for a DryModel at the surface, I found that the T resulting from setting the BC for theta_liq is not what it is supposed to be. Its value oscillates around the value set by theta_liq. Since the variable of interest is T, the BC should be in this variable. 

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
