### PR TITLE
Add keyword support for grid-stretching in GCM/LES Configurations.

### DIFF
--- a/experiments/TestCase/solid_body_rotation_fvm.jl
+++ b/experiments/TestCase/solid_body_rotation_fvm.jl
@@ -14,6 +14,7 @@ using ClimateMachine.SystemSolvers: ManyColumnLU
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.Mesh.Interpolation
+using ClimateMachine.Mesh.Topologies
 using ClimateMachine.TemperatureProfiles
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Thermodynamics: air_density, total_energy
@@ -79,6 +80,7 @@ function config_solid_body_rotation(
         model = model,
         numerical_flux_first_order = RoeNumericalFlux(),
         fv_reconstruction = HBFVReconstruction(model, fv_reconstruction),
+        grid_stretching = SingleExponentialStretching(1.5),
     )
 
     return config

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -176,6 +176,7 @@ function AtmosLESConfiguration(
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
     numerical_flux_gradient = CentralNumericalFluxGradient(),
     fv_reconstruction = nothing,
+    grid_stretching = (nothing, nothing, nothing),
 ) where {FT <: AbstractFloat}
 
     (polyorder_horz, polyorder_vert) = get_polyorders(N)
@@ -183,9 +184,24 @@ function AtmosLESConfiguration(
     print_model_info(model, mpicomm)
 
     brickrange = (
-        grid1d(xmin, xmax, elemsize = Δx * max(polyorder_horz, 1)),
-        grid1d(ymin, ymax, elemsize = Δy * max(polyorder_horz, 1)),
-        grid1d(zmin, zmax, elemsize = Δz * max(polyorder_vert, 1)),
+        grid1d(
+            xmin,
+            xmax,
+            grid_stretching[1],
+            elemsize = Δx * max(polyorder_horz, 1),
+        ),
+        grid1d(
+            ymin,
+            ymax,
+            grid_stretching[2],
+            elemsize = Δy * max(polyorder_horz, 1),
+        ),
+        grid1d(
+            zmin,
+            zmax,
+            grid_stretching[3],
+            elemsize = Δz * max(polyorder_vert, 1),
+        ),
     )
     topology = StackedBrickTopology(
         mpicomm,
@@ -267,6 +283,7 @@ function AtmosGCMConfiguration(
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
     numerical_flux_gradient = CentralNumericalFluxGradient(),
     fv_reconstruction = nothing,
+    grid_stretching = nothing,
 ) where {FT <: AbstractFloat}
 
     (polyorder_horz, polyorder_vert) = get_polyorders(N)
@@ -277,6 +294,7 @@ function AtmosGCMConfiguration(
     vert_range = grid1d(
         _planet_radius,
         FT(_planet_radius + domain_height),
+        grid_stretching,
         nelem = nelem_vert,
     )
 


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->

Adds keyword support for grid stretching functions in GCM / LES configurations 
<!-- Check all the boxes below before taking the PR out of draft -->

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [N/A] Unit tests are included OR N/A. [Existing feature is tested. Adds keyword argument support in `driver_configs.jl`]
- [N/A] Code is exercised in an integration test OR N/A. [See above]
- [N/A] Documentation has been added/updated OR N/A.
