### PR TITLE
Allow updraft zero area fraction

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -95,7 +95,6 @@ using ..DGMethods.NumericalFluxes:
 
 import ..Courant: advective_courant, nondiffusive_courant, diffusive_courant
 
-
 """
     AtmosModel <: BalanceLaw
 

--- a/test/Atmos/EDMF/closures/entr_detr.jl
+++ b/test/Atmos/EDMF/closures/entr_detr.jl
@@ -64,7 +64,7 @@ function entr_detr(
     lim_amp = entr.lim_amp
     w_min = entr.w_min
     # precompute vars
-    w_up_i = up[i].ρaw / up[i].ρa
+    w_up_i = fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)
     sqrt_tke = sqrt(max(en.ρatke, 0) * ρ_inv / env.a)
     # ensure far from zero
     Δw = filter_w(w_up_i - env.w, w_min)

--- a/test/Atmos/EDMF/closures/mixing_length.jl
+++ b/test/Atmos/EDMF/closures/mixing_length.jl
@@ -83,7 +83,9 @@ function mixing_length(
     # Dissipation term
     b = FT(0)
     a_up = vuntuple(i -> up[i].ρa * ρinv, N_up)
-    w_up = vuntuple(i -> up[i].ρaw / up[i].ρa, N_up)
+    w_up = vuntuple(N_up) do i
+        fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)
+    end
     b = sum(
         ntuple(N_up) do i
             Δ[i] / gm.ρ / env.a *

--- a/test/Atmos/EDMF/closures/pressure.jl
+++ b/test/Atmos/EDMF/closures/pressure.jl
@@ -33,13 +33,12 @@ function perturbation_pressure(
     i,
 ) where {FT}
     @unpack state, diffusive, aux = args
-
     # Alias convention:
     up = state.turbconv.updraft
     up_aux = aux.turbconv.updraft
     up_dif = diffusive.turbconv.updraft
 
-    w_up_i = up[i].ρaw / up[i].ρa
+    w_up_i = fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)
 
     nh_press_buoy = press.α_b * up_aux[i].buoyancy
     nh_pressure_adv = -press.α_a * w_up_i * up_dif[i].∇w[3]

--- a/test/Atmos/EDMF/helper_funcs/nondimensional_exchange_functions.jl
+++ b/test/Atmos/EDMF/helper_funcs/nondimensional_exchange_functions.jl
@@ -44,7 +44,7 @@ function nondimensional_exchange_functions(
     N_up = n_updrafts(m.turbconv)
     ρinv = 1 / gm.ρ
     a_up_i = up[i].ρa * ρinv
-    w_up_i = up[i].ρaw / up[i].ρa
+    w_up_i = fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)
 
     # thermodynamic variables
     RH_up = relative_humidity(ts_up[i])

--- a/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
@@ -139,12 +139,12 @@ end
 ####
 
 function new_thermo_state_up(
-    m::AtmosModel,
+    m::AtmosModel{FT},
     moist::DryModel,
     state::Vars,
     aux::Vars,
     ts::ThermodynamicState,
-)
+) where {FT}
     N_up = n_updrafts(m.turbconv)
     up = state.turbconv.updraft
     p = air_pressure(ts)
@@ -153,20 +153,21 @@ function new_thermo_state_up(
     ts_up = vuntuple(N_up) do i
         ρa_up = up[i].ρa
         ρaθ_liq_up = up[i].ρaθ_liq
-        θ_liq_up = ρaθ_liq_up / ρa_up
-
+        θ_liq_up =
+            fix_void_up(ρa_up, ρaθ_liq_up / ρa_up, liquid_ice_pottemp(ts))
         PhaseDry_pθ(m.param_set, p, θ_liq_up)
     end
     return ts_up
 end
 
 function new_thermo_state_up(
-    m::AtmosModel,
+    m::AtmosModel{FT},
     moist::EquilMoist,
     state::Vars,
     aux::Vars,
     ts::ThermodynamicState,
-)
+) where {FT}
+
     N_up = n_updrafts(m.turbconv)
     up = state.turbconv.updraft
     p = air_pressure(ts)
@@ -176,9 +177,13 @@ function new_thermo_state_up(
         ρa_up = up[i].ρa
         ρaθ_liq_up = up[i].ρaθ_liq
         ρaq_tot_up = up[i].ρaq_tot
-        θ_liq_up = ρaθ_liq_up / ρa_up
-        q_tot_up = ρaq_tot_up / ρa_up
-
+        θ_liq_up =
+            fix_void_up(ρa_up, ρaθ_liq_up / ρa_up, liquid_ice_pottemp(ts))
+        q_tot_up = fix_void_up(
+            ρa_up,
+            ρaq_tot_up / ρa_up,
+            total_specific_humidity(ts),
+        )
         PhaseEquil_pθq(m.param_set, p, θ_liq_up, q_tot_up)
     end
     return ts_up
@@ -203,6 +208,8 @@ function new_thermo_state_en(
     a_min = m.turbconv.subdomains.a_min
     a_max = m.turbconv.subdomains.a_max
     if !(0 <= θ_liq_en)
+        @print("ρaθ_liq_up = ", up[1].ρaθ_liq, "\n")
+        @print("θ_liq = ", θ_liq, "\n")
         @print("θ_liq_en = ", θ_liq_en, "\n")
         error("Environment θ_liq_en out-of-bounds in new_thermo_state_en")
     end

--- a/test/Atmos/EDMF/helper_funcs/utility_funcs.jl
+++ b/test/Atmos/EDMF/helper_funcs/utility_funcs.jl
@@ -32,3 +32,14 @@ we need this to avoid domain error in certain
 circumstances.
 """
 enforce_positivity(x::FT) where {FT} = max(x, FT(0))
+
+"""
+    fix_void_up(ρa_up_i::FT, val::FT, fallback = FT(0)) where {FT}
+
+Substitute value by a consistent fallback in case of
+negligible area fraction (void updraft).
+"""
+function fix_void_up(ρa_up_i::FT, val::FT, fallback = FT(0)) where {FT}
+    tol = sqrt(eps(FT))
+    return ρa_up_i > tol ? val : fallback
+end

--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -16,13 +16,13 @@ best_mse[:Bomex]["ρ"] = 3.4943021267397123e-02
 best_mse[:Bomex]["ρu[1]"] = 3.0714039084256679e+03
 best_mse[:Bomex]["ρu[2]"] = 1.3375796498101822e-03
 best_mse[:Bomex]["moisture.ρq_tot"] = 4.8463531712319707e-02
-best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.1572840536769354e+02
+best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.1572840541674498e+02
 best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5666903275492686e+01
 best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6436084624020341e+02
-best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 8.0001172664757931e+01
+best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 8.0001172665962883e+01
 best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4920000484896258e-02
-best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0208723977569374e+00
-best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0782418080532498e+01
+best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0208723977818579e+00
+best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0782418080562499e+01
 #! format: on
 
 sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + eps()


### PR DESCRIPTION
### Description

This PR makes the EDMF model capable of simulating conditions of zero updraft area fraction.

Co-authored by: @charleskawczynski .

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
