### PR TITLE
Implements SplitExplicitOceanSuperModel

### DIFF
--- a/src/Ocean/Ocean.jl
+++ b/src/Ocean/Ocean.jl
@@ -47,8 +47,13 @@ include("OceanProblems/OceanProblems.jl")
 include("SuperModels/SuperModels.jl")
 
 using .OceanProblems: InitialConditions
+
 using .SuperModels:
-    HydrostaticBoussinesqSuperModel, current_time, current_step, Δt
+    SplitExplicitOceanSuperModel,
+    HydrostaticBoussinesqSuperModel,
+    current_time,
+    current_step,
+    Δt
 
 include("JLD2Writer.jl")
 

--- a/src/Ocean/Ocean.jl
+++ b/src/Ocean/Ocean.jl
@@ -44,7 +44,7 @@ include("SplitExplicit/SplitExplicitModel.jl")
 include("SplitExplicit01/SplitExplicitModel.jl")
 include("OceanProblems/OceanProblems.jl")
 
-include("SuperModels.jl")
+include("SuperModels/SuperModels.jl")
 
 using .OceanProblems: InitialConditions
 using .SuperModels:

--- a/src/Ocean/OceanProblems/initial_value_problem.jl
+++ b/src/Ocean/OceanProblems/initial_value_problem.jl
@@ -98,3 +98,72 @@ function ocean_init_state!(
 
     return nothing
 end
+
+######
+###### Functionality for SplitExplicit01
+######
+
+function ocean_init_state!(
+    ivp::InitialValueProblem,
+    state,
+    aux,
+    local_geometry,
+    time,
+)
+
+    ics = ivp.initial_conditions
+    x, y, z = local_geometry.coord
+
+    state.u = @SVector [ics.u(x, y, z), ics.v(x, y, z)]
+    state.θ = ics.θ(x, y, z)
+    state.η = ics.η(x, y, z)
+
+    return nothing
+end
+
+"""
+    ocean_init_aux!(::OceanModel, ivp::InitialValueProblem, state, aux, local_geometry, time)
+
+Initialize `aux`iliary variables for `InitialValueProblem` by zeroing them out.
+"""
+function ocean_init_aux!(
+    ::OceanModel,
+    ivp::InitialValueProblem,
+    state,
+    aux,
+    local_geometry,
+    time,
+)
+
+    aux.w = 0
+    aux.pkin = 0
+    aux.wz0 = 0
+    aux.u_d = @SVector [0, 0]
+    aux.ΔGu = @SVector [0, 0]
+    
+    return nothing
+end
+
+"""
+    ocean_init_aux!(::BarotropicModel, ivp::InitialValueProblem, state, aux, local_geometry, time)
+
+Initialize `aux`iliary variables for `InitialValueProblem` by zeroing them out.
+"""
+function ocean_init_aux!(
+    ::BarotropicModel,
+    ivp::InitialValueProblem,
+    state,
+    aux,
+    local_geometry,
+    time,
+)
+
+    aux.Gᵁ = 0
+    aux.U_c = @SVector [0, 0]
+    aux.η_c = 0
+    aux.U_s = @SVector [0, 0]
+    aux.η_s = 0
+    aux.Δu = @SVector [0, 0]
+    
+    return nothing
+end

--- a/src/Ocean/OceanProblems/simple_box_problem.jl
+++ b/src/Ocean/OceanProblems/simple_box_problem.jl
@@ -79,6 +79,7 @@ northern hemisphere coriolis
     ::AbstractSimpleBoxProblem,
     y,
 ) = m.fₒ + m.β * y
