### PR TITLE
Add linearized_pressure wrapper, more compact namedtuples

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -506,7 +506,7 @@ equations.
 
     flux_pad = SVector(1, 1, 1)
     tend = Flux{FirstOrder}()
-    _args = (state = state, aux = aux, t = t, direction = direction)
+    _args = (; state, aux, t, direction)
     args = merge(_args, (precomputed = precompute(atmos, _args, tend),))
     flux.ρ = Σfluxes(eq_tends(Mass(), atmos, tend), atmos, args) .* flux_pad
     flux.ρu =
@@ -653,13 +653,7 @@ function. Contributions from subcomponents are then assembled (pointwise).
     flux_pad = SVector(1, 1, 1)
     tend = Flux{SecondOrder}()
 
-    _args = (
-        state = state,
-        aux = aux,
-        t = t,
-        diffusive = diffusive,
-        hyperdiffusive = hyperdiffusive,
-    )
+    _args = (; state, aux, t, diffusive, hyperdiffusive)
 
     args = merge(_args, (precomputed = precompute(atmos, _args, tend),))
 
@@ -853,13 +847,7 @@ function source!(
     ρu_pad = SVector(1, 1, 1)
     tend = Source()
 
-    _args = (
-        state = state,
-        aux = aux,
-        t = t,
-        direction = direction,
-        diffusive = diffusive,
-    )
+    _args = (; state, aux, t, direction, diffusive)
 
     args = merge(_args, (precomputed = precompute(atmos, _args, tend),))
 

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -35,6 +35,15 @@ function linearized_air_pressure(
     )
 end
 
+@inline linearized_pressure(atmos, state::Vars, aux::Vars) =
+    linearized_pressure(
+        atmos.moisture,
+        atmos.param_set,
+        atmos.orientation,
+        state,
+        aux,
+    )
+
 @inline function linearized_pressure(
     ::DryModel,
     param_set::AbstractParameterSet,
@@ -223,13 +232,7 @@ function flux_first_order!(
     e_pot = gravitational_potential(lm.atmos.orientation, aux)
 
     flux.ρ = state.ρu
-    pL = linearized_pressure(
-        lm.atmos.moisture,
-        lm.atmos.param_set,
-        lm.atmos.orientation,
-        state,
-        aux,
-    )
+    pL = linearized_pressure(lm.atmos, state, aux)
     flux.ρu += pL * I
     flux.ρe = ((ref.ρe + ref.p) / ref.ρ - e_pot) * state.ρu
     nothing
@@ -258,13 +261,7 @@ function flux_first_order!(
     e_pot = gravitational_potential(lm.atmos.orientation, aux)
 
     flux.ρ = state.ρu
-    pL = linearized_pressure(
-        lm.atmos.moisture,
-        lm.atmos.param_set,
-        lm.atmos.orientation,
-        state,
-        aux,
-    )
+    pL = linearized_pressure(lm.atmos, state, aux)
     flux.ρu += pL * I
     flux.ρe = ((ref.ρe + ref.p) / ref.ρ) * state.ρu
     nothing
@@ -324,13 +321,7 @@ function numerical_flux_first_order!(
     ref_h⁻ = (ref_ρe⁻ + ref_p⁻) / ref_ρ⁻
     ref_c⁻ = soundspeed_air(param_set, ref_T⁻)
 
-    pL⁻ = linearized_pressure(
-        atmos.moisture,
-        param_set,
-        atmos.orientation,
-        state_prognostic⁻,
-        state_auxiliary⁻,
-    )
+    pL⁻ = linearized_pressure(atmos, state_prognostic⁻, state_auxiliary⁻)
 
     ρu⁺ = state_prognostic⁺.ρu
 
@@ -341,13 +332,7 @@ function numerical_flux_first_order!(
     ref_h⁺ = (ref_ρe⁺ + ref_p⁺) / ref_ρ⁺
     ref_c⁺ = soundspeed_air(param_set, ref_T⁺)
 
-    pL⁺ = linearized_pressure(
-        atmos.moisture,
-        param_set,
-        atmos.orientation,
-        state_prognostic⁺,
-        state_auxiliary⁺,
-    )
+    pL⁺ = linearized_pressure(atmos, state_prognostic⁺, state_auxiliary⁺)
 
     # not sure if arithmetic averages are a good idea here
     h̃ = (ref_h⁻ + ref_h⁺) / 2
@@ -433,13 +418,7 @@ function numerical_flux_first_order!(
 
     ref_c⁻ = soundspeed_air(param_set, ref_T⁻, ref_q_pt⁻)
 
-    pL⁻ = linearized_pressure(
-        atmos.moisture,
-        param_set,
-        atmos.orientation,
-        state_prognostic⁻,
-        state_auxiliary⁻,
-    )
+    pL⁻ = linearized_pressure(atmos, state_prognostic⁻, state_auxiliary⁻)
 
     ρu⁺ = state_prognostic⁺.ρu
 
@@ -454,13 +433,7 @@ function numerical_flux_first_order!(
     _R_m⁺ = gas_constant_air(param_set, ref_q_pt⁺)
     ref_h⁺ = total_specific_enthalpy(ref_ρe⁺, _R_m⁺, ref_T⁺)
     ref_c⁺ = soundspeed_air(param_set, ref_T⁺, ref_q_pt⁺)
-    pL⁺ = linearized_pressure(
-        atmos.moisture,
-        param_set,
-        atmos.orientation,
-        state_prognostic⁺,
-        state_auxiliary⁺,
-    )
+    pL⁺ = linearized_pressure(atmos, state_prognostic⁺, state_auxiliary⁺)
 
     # not sure if arithmetic averages are a good idea here
     ref_h̃ = (ref_h⁻ + ref_h⁺) / 2


### PR DESCRIPTION
### Description

Peeled off from #1847. This PR adds a wrapper for `linearized_pressure` and uses Julia's `(;)` NamedTuple constructor syntax.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
