### PR TITLE
Add NodalStack utils and iterator

### DIFF
--- a/docs/src/APIs/Utilities/SingleStackUtils.md
+++ b/docs/src/APIs/Utilities/SingleStackUtils.md
@@ -15,4 +15,5 @@ reduce_nodal_stack
 reduce_element_stack
 horizontally_average!
 dict_of_nodal_states
+NodalStack
 ```

--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -7,9 +7,11 @@ export get_vars_from_nodal_stack,
     reduce_nodal_stack,
     reduce_element_stack,
     horizontally_average!,
-    dict_of_nodal_states
+    dict_of_nodal_states,
+    NodalStack
 
 using OrderedCollections
+using UnPack
 using StaticArrays
 import KernelAbstractions: CPU
 
@@ -451,6 +453,250 @@ function dict_of_nodal_states(
         push!(all_state_vars, state_vars...)
     end
     return OrderedDict(all_state_vars...)
+end
+
+# A container for holding various
+# global or point-wise states:
+struct States{P, A, D, HD}
+    prog::P
+    aux::A
+    diffusive::D
+    hyperdiffusive::HD
+end
+
+"""
+    NodalStack(
+            bl::BalanceLaw,
+            grid::DiscontinuousSpectralElementGrid,
+            prognostic,
+            auxiliary,
+            diffusive,
+            hyperdiffusive;
+            i = 1,
+            j = 1,
+            interp = true,
+        )
+
+A struct whose `iterate(::NodalStack)` traverses
+the nodal stack and returns a NamedTuple of
+point-wise fields (`Vars`).
+
+# Example
+```julia
+for state_local in NodalStack(
+        bl,
+        grid,
+        prognostic, # global field along nodal stack
+        auxiliary,
+        diffusive,
+        hyperdiffusive
+    )
+prog = state_local.prog # point-wise field along nodal stack
+end
+```
+
+## TODO: Make `prognostic`, `auxiliary`, `diffusive`, `hyperdiffusive` optional
+
+# Arguments
+ - `bl` the balance law
+ - `grid` the discontinuous spectral element grid
+ - `prognostic` the global prognostic state
+ - `auxiliary` the global auxiliary state
+ - `diffusive` the global diffusive state (gradient-flux)
+ - `hyperdiffusive` the global hyperdiffusive state
+ - `i,j` the `i,j`'th nodal stack (in the horizontal directions)
+ - `interp` a bool indicating whether to
+    interpolate the duplicate Gauss-Lebotto
+    points at the element faces.
+
+!!! warn
+    Before iterating, the data is transferred from the
+    device (GPU) to the host (CPU), as this is intended
+    for debugging / diagnostics usage.
+"""
+struct NodalStack{N, BL, G, S, VR, TI, TJ, CI, IN}
+    bl::BL
+    grid::G
+    states::S
+    vrange::VR
+    i::TI
+    j::TJ
+    cart_ind::CI
+    interp::IN
+    function NodalStack(
+        bl::BalanceLaw,
+        grid::DiscontinuousSpectralElementGrid,
+        prognostic,
+        auxiliary,
+        diffusive,
+        hyperdiffusive;
+        i = 1,
+        j = 1,
+        interp = true,
+    )
+        states = States(prognostic, auxiliary, diffusive, hyperdiffusive)
+        vrange = 1:size(prognostic, 3)
+        grid_info = basic_grid_info(grid)
+        @unpack Nqk = grid_info
+        # Store cartesian indices, so we can map the iter_state
+        # to the cartesian space `Q[i, var, j]`
+        if interp
+            cart_ind = CartesianIndices(((Nqk - 1), size(prognostic, 3)))
+        else
+            cart_ind = CartesianIndices((Nqk, size(prognostic, 3)))
+        end
+        args = (bl, grid, states, vrange, i, j, cart_ind, interp)
+        BL, G, S, VR, TI, TJ, CI, IN = typeof.(args)
+        if interp
+            len = size(prognostic, 3) * (Nqk - 1) + 1
+        else
+            len = size(prognostic, 3) * Nqk
+        end
+        new{len, BL, G, S, VR, TI, TJ, CI, IN}(args...)
+    end
+end
+
+# Convenience wrapper
+NodalStack(solver_config; kwargs...) = NodalStack(
+    solver_config.dg.balance_law,
+    solver_config.dg.grid,
+    solver_config.Q,
+    solver_config.dg.state_auxiliary,
+    solver_config.dg.state_gradient_flux,
+    solver_config.dg.states_higher_order[2];
+    kwargs...,
+)
+
+Base.length(gs::NodalStack{N}) where {N} = N
+
+# Helper function
+get_state(v, state, vid⁻, vid⁺, ev⁻, ev⁺, J⁻, J⁺) =
+    (J⁻ * state[vid⁻, v, ev⁻] + J⁺ * state[vid⁺, v, ev⁺]) / (J⁻ + J⁺)
+
+to_cpu(state) =
+    array_device(state) isa CPU ? state.realdata : Array(state.realdata)
+
+function interp_top(state, args, n_vars, bl, st)
+    vs = Vars{vars_state(bl, st, eltype(state))}
+    if n_vars ≠ 0
+        return vs(map(v -> get_state(v, state, args...), 1:n_vars))
+    else
+        return nothing
+    end
+end
+
+function interp_bot(state, vid⁻, ev⁻, n_vars, bl, st)
+    vs = Vars{vars_state(bl, st, eltype(state))}
+    if n_vars ≠ 0
+        return vs(map(v -> state[vid⁻, v, ev⁻], 1:n_vars))
+    else
+        return nothing
+    end
+end
+
+function no_interp(state, ijk, ev, n_vars, bl, st)
+    vs = Vars{vars_state(bl, st, eltype(state))}
+    if n_vars ≠ 0
+        return vs(map(v -> state[ijk, v, ev], 1:n_vars))
+    else
+        return nothing
+    end
+end
+
+function Base.iterate(gs::NodalStack, iter_state = 1)
+    iter_state > length(gs) && return nothing
+
+    # extract grid information
+    grid = gs.grid
+    FT = eltype(grid)
+    grid_info = basic_grid_info(grid)
+    @unpack N, Nq, Np, Nqk = grid_info
+    @inbounds Nq1, Nq2 = Nq[1], Nq[2]
+    states = gs.states
+    bl = gs.bl
+    interp = gs.interp
+
+    # bring `Q` to the host if needed
+
+    prognostic = to_cpu(states.prog)
+    auxiliary = to_cpu(states.aux)
+    diffusive = to_cpu(states.diffusive)
+    hyperdiffusive = to_cpu(states.hyperdiffusive)
+
+    n_vars_prog = size(prognostic, 2)
+    n_vars_aux = size(auxiliary, 2)
+    n_vars_diff = size(diffusive, 2)
+    n_vars_hd = size(hyperdiffusive, 2)
+
+    elemtobndy = convert(Array, grid.elemtobndy)
+    vmap⁻ = convert(Array, grid.vmap⁻)
+    vmap⁺ = convert(Array, grid.vmap⁺)
+    vgeo = convert(Array, grid.vgeo)
+    i, j = gs.i, gs.j
+    if iter_state == length(gs)
+        ijk_cart = (Nqk, size(states.prog, 3))
+    else
+        ijk_cart = Tuple(gs.cart_ind[iter_state])
+    end
+    ev = ijk_cart[2]
+    k = ijk_cart[1]
+    iter_state⁺ = iter_state + 1
+    if interp && k == 1 && elemtobndy[5, ev] == 0
+        # Get face degree of freedom number
+        n = i + Nq1 * ((j - 1))
+        # get the element numbers
+        ev⁻ = ev
+        # Get neighboring id data
+        id⁻, id⁺ = vmap⁻[n, 5, ev⁻], vmap⁺[n, 5, ev⁻]
+        ev⁺ = ((id⁺ - 1) ÷ Np) + 1
+        # get the volume degree of freedom numbers
+        vid⁻, vid⁺ = ((id⁻ - 1) % Np) + 1, ((id⁺ - 1) % Np) + 1
+        J⁻, J⁺ = vgeo[vid⁻, Grids._M, ev⁻], vgeo[vid⁺, Grids._M, ev⁺]
+
+        args = (vid⁻, vid⁺, ev⁻, ev⁺, J⁻, J⁺)
+#! format: off
+        prog = interp_top(prognostic, args, n_vars_prog, bl, Prognostic())
+        aux = interp_top(auxiliary, args, n_vars_aux, bl, Auxiliary())
+        ∇flux = interp_top(diffusive, args, n_vars_diff, bl, GradientFlux())
+        hyperdiff = interp_top(hyperdiffusive, args, n_vars_hd, bl, Hyperdiffusive())
+#! format: on
+
+        return ((; prog, aux, ∇flux, hyperdiff), iter_state⁺)
+
+    elseif interp && k == Nqk && elemtobndy[6, ev] == 0
+        # Get face degree of freedom number
+        n = i + Nq1 * ((j - 1))
+        # get the element numbers
+        ev⁻ = ev
+        # Get neighboring id data
+        id⁻, id⁺ = vmap⁻[n, 6, ev⁻], vmap⁺[n, 6, ev⁻]
+        # periodic and need to handle this point (otherwise handled above)
+        if id⁺ == id⁻
+            vid⁻ = ((id⁻ - 1) % Np) + 1
+
+#! format: off
+            prog = interp_bot(prognostic, vid⁻, ev⁻, n_vars_prog, bl, Prognostic())
+            aux = interp_bot(auxiliary, vid⁻, ev⁻, n_vars_aux, bl, Auxiliary())
+            ∇flux = interp_bot(diffusive, vid⁻, ev⁻, n_vars_diff, bl, GradientFlux())
+            hyperdiff = interp_bot( hyperdiffusive, vid⁻, ev⁻, n_vars_hd, bl, Hyperdiffusive())
+#! format: on
+
+            return ((; prog, aux, ∇flux, hyperdiff), iter_state⁺)
+        else
+            error("uncaught case in iterate(::NodalStack)")
+        end
+    else
+        ijk = i + Nq1 * ((j - 1) + Nq2 * (k - 1))
+
+#! format: off
+        prog = no_interp(prognostic, ijk, ev, n_vars_prog, bl, Prognostic())
+        aux = no_interp(auxiliary, ijk, ev, n_vars_aux, bl, Auxiliary())
+        ∇flux = no_interp(diffusive, ijk, ev, n_vars_diff, bl, GradientFlux())
+        hyperdiff = no_interp(hyperdiffusive, ijk, ev, n_vars_hd, bl, Hyperdiffusive())
+#! format: on
+
+        return ((; prog, aux, ∇flux, hyperdiff), iter_state⁺)
+    end
 end
 
 end # module

--- a/test/Utilities/SingleStackUtils/ssu_tests.jl
+++ b/test/Utilities/SingleStackUtils/ssu_tests.jl
@@ -210,5 +210,32 @@ function main()
         vars_state(m, Prognostic(), FT),
     )
 
+    # Test NodalStack iterator (without interpolation)
+    nodal_stack = NodalStack(solver_config; interp = false)
+    ρ_iter = [local_states.prog.ρ for local_states in nodal_stack]
+    dons = get_vars_from_nodal_stack(
+        solver_config.dg.grid,
+        solver_config.Q,
+        vars_state(m, Prognostic(), FT);
+        interp = false,
+    )
+    ρ_vfns = dons["ρ"]
+    @test all(ρ_iter .≈ ρ_vfns)
+
+    # Test NodalStack iterator (with interpolation)
+    nodal_stack = NodalStack(solver_config; interp = true)
+    ρ_iter = [local_states.prog.ρ for local_states in nodal_stack]
+    dons = get_vars_from_nodal_stack(
+        solver_config.dg.grid,
+        solver_config.Q,
+        vars_state(m, Prognostic(), FT);
+        interp = true,
+    )
+    ρ_vfns_interp = dons["ρ"]
+    @test all(ρ_iter .≈ ρ_vfns_interp)
+    return nothing
 end
-main()
+
+@testset "Single Stack Utils" begin
+    main()
+end


### PR DESCRIPTION
### Description

This PR adds `NodalStack` with `iterate(::NodalStack)`. `iterate(::NodalStack)` traverses the nodal stack and returns a `NamedTuple` of prognostic, auxiliary, diffusive, and hyperdiffusive `Vars`, so that we can write a simple callback that calls each of the physics kernels (and `precompute` caches). For example:

```julia
    nodal_stack = NodalStack(solver_config; interp = true) # Allows for on-the-fly interpolating
    ρ = [local_states.prog.ρ for local_states in nodal_stack] # `local_states.prog` is a `Vars{vars_state()}()` instance.
    # ρ is a vector of values along the interpolated nodal stack (at `i=1,j=1`, optional kwargs to `NodalStack`)