+
 @inline coriolis_parameter(
     m::Union{SWModel, BarotropicModel},
     ::AbstractSimpleBoxProblem,

--- a/src/Ocean/SplitExplicit01/BarotropicModel.jl
+++ b/src/Ocean/SplitExplicit01/BarotropicModel.jl
@@ -44,6 +44,7 @@ function init_state_auxiliary!(
     grid,
     direction,
 )
+    #=
     init_state_auxiliary!(
         m,
         (m, A, tmp, geom) -> ocean_init_aux!(m, m.baroclinic.problem, A, geom),
@@ -51,6 +52,7 @@ function init_state_auxiliary!(
         grid,
         direction,
     )
+    =#
 end
 
 function vars_state(m::BarotropicModel, ::Gradient, T)

--- a/src/Ocean/SplitExplicit01/OceanModel.jl
+++ b/src/Ocean/SplitExplicit01/OceanModel.jl
@@ -189,6 +189,7 @@ function init_state_auxiliary!(
     grid,
     direction,
 )
+    #=
     init_state_auxiliary!(
         m,
         (m, A, tmp, geom) -> ocean_init_aux!(m, m.problem, A, geom),
@@ -196,6 +197,7 @@ function init_state_auxiliary!(
         grid,
         direction,
     )
+    =#
 end
 
 function vars_state(m::OceanModel, ::Gradient, T)

--- a/src/Ocean/SplitExplicit01/SplitExplicitModel.jl
+++ b/src/Ocean/SplitExplicit01/SplitExplicitModel.jl
@@ -71,8 +71,8 @@ import ...SystemSolvers: BatchedGeneralizedMinimalResidual, linearsolve!
 
 abstract type AbstractOceanModel <: BalanceLaw end
 
-function ocean_init_aux! end
-function ocean_init_state! end
+import ..Ocean: ocean_init_aux!, ocean_init_state!
+
 function ocean_model_boundary! end
 function set_fast_for_stepping! end
 function initialize_fast_state! end

--- a/src/Ocean/SuperModels/SuperModels.jl
+++ b/src/Ocean/SuperModels/SuperModels.jl
@@ -1,0 +1,21 @@
+module SuperModels
+
+using MPI
+
+using ClimateMachine
+
+using ClimateMachine: Settings
+
+using ...DGMethods.NumericalFluxes
+
+using ..OceanProblems: InitialValueProblem, InitialConditions
+using ..Domains: array_type
+using ..Ocean: FreeSlip, Impenetrable, Insulating, OceanBC, Penetrable
+using ..Ocean.Fields: SpectralElementField
+
+using ...Mesh.Filters: CutoffFilter, ExponentialFilter
+using ...Mesh.Grids: polynomialorders, DiscontinuousSpectralElementGrid
+
+include("hydrostatic_boussinesq_super_model.jl")
+
+end # module

--- a/src/Ocean/SuperModels/SuperModels.jl
+++ b/src/Ocean/SuperModels/SuperModels.jl
@@ -17,5 +17,6 @@ using ...Mesh.Filters: CutoffFilter, ExponentialFilter
 using ...Mesh.Grids: polynomialorders, DiscontinuousSpectralElementGrid
 
 include("hydrostatic_boussinesq_super_model.jl")
+include("split_explicit_ocean_super_model.jl")
 
 end # module

--- a/src/Ocean/SuperModels/hydrostatic_boussinesq_super_model.jl
+++ b/src/Ocean/SuperModels/hydrostatic_boussinesq_super_model.jl
@@ -198,8 +198,9 @@ end
 
 current_time(model::HydrostaticBoussinesqSuperModel) =
     model.solver_configuration.solver.t
+
 Δt(model::HydrostaticBoussinesqSuperModel) =
     model.solver_configuration.solver.dt
+
 current_step(model::HydrostaticBoussinesqSuperModel) =
     model.solver_configuration.solver.steps
-

--- a/src/Ocean/SuperModels/hydrostatic_boussinesq_super_model.jl
+++ b/src/Ocean/SuperModels/hydrostatic_boussinesq_super_model.jl
@@ -1,23 +1,5 @@
-module SuperModels
-
-using MPI
-
-using ClimateMachine
-
-using ClimateMachine: Settings
-
-using ...DGMethods.NumericalFluxes
-
 using ..HydrostaticBoussinesq:
     HydrostaticBoussinesqModel, NonLinearAdvectionTerm, Forcing
-
-using ..OceanProblems: InitialValueProblem, InitialConditions
-using ..Domains: array_type
-using ..Ocean: FreeSlip, Impenetrable, Insulating, OceanBC, Penetrable
-using ..Ocean.Fields: SpectralElementField
-
-using ...Mesh.Filters: CutoffFilter, ExponentialFilter
-using ...Mesh.Grids: polynomialorders, DiscontinuousSpectralElementGrid
 
 using ClimateMachine:
     LS3NRK33Heuns,
@@ -221,4 +203,3 @@ current_time(model::HydrostaticBoussinesqSuperModel) =
 current_step(model::HydrostaticBoussinesqSuperModel) =
     model.solver_configuration.solver.steps
 
-end # module

--- a/src/Ocean/SuperModels/hydrostatic_ocean_model.jl
+++ b/src/Ocean/SuperModels/hydrostatic_ocean_model.jl
@@ -1,0 +1,285 @@
+using LinearAlgebra
+using StaticArrays
+using Logging
+using Printf
+using Dates
+
+using ...BalanceLaws: vars_state, Prognostic, Auxiliary
+using ...Mesh.Topologies
+using ...Mesh.Grids
+using ...Mesh.Filters
+using ...DGMethods
+using ...DGMethods.NumericalFluxes
+using ...MPIStateArrays
+using ...ODESolvers
+using ...VariableTemplates: flattenednames
+using ...Ocean.SplitExplicit01
+using ...GenericCallbacks
+using ...VTK
+using ...Checkpoint
+
+import ...DGMethods:
+    update_auxiliary_state!,
+    update_auxiliary_state_gradient!,
+    VerticalDirection
+
+import ..Ocean.SplitExplicit01:
+    ocean_init_aux!,
+    ocean_init_state!,
+    ocean_boundary_state!,
+    CoastlineFreeSlip,
+    CoastlineNoSlip,
+    OceanFloorFreeSlip,
+    OceanFloorNoSlip,
+    OceanSurfaceNoStressNoForcing,
+    OceanSurfaceStressNoForcing,
+    OceanSurfaceNoStressForcing,
+    OceanSurfaceStressForcing
+
+using CLIMAParameters.Planet: grav
+
+#####
+##### It's super good
+#####
+
+struct HydrostaticOceanSuperModel{D, G, B, C, F, T}
+    domain::D
+    grid::G
+    barotropic::B
+    baroclinic::C
+    fields::F
+    timestepper::T
+end
+
+"""
+    HydrostaticOceanSuperModel(; domain, time_step, parameters,
+         initial_conditions = InitialConditions(),
+         turbulence_closure = (νʰ=0, νᶻ=0, κʰ=0, κᶻ=0, κᶜ=0),
+                   coriolis = (f₀=0, β=0),
+        rusanov_wave_speeds = (cʰ=0, cᶻ=0),
+                   buoyancy = (αᵀ=0,)
+           numerical_fluxes = ( first_order = RusanovNumericalFlux(),
+                               second_order = CentralNumericalFluxSecondOrder(),
+                                   gradient = CentralNumericalFluxGradient())
+                timestepper = ClimateMachine.ExplicitSolverType(solver_method=LS3NRK33Heuns),
+    )
+
+Builds a `SuperModel` that solves the Hydrostatic Boussinesq equations.
+
+Note: `fast_time_step` is adjusted so that `fast_time_step / slow_time_step` is a
+multiple of 12.
+
+`relative_fast_averaging_window` controls time-averaging required to reconcile the 
+fast barotropic and slow baroclinic mode. In particular `relative_fast_averaging_window` is
+the size of the averaging window for the barotropic mode relative to the `slow_time_step`.
+We must have `ϵ > relative_fast_averaging_window >= 1` where `ϵ` is not that small (probably
+you want `ϵ > 1/8`).
+
+Note: `relative_fast_averaging_window` is a *target* window which is adjusted depending on
+the number of Runge-Kutta stages.
+"""
+function HydrostaticOceanSuperModel(;
+    domain,
+    parameters,
+    slow_time_step,
+    fast_time_step,
+    relative_fast_averaging_window = 1/3,
+    implicit_gmres_stages = 0,
+    initial_conditions = InitialConditions(),
+    turbulence_closure = (νʰ = 0, νᶻ = 0, κʰ = 0, κᶻ = 0, κᶜ = 0),
+    coriolis = (f₀ = 0, β = 0),
+    rusanov_wave_speeds = (cʰ = 0, cᶻ = 0),
+    buoyancy = (αᵀ = 0,),
+    forcing = Forcing(),
+    numerical_fluxes = (
+        first_order = RusanovNumericalFlux(),
+        second_order = CentralNumericalFluxSecondOrder(),
+        gradient = CentralNumericalFluxGradient(),
+    ),
+    timestepper = ClimateMachine.ExplicitSolverType(
+        solver_method = LS3NRK33Heuns,
+    ),
+    filters = nothing,
+    modeldata = NamedTuple(),
+    array_type = Settings.array_type,
+    mpicomm = MPI.COMM_WORLD,
+    init_on_cpu = true,
+    boundary_tags = ((0, 0), (0, 0), (1, 2)),
+    boundary_conditions = (
+        CoastlineNoSlip(),
+        OceanFloorNoSlip(),
+        OceanSurfaceStressForcing(),
+    ),
+)
+    
+    #####
+    ##### Build the grid
+    #####
+
+    # Change global setting if its set here
+    Settings.array_type = array_type
+    FT = eltype(domain)
+
+    west, east = domain.x
+    south, north = domain.y
+    bottom, top = domain.z
+
+    element_coordinates = (
+        range(west, east, length = domain.Ne.x + 1),
+        range(south, north, length = domain.Ne.y + 1),
+        range(bottom, top, length = domain.Ne.z + 1),
+    )
+
+    topology = StackedBrickTopology(
+        mpicomm,
+        element_coordinates;
+        periodicity = tuple(domain.periodicity...),
+        boundary = boundary_tags,
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = array_typ,
+        polynomialorder = Np,
+    )
+
+    horizontal_topology = BrickTopology(
+        mpicomm,
+        element_coordinates[1:2],
+        periodicity = tuple(domain.periodicity[1], domain.periodicity[2]),
+    )
+
+    horizontal_grid = DiscontinuousSpectralElementGrid(
+        horizontal_topology,
+        FloatType = FT,
+        DeviceArray = array_type,
+        polynomialorder = domain.Np,
+    )
+
+    #####
+    ##### Construct generic problem type InitialValueProblem
+    #####
+
+    problem = InitialValueProblem{FT}(
+        dimensions = (domain.L.x, domain.L.y, domain.L.z),
+        initial_conditions = initial_conditions,
+        boundary_conditions = boundary_conditions,
+    )
+
+    #####
+    ##### Build HydrostaticBoussinesqModel/Equations
+    #####
+
+    baroclinic_equations = OceanModel{eltype(domain)}(problem;
+        grav = grav(parameters),
+        cʰ = convert(FT, rusanov_wave_speeds.cʰ),
+        cᶻ = convert(FT, rusanov_wave_speeds.cᶻ),
+        αᵀ = convert(FT, buoyancy.αᵀ),
+        νʰ = convert(FT, turbulence_closure.νʰ),
+        νᶻ = convert(FT, turbulence_closure.νᶻ),
+        κʰ = convert(FT, turbulence_closure.κʰ),
+        κᶻ = convert(FT, turbulence_closure.κᶻ),
+        κᶜ = convert(FT, turbulence_closure.κᶜ),
+        fₒ = convert(FT, coriolis.f₀),
+        β = convert(FT, coriolis.β),
+        add_fast_substeps = 1 / relative_fast_averaging_window,
+        numImplSteps = implicit_gmres_stages,
+        ivdc_dt = slow_time_step / implicit_gmres_stages,
+    )
+
+    barotropic_equations = BarotropicModel(model)
+
+    ####
+    #### "modeldata"
+    ####
+    #### OceanModels require filters (?). If one was not provided, we build a default.
+    ####
+
+    # Default vertical filter and horizontal exponential filter:
+    if isnothing(filters)
+        filters = (
+            vert_filter = CutoffFilter(grid, polynomialorders(grid)),
+            exp_filter = ExponentialFilter(grid, 1, 8),
+        )
+    end
+
+    modeldata = merge(modeldata, filters)
+
+    min_Δx = min_node_distance(grid, HorizontalDirection())
+    min_Δz = min_node_distance(grid, VerticalDirection())
+    c = sqrt(grav(parameters) * domain.L.z)
+
+    @info @sprintf(
+        """ Gravity wave CFL condition
+            min(Δx) / 2√(gH) = %.1f
+              fast time step = %.1f
+            Gravity wave CFL = %.1f""",
+        min_Δx / 2c,
+        fast_time_step,
+        fast_time_step * 2c / min_Δx,
+    )
+
+    # 2 horizontal directions + harmonic viscosity or diffusion: 2^2 factor in CFL:
+    viscous_time_step_limit = 1 / (2 * model.νʰ / min_Δx^2 + model.νᶻ / min_Δz^2) / 4
+    diffusive_time_step_limit = 1 / (2 * model.κʰ / min_Δx^2 + model.κᶻ / min_Δz^2) / 4
+
+    @info @sprintf(
+        """ Viscous and diffusive CFL conditions
+            1 / (8νʰ / min(Δx)^2 + 4νᶻ / min(Δz)^2) = %.1f
+            1 / (8κʰ / min(Δx)^2 + 4κᶻ / min(Δz)^2) = %.1f
+                                     slow time step = %.1f
+                                        Viscous CFL = %.1f
+                                      Diffusive CFL = %.1f"""
+        viscous_time_step_limit,
+        diffusive_time_step_limit,
+        slow_time_step,
+        slow_time_step / viscous_time_step_limit,
+        slow_time_step / diffusive_time_step_limit,
+    )
+
+    baroclinic_discretization = OceanDGModel(
+        baroclinic_equations,
+        grid,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+
+    barotropic_discretization = DGModel(
+        barotropic_equations,
+        horizontal_grid,
+        RusanovNumericalFlux(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    )
+
+    baroclinic_state = init_ode_state(baroclinic_discretization, FT(0); init_on_cpu = true)
+    barotropic_state = init_ode_state(barotropic_discretization, FT(0); init_on_cpu = true)
+
+    u = SpectralElementField(domain, grid, state, 1)
+    v = SpectralElementField(domain, grid, state, 2)
+    η = SpectralElementField(domain, grid, state, 3)
+    θ = SpectralElementField(domain, grid, state, 4)
+
+    fields = (u = u, v = v, η = η, θ = θ)
+
+    return HydrostaticBoussinesqSuperModel(
+        domain,
+        grid,
+        equations,
+        state,
+        fields,
+        numerical_fluxes,
+        timestepper,
+        solver_configuration,
+    )
+end
+
+current_time(model::HydrostaticBoussinesqSuperModel) =
+    model.solver_configuration.solver.t
+Δt(model::HydrostaticBoussinesqSuperModel) =
+    model.solver_configuration.solver.dt
+current_step(model::HydrostaticBoussinesqSuperModel) =
+    model.solver_configuration.solver.steps
+

--- a/tutorials/Ocean/internal_wave.jl
+++ b/tutorials/Ocean/internal_wave.jl
@@ -98,6 +98,21 @@ time_step = 0.005 # close to Δx / c = 0.5 * 1/16, where Δx is nominal resoluti
 
 # and build a model with a smidgeon of viscosity and diffusion,
 
+using ClimateMachine.Ocean.SuperModels: SplitExplicitOceanSuperModel
+
+model = SplitExplicitOceanSuperModel(
+    domain = domain,
+    parameters = NonDimensionalParameters(),
+    barotropic_time_step = time_step,
+    baroclinic_time_step = time_step / 24,
+    initial_conditions = initial_conditions,
+    turbulence_closure = (νʰ = 1e-6, νᶻ = 1e-6, κʰ = 1e-6, κᶻ = 1e-6, κᶜ = 1.0),
+    coriolis = (f₀ = f, β = 0),
+    buoyancy = (αᵀ = αᵀ,),
+    boundary_tags = ((1, 1), (1, 1), (1, 2)),
+)
+
+#=
 using ClimateMachine.Ocean: HydrostaticBoussinesqSuperModel
 
 model = HydrostaticBoussinesqSuperModel(
@@ -237,3 +252,4 @@ animation = @animate for (i, state) in enumerate(fetched_states)
 end
 
 gif(animation, "internal_wave.gif", fps = 8) # hide
+=#

--- a/tutorials/Ocean/internal_wave.jl
+++ b/tutorials/Ocean/internal_wave.jl
@@ -112,20 +112,6 @@ model = SplitExplicitOceanSuperModel(
     boundary_tags = ((1, 1), (1, 1), (1, 2)),
 )
 
-#=
-using ClimateMachine.Ocean: HydrostaticBoussinesqSuperModel
-
-model = HydrostaticBoussinesqSuperModel(
-    domain = domain,
-    time_step = time_step,
-    initial_conditions = initial_conditions,
-    parameters = NonDimensionalParameters(),
-    turbulence_closure = (νʰ = 1e-6, νᶻ = 1e-6, κʰ = 1e-6, κᶻ = 1e-6),
-    coriolis = (f₀ = f, β = 0),
-    buoyancy = (αᵀ = αᵀ,),
-    boundary_tags = ((1, 1), (1, 1), (1, 2)),
-)
-
 # # Fetching data for an animation
 #
 # To animate the `ClimateMachine.Ocean` solution, we assemble and
@@ -178,7 +164,6 @@ end
 #
 # We're ready to launch.
 
-model.solver_configuration.timeend = 6 * 2π / ω
 ## model.solver.dt = 0.05 # make this work
 
 @info """ Simulating a hydrostatic Gaussian wave packet with parameters
@@ -194,9 +179,13 @@ model.solver_configuration.timeend = 6 * 2π / ω
 
 """
 
-result = ClimateMachine.invoke!(
-    model.solver_configuration;
-    user_callbacks = [tiny_progress_printer, data_fetcher],
+using ClimateMachine.ODESolvers: solve!
+
+solve!(
+    (slow = model.baroclinic.state, fast = model.barotropic.state),
+    model.solver,
+    timeend = 6 * 2π / ω,
+    callbacks = [tiny_progress_printer, data_fetcher],
 )
 
 # # Animating the result
@@ -252,4 +241,3 @@ animation = @animate for (i, state) in enumerate(fetched_states)
 end
 
 gif(animation, "internal_wave.gif", fps = 8) # hide
-=#


### PR DESCRIPTION
### Description

This PR implements a "Super Model" similar to the `HydrostaticBoussinesqSuperModel` for the "split-explicit" formulation of the hydrostatic Boussinesq equations called `SplitExplicitOceanSuperModel`. The split-explicit formulation of the hydrostatic Boussinesq equations integrates the barotropic (vertically-integrated) component of the solution with a small "fast" time step, while integrating the baroclinic (deviation from the vertical integral) component with the large "slow" time step. The barotropic component is time-averaged and "reconciled" with the baroclinic component prior to a baroclinic time step.

For the purpose of this PR, I have adapted `tutorials/Ocean/internal_wave.jl` to use `SplitExplicitOceanSuperModel` rather than `HydrostaticBoussinesqSuperModel`. In the future, we would like to re-implement the tests for code in `/Ocean/SplitExplicit01` to use `SplitExplicitOceanSuperModel`.

I hope to add a discussion of the keyword arguments for `SplitExplicitOceanSuperModel` to this PR soon.

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A
- [ ] `Base.show` method for `SplitExplicitOceanSuperModel`
- [ ] Internal wave example runs successfully
