### PR TITLE
Add thermo mixing ratio functions

### DIFF
--- a/docs/src/APIs/Common/Thermodynamics.md
+++ b/docs/src/APIs/Common/Thermodynamics.md
@@ -63,6 +63,7 @@ liquid_fraction
 liquid_ice_pottemp
 liquid_ice_pottemp_sat
 liquid_specific_humidity
+mixing_ratios
 moist_static_energy
 q_vap_saturation
 q_vap_saturation_liquid
@@ -74,6 +75,7 @@ saturation_adjustment
 saturation_excess
 saturation_vapor_pressure
 soundspeed_air
+shum_to_mixing_ratio
 specific_enthalpy
 specific_volume
 supersaturation

--- a/src/Common/Thermodynamics/relations.jl
+++ b/src/Common/Thermodynamics/relations.jl
@@ -45,6 +45,8 @@ export liquid_fraction, PhasePartition_equil
 export dry_pottemp
 export virtual_pottemp
 export exner
+export shum_to_mixing_ratio
+export mixing_ratios
 export liquid_ice_pottemp
 export liquid_ice_pottemp_sat
 export relative_humidity
@@ -2184,6 +2186,44 @@ exner(ts::ThermodynamicState) = exner(
     air_density(ts),
     PhasePartition(ts),
 )
+
+"""
+    shum_to_mixing_ratio(q, q_tot)
+
+Mixing ratio, from specific humidity
+ - `q` specific humidity
+ - `q_tot` total specific humidity
+"""
+function shum_to_mixing_ratio(q::FT, q_tot::FT) where {FT <: Real}
+    return q / (1 - q_tot)
+end
+
+"""
+    mixing_ratios(q::PhasePartition)
+
+Mixing ratios
+ - `r.tot` total mixing ratio
+ - `r.liq` liquid mixing ratio
+ - `r.ice` ice mixing ratio
+given a phase partition, `q`.
+"""
+function mixing_ratios(q::PhasePartition{FT}) where {FT <: Real}
+    return PhasePartition(
+        shum_to_mixing_ratio(q.tot, q.tot),
+        shum_to_mixing_ratio(q.liq, q.tot),
+        shum_to_mixing_ratio(q.ice, q.tot),
+    )
+end
+
+"""
+    mixing_ratios(ts::ThermodynamicState)
+
+Mixing ratios stored, in a phase partition, for
+ - total specific humidity
+ - liquid specific humidity
+ - ice specific humidity
+"""
+mixing_ratios(ts::ThermodynamicState) = mixing_ratios(PhasePartition(ts))
 
 """
     relative_humidity(param_set, T, p, phase_type, q::PhasePartition)

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -430,6 +430,20 @@ end
     q_tot = FT(0.23)
     @test TD.exner_given_pressure(param_set, p, PhasePartition(q_tot)) isa
           typeof(p)
+
+    q_tot = 0.1
+    q_liq = 0.05
+    q_ice = 0.01
+    mr = shum_to_mixing_ratio(q_tot, q_tot)
+    @test mr == q_tot / (1 - q_tot)
+    mr = shum_to_mixing_ratio(q_liq, q_tot)
+    @test mr == q_liq / (1 - q_tot)
+
+    q = PhasePartition(q_tot, q_liq, q_ice)
+    mrs = mixing_ratios(q)
+    @test mrs.tot == q_tot / (1 - q_tot)
+    @test mrs.liq == q_liq / (1 - q_tot)
+    @test mrs.ice == q_ice / (1 - q_tot)
 end
 
 
@@ -1086,6 +1100,10 @@ end
     @test PhasePartition(ts_eq).tot ≈ PhasePartition(ts_dry).tot
     @test PhasePartition(ts_eq).liq ≈ PhasePartition(ts_dry).liq
     @test PhasePartition(ts_eq).ice ≈ PhasePartition(ts_dry).ice
+
+    @test mixing_ratios(ts_eq).tot ≈ mixing_ratios(ts_dry).tot
+    @test mixing_ratios(ts_eq).liq ≈ mixing_ratios(ts_dry).liq
+    @test mixing_ratios(ts_eq).ice ≈ mixing_ratios(ts_dry).ice
 
     ts_dry = PhaseDry.(param_set, e_int, ρ)
     ts_eq = PhaseEquil.(param_set, e_int, ρ, q_tot .* 0)


### PR DESCRIPTION
### Description

Add thermo method `shum_to_mixing_ratio` for computing mixing ratios (needed for radiation). I've also added a convenience method, `mixing_ratios`, which accepts a `PhasePartition`, and returns a `PhasePartition` of mixing ratios.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
