### PR TITLE
Add option to set Newton-Raphson tolerance for interpolation

### DIFF
--- a/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
+++ b/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
@@ -243,8 +243,8 @@ function config_diagnostics(::Type{FT}, driver_config) where {FT}
 
     interpol = ClimateMachine.InterpolationConfiguration(
         driver_config,
-        boundaries,
-        [lats, lons, lvls],
+        boundaries;
+        axes = [lats, lons, lvls],
     )
 
     # Setup diagnostics group(s)

--- a/experiments/TestCase/baroclinic_wave.jl
+++ b/experiments/TestCase/baroclinic_wave.jl
@@ -325,8 +325,8 @@ function config_diagnostics(FT, driver_config)
 
     interpol = ClimateMachine.InterpolationConfiguration(
         driver_config,
-        boundaries,
-        [lats, lons, lvls],
+        boundaries;
+        axes = [lats, lons, lvls],
     )
 
     dgngrp = setup_atmos_default_diagnostics(

--- a/experiments/TestCase/solid_body_rotation_fvm.jl
+++ b/experiments/TestCase/solid_body_rotation_fvm.jl
@@ -19,6 +19,7 @@ using ClimateMachine.TemperatureProfiles
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Thermodynamics: air_density, total_energy
 import ClimateMachine.DGMethods.FVReconstructions: FVLinear
+using ClimateMachine.Spectra: compute_gaussian!
 
 using LinearAlgebra
 using StaticArrays
@@ -80,7 +81,7 @@ function config_solid_body_rotation(
         model = model,
         numerical_flux_first_order = RoeNumericalFlux(),
         fv_reconstruction = HBFVReconstruction(model, fv_reconstruction),
-        grid_stretching = SingleExponentialStretching(1.5),
+        grid_stretching = SingleExponentialStretching(2),
     )
 
     return config
@@ -93,7 +94,7 @@ function main()
     n_horz = 8                              # horizontal element number
     n_vert = 20                               # vertical element number
     timestart::FT = 0                        # start time (s)
-    timeend::FT = 7200    # end time (s)
+    timeend::FT = 3600    # end time (s)
     fv_reconstruction = FVLinear()
 
     # Set up a reference state for linearization of equations
@@ -193,15 +194,31 @@ function config_diagnostics(FT, driver_config)
     _planet_radius = FT(planet_radius(param_set))
 
     info = driver_config.config_info
+
+    # Setup diagnostic grid(s)
+    nlats = 128
+
+    sinθ, wts = compute_gaussian!(nlats)
+    lats = asin.(sinθ) .* 180 / π
+    lons = 180.0 ./ nlats * collect(FT, 1:1:(2nlats))[:] .- 180.0
+
     boundaries = [
-        FT(-90.0) FT(-180.0) _planet_radius
-        FT(90.0) FT(180.0) FT(_planet_radius + info.domain_height)
+        FT(lats[1]) FT(lons[1]) _planet_radius
+        FT(lats[end]) FT(lons[end]) FT(_planet_radius + info.domain_height)
     ]
-    resolution = (FT(2), FT(2), FT(1000)) # in (deg, deg, m)
+
+    lvls = collect(range(
+        boundaries[1, 3],
+        boundaries[2, 3],
+        step = FT(1000), # in m
+    ))
+
     interpol = ClimateMachine.InterpolationConfiguration(
+        driver_config.grid.topology,
         driver_config,
         boundaries,
-        resolution,
+        [lats, lons, lvls];
+        nr_toler = FT(1e-7),
     )
 
     dgngrp = setup_atmos_default_diagnostics(

--- a/src/Numerics/Mesh/Interpolation.jl
+++ b/src/Numerics/Mesh/Interpolation.jl
@@ -697,7 +697,8 @@ struct InterpolationCubedSphere{
         nhor::Int,
         lat_grd::AbstractArray{FT, 1},
         long_grd::AbstractArray{FT, 1},
-        rad_grd::AbstractArray{FT},
+        rad_grd::AbstractArray{FT};
+        nr_toler = nothing,
     ) where {FT <: AbstractFloat}
         mpicomm = MPI.COMM_WORLD
         pid = MPI.Comm_rank(mpicomm)
@@ -709,7 +710,10 @@ struct InterpolationCubedSphere{
         qm = polynomialorders(grid) .+ 1
         toler1 = FT(eps(FT) * vert_range[1] * 2.0) # tolerance for unwarp function
         toler2 = FT(eps(FT) * 4.0)                 # tolerance
-        toler3 = FT(eps(FT) * vert_range[1] * 10.0) # tolerance for Newton-Raphson
+        # tolerance for Newton-Raphson
+        if isnothing(nr_toler)
+            nr_toler = FT(eps(FT) * vert_range[1] * 10.0)
+        end
 
         Nel = length(grid.topology.realelems) # # of local elements on the local process
 
@@ -850,7 +854,7 @@ struct InterpolationCubedSphere{
                             view(grid.topology.elemtocoord, 3, :, el_loc),
                             uw_grd,
                             diffv,
-                            toler3,
+                            nr_toler,
                             ξ,
                         )
                         push!(ξ1[el_loc], ξ[1])


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
Setting up a cubed sphere interpolated grid can fail when the DG grid is stretched beyond a certain point. Allowing control of the tolerance is a temporary fix until @skandalaCLIMA implements a proper one.

Also cleaned up the interface to `InterpolationConfiguration` a little.

<!-- Check all the boxes below before taking the PR out of draft -->

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
