### PR TITLE
Yc/unify void up bounds check

### DIFF
--- a/docs/src/APIs/Common/Thermodynamics.md
+++ b/docs/src/APIs/Common/Thermodynamics.md
@@ -63,6 +63,7 @@ liquid_fraction
 liquid_ice_pottemp
 liquid_ice_pottemp_sat
 liquid_specific_humidity
+mixing_ratios
 moist_static_energy
 q_vap_saturation
 q_vap_saturation_liquid
@@ -74,6 +75,7 @@ saturation_adjustment
 saturation_excess
 saturation_vapor_pressure
 soundspeed_air
+shum_to_mixing_ratio
 specific_enthalpy
 specific_volume
 supersaturation

--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -45,6 +45,8 @@ export liquid_fraction, PhasePartition_equil
 export dry_pottemp
 export virtual_pottemp
 export exner
+export shum_to_mixing_ratio
+export mixing_ratios
 export liquid_ice_pottemp
 export liquid_ice_pottemp_sat
 export relative_humidity
@@ -2184,6 +2186,44 @@ exner(ts::ThermodynamicState) = exner(
     air_density(ts),
     PhasePartition(ts),
 )
+
+"""
+    shum_to_mixing_ratio(q, q_tot)
+
+Mixing ratio, from specific humidity
+ - `q` specific humidity
+ - `q_tot` total specific humidity
+"""
+function shum_to_mixing_ratio(q::FT, q_tot::FT) where {FT <: Real}
+    return q / (1 - q_tot)
+end
+
+"""
+    mixing_ratios(q::PhasePartition)
+
+Mixing ratios
+ - `r.tot` total mixing ratio
+ - `r.liq` liquid mixing ratio
+ - `r.ice` ice mixing ratio
+given a phase partition, `q`.
+"""
+function mixing_ratios(q::PhasePartition{FT}) where {FT <: Real}
+    return PhasePartition(
+        shum_to_mixing_ratio(q.tot, q.tot),
+        shum_to_mixing_ratio(q.liq, q.tot),
+        shum_to_mixing_ratio(q.ice, q.tot),
+    )
+end
+
+"""
+    mixing_ratios(ts::ThermodynamicState)
+
+Mixing ratios stored, in a phase partition, for
+ - total specific humidity
+ - liquid specific humidity
+ - ice specific humidity
+"""
+mixing_ratios(ts::ThermodynamicState) = mixing_ratios(PhasePartition(ts))
 
 """
     relative_humidity(param_set, T, p, phase_type, q::PhasePartition)

--- a/test/Atmos/EDMF/closures/entr_detr.jl
+++ b/test/Atmos/EDMF/closures/entr_detr.jl
@@ -68,7 +68,13 @@ function entr_detr(
     lim_amp = entr.lim_amp
     w_min = entr.w_min
     # precompute vars
-    w_up_i = fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)
+    w_up_i = fix_void_up(
+        m.turbconv,
+        up[i].ρa*ρ_inv,
+        up[i].ρaw / up[i].ρa,
+        gm.ρu[3],
+        gm.ρu[3],
+    )
     sqrt_tke = sqrt(max(en.ρatke, 0) * ρ_inv / env.a)
     # ensure far from zero
     Δw = filter_w(w_up_i - env.w, w_min)

--- a/test/Atmos/EDMF/closures/mixing_length.jl
+++ b/test/Atmos/EDMF/closures/mixing_length.jl
@@ -84,7 +84,7 @@ function mixing_length(
     b = FT(0)
     a_up = vuntuple(i -> up[i].ρa * ρinv, N_up)
     w_up = vuntuple(N_up) do i
-        fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)
+        fix_void_up(m.turbconv, up[i].ρa/gm.ρ, up[i].ρaw / up[i].ρa)
     end
     b = sum(
         ntuple(N_up) do i

--- a/test/Atmos/EDMF/closures/pressure.jl
+++ b/test/Atmos/EDMF/closures/pressure.jl
@@ -41,7 +41,13 @@ function perturbation_pressure(
     up_aux = aux.turbconv.updraft
     up_dif = diffusive.turbconv.updraft
 
-    w_up_i = fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)
+    w_up_i = fix_void_up(
+        m.turbconv,
+        up[i].ρa/state.ρ,
+        up[i].ρaw / up[i].ρa,
+        state.ρu[3],
+        state.ρu[3],
+    )
 
     nh_press_buoy = press.α_b * buoy.up[i]
     nh_pressure_adv = -press.α_a * w_up_i * up_dif[i].∇w[3]

--- a/test/Atmos/EDMF/helper_funcs/nondimensional_exchange_functions.jl
+++ b/test/Atmos/EDMF/helper_funcs/nondimensional_exchange_functions.jl
@@ -47,7 +47,13 @@ function nondimensional_exchange_functions(
     N_up = n_updrafts(m.turbconv)
     ρinv = 1 / gm.ρ
     a_up_i = up[i].ρa * ρinv
-    w_up_i = fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)
+    w_up_i = fix_void_up(
+        m.turbconv,
+        up[i].ρa,
+        up[i].ρaw / up[i].ρa,
+        gm.ρu[3],
+        gm.ρu[3],
+    )
 
     # thermodynamic variables
     RH_up = relative_humidity(ts_up[i])

--- a/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
@@ -153,8 +153,13 @@ function new_thermo_state_up(
     ts_up = vuntuple(N_up) do i
         ρa_up = up[i].ρa
         ρaθ_liq_up = up[i].ρaθ_liq
-        θ_liq_up =
-            fix_void_up(ρa_up, ρaθ_liq_up / ρa_up, liquid_ice_pottemp(ts))
+        θ_liq_up = fix_void_up(
+            m.turbconv,
+            ρa_up/state.ρ,
+            ρaθ_liq_up / ρa_up,
+            liquid_ice_pottemp(ts),
+            liquid_ice_pottemp(ts),
+        )
         PhaseDry_pθ(m.param_set, p, θ_liq_up)
     end
     return ts_up
@@ -177,11 +182,18 @@ function new_thermo_state_up(
         ρa_up = up[i].ρa
         ρaθ_liq_up = up[i].ρaθ_liq
         ρaq_tot_up = up[i].ρaq_tot
-        θ_liq_up =
-            fix_void_up(ρa_up, ρaθ_liq_up / ρa_up, liquid_ice_pottemp(ts))
+        θ_liq_up = fix_void_up(
+            m.turbconv,
+            ρa_up/state.ρ,
+            ρaθ_liq_up / ρa_up,
+            liquid_ice_pottemp(ts),
+            liquid_ice_pottemp(ts),
+        )
         q_tot_up = fix_void_up(
-            ρa_up,
+            m.turbconv,
+            ρa_up/state.ρ,
             ρaq_tot_up / ρa_up,
+            total_specific_humidity(ts),
             total_specific_humidity(ts),
         )
         PhaseEquil_pθq(m.param_set, p, θ_liq_up, q_tot_up)

--- a/test/Atmos/EDMF/helper_funcs/utility_funcs.jl
+++ b/test/Atmos/EDMF/helper_funcs/utility_funcs.jl
@@ -39,7 +39,27 @@ enforce_positivity(x::FT) where {FT} = max(x, FT(0))
 Substitute value by a consistent fallback in case of
 negligible area fraction (void updraft).
 """
