### PR TITLE
Relax acceptable MSE condition

### DIFF
--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -25,7 +25,7 @@ best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0208723977818579e+00
 best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0782418080562499e+01
 #! format: on
 
-sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + eps()
+sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + sqrt(eps())
 
 function test_mse(computed_mse, best_mse, key)
     mse_not_regressed = sufficient_mse(computed_mse[key], best_mse[key])


### PR DESCRIPTION
### Description

Relaxes the MSE condition for Bomex. The requirement is now that the percentage change in MSE from best to computed is lower than +sqrt(eps).

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
