### PR TITLE
Fix +- bug in single stack utils

### DIFF
--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -91,7 +91,7 @@ function get_vars_from_nodal_stack(
             # get the volume degree of freedom numbers
             vid⁻, vid⁺ = ((id⁻ - 1) % Np) + 1, ((id⁺ - 1) % Np) + 1
 
-            J⁺, J⁻ = vgeo[vid⁻, Grids._M, ev⁻], vgeo[vid⁺, Grids._M, ev⁺]
+            J⁻, J⁺ = vgeo[vid⁻, Grids._M, ev⁻], vgeo[vid⁺, Grids._M, ev⁺]
             state_local = J⁻ * state_data[vid⁻, v, ev⁻]
             state_local += J⁺ * state_data[vid⁺, v, ev⁺]
             state_local /= (J⁻ + J⁺)


### PR DESCRIPTION
### Description

Not sure if/what effect this has on the single stack utils, but it looked like the +/- states were flipped for `J`.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
