### PR TITLE
Fix NamedTuple keys, add error handling

### DIFF
--- a/src/Utilities/SingleStackUtils/single_stack_diagnostics.jl
+++ b/src/Utilities/SingleStackUtils/single_stack_diagnostics.jl
@@ -1,4 +1,12 @@
 using ..Orientations
+import ..VariableTemplates: flattened_named_tuple
+using ..VariableTemplates
+
+# Sometimes `NodalStack` returns local states
+# that is `nothing`. Here, we return `nothing`
+# to preserve the keys (e.g., `hyperdiff`)
+# when misssing.
+flattened_named_tuple(v::Nothing, ft::FlattenType = FlattenArr()) = nothing
 
 """
     single_stack_diagnostics(

--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -3,6 +3,7 @@ module VariableTemplates
 export varsize, Vars, Grad, @vars, varsindex, varsindices
 
 using StaticArrays
+using LinearAlgebra
 
 """
     varsindex(S, p::Symbol, [sp::Symbol...])
@@ -429,10 +430,12 @@ function getpropertyorindex end
 # Redirect to Base getproperty/getindex:
 Base.@propagate_inbounds getpropertyorindex(t::Tuple, ::Val{i}) where {i} =
     Base.getindex(t, i)
-Base.@propagate_inbounds getpropertyorindex(a::SArray, ::Val{i}) where {i} =
-    Base.getindex(a, i)
-Base.@propagate_inbounds getpropertyorindex(nt::AbstractVars, s::Symbol) =
-    Base.getproperty(nt, s)
+Base.@propagate_inbounds getpropertyorindex(
+    a::AbstractArray,
+    ::Val{i},
+) where {i} = Base.getindex(a, i)
+Base.@propagate_inbounds getpropertyorindex(v::AbstractVars, s::Symbol) =
+    Base.getproperty(v, s)
 Base.@propagate_inbounds getpropertyorindex(
     v::AbstractVars,
     ::Val{i},
@@ -443,8 +446,10 @@ Base.@propagate_inbounds getpropertyorindex(
     v::AbstractVars,
     t::Tuple{A},
 ) where {A} = getpropertyorindex(v, t[1])
-Base.@propagate_inbounds getpropertyorindex(a::SArray, t::Tuple{A}) where {A} =
-    getpropertyorindex(a, t[1])
+Base.@propagate_inbounds getpropertyorindex(
+    a::AbstractArray,
+    t::Tuple{A},
+) where {A} = getpropertyorindex(a, t[1])
 
 # Peel first element from tuple and recurse:
 Base.@propagate_inbounds getpropertyorindex(v::AbstractVars, t::Tuple) =


### PR DESCRIPTION
### Description

After #1929, there is some mismatch with the keys and values returned from `flattened_named_tuple` and thus `single_stack_diagnostics` (e.g., IIRC, mixing length). cc @yairchn @ilopezgp. This PR should fix this mismatch. Specifically, adding

```julia
    length(keys_) == length(vals) || error("key-value mismatch")
```

to `flattened_named_tuple` errors on master due to improper handling of `SHermitianCompact` and `Diagonal` arrays. This required some changes / additions to `flattened_nt_vals`.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
