### PR TITLE
add diffusion in the updrafts at the lower levels

### DIFF
--- a/experiments/AtmosLES/bomex_les.jl
+++ b/experiments/AtmosLES/bomex_les.jl
@@ -49,6 +49,8 @@ function main()
     #timeend = FT(3600 * 6)
     CFLmax = FT(0.35)
 
+    C_smag = FT(0.23)     # Smagorinsky coefficient
+
     # Choose default IMEX solver
     ode_solver_type = ClimateMachine.IMEXSolverType()
 
@@ -56,8 +58,9 @@ function main()
         FT,
         config_type,
         zmax,
-        surface_flux,
+        surface_flux;
         moisture_model = moisture_model,
+        turbulence = SmagorinskyLilly{FT}(C_smag),
     )
     ics = model.problem.init_state_prognostic
     # Assemble configuration

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -362,8 +362,6 @@ function bomex_model(
 
     ics = init_bomex!     # Initial conditions
 
-    C_smag = FT(0.23)     # Smagorinsky coefficient
-
     u_star = FT(0.28)     # Friction velocity
     C_drag = FT(0.0011)   # Bulk transfer coefficient
 
@@ -478,7 +476,7 @@ function bomex_model(
         config_type,
         param_set;
         problem = problem,
-        turbulence = SmagorinskyLilly{FT}(C_smag),
+        turbulence = turbulence,
         moisture = moisture,
         source = source,
         turbconv = turbconv,

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -355,6 +355,7 @@ function bomex_model(
     config_type,
     zmax,
     surface_flux;
+    turbulence = ConstantKinematicViscosity(FT(0)),
     turbconv = NoTurbConv(),
     moisture_model = "equilibrium",
 ) where {FT}

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -1098,7 +1098,8 @@ function flux(::Diffusion{up_ρa{i}}, atmos, args) where {i}
     up_dif = diffusive.turbconv.updraft
     gm = state
     z = altitute(atmos, aux)
-    α = FT(5e-2)
+    # α = FT(5e-2)
+    α = atmos.turbconv.surface.α_surf
     K = exp(-α*z)
     ẑ = vertical_unit_vector(atmos, aux)
     return -K * up_dif.∇ρa[3] * ẑ
@@ -1113,7 +1114,8 @@ function flux(::Diffusion{up_ρaw{i}}, atmos, args) where {i}
     up_dif = diffusive.turbconv.updraft
     gm = state
     z = altitute(atmos, aux)
-    α = FT(5e-2)
+    # α = FT(5e-2)
+    α = atmos.turbconv.surface.α_surf
     K = exp(-α*z)
     ẑ = vertical_unit_vector(atmos, aux)
     return - K * up_dif.∇ρaw[3] * ẑ
@@ -1127,7 +1129,8 @@ function flux(::Diffusion{up_ρaθ_liq{i}}, atmos, args) where {i}
     up_dif = diffusive.turbconv.updraft
     gm = state
     z = altitute(atmos, aux)
-    α = FT(5e-2)
+    # α = FT(5e-2)
+    α = atmos.turbconv.surface.α_surf
     K = exp(-α*z)
     ẑ = vertical_unit_vector(atmos, aux)
     return - K * up_dif.∇ρaθ_liq[3] * ẑ
@@ -1141,7 +1144,8 @@ function flux(::Diffusion{up_ρaq_tot{i}}, atmos, args) where {i}
     up_dif = diffusive.turbconv.updraft
     gm = state
     z = altitute(atmos, aux)
-    α = FT(5e-2)
+    # α = FT(5e-2)
+    α = atmos.turbconv.surface.α_surf
     K = exp(-α*z)
     ẑ = vertical_unit_vector(atmos, aux)
     return - K * up_dif.∇ρaq_tot[3] * ẑ

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -96,7 +96,11 @@ function vars_state(m::EDMF, st::Prognostic, FT)
 end
 
 function vars_state(::Updraft, ::Gradient, FT)
-    @vars(w::FT,)
+    @vars(ρa::FT,
+          ρaw::FT,
+          ρaθ_liq::FT,
+          ρaq_tot::FT,
+          w::FT,)
 end
 
 function vars_state(::Environment, ::Gradient, FT)
@@ -131,7 +135,11 @@ function vars_state(m::NTuple{N, Updraft}, st::GradientFlux, FT) where {N}
 end
 
 function vars_state(::Updraft, st::GradientFlux, FT)
-    @vars(∇w::SVector{3, FT},)
+    @vars(∇ρa::SVector{3, FT},
+          ∇ρaw::SVector{3, FT},
+          ∇ρaθ_liq::SVector{3, FT},
+          ∇ρaq_tot::SVector{3, FT},
+          ∇w::SVector{3, FT},)
 end
 
 function vars_state(::Environment, ::GradientFlux, FT)
@@ -387,6 +395,10 @@ function compute_gradient_argument!(
     env = environment_vars(state, aux, N_up)
 
     @unroll_map(N_up) do i
+        up_tf[i].ρa = up[i].ρa
+        up_tf[i].ρaw = up[i].ρaw
+        up_tf[i].ρaθ_liq = up[i].ρaθ_liq
+        up_tf[i].ρaq_tot = up[i].ρaq_tot
         up_tf[i].w = up[i].ρaw / up[i].ρa
     end
     _grav::FT = grav(m.param_set)
@@ -436,6 +448,10 @@ function compute_gradient_flux!(
     en_∇tf = ∇transform.turbconv.environment
 
     @unroll_map(N_up) do i
+        up_dif[i].∇ρa = up_∇tf[i].ρa
+        up_dif[i].∇ρaw = up_∇tf[i].ρaw
+        up_dif[i].∇ρaθ_liq = up_∇tf[i].ρaθ_liq
+        up_dif[i].∇ρaq_tot = up_∇tf[i].ρaq_tot
         up_dif[i].∇w = up_∇tf[i].w
     end
 
@@ -1074,6 +1090,63 @@ function flux(::Diffusion{en_ρatke}, atmos, args)
     return -gm.ρ * env.a * K_m * en_dif.∇tke[3] * ẑ
 end
 
+function flux(::Diffusion{up_ρa{i}}, atmos, args) where {i}
+    @unpack state, aux = args
+    @unpack ρa_up = args.precomputed.turbconv
+    FT = eltype(atmos)
+    up = state.turbconv.updraft
+    up_dif = diffusive.turbconv.updraft
+    gm = state
+    z = altitute(atmos, aux)
+    α = FT(5e-2)
+    K = exp(-α*z)
+    ẑ = vertical_unit_vector(atmos, aux)
+    return -K * up_dif.∇ρa[3] * ẑ
+end
+
+
+function flux(::Diffusion{up_ρaw{i}}, atmos, args) where {i}
+    @unpack state, aux = args
+    @unpack ρa_up = args.precomputed.turbconv
+    FT = eltype(atmos)
+    up = state.turbconv.updraft
+    up_dif = diffusive.turbconv.updraft
+    gm = state
+    z = altitute(atmos, aux)
+    α = FT(5e-2)
+    K = exp(-α*z)
+    ẑ = vertical_unit_vector(atmos, aux)
+    return - K * up_dif.∇ρaw[3] * ẑ
+end
+
+function flux(::Diffusion{up_ρaθ_liq{i}}, atmos, args) where {i}
+    @unpack state, aux = args
+    @unpack ρa_up = args.precomputed.turbconv
+    FT = eltype(atmos)
+    up = state.turbconv.updraft
+    up_dif = diffusive.turbconv.updraft
+    gm = state
+    z = altitute(atmos, aux)
+    α = FT(5e-2)
+    K = exp(-α*z)
+    ẑ = vertical_unit_vector(atmos, aux)
+    return - K * up_dif.∇ρaθ_liq[3] * ẑ
+end
+
+function flux(::Diffusion{up_ρaq_tot{i}}, atmos, args) where {i}
+    @unpack state, aux = args
+    @unpack ρa_up = args.precomputed.turbconv
+    FT = eltype(atmos)
+    up = state.turbconv.updraft
+    up_dif = diffusive.turbconv.updraft
+    gm = state
+    z = altitute(atmos, aux)
+    α = FT(5e-2)
+    K = exp(-α*z)
+    ẑ = vertical_unit_vector(atmos, aux)
+    return - K * up_dif.∇ρaq_tot[3] * ẑ
+end
+
 function flux_second_order!(
     turbconv::EDMF{FT},
     flux::Grad,
@@ -1086,6 +1159,20 @@ function flux_second_order!(
     flux_pad = SVector(1, 1, 1)
     # in future GCM implementations we need to think about grid mean advection
     tend = Flux{SecondOrder}()
+
+    up_flx = flux.turbconv.updraft
+    en_flx = flux.turbconv.environment
+    N_up = n_updrafts(turbconv)
+
+    @unroll_map(N_up) do i
+        up_flx[i].ρa = Σfluxes(eq_tends(up_ρa{i}(), atmos, tend), atmos, args).* flux_pad
+        up_flx[i].ρaw = Σfluxes(eq_tends(up_ρaw{i}(), atmos, tend), atmos, args).* flux_pad
+        up_flx[i].ρaθ_liq =
+            Σfluxes(eq_tends(up_ρaθ_liq{i}(), atmos, tend), atmos, args).* flux_pad
+        up_flx[i].ρaq_tot =
+            Σfluxes(eq_tends(up_ρaq_tot{i}(), atmos, tend), atmos, args).* flux_pad
+    end
+
     en_flx.ρatke =
         Σfluxes(eq_tends(en_ρatke(), atmos, tend), atmos, args) .* flux_pad
     # in the EDMF second order (diffusive) fluxes

--- a/test/Atmos/EDMF/edmf_model.jl
+++ b/test/Atmos/EDMF/edmf_model.jl
@@ -114,6 +114,8 @@ Constructor for `SurfaceModel` for EDMF, given:
 """
 function SurfaceModel{FT}(N_up;) where {FT}
     a_surf::FT = 0.1
+    "exponential decay rate for surface upd diffusivity"
+    α_surf::FT = 5e-2
 
     surface_scalar_coeff = SVector(
         ntuple(N_up) do i


### PR DESCRIPTION
### Description
This draft PR adds updraft diffusion with an exponentially decaying diffusivity 
K=exp(-αz); the goal is for this diffusivity to transport vertically the updraft buoyancy from the first to the second level while having w=0 at the first model level. Currently it does not work in bomex, as the results without Smagorinsky are very bad. I would ask your opinion on why is it the case 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
