### PR TITLE
Move turbconv fields from aux to cache

### DIFF
--- a/test/Atmos/EDMF/closures/entr_detr.jl
+++ b/test/Atmos/EDMF/closures/entr_detr.jl
@@ -7,9 +7,10 @@ function entr_detr(
     ts_up,
     ts_en,
     env,
+    buoy,
 ) where {FT}
     EΔ_up = ntuple(n_updrafts(bl.turbconv)) do i
-        entr_detr(bl, bl.turbconv.entr_detr, state, aux, ts_up, ts_en, env, i)
+        entr_detr(bl, bl.turbconv.entr_detr, state, aux, ts_up, ts_en, env, buoy, i)
     end
     E_dyn, Δ_dyn, E_trb = ntuple(i -> map(x -> x[i], EΔ_up), 3)
     return E_dyn, Δ_dyn, E_trb
@@ -24,6 +25,7 @@ end
         ts_up,
         ts_en,
         env,
+        buoy,
         i,
     ) where {FT}
 
@@ -37,6 +39,7 @@ Cohen et al. (JAMES, 2020), given:
  - `ts_up`, updraft thermodynamic states
  - `ts_en`, environment thermodynamic states
  - `env`, NamedTuple of environment variables
+ - `buoy`, NamedTuple of environment and updraft buoyancies
  - `i`, index of the updraft
 """
 function entr_detr(
@@ -47,6 +50,7 @@ function entr_detr(
     ts_up,
     ts_en,
     env,
+    buoy,
     i,
 ) where {FT}
 
@@ -69,7 +73,7 @@ function entr_detr(
     # ensure far from zero
     Δw = filter_w(w_up_i - env.w, w_min)
     w_up_i = filter_w(w_up_i, w_min)
-    Δb = up_aux[i].buoyancy - en_aux.buoyancy
+    Δb = buoy.up[i] - buoy.en
     D_E, D_δ, M_δ, M_E = nondimensional_exchange_functions(
         m,
         entr,
@@ -78,6 +82,7 @@ function entr_detr(
         ts_up,
         ts_en,
         env,
+        buoy,
         i,
     )
 

--- a/test/Atmos/EDMF/closures/pressure.jl
+++ b/test/Atmos/EDMF/closures/pressure.jl
@@ -1,8 +1,8 @@
 #### Pressure model kernels
 
-function perturbation_pressure(bl::AtmosModel{FT}, args, env) where {FT}
+function perturbation_pressure(bl::AtmosModel{FT}, args, env, buoy) where {FT}
     dpdz = ntuple(n_updrafts(bl.turbconv)) do i
-        perturbation_pressure(bl, bl.turbconv.pressure, args, env, i)
+        perturbation_pressure(bl, bl.turbconv.pressure, args, env, buoy, i)
     end
     return dpdz
 end
@@ -13,6 +13,7 @@ end
         press::PressureModel,
         args,
         env,
+        buoy,
         i,
     ) where {FT}
 
@@ -23,6 +24,7 @@ for updraft i following He et al. (JAMES, 2020), given:
  - `press`, a `PressureModel`
  - `args`, top-level arguments
  - `env`, NamedTuple of environment variables
+ - `buoy`, NamedTuple of environment and updraft buoyancies
  - `i`, index of the updraft
 """
 function perturbation_pressure(
@@ -30,6 +32,7 @@ function perturbation_pressure(
     press::PressureModel,
     args,
     env,
+    buoy,
     i,
 ) where {FT}
     @unpack state, diffusive, aux = args
@@ -40,7 +43,7 @@ function perturbation_pressure(
 
     w_up_i = fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)
 
-    nh_press_buoy = press.α_b * up_aux[i].buoyancy
+    nh_press_buoy = press.α_b * buoy.up[i]
     nh_pressure_adv = -press.α_a * w_up_i * up_dif[i].∇w[3]
     nh_pressure_drag =
         press.α_d * (w_up_i - env.w) * abs(w_up_i - env.w) / press.H_up

--- a/test/Atmos/EDMF/helper_funcs/diagnose_environment.jl
+++ b/test/Atmos/EDMF/helper_funcs/diagnose_environment.jl
@@ -1,72 +1,55 @@
 #### Diagnose environment variables
 
 """
-    environment_vars(state::Vars, aux::Vars, N_up::Int)
+    environment_vars(state::Vars, N_up::Int)
 
 A NamedTuple of environment variables
 """
-function environment_vars(state::Vars, aux::Vars, N_up::Int)
-    return (
-        a = environment_area(state, aux, N_up),
-        w = environment_w(state, aux, N_up),
-    )
+function environment_vars(state::Vars, N_up::Int)
+    return (a = environment_area(state, N_up), w = environment_w(state, N_up))
 end
 
 """
     environment_area(
         state::Vars,
-        aux::Vars,
         N_up::Int,
     )
 
 Returns the environmental area fraction, given:
  - `state`, state variables
- - `aux`, auxiliary variables
  - `N_up`, number of updrafts
 """
-function environment_area(state::Vars, aux::Vars, N_up::Int)
+function environment_area(state::Vars, N_up::Int)
     up = state.turbconv.updraft
     return 1 - sum(vuntuple(i -> up[i].ρa, N_up)) / state.ρ
 end
 
 """
-    environment_w(
-        state::Vars,
-        aux::Vars,
-        N_up::Int,
-    )
+    environment_w(state::Vars, N_up::Int)
 
 Returns the environmental vertical velocity, given:
  - `state`, state variables
- - `aux`, auxiliary variables
  - `N_up`, number of updrafts
 """
-function environment_w(state::Vars, aux::Vars, N_up::Int)
+function environment_w(state::Vars, N_up::Int)
     ρ_inv = 1 / state.ρ
-    a_en = environment_area(state, aux, N_up)
+    a_en = environment_area(state, N_up)
     up = state.turbconv.updraft
     return (state.ρu[3] - sum(vuntuple(i -> up[i].ρaw, N_up))) / a_en * ρ_inv
 end
 
 """
-    grid_mean_b(
-        state::Vars,
-        aux::Vars,
-        N_up::Int,
-    )
+    grid_mean_b(env, a_up, N_up::Int, buoyancy_up, buoyancy_en)
 
 Returns the grid-mean buoyancy with respect to the
 reference state, given:
- - `state`, state variables
- - `aux`, auxiliary variables
+ - `env`, environment variables
+ - `a_up`, updraft area fractions
  - `N_up`, number of updrafts
+ - `buoyancy_up`, updraft buoyancies
+ - `buoyancy_en`, environment buoyancy
 """
-function grid_mean_b(state::Vars, aux::Vars, N_up::Int)
-    ρ_inv = 1 / state.ρ
-    a_en = environment_area(state, aux, N_up)
-    up = state.turbconv.updraft
-    en_aux = aux.turbconv.environment
-    up_aux = aux.turbconv.updraft
-    up_buoy = sum(vuntuple(i -> up_aux[i].buoyancy * up[i].ρa * ρ_inv, N_up))
-    return a_en * en_aux.buoyancy + up_buoy
+function grid_mean_b(env, a_up, N_up::Int, buoyancy_up, buoyancy_en)
+    ∑abuoyancy_up = sum(vuntuple(i -> buoyancy_up[i] * a_up[i], N_up))
+    return env.a * buoyancy_en + ∑abuoyancy_up
 end

--- a/test/Atmos/EDMF/helper_funcs/nondimensional_exchange_functions.jl
+++ b/test/Atmos/EDMF/helper_funcs/nondimensional_exchange_functions.jl
@@ -8,6 +8,7 @@
         ts_up,
         ts_en,
         env,
+        buoy,
         i,
     ) where {FT}
 
