### PR TITLE
build sysimg but don't fail on error, disable running tests with sysimg until 1.5.4 bugfix

### DIFF
--- a/.github/workflows/OS-UnitTests.yml
+++ b/.github/workflows/OS-UnitTests.yml
@@ -72,10 +72,11 @@ jobs:
 
     - name: Build System Image
       if: steps.filter.outputs.run_test == 'true'
+      continue-on-error: true
       run: |
         julia --project=@. .dev/systemimage/climate_machine_image.jl ClimateMachine.so true
 
     - name: Run Unit Tests
       if: steps.filter.outputs.run_test == 'true'
       run: |
-        julia --project=@. -J ClimateMachine.so -e 'using Pkg; Pkg.test()'
+        julia --project=@. -e 'using Pkg; Pkg.test()'


### PR DESCRIPTION
### Description

Due to bugs in the julia 1.5.(2,3) runtime, the CI sysimg build is currently broken.  Disable until Julia v1.5.4 with included bugfixes is released https://github.com/JuliaLang/julia/pull/39351.


<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
