### PR TITLE
Move random perturbations to LES experiment files

### DIFF
--- a/experiments/AtmosLES/bomex_les.jl
+++ b/experiments/AtmosLES/bomex_les.jl
@@ -1,4 +1,14 @@
+using Random
 include("bomex_model.jl")
+
+function add_perturbations!(state, localgeo)
+    FT = eltype(state)
+    z = localgeo.coord[3]
+    if z <= FT(400) # Add random perturbations to bottom 400m of model
+        state.ρe += (rand() - 0.5) * state.ρe / 100
+        state.moisture.ρq_tot += (rand() - 0.5) * state.moisture.ρq_tot / 100
+    end
+end
 
 function main()
     # add a command line argument to specify the kind of surface flux

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -30,7 +30,6 @@ using Distributions
 using DocStringExtensions
 using LinearAlgebra
 using Printf
-using Random
 using StaticArrays
 using Test
 
@@ -250,6 +249,8 @@ function source(s::BomexTendencies{TotalMoisture}, m, args)
     return ρ∂qt∂t - state.ρ * w_s * dot(k̂, diffusive.moisture.∇q_tot)
 end
 
+add_perturbations!(state, localgeo) = nothing
+
 """
   Initial Condition for BOMEX LES
 """
@@ -343,10 +344,7 @@ function init_bomex!(problem, bl, state, aux, localgeo, t)
         state.moisture.ρq_ice = FT(0)
     end
 
-    if z <= FT(400) # Add random perturbations to bottom 400m of model
-        state.ρe += rand() * ρe_tot / 100
-        state.moisture.ρq_tot += rand() * ρ * q_tot / 100
-    end
+    add_perturbations!(state, localgeo)
     init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
 end
 

--- a/experiments/AtmosLES/stable_bl_les.jl
+++ b/experiments/AtmosLES/stable_bl_les.jl
@@ -1,4 +1,13 @@
+using Random
 include("stable_bl_model.jl")
+
+function add_perturbations!(state, localgeo)
+    FT = eltype(state)
+    z = localgeo.coord[3]
+    if z <= FT(50) # Add random perturbations to bottom 50m of model
+        state.ρe += (rand() - 0.5) * state.ρe / 100
+    end
+end
 
 function main()
 

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -13,7 +13,6 @@
 
 using ArgParse
 using Distributions
-using Random
 using StaticArrays
 using Test
 using DocStringExtensions
@@ -117,6 +116,8 @@ function source(s::StableBLSponge{Momentum}, m, args)
     end
 end
 
+add_perturbations!(state, localgeo) = nothing
+
 """
   Initial Condition for StableBoundaryLayer LES
 """
@@ -170,9 +171,7 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     if !(bl.moisture isa DryModel)
         state.moisture.ρq_tot = ρ * q_tot
     end
-    if z <= FT(50) # Add random perturbations to bottom 50m of model
-        state.ρe += rand() * ρe_tot / 100
-    end
+    add_perturbations!(state, localgeo)
     init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
 end
 

--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -12,17 +12,17 @@ include(joinpath(@__DIR__, "compute_mse.jl"))
 #! format: off
 best_mse = Dict()
 best_mse[:Bomex] = Dict()
-best_mse[:Bomex]["ρ"] = 3.4943021267397123e-02
-best_mse[:Bomex]["ρu[1]"] = 3.0714039084256679e+03
-best_mse[:Bomex]["ρu[2]"] = 1.3375796498101822e-03
-best_mse[:Bomex]["moisture.ρq_tot"] = 4.8463531712319707e-02
-best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.1572840541674498e+02
-best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5666903275492686e+01
-best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6436084624020341e+02
-best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 8.0001172665962883e+01
-best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4920000484896258e-02
-best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0208723977818579e+00
-best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0782418080562499e+01
+best_mse[:Bomex]["ρ"] = 3.4917543567416755e-02
+best_mse[:Bomex]["ρu[1]"] = 3.0715061616086027e+03
+best_mse[:Bomex]["ρu[2]"] = 1.2895273328644972e-03
+best_mse[:Bomex]["moisture.ρq_tot"] = 4.1330591681441348e-02
+best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.6415719930880925e+02
+best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5667223192888514e+01
+best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6435555167634794e+02
+best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9564915645201182e+01
+best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4288782126742318e-02
+best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0095910670762631e+00
+best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0768554319447651e+01
 #! format: on
 
 sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + sqrt(eps())


### PR DESCRIPTION
### Description

The random perturbations needed to break symmetry are moved to the LES experiment files, the only case when they are needed. Furthermore, the random perturbations are now centered around zero.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