-function fix_void_up(ρa_up_i::FT, val::FT, fallback = FT(0)) where {FT}
-    tol = sqrt(eps(FT))
-    return ρa_up_i > tol ? val : fallback
+# function fix_void_up(a_up_i::FT, val::FT, fallback = FT(0)) where {FT}
+#     tol = sqrt(eps(FT))
+#     return a_up_i > tol ? val : fallback
+# end
+
+function fix_void_up(
+    turbconv::EDMF,
+    a_up_i::FT,
+    val::FT,
+    fallback_low = FT(0),
+    fallback_high = FT(1),
+) where {FT}
+    # tol = sqrt(eps(FT))
+    a_min = turbconv.subdomains.a_min
+    a_max = turbconv.subdomains.a_max
+    if a_up_i > a_max
+        output = fallback_high
+    elseif a_up_i < a_min
+        output = fallback_low
+    else
+        output = val
+    end
+    return output
 end

--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -16,13 +16,13 @@ best_mse[:Bomex]["ρ"] = 3.4917543567416755e-02
 best_mse[:Bomex]["ρu[1]"] = 3.0715061616086027e+03
 best_mse[:Bomex]["ρu[2]"] = 1.2895273328644972e-03
 best_mse[:Bomex]["moisture.ρq_tot"] = 4.1330591681441348e-02
