### PR TITLE
Remove unused AbstractSource

### DIFF
--- a/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
+++ b/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
@@ -146,17 +146,17 @@ function source(s::LargeScaleProcess{TotalMoisture}, m, args)
     return state.ρ * q_tot_tendency
 end
 
-# Large-scale subsidence forcing
 """
-    Subsidence <: AbstractSource
+    LargeScaleSubsidence{PV <: Union{Mass, Energy, TotalMoisture}} <:
+       TendencyDef{Source, PV}
 
-Subsidence tendency, given a vertical velocity at the large scale,
-obtained from the GCM data.
+Large-scale subsidence tendency, given a vertical velocity
+at the large scale, obtained from the GCM data.
 
-    wap = GCM vertical velocity [Pa s⁻¹]. Note the conversion required
+```
+wap = GCM vertical velocity [Pa s⁻¹]. Note the conversion required
+```
 """
-struct SubsidenceTendency <: AbstractSource end
-
 struct LargeScaleSubsidence{PV <: Union{Mass, Energy, TotalMoisture}} <:
        TendencyDef{Source, PV} end
 

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -451,9 +451,6 @@ gravitational_potential(bl, aux) = gravitational_potential(bl.orientation, aux)
 turbulence_tensors(atmos::AtmosModel, args...) =
     turbulence_tensors(atmos.turbulence, atmos, args...)
 
-export AbstractSource
-abstract type AbstractSource end
-
 include("declare_prognostic_vars.jl") # declare prognostic variables
 include("multiphysics_types.jl")      # types for multi-physics tendencies
 include("tendencies_mass.jl")         # specify mass tendencies

--- a/src/Atmos/Model/multiphysics_types.jl
+++ b/src/Atmos/Model/multiphysics_types.jl
@@ -93,7 +93,9 @@ end
 
 export WarmRain_1M
 """
-    WarmRain_1M{FT} <: AbstractSource
+    WarmRain_1M{PV <: Union{Mass, Energy, TotalMoisture, LiquidMoisture, Rain},
+        } <: TendencyDef{Source, PV}
+
 A collection of source/sink terms related to 1-moment warm rain microphysics.
 """
 struct WarmRain_1M{
@@ -155,7 +157,9 @@ end
 
 export RainSnow_1M
 """
-    RainSnow_1M{FT} <: AbstractSource
+    RainSnow_1M{PV <: Union{Mass, Energy, Moisture, Rain, Snow}} <:
+       TendencyDef{Source, PV}
+
 A collection of source/sink terms related to 1-moment rain and snow microphysics
 """
 struct RainSnow_1M{PV <: Union{Mass, Energy, Moisture, Rain, Snow}} <:


### PR DESCRIPTION
### Description

I must have missed removing `AbstractSource` in #1879. This removes it and fixes some doc strings. (`SubsidenceTendency` is also removed as it is unused.)

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
