### PR TITLE
Use better thermo constructor call

### DIFF
--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -114,15 +114,16 @@ function ref_state_finalize_init!(
 
     # Update temperature to be exactly consistent with
     # p, ρ, and q_pt
-    T = TD.air_temperature_from_ideal_gas_law(atmos.param_set, p, ρ, q_pt)
+    if atmos.moisture isa DryModel
+        ts = PhaseDry_ρp(atmos.param_set, ρ, p)
+    else
+        ts = PhaseEquil_ρpq(atmos.param_set, ρ, p, q_pt.tot)
+    end
+    T = air_temperature(ts)
+    q_pt = PhasePartition(ts)
     q_tot = q_pt.tot
     q_liq = q_pt.liq
     q_ice = q_pt.ice
-    if atmos.moisture isa DryModel
-        ts = PhaseDry_ρT(atmos.param_set, ρ, T)
-    else
-        ts = PhaseEquil_ρTq(atmos.param_set, ρ, T, q_tot)
-    end
 
     aux.ref_state.ρq_tot = ρ * q_tot
     aux.ref_state.ρq_liq = ρ * q_liq
@@ -154,7 +155,7 @@ function atmos_init_aux!(
     vertical_fvm = polynomialorders(grid)[end] == 0
 
     if vertical_fvm
-        # Vertical finite volume scheme 
+        # Vertical finite volume scheme
         # pᵢ - pᵢ₊₁ =  g ρᵢ₊₁ Δzᵢ₊₁/2 + g ρᵢ Δzᵢ/2
         fvm_balance!(fvm_balance_init!, atmos, state_auxiliary, grid)
     else


### PR DESCRIPTION
### Description

Use `PhaseEquil_ρp[q]` instead of `air_temperature_from_ideal_gas_law`, as this is already done in `PhaseEquil_ρp[q]`, which uses the relevant available variables.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
