### PR TITLE
Fix artifacts race condition

### DIFF
--- a/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
+++ b/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
@@ -40,13 +40,6 @@ const param_set = EarthParameterSet()
 using ClimateMachine.Atmos: altitude, recover_thermo_state
 import ClimateMachine.BalanceLaws: source, eq_tends
 
-# path to download artifacts
-const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
-    @__DIR__
-else
-    mktempdir(@__DIR__; prefix = "artifact_")
-end
-
 # Citation for problem setup
 ## CMIP6 Test Dataset - cfsites
 ## [Webb2017](@cite)
@@ -278,7 +271,8 @@ function get_gcm_info(group_id)
     @printf("--------------------------------------------------\n")
 
     lsforcing_dataset = ArtifactWrapper(
-        joinpath(ARTIFACT_DIR, "Artifacts.toml"),
+        @__DIR__,
+        isempty(get(ENV, "CI", "")),
         "lsforcing",
         ArtifactFile[ArtifactFile(
             url = "https://caltech.box.com/shared/static/dszfbqzwgc9a55vhxd43yenvebcb6bcj.nc",

--- a/experiments/AtmosLES/squall_line.jl
+++ b/experiments/AtmosLES/squall_line.jl
@@ -51,13 +51,6 @@ const microphys = MicropysicsParameterSet(
 )
 const param_set = EarthParameterSet(microphys)
 
-# path to download artifacts
-const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
-    @__DIR__
-else
-    mktempdir(@__DIR__; prefix = "artifact_")
-end
-
 """
   Define initial conditions based on sounding data
 """
@@ -137,7 +130,8 @@ function read_sounding()
     # separate folder.
 
     soundings_dataset = ArtifactWrapper(
-        joinpath(ARTIFACT_DIR, "Artifacts.toml"),
+        @__DIR__,
+        isempty(get(ENV, "CI", "")),
         "soundings",
         ArtifactFile[ArtifactFile(
             url = "https://caltech.box.com/shared/static/rjnvt2dlw7etm1c7mmdfrkw5gnfds5lx.nc",

--- a/src/InputOutput/ArtifactWrappers/ArtifactWrappers.jl
+++ b/src/InputOutput/ArtifactWrappers/ArtifactWrappers.jl
@@ -28,7 +28,8 @@ A set of data files to be downloaded, grouped by `data_name`. Example:
 
 ```
 dataset = ArtifactWrapper(
-    "Artifacts.toml",
+    @__DIR__,
+    isempty(get(ENV, "CI", "")),
     "MyDataSet",
     ArtifactFile[
         ArtifactFile(
@@ -47,6 +48,10 @@ dataset = ArtifactWrapper(
 $(FIELDS)
 """
 struct ArtifactWrapper
+    "Directory to store artifact / data"
+    artifact_dir::AbstractString
+    "Locally running (not using CI)"
+    local_run::Bool
     "Path to the used Artifacts.toml"
     artifact_toml::AbstractString
     "Unique name of dataset"
@@ -54,6 +59,20 @@ struct ArtifactWrapper
     "Array of `ArtifactFile`'s, grouped by this dataset"
     artifact_files::Vector{ArtifactFile}
 end
+function ArtifactWrapper(artifact_dir, local_run, data_name, artifact_files)
+    if !local_run
+        artifact_dir = mktempdir(artifact_dir; prefix = "artifact_")
+    end
+    artifact_toml = joinpath(artifact_dir, "Artifacts.toml")
+    return ArtifactWrapper(
+        artifact_dir,
+        local_run,
+        artifact_toml,
+        data_name,
+        artifact_files,
+    )
+end
+
 
 """
     get_data_folder(art_wrap::ArtifactWrapper)
@@ -67,43 +86,56 @@ dataset_path = get_data_folder(dataset)
 ```
 """
 function get_data_folder(art_wrap::ArtifactWrapper)
-    # Query the `Artifacts.toml` file for the hash bound to the name
-    # data_name (returns `nothing` if no such binding exists)
-    data_hash = artifact_hash(art_wrap.data_name, art_wrap.artifact_toml)
+    if !art_wrap.local_run
+        # When running multiple jobs, create_artifact
+        # has a race condition when creating/moving
+        # files. So, when using CI, just download
+        # the data files:
+        filenames = [af.filename for af in art_wrap.artifact_files]
+        urls = [af.url for af in art_wrap.artifact_files]
+        for (url, filename) in zip(urls, filenames)
+            download("$(url)", joinpath(art_wrap.artifact_dir, filename))
+        end
+        return art_wrap.artifact_dir
+    else
+        # Query the `Artifacts.toml` file for the hash bound to the name
+        # data_name (returns `nothing` if no such binding exists)
+        data_hash = artifact_hash(art_wrap.data_name, art_wrap.artifact_toml)
 
-    # If the name was not bound, or the hash it was bound to does not
-    # exist, create it!
-    if data_hash == nothing || !artifact_exists(data_hash)
-        # create_artifact() returns the content-hash of the artifact
-        # directory once we're finished creating it
-        data_hash = create_artifact() do artifact_dir
-            # We create the artifact by simply downloading a few files
-            # into the new artifact directory
-            filenames = [af.filename for af in art_wrap.artifact_files]
-            urls = [af.url for af in art_wrap.artifact_files]
-            for (url, filename) in zip(urls, filenames)
-                download("$(url)", joinpath(artifact_dir, filename))
+        # If the name was not bound, or the hash it was bound to does not
+        # exist, create it!
+        if data_hash == nothing || !artifact_exists(data_hash)
+            # create_artifact() returns the content-hash of the artifact
+            # directory once we're finished creating it
+            data_hash = create_artifact() do artifact_dir
+                # We create the artifact by simply downloading a few files
+                # into the new artifact directory
+                filenames = [af.filename for af in art_wrap.artifact_files]
+                urls = [af.url for af in art_wrap.artifact_files]
+                for (url, filename) in zip(urls, filenames)
+                    download("$(url)", joinpath(artifact_dir, filename))
+                end
             end
+
+            # Now bind that hash within our `Artifacts.toml`. `force = true`
+            # means that if it already exists, just overwrite with the new
+            # content-hash.  Unless the source files change, we do not expect
+            # the content hash to change, so this should not cause
+            # unnecessary version control churn.
+            bind_artifact!(
+                art_wrap.artifact_toml,
+                art_wrap.data_name,
+                data_hash,
+                force = true,
+            )
         end
 
-        # Now bind that hash within our `Artifacts.toml`. `force = true`
-        # means that if it already exists, just overwrite with the new
-        # content-hash.  Unless the source files change, we do not expect
-        # the content hash to change, so this should not cause
-        # unnecessary version control churn.
-        bind_artifact!(
-            art_wrap.artifact_toml,
-            art_wrap.data_name,
-            data_hash,
-            force = true,
-        )
+        # Get the path of the dataset, either newly created or
+        # previously generated. This should be something like:
+        # `~/.julia/artifacts/dbd04e28be047a54fbe9bf67e934be5b5e0d357a`
+        dataset_path = artifact_path(data_hash)
+        return dataset_path
     end
-
-    # Get the path of the dataset, either newly created or
-    # previously generated. This should be something like:
-    # `~/.julia/artifacts/dbd04e28be047a54fbe9bf67e934be5b5e0d357a`
-    dataset_path = artifact_path(data_hash)
-    return dataset_path
 end
 
 end # module

--- a/test/Atmos/EDMF/compute_mse.jl
+++ b/test/Atmos/EDMF/compute_mse.jl
@@ -1,12 +1,5 @@
 using ClimateMachine
 
-# path to download artifacts
-const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
-    @__DIR__
-else
-    mktempdir(@__DIR__; prefix = "artifact_")
-end
-
 if parse(Bool, get(ENV, "CLIMATEMACHINE_PLOT_EDMF_COMPARISON", "false"))
     using Plots
 end
@@ -21,7 +14,8 @@ using ClimateMachine.ArtifactWrappers
 # Get PyCLES_output dataset folder:
 #! format: off
 PyCLES_output_dataset = ArtifactWrapper(
-    joinpath(ARTIFACT_DIR, "Artifacts.toml"),
+    @__DIR__,
+    isempty(get(ENV, "CI", "")),
     "PyCLES_output",
     ArtifactFile[
     # ArtifactFile(url = "https://caltech.box.com/shared/static/johlutwhohvr66wn38cdo7a6rluvz708.nc", filename = "Rico.nc",),

--- a/test/Atmos/Model/ref_state.jl
+++ b/test/Atmos/Model/ref_state.jl
@@ -5,16 +5,10 @@ using ClimateMachine.ArtifactWrappers
 using ClimateMachine.Thermodynamics
 const TD = Thermodynamics
 
-# path to download artifacts
-const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
-    @__DIR__
-else
-    mktempdir(@__DIR__; prefix = "artifact_")
-end
-
 @testset "Hydrostatic reference states - regression test" begin
     ref_state_dataset = ArtifactWrapper(
-        joinpath(ARTIFACT_DIR, "Artifacts.toml"),
+        @__DIR__,
+        isempty(get(ENV, "CI", "")),
         "ref_state",
         ArtifactFile[ArtifactFile(
             url = "https://caltech.box.com/shared/static/gyq292ns79wm9xpmy1sse3qtnpcxw54q.jld2",

--- a/test/Common/Thermodynamics/data_tests.jl
+++ b/test/Common/Thermodynamics/data_tests.jl
@@ -2,16 +2,10 @@ using Pkg.Artifacts
 
 using ClimateMachine.ArtifactWrappers
 
-# path to download artifacts
-const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
-    @__DIR__
-else
-    mktempdir(@__DIR__; prefix = "artifact_")
-end
-
 # Get dycoms dataset folder:
 dycoms_dataset = ArtifactWrapper(
-    joinpath(ARTIFACT_DIR, "Artifacts.toml"),
+    @__DIR__,
+    isempty(get(ENV, "CI", "")),
     "dycoms",
     ArtifactFile[ArtifactFile(
         url = "https://caltech.box.com/shared/static/bxau6i46y6ikxn2sy9krgz0sw5vuptfo.nc",

--- a/test/Land/Model/haverkamp_implicit_test.jl
+++ b/test/Land/Model/haverkamp_implicit_test.jl
@@ -31,15 +31,9 @@ using ClimateMachine.BalanceLaws:
     BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, vars_state
 using ClimateMachine.ArtifactWrappers
 
-# path to download artifacts
-const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
-    @__DIR__
-else
-    mktempdir(@__DIR__; prefix = "artifact_")
-end
-
 haverkamp_dataset = ArtifactWrapper(
-    joinpath(ARTIFACT_DIR, "Artifacts.toml"),
+    @__DIR__,
+    isempty(get(ENV, "CI", "")),
     "richards",
     ArtifactFile[ArtifactFile(
         url = "https://caltech.box.com/shared/static/dfijf07io7h5dk1k87saaewgsg9apq8d.csv",

--- a/test/Land/Model/haverkamp_test.jl
+++ b/test/Land/Model/haverkamp_test.jl
@@ -30,15 +30,9 @@ using ClimateMachine.BalanceLaws:
     BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, vars_state
 using ClimateMachine.ArtifactWrappers
 
-# path to download artifacts
-const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
-    @__DIR__
-else
-    mktempdir(@__DIR__; prefix = "artifact_")
-end
-
 haverkamp_dataset = ArtifactWrapper(
-    joinpath(ARTIFACT_DIR, "Artifacts.toml"),
+    @__DIR__,
+    isempty(get(ENV, "CI", "")),
     "richards",
     ArtifactFile[ArtifactFile(
         url = "https://caltech.box.com/shared/static/dfijf07io7h5dk1k87saaewgsg9apq8d.csv",

--- a/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
+++ b/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
@@ -107,13 +107,6 @@ using ClimateMachine.BalanceLaws:
 import ClimateMachine.DGMethods: calculate_dt
 using ClimateMachine.ArtifactWrappers
 
-# path to download artifacts
-const ARTIFACT_DIR = if isempty(get(ENV, "CI", ""))
-    @__DIR__
-else
-    mktempdir(@__DIR__; prefix = "artifact_")
-end
-
 # # Preliminary set-up
 # Get the parameter set, which holds constants used across CliMA models.
 struct EarthParameterSet <: AbstractEarthParameterSet end
@@ -435,7 +428,8 @@ plot(
 plot!(T_init.(z), z, label = "Initial condition")
 filename = "bonan_heat_data.csv"
 bonan_dataset = ArtifactWrapper(
-    joinpath(ARTIFACT_DIR, "Artifacts.toml"),
+    @__DIR__,
+    isempty(get(ENV, "CI", "")),
     "bonan_soil_heat",
     ArtifactFile[ArtifactFile(
         url = "https://caltech.box.com/shared/static/99vm8q8tlyoulext6c35lnd3355tx6bu.csv",


### PR DESCRIPTION
### Description

This PR adds a field `local_run` to the `ArtifactsWrapper`, and if `false` (meaning running CI), then data files are only downloaded to the given directory--hashes / toml files are not created. My hope is that this closes #1678.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
