### PR TITLE
Add single stack diagnostics, replace dons in some experiments

### DIFF
--- a/docs/src/APIs/Utilities/SingleStackUtils.md
+++ b/docs/src/APIs/Utilities/SingleStackUtils.md
@@ -16,4 +16,5 @@ reduce_element_stack
 horizontally_average!
 dict_of_nodal_states
 NodalStack
+single_stack_diagnostics
 ```

--- a/docs/src/APIs/Utilities/VariableTemplates.md
+++ b/docs/src/APIs/Utilities/VariableTemplates.md
@@ -18,6 +18,7 @@ Vars
 vuntuple
 unroll_map
 flattened_tup_chain
+flattened_named_tuple
 varsize
 varsindices
 varsindex

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -125,6 +125,7 @@ struct DriverConfiguration{FT}
 end
 
 function print_model_info(model)
+    @show ClimateMachine.array_type()
     msg = "Model composition\n"
     for key in fieldnames(typeof(model))
         msg =

--- a/src/Driver/solver_config_wrappers.jl
+++ b/src/Driver/solver_config_wrappers.jl
@@ -1,0 +1,26 @@
+import ..SingleStackUtils: single_stack_diagnostics, NodalStack
+using ..ODESolvers
+
+# Convenience wrapper
+single_stack_diagnostics(solver_config; kwargs...) = single_stack_diagnostics(
+    solver_config.dg.grid,
+    solver_config.dg.balance_law,
+    gettime(solver_config.solver),
+    solver_config.dg.direction;
+    prognostic = solver_config.Q,
+    auxiliary = solver_config.dg.state_auxiliary,
+    diffusive = solver_config.dg.state_gradient_flux,
+    hyperdiffusive = solver_config.dg.states_higher_order[2],
+    kwargs...,
+)
+
+# Convenience wrapper
+NodalStack(solver_config; kwargs...) = NodalStack(
+    solver_config.dg.balance_law,
+    solver_config.dg.grid;
+    prognostic = solver_config.Q,
+    auxiliary = solver_config.dg.state_auxiliary,
+    diffusive = solver_config.dg.state_gradient_flux,
+    hyperdiffusive = solver_config.dg.states_higher_order[2],
+    kwargs...,
+)

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -293,3 +293,5 @@ function write_debug_init_vtk_and_pvtu(
         writepvtu(pvtuprefix, prefixes, state_names, eltype(state))
     end
 end
+
+include("solver_config_wrappers.jl")

--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -8,7 +8,8 @@ export get_vars_from_nodal_stack,
     reduce_element_stack,
     horizontally_average!,
     dict_of_nodal_states,
-    NodalStack
+    NodalStack,
+    single_stack_diagnostics
 
 using OrderedCollections
 using UnPack
@@ -525,11 +526,11 @@ struct NodalStack{N, BL, G, S, VR, TI, TJ, CI, IN}
     interp::IN
     function NodalStack(
         bl::BalanceLaw,
-        grid::DiscontinuousSpectralElementGrid,
+        grid::DiscontinuousSpectralElementGrid;
         prognostic,
         auxiliary,
         diffusive,
-        hyperdiffusive;
+        hyperdiffusive,
         i = 1,
         j = 1,
         interp = true,
@@ -555,17 +556,6 @@ struct NodalStack{N, BL, G, S, VR, TI, TJ, CI, IN}
         new{len, BL, G, S, VR, TI, TJ, CI, IN}(args...)
     end
 end
-
-# Convenience wrapper
-NodalStack(solver_config; kwargs...) = NodalStack(
-    solver_config.dg.balance_law,
-    solver_config.dg.grid,
-    solver_config.Q,
-    solver_config.dg.state_auxiliary,
-    solver_config.dg.state_gradient_flux,
-    solver_config.dg.states_higher_order[2];
-    kwargs...,
-)
 
 Base.length(gs::NodalStack{N}) where {N} = N
 
@@ -698,5 +688,7 @@ function Base.iterate(gs::NodalStack, iter_state = 1)
         return ((; prog, aux, ∇flux, hyperdiff), iter_state⁺)
     end
 end
+
+include("single_stack_diagnostics.jl")
 
 end # module

--- a/src/Utilities/SingleStackUtils/single_stack_diagnostics.jl
+++ b/src/Utilities/SingleStackUtils/single_stack_diagnostics.jl
@@ -1,0 +1,84 @@
+using ..Orientations
+
+"""
+    single_stack_diagnostics(
+        grid::DiscontinuousSpectralElementGrid,
+        bl::BalanceLaw,
+        t::Real,
+        direction;
+        kwargs...,
+    )
+
+# Arguments
+ - `grid` the grid
+ - `bl` the balance law
+ - `t` time
+ - `direction` direction
+ - `kwargs` keyword arguments, passed to [`NodalStack`](@ref).
+
+An array of nested NamedTuples, containing results of
+ - `z` - altitude
+ - `prog` - the prognostic state
+ - `aux` - the auxiliary state
+ - `∇flux` - the gradient-flux (diffusive) state
+ - `hyperdiff` - the hyperdiffusive state
+
+and all the nested NamedTuples, merged together,
+from the `precompute` methods.
+"""
+function single_stack_diagnostics(
+    grid::DiscontinuousSpectralElementGrid,
+    bl::BalanceLaw,
+    t::Real,
+    direction;
+    kwargs...,
+)
+    return [
+        begin
+            @unpack prog, aux, ∇flux, hyperdiff = local_states
+            diffusive = ∇flux
+            state = prog
+            hyperdiffusive = hyperdiff
+
+            _args_fx1 = (; state, aux, t, direction)
+            _args_fx2 = (; state, aux, t, diffusive, hyperdiffusive)
+            _args_src = (; state, aux, t, direction, diffusive)
+
+            cache_fx1 = precompute(bl, _args_fx1, Flux{FirstOrder}())
+            cache_fx2 = precompute(bl, _args_fx2, Flux{SecondOrder}())
+            cache_src = precompute(bl, _args_src, Source())
+
+            # cache_fx1, cache_fx2, and cache_src have overlapping
+            # data, only need one copy, so merge:
+            cache = merge(cache_fx1, cache_fx2, cache_src)
+
+            z = altitude(bl, aux)
+
+            # TODO: Use flatten_named_tuple = true, and flatten arrays
+            flatten_named_tuple = false
+            if flatten_named_tuple
+                nt = (;
+                    z = altitude(bl, aux),
+                    prog = flattened_named_tuple(prog), # Vars -> flattened NamedTuples
+                    aux = flattened_named_tuple(aux), # Vars -> flattened NamedTuples
+                    ∇flux = flattened_named_tuple(∇flux), # Vars -> flattened NamedTuples
+                    hyperdiff = flattened_named_tuple(hyperdiff), # Vars -> flattened NamedTuples
+                    cache = cache,
+                )
+                # Flatten top level:
+                flattened_named_tuple(nt)
+            else
+                nt = (;
+                    z = altitude(bl, aux),
+                    prog = prog,
+                    aux = aux,
+                    ∇flux = ∇flux,
+                    hyperdiff = hyperdiff,
+                    cache = cache,
+                )
+                nt
+            end
+            nt
+        end for local_states in NodalStack(bl, grid; kwargs...)
+    ]
+end

--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -119,7 +119,6 @@ varsize(::Type{NamedTuple{(), Tuple{}}}) = 0
 varsize(::Type{SArray{S, T, N} where L}) where {S, T, N} = prod(S.parameters)
 
 include("var_names.jl")
-include("flattened_tup_chain.jl")
 
 # TODO: should be possible to get rid of @generated
 @generated function varsize(::Type{S}) where {S}
@@ -456,5 +455,7 @@ Base.@propagate_inbounds function Base.getindex(
         return Base.getproperty(p, tup_chain[2:end])
     end
 end
+
+include("flattened_tup_chain.jl")
 
 end # module

--- a/src/Utilities/VariableTemplates/flattened_tup_chain.jl
+++ b/src/Utilities/VariableTemplates/flattened_tup_chain.jl
@@ -1,4 +1,4 @@
-export flattened_tup_chain
+export flattened_tup_chain, flattened_named_tuple
 
 flattened_tup_chain(::Type{NamedTuple{(), Tuple{}}}; prefix = (Symbol(),)) = ()
 flattened_tup_chain(::Type{T}; prefix = (Symbol(),)) where {T <: Real} =
@@ -9,6 +9,7 @@ flattened_tup_chain(
     ::Type{T};
     prefix = (Symbol(),),
 ) where {T <: SHermitianCompact} = (prefix,)
+flattened_tup_chain(::Type{T}; prefix = (Symbol(),)) where {T} = (prefix,)
 
 """
     flattened_tup_chain(::Type{T}) where {T <: Union{NamedTuple,NTuple}}
@@ -33,3 +34,53 @@ function flattened_tup_chain(
     Iterators.flatten |>
     collect
 end
+flattened_tup_chain(::AbstractVars{S}) where {S} = flattened_tup_chain(S)
+
+"""
+    flattened_named_tuple(v::AbstractVars)
+
+A flattened NamedTuple, given a `Vars` instance.
+
+# Example:
+
+```julia
+using Test
+using ClimateMachine.VariableTemplates
+nt = (x = 1, a = (y = 2, z = 3, b = ((a = 1,), (a = 2,), (a = 3,))));
+fnt = flattened_named_tuple(nt);
+@test keys(fnt) == (:x, :a_y, :a_z, :a_b_1_a, :a_b_2_a, :a_b_3_a)
+@test length(fnt) == 6
+@test fnt.x == 1
+@test fnt.a_y == 2
+@test fnt.a_z == 3
+@test fnt.a_b_1_a == 1
+@test fnt.a_b_2_a == 2
+@test fnt.a_b_3_a == 3
+```
+"""
+function flattened_named_tuple end
+
+function flattened_named_tuple(v::AbstractVars)
+    ftc = flattened_tup_chain(v)
+    keys_ = Symbol.(join.(ftc, :_))
+    vals = map(x -> getproperty(v, x), ftc)
+    return (; zip(keys_, vals)...)
+end
+flattened_named_tuple(v::Nothing) = NamedTuple()
+
+function flattened_named_tuple(nt::NamedTuple)
+    ftc = flattened_tup_chain(typeof(nt))
+    keys_ = Symbol.(join.(ftc, :_))
+    vals = flattened_nt_vals(nt)
+    return (; zip(keys_, vals)...)
+end
+
+flattened_nt_vals(a::NamedTuple) = flattened_nt_vals(Tuple(a))
+flattened_nt_vals(a::NamedTuple{(), Tuple{}}) = (nothing,)
+flattened_nt_vals(a) = (a,)
+flattened_nt_vals(a::NamedTuple, b...) =
+    tuple(flattened_nt_vals(a)..., flattened_nt_vals(b...)...)
+flattened_nt_vals(a::NamedTuple{(), Tuple{}}, b...) =
+    tuple(nothing, flattened_nt_vals(b...)...)
+flattened_nt_vals(a, b...) = tuple(values(a), flattened_nt_vals(b...)...)
+flattened_nt_vals(x::Tuple) = flattened_nt_vals(x...)

--- a/test/Atmos/EDMF/bomex_edmf.jl
+++ b/test/Atmos/EDMF/bomex_edmf.jl
@@ -4,7 +4,6 @@ ClimateMachine.init(;
     output_dir = get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", "output"),
     fix_rng_seed = true,
 )
-@show ClimateMachine.array_type()
 using ClimateMachine.SingleStackUtils
 using ClimateMachine.Checkpoint
 using ClimateMachine.DGMethods
@@ -12,6 +11,7 @@ using ClimateMachine.SystemSolvers
 import ClimateMachine.DGMethods: custom_filter!
 using ClimateMachine.Mesh.Filters: apply!
 using ClimateMachine.BalanceLaws: vars_state
+using JLD2, FileIO
 const clima_dir = dirname(dirname(pathof(ClimateMachine)));
 
 include(joinpath(clima_dir, "experiments", "AtmosLES", "bomex_model.jl"))
@@ -201,9 +201,7 @@ function main(::Type{FT}) where {FT}
         nothing
     end
 
-    # state_types = (Prognostic(), Auxiliary(), GradientFlux())
-    state_types = (Prognostic(), Auxiliary())
-    dons_arr = [dict_of_nodal_states(solver_config, state_types; interp = true)]
+    diag_arr = [single_stack_diagnostics(solver_config)]
     time_data = FT[0]
 
     # Define the number of outputs from `t0` to `timeend`
@@ -213,10 +211,13 @@ function main(::Type{FT}) where {FT}
 
     cb_data_vs_time =
         GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
-            push!(
-                dons_arr,
-                dict_of_nodal_states(solver_config, state_types; interp = true),
-            )
+            diag_vs_z = single_stack_diagnostics(solver_config)
+
+            nstep = getsteps(solver_config.solver)
+            # Save to disc (for debugging):
+            # @save "bomex_edmf_nstep=$nstep.jld2" diag_vs_z
+
+            push!(diag_arr, diag_vs_z)
             push!(time_data, gettime(solver_config.solver))
             nothing
         end
@@ -239,13 +240,15 @@ function main(::Type{FT}) where {FT}
         check_euclidean_distance = true,
     )
 
-    dons = dict_of_nodal_states(solver_config, state_types; interp = true)
-    push!(dons_arr, dons)
+    diag_vs_z = single_stack_diagnostics(solver_config)
+    push!(diag_arr, diag_vs_z)
     push!(time_data, gettime(solver_config.solver))
 
-    return solver_config, dons_arr, time_data, state_types
+    return solver_config, diag_arr, time_data
 end
 
-solver_config, dons_arr, time_data, state_types = main(Float64)
+solver_config, diag_arr, time_data = main(Float64)
 
 include(joinpath(@__DIR__, "report_mse_bomex.jl"))
+
+nothing

--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -33,6 +33,24 @@ function test_mse(computed_mse, best_mse, key)
     mse_not_regressed || @show key
 end
 
+#! format: off
+dons(diag_vs_z) = Dict(
+    "z" => [ca.z for ca in diag_vs_z],
+    "ρ" => [ca.prog.ρ for ca in diag_vs_z],
+    "ρu[1]" => [ca.prog.ρu[1] for ca in diag_vs_z],
+    "moisture.ρq_tot" => [ca.prog.moisture.ρq_tot for ca in diag_vs_z],
+    "turbconv.updraft[1].ρa" => [ca.prog.turbconv.updraft[1].ρa for ca in diag_vs_z],
+    "turbconv.updraft[1].ρaw" => [ca.prog.turbconv.updraft[1].ρaw for ca in diag_vs_z],
+    "turbconv.updraft[1].ρaθ_liq" => [ca.prog.turbconv.updraft[1].ρaθ_liq for ca in diag_vs_z],
+    "turbconv.updraft[1].ρaq_tot" => [ca.prog.turbconv.updraft[1].ρaq_tot for ca in diag_vs_z],
+    "turbconv.environment.ρatke" => [ca.prog.turbconv.environment.ρatke for ca in diag_vs_z],
+    "turbconv.environment.ρaθ_liq_cv" => [ca.prog.turbconv.environment.ρaθ_liq_cv for ca in diag_vs_z],
+    "turbconv.environment.ρaq_tot_cv" => [ca.prog.turbconv.environment.ρaq_tot_cv for ca in diag_vs_z],
+)
+#! format: on
+
+dons_arr = [dons(diag_vs_z) for diag_vs_z in diag_arr]
+
 computed_mse = Dict(
     k => compute_mse(
         solver_config.dg.grid,

--- a/test/Atmos/EDMF/stable_bl_edmf.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf.jl
@@ -1,5 +1,4 @@
-# using FileIO
-# using JLD2
+using JLD2, FileIO
 using ClimateMachine
 ClimateMachine.init(;
     parse_clargs = true,
@@ -185,23 +184,7 @@ function main(::Type{FT}) where {FT}
         nothing
     end
 
-    # State variable
-    Q = solver_config.Q
-    # Volume geometry information
-    vgeo = driver_config.grid.vgeo
-    M = vgeo[:, Grids._M, :]
-    # Unpack prognostic vars
-    ρ₀ = Q.ρ
-    ρe₀ = Q.ρe
-    # DG variable sums
-    Σρ₀ = sum(ρ₀ .* M)
-    Σρe₀ = sum(ρe₀ .* M)
-
-    grid = driver_config.grid
-
-    # state_types = (Prognostic(), Auxiliary(), GradientFlux())
-    state_types = (Prognostic(), Auxiliary(), GradientFlux())
-    dons_arr = [dict_of_nodal_states(solver_config, state_types; interp = true)]
+    diag_arr = [single_stack_diagnostics(solver_config)]
     time_data = FT[0]
 
     # Define the number of outputs from `t0` to `timeend`
@@ -211,24 +194,21 @@ function main(::Type{FT}) where {FT}
 
     cb_data_vs_time =
         GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
-            push!(
-                dons_arr,
-                dict_of_nodal_states(solver_config, state_types; interp = true),
-            )
+            diag_vs_z = single_stack_diagnostics(solver_config)
+
+            nstep = getsteps(solver_config.solver)
+            # Save to disc (for debugging):
+            # @save "bomex_edmf_nstep=$nstep.jld2" diag_vs_z
+
+            push!(diag_arr, diag_vs_z)
             push!(time_data, gettime(solver_config.solver))
             nothing
         end
 
-    cb_check_cons = GenericCallbacks.EveryXSimulationSteps(3000) do
-        Q = solver_config.Q
-        δρ = (sum(Q.ρ .* M) - Σρ₀) / Σρ₀
-        δρe = (sum(Q.ρe .* M) .- Σρe₀) ./ Σρe₀
-        @show (abs(δρ))
-        @show (abs(δρe))
-        @test (abs(δρ) <= 0.001)
-        @test (abs(δρe) <= 0.1)
-        nothing
-    end
+    check_cons = (
+        ClimateMachine.ConservationCheck("ρ", "3000steps", FT(0.001)),
+        ClimateMachine.ConservationCheck("ρe", "3000steps", FT(0.1)),
+    )
 
     cb_print_step = GenericCallbacks.EveryXSimulationSteps(100) do
         @show getsteps(solver_config.solver)
@@ -238,23 +218,19 @@ function main(::Type{FT}) where {FT}
     result = ClimateMachine.invoke!(
         solver_config;
         diagnostics_config = dgn_config,
-        user_callbacks = (
-            cbtmarfilter,
-            cb_check_cons,
-            cb_data_vs_time,
-            cb_print_step,
-        ),
+        check_cons = check_cons,
+        user_callbacks = (cbtmarfilter, cb_data_vs_time, cb_print_step),
         check_euclidean_distance = true,
     )
 
-    dons = dict_of_nodal_states(solver_config, state_types; interp = true)
-    push!(dons_arr, dons)
+    diag_vs_z = single_stack_diagnostics(solver_config)
+    push!(diag_arr, diag_vs_z)
     push!(time_data, gettime(solver_config.solver))
 
-    return solver_config, dons_arr, time_data, state_types
+    return solver_config, diag_arr, time_data
 end
 
-solver_config, dons_arr, time_data, state_types = main(Float64)
+solver_config, diag_arr, time_data = main(Float64)
 
 ## Uncomment lines to save output using JLD2
 #
@@ -271,3 +247,5 @@ solver_config, dons_arr, time_data, state_types = main(Float64)
 #     "z",
 #     z,
 # )
+
+nothing

--- a/test/Atmos/EDMF/stable_bl_single_stack_implicit.jl
+++ b/test/Atmos/EDMF/stable_bl_single_stack_implicit.jl
@@ -11,6 +11,7 @@ ClimateMachine.init(;
 using ClimateMachine.SingleStackUtils
 using ClimateMachine.Checkpoint
 using ClimateMachine.BalanceLaws: vars_state
+using JLD2, FileIO
 const clima_dir = dirname(dirname(pathof(ClimateMachine)));
 
 include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))
@@ -123,10 +124,10 @@ function main(::Type{FT}) where {FT}
         JacobianFreeNewtonKrylovSolver(Q, linearsolver; tol = 1e-4, ϵ = 1.e-10)
 
     # this is a second order time integrator, to change it to a first order time integrator
-    # change it ARK1ForwardBackwardEuler, which can reduce the cost by half at the cost of accuracy 
+    # change it ARK1ForwardBackwardEuler, which can reduce the cost by half at the cost of accuracy
     # and stability
-    # preconditioner_update_freq = 50 means updating the preconditioner every 50 Newton solves, 
-    # update it more freqent will accelerate the convergence of linear solves, but updating it 
+    # preconditioner_update_freq = 50 means updating the preconditioner every 50 Newton solves,
+    # update it more freqent will accelerate the convergence of linear solves, but updating it
     # is very expensive
     ode_solver = ARK2ImplicitExplicitMidpoint(
         dg,
@@ -179,19 +180,7 @@ function main(::Type{FT}) where {FT}
         nothing
     end
 
-    # State variable
-    Q = solver_config.Q
-    # Compute total mass and total energy
-    ρ_idx = varsindices(vars_state(dg.balance_law, Prognostic(), FT), "ρ")
-    ρe_idx = varsindices(vars_state(dg.balance_law, Prognostic(), FT), "ρe")
-    Σρ₀ = weightedsum(Q, ρ_idx)
-    Σρe₀ = weightedsum(Q, ρe_idx)
-
-    grid = driver_config.grid
-
-    # state_types = (Prognostic(), Auxiliary(), GradientFlux())
-    state_types = (Prognostic(), Auxiliary())
-    dons_arr = [dict_of_nodal_states(solver_config, state_types; interp = true)]
+    diag_arr = [single_stack_diagnostics(solver_config)]
     time_data = FT[0]
 
     # Define the number of outputs from `t0` to `timeend`
@@ -201,24 +190,21 @@ function main(::Type{FT}) where {FT}
 
     cb_data_vs_time =
         GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
-            push!(
-                dons_arr,
-                dict_of_nodal_states(solver_config, state_types; interp = true),
-            )
+            diag_vs_z = single_stack_diagnostics(solver_config)
+
+            nstep = getsteps(solver_config.solver)
+            # Save to disc (for debugging):
+            # @save "bomex_edmf_nstep=$nstep.jld2" diag_vs_z
+
+            push!(diag_arr, diag_vs_z)
             push!(time_data, gettime(solver_config.solver))
             nothing
         end
 
-    cb_check_cons = GenericCallbacks.EveryXSimulationSteps(3000) do
-        Q = solver_config.Q
-        δρ = (weightedsum(Q, ρ_idx) - Σρ₀) / Σρ₀
-        δρe = (weightedsum(Q, ρe_idx) .- Σρe₀) ./ Σρe₀
-        @show (abs(δρ))
-        @show (abs(δρe))
-        @test (abs(δρ) <= 0.001)
-        @test (abs(δρe) <= 0.1)
-        nothing
-    end
+    check_cons = (
+        ClimateMachine.ConservationCheck("ρ", "3000steps", FT(0.001)),
+        ClimateMachine.ConservationCheck("ρe", "3000steps", FT(0.1)),
+    )
 
     cb_print_step = GenericCallbacks.EveryXSimulationSteps(100) do
         @show getsteps(solver_config.solver)
@@ -228,20 +214,18 @@ function main(::Type{FT}) where {FT}
     result = ClimateMachine.invoke!(
         solver_config;
         diagnostics_config = dgn_config,
-        user_callbacks = (
-            cbtmarfilter,
-            cb_check_cons,
-            cb_data_vs_time,
-            cb_print_step,
-        ),
+        check_cons = check_cons,
+        user_callbacks = (cbtmarfilter, cb_data_vs_time, cb_print_step),
         check_euclidean_distance = true,
     )
 
-    dons = dict_of_nodal_states(solver_config, state_types; interp = true)
-    push!(dons_arr, dons)
+    diag_vs_z = single_stack_diagnostics(solver_config)
+    push!(diag_arr, diag_vs_z)
     push!(time_data, gettime(solver_config.solver))
 
-    return solver_config, dons_arr, time_data, state_types
+    return solver_config, diag_arr, time_data
 end
 
-solver_config, dons_arr, time_data, state_types = main(Float64)
+solver_config, diag_arr, time_data = main(Float64)
+
+nothing

--- a/test/Utilities/VariableTemplates/test_complex_models.jl
+++ b/test/Utilities/VariableTemplates/test_complex_models.jl
@@ -139,4 +139,19 @@ using ClimateMachine.VariableTemplates: wrap_val
               getproperty(v, (:ntuple_model, unval(i), :scalar_model, :x))
     end
 
+    # Test converting to flattened NamedTuple
+    fnt = flattened_named_tuple(v)
+    @test fnt.ntuple_model_1_scalar_model_x == 1.0f0
+    @test fnt.ntuple_model_1_vector_model_x == Float32[2.0, 3.0, 4.0]
+    @test fnt.ntuple_model_2_scalar_model_x == 5.0f0
+    @test fnt.ntuple_model_2_vector_model_x == Float32[6.0, 7.0, 8.0]
+    @test fnt.ntuple_model_3_scalar_model_x == 9.0f0
+    @test fnt.ntuple_model_3_vector_model_x == Float32[10.0, 11.0, 12.0]
+    @test fnt.ntuple_model_4_scalar_model_x == 13.0f0
+    @test fnt.ntuple_model_4_vector_model_x == Float32[14.0, 15.0, 16.0]
+    @test fnt.ntuple_model_5_scalar_model_x == 17.0f0
+    @test fnt.ntuple_model_5_vector_model_x == Float32[18.0, 19.0, 20.0]
+    @test fnt.vector_model_x == Float32[21.0, 22.0, 23.0]
+    @test fnt.scalar_model_x == 24.0f0
+
 end


### PR DESCRIPTION
### Description

This PR adds `single_stack_diagnostics`, which returns an array of entries. Unlike `dict_of_nodal_states`, which returns a dictionary of arrays, `single_stack_diagnostics` returns an array of (basically) dictionaries. This may not be super-performant, but allows us to contain all of the `Vars` instances in each entry, so that we can compute and also include all quantities returned from, for example, `precompute()`--which we hope to be helpful for debugging. The other advantage of adding this is that we'll be able to (in the single stack configurations, at least) stop using aux for diagnostics, which results in global memory reads, and performs unnecessary computations at each RHS evaluation.

A next step might be splitting `precompute` (in `BalanceLaws`) into `precompute` and `diagnostics`. `precompute` can compute all quantities needed to solve the system of equations, and `diagnostics` (which can work in exactly the same way), can compute additional diagnostics quantities.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