-best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.6415719930880925e+02
-best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5667223192888514e+01
+best_mse[:Bomex]["turbconv.environment.ρatke"] = 6.6868199378725114e+02
+best_mse[:Bomex]["turbconv.environment.ρaθ_liq_cv"] = 8.5667224210019953e+01
 best_mse[:Bomex]["turbconv.environment.ρaq_tot_cv"] = 1.6435555167634794e+02
-best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9564915645201182e+01
-best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.4288782126742318e-02
-best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0095910670762631e+00
-best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0768554319447651e+01
+best_mse[:Bomex]["turbconv.updraft[1].ρa"] = 7.9962915358154191e+01
+best_mse[:Bomex]["turbconv.updraft[1].ρaw"] = 8.5167510817010642e-02
+best_mse[:Bomex]["turbconv.updraft[1].ρaθ_liq"] = 9.0184987300428983e+00
+best_mse[:Bomex]["turbconv.updraft[1].ρaq_tot"] = 1.0779279608651940e+01
 #! format: on
 
 sufficient_mse(computed_mse, best_mse) = computed_mse <= best_mse + sqrt(eps())

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -430,6 +430,20 @@ end
     q_tot = FT(0.23)
     @test TD.exner_given_pressure(param_set, p, PhasePartition(q_tot)) isa
           typeof(p)
+
+    q_tot = 0.1
+    q_liq = 0.05
+    q_ice = 0.01
+    mr = shum_to_mixing_ratio(q_tot, q_tot)
+    @test mr == q_tot / (1 - q_tot)
+    mr = shum_to_mixing_ratio(q_liq, q_tot)
+    @test mr == q_liq / (1 - q_tot)
+
+    q = PhasePartition(q_tot, q_liq, q_ice)
+    mrs = mixing_ratios(q)
+    @test mrs.tot == q_tot / (1 - q_tot)
+    @test mrs.liq == q_liq / (1 - q_tot)
+    @test mrs.ice == q_ice / (1 - q_tot)
 end
 
 
@@ -1086,6 +1100,10 @@ end
     @test PhasePartition(ts_eq).tot ≈ PhasePartition(ts_dry).tot
     @test PhasePartition(ts_eq).liq ≈ PhasePartition(ts_dry).liq
     @test PhasePartition(ts_eq).ice ≈ PhasePartition(ts_dry).ice
+
+    @test mixing_ratios(ts_eq).tot ≈ mixing_ratios(ts_dry).tot
+    @test mixing_ratios(ts_eq).liq ≈ mixing_ratios(ts_dry).liq
+    @test mixing_ratios(ts_eq).ice ≈ mixing_ratios(ts_dry).ice
 
     ts_dry = PhaseDry.(param_set, e_int, ρ)
     ts_eq = PhaseEquil.(param_set, e_int, ρ, q_tot .* 0)


### PR DESCRIPTION
### Description
In this draft PR I unify the functions 'fix_void_up' and 'enforce_unit_bounds' using a_min as the threshold for both. 
'fix_void_up' now receives 'a_up' rather than 'ρa_up' and has a fallback for both a<a_min and a>a_max. 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
