### PR TITLE
Adjust diagnostics output for BOMEX single stack and BOMEX EDMF

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1351,7 +1351,7 @@ steps:
   - label: "gpu_bomex_single_stack"
     key: "gpu_bomex_single_stack"
     command:
-      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex_single_stack.jl --diagnostics=default --fix-rng-seed"
+      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex_single_stack.jl --fix-rng-seed"
     agents:
       config: gpu
       queue: central
@@ -1361,7 +1361,7 @@ steps:
   - label: "gpu_bomex_single_stack_nonequil"
     key: "gpu_bomex_single_stack_nonequil"
     command:
-      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex_single_stack.jl --moisture-model nonequilibrium --diagnostics=default --fix-rng-seed"
+      - "mpiexec julia --color=yes --project experiments/AtmosLES/bomex_single_stack.jl --moisture-model nonequilibrium --fix-rng-seed"
     agents:
       config: gpu
       queue: central

--- a/experiments/AtmosLES/bomex_les.jl
+++ b/experiments/AtmosLES/bomex_les.jl
@@ -92,7 +92,7 @@ function main()
         Courant_number = CFLmax,
         CFL_direction = HorizontalDirection(),
     )
-    dgn_config = config_diagnostics(driver_config)
+    dgn_config = config_diagnostics(driver_config, timeend)
 
     if moisture_model == "equilibrium"
         filter_vars = ("moisture.ρq_tot",)
@@ -122,6 +122,25 @@ function main()
         check_cons = check_cons,
         check_euclidean_distance = true,
     )
+end
+
+function config_diagnostics(driver_config, timeend)
+    default_interval = "$(cld(timeend, 2) + 10)ssecs"
+    default_dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
+        default_interval,
+        driver_config.name,
+    )
+    core_interval = "$(cld(timeend, 4) + 10)ssecs"
+    core_dgngrp = setup_atmos_core_diagnostics(
+        AtmosLESConfigType(),
+        core_interval,
+        driver_config.name,
+    )
+    return ClimateMachine.DiagnosticsConfiguration([
+        default_dgngrp,
+        core_dgngrp,
+    ])
 end
 
 main()

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -483,20 +483,3 @@ function bomex_model(
 
     return model
 end
-
-function config_diagnostics(driver_config)
-    default_dgngrp = setup_atmos_default_diagnostics(
-        AtmosLESConfigType(),
-        "2500steps",
-        driver_config.name,
-    )
-    core_dgngrp = setup_atmos_core_diagnostics(
-        AtmosLESConfigType(),
-        "2500steps",
-        driver_config.name,
-    )
-    return ClimateMachine.DiagnosticsConfiguration([
-        default_dgngrp,
-        core_dgngrp,
-    ])
-end

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -20,8 +20,12 @@ struct AtmosGCMSpecificInfo{FT} <: ConfigSpecificInfo
     nelem_horz::Int
 end
 struct OceanBoxGCMSpecificInfo <: ConfigSpecificInfo end
-struct SingleStackSpecificInfo <: ConfigSpecificInfo end
+struct SingleStackSpecificInfo{FT} <: ConfigSpecificInfo
+    zmax::FT
+    hmax::FT
+end
 struct MultiColumnLandSpecificInfo <: ConfigSpecificInfo end
+
 include("SolverTypes/SolverTypes.jl")
 
 """
@@ -560,7 +564,7 @@ Establishing single stack configuration for %s
         numerical_flux_second_order,
         numerical_flux_gradient,
         fv_reconstruction,
-        SingleStackSpecificInfo(),
+        SingleStackSpecificInfo(zmax, hmax),
     )
 end
 


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
Separate diagnostics configuration for the 3 BOMEX experiments (LES, single stack, and EDMF). Single stack and EDMF modified to use the `DumpState` diagnostics group (instead of the `AtmosLESDefault` and `AtmosLESCore` used for LES).

<!-- Check all the boxes below before taking the PR out of draft -->

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