```

Next, a cache diagnostics (to be included in a later PR) will be:

```julia
function cache_diagnostics(solver_config)
    bl = solver_config.dg.balance_law
    t = gettime(solver_config.solver)
    direction = solver_config.diffdir
    return [
        begin
            @unpack prog, aux, ∇flux, hyperdiff = local_states
            diffusive = ∇flux
            state = prog
            hyperdiffusive = hyperdiff

            _args_fx1 = (;state,aux,t,direction)
            _args_fx2 = (;state,aux,t,diffusive, hyperdiffusive)
            _args_src = (;state,aux,t,direction, diffusive)

            cache_fx1 = precompute(bl, _args_fx1, Flux{FirstOrder}())
            cache_fx2 = precompute(bl, _args_fx2, Flux{SecondOrder}())
            cache_src = precompute(bl, _args_src, Source())

            merge(cache_fx1, cache_fx2, cache_src)
        end for local_states in NodalStack(solver_config)
    ]
end
```

This has some nice long-term benefits:
 - Users (single-stack for now) will be less inclined to dump diagnostics fields into `aux`, which has been very common and will eventually need to be undone because doing so adds global memory reads/writes at every tendency evaluation.
 - The performance/debugging can be easily managed, from the driver level, by reducing the diagnostics frequency.
 - Changing what is incorporated in these diagnostics is even easier than adding new `aux` fields (no need to modify `vars_state(, ::Auxiliary, )`)

Edit: renamed `GridStack` -> `NodalStack`

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