@@ -20,6 +21,7 @@ functions following Cohen et al. (JAMES, 2020), given:
  - `ts_up`, updraft thermodynamic states
  - `ts_en`, environment thermodynamic states
  - `env`, NamedTuple of environment variables
+ - `buoy`, NamedTuple of environment and updraft buoyancies
  - `i`, the updraft index
 """
 function nondimensional_exchange_functions(
@@ -30,6 +32,7 @@ function nondimensional_exchange_functions(
     ts_up,
     ts_en,
     env,
+    buoy,
     i,
 ) where {FT}
 
@@ -51,7 +54,7 @@ function nondimensional_exchange_functions(
     RH_en = relative_humidity(ts_en)
 
     Δw = filter_w(w_up_i - env.w, w_min)
-    Δb = up_aux[i].buoyancy - en_aux.buoyancy
+    Δb = buoy.up[i] - buoy.en
 
     c_δ = sign(condensate(ts_en) + condensate(ts_up[i])) * entr.c_δ
 

--- a/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
@@ -203,7 +203,7 @@ function new_thermo_state_en(
     ρ_inv = 1 / state.ρ
     p = air_pressure(ts)
     θ_liq = liquid_ice_pottemp(ts)
-    a_en = environment_area(state, aux, N_up)
+    a_en = environment_area(state, N_up)
     θ_liq_en = (θ_liq - sum(vuntuple(j -> up[j].ρaθ_liq * ρ_inv, N_up))) / a_en
     a_min = m.turbconv.subdomains.a_min
     a_max = m.turbconv.subdomains.a_max
@@ -232,7 +232,7 @@ function new_thermo_state_en(
     p = air_pressure(ts)
     θ_liq = liquid_ice_pottemp(ts)
     q_tot = total_specific_humidity(ts)
-    a_en = environment_area(state, aux, N_up)
+    a_en = environment_area(state, N_up)
     θ_liq_en = (θ_liq - sum(vuntuple(j -> up[j].ρaθ_liq * ρ_inv, N_up))) / a_en
     q_tot_en = (q_tot - sum(vuntuple(j -> up[j].ρaq_tot * ρ_inv, N_up))) / a_en
     a_min = m.turbconv.subdomains.a_min
@@ -310,7 +310,7 @@ function recover_thermo_state_en(
     T_en = aux.turbconv.environment.T
     ρ_inv = 1 / state.ρ
     q_tot = total_specific_humidity(ts)
-    a_en = environment_area(state, aux, N_up)
+    a_en = environment_area(state, N_up)
     q_tot_en = (q_tot - sum(vuntuple(i -> up[i].ρaq_tot, N_up)) * ρ_inv) / a_en
     ρ_en = air_density(param_set, T_en, p, PhasePartition(q_tot_en))
     q_en = PhasePartition_equil(param_set, T_en, ρ_en, q_tot_en, PhaseEquil)


### PR DESCRIPTION
### Description

This PR removes some turbconv aux fields, and instead computes them in (arbitrarily) the first order flux, so that it will be available in `single_stack_diagnostics`.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
