### PR TITLE
enable horizontal hyperdiffusion for dgfvm

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -363,6 +363,15 @@ steps:
       queue: central
       slurm_ntasks: 2
 
+  - label: "cpu_fvm_spherical_hyperdiffusion"
+    key: "cpu_fvm_spherical_hyperdiffusion"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_spherical_hyperdiffusion.jl "
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 2
+
   - label: "cpu_fvm_advection_diffusion"
     key: "cpu_fvm_advection_diffusion"
     command:
@@ -852,6 +861,16 @@ steps:
     key: "gpu_fvm_advection"
     command:
       - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl "
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 2
+      slurm_gres: "gpu:1"
+
+  - label: "gpu_fvm_spherical_hyperdiffusion"
+    key: "gpu_fvm_spherical_hyperdiffusion"
+    command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/advection_diffusion/fvm_spherical_hyperdiffusion.jl "
     agents:
       config: gpu
       queue: central

--- a/experiments/TestCase/solid_body_rotation_fvm.jl
+++ b/experiments/TestCase/solid_body_rotation_fvm.jl
@@ -66,7 +66,7 @@ function config_solid_body_rotation(
         init_state_prognostic = init_solid_body_rotation!,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
-        #hyperdiffusion = DryBiharmonic(FT(8 * 3600)),
+        hyperdiffusion = DryBiharmonic(FT(8 * 3600)),
         moisture = DryModel(),
         source = (Gravity(), Coriolis()),
     )

--- a/src/Numerics/DGMethods/DGFVModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGFVModel_kernels.jl
@@ -72,7 +72,6 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
         num_state_auxiliary = number_states(balance_law, Auxiliary())
         num_state_gradient_flux = number_states(balance_law, GradientFlux())
         num_state_hyperdiffusive = number_states(balance_law, Hyperdiffusive())
-        @assert num_state_hyperdiffusive == 0
 
         nface = info.nface
         Np = info.Np
@@ -164,6 +163,13 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
         # being evaluated for. In this case we only have `VerticalDirection()`
         # faces
         face_direction = (VerticalDirection(),)
+    end
+
+    # Support only Horizontal hyperdiffusion, set vertical state  hyperdiffusion to 0
+    @unroll for k in 1:stencil_diameter
+        @unroll for s in 1:num_state_hyperdiffusive
+            @inbounds local_state_hyperdiffusive[k][s] = 0
+        end
     end
 
     # Optimization ideas:

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_spherical_hyperdiffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_spherical_hyperdiffusion.jl
@@ -1,0 +1,181 @@
+using MPI
+using ClimateMachine
+using Logging
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+import ClimateMachine.DGMethods.FVReconstructions: FVConstant, FVLinear
+
+using ClimateMachine.MPIStateArrays
+using LinearAlgebra
+using Printf
+using Dates
+using ClimateMachine.GenericCallbacks:
+    EveryXWallTimeSeconds, EveryXSimulationSteps
+using ClimateMachine.ODESolvers
+using ClimateMachine.VTK: writevtk, writepvtu
+using ClimateMachine.Mesh.Grids: min_node_distance
+using ClimateMachine.Atmos: SphericalOrientation, latitude, longitude
+
+using ClimateMachine.Orientations
+using CLIMAParameters
+using CLIMAParameters.Planet
+
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+CLIMAParameters.Planet.planet_radius(::EarthParameterSet) = 60e3
+
+
+
+const output = parse(Bool, lowercase(get(ENV, "JULIA_CLIMA_OUTPUT", "false")))
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+
+include("hyperdiffusion_model.jl")
+
+struct ConstantHyperDiffusion{dim, dir, FT} <: HyperDiffusionProblem
+    D::FT
+    l::FT
+    m::FT
+end
+
+function nodal_init_state_auxiliary!(
+    balance_law::HyperDiffusion,
+    aux::Vars,
+    tmp::Vars,
+    geom::LocalGeometry,
+)
+    FT = eltype(aux)
+    aux.D = balance_law.problem.D * SMatrix{3, 3, Float64}(I)
+    aux.coord = geom.coord
+end
+
+"""
+    initial condition is given by ρ0 = ρ0(r)
+    test: ∇^4_horz ρ0(r) = 0
+"""
+
+function initial_condition!(
+    problem::ConstantHyperDiffusion{dim, dir},
+    state,
+    aux,
+    x,
+    t,
+) where {dim, dir}
+    @inbounds begin
+        FT = eltype(state)
+        # import planet paraset
+        _a::FT = planet_radius(param_set)
+        r = norm(aux.coord)
+        z = r - _a
+        domain_height = 30.0e3
+        state.ρ = cos(z / domain_height)
+    end
+end
+
+function run(mpicomm, ArrayType, dim, topl, N, FT, direction, τ, l, m)
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = N,
+        meshwarp = ClimateMachine.Mesh.Topologies.cubedshellwarp,
+    )
+    dx = min_node_distance(grid, HorizontalDirection())
+    dz = min_node_distance(grid, VerticalDirection())
+
+    D = (dx / 2)^4 / 2 / τ
+
+    model = HyperDiffusion{dim}(ConstantHyperDiffusion{dim, direction(), FT}(
+        D,
+        l,
+        m,
+    ))
+    dg = DGFVModel(
+        model,
+        grid,
+        FVLinear(),
+        CentralNumericalFluxFirstOrder(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+        direction = direction(),
+    )
+
+    Q0 = init_ode_state(dg, FT(0))
+    @info "Δ(horz) Δ(vert)" (dx, dz)
+
+    rhs_DGsource = similar(Q0)
+
+    dg(rhs_DGsource, Q0, nothing, 0)
+
+    result = norm(rhs_DGsource)
+
+    return result
+end
+
+using Test
+let
+    ClimateMachine.init()
+    ArrayType = ClimateMachine.array_type()
+    mpicomm = MPI.COMM_WORLD
+
+    dim = 3
+    domain_height = 30.0e3
+
+    _a = planet_radius(param_set)
+    vert_num_elem = 20
+    polynomialorder = (5, 0)
+
+    @testset "$(@__FILE__)" begin
+        for FT in (Float64,)
+            for base_num_elem in (8,)
+                for direction in (HorizontalDirection,)
+                    for τ in (1,) # time scale for hyperdiffusion
+
+                        topl = StackedCubedSphereTopology(
+                            mpicomm,
+                            base_num_elem,
+                            grid1d(
+                                _a,
+                                _a + domain_height,
+                                nelem = vert_num_elem,
+                            ),
+                        )
+
+                        @info "Array FT nhorz nvert poly τ" (
+                            ArrayType,
+                            FT,
+                            base_num_elem,
+                            vert_num_elem,
+                            polynomialorder,
+                            τ,
+                        )
+                        result = run(
+                            mpicomm,
+                            ArrayType,
+                            dim,
+                            topl,
+                            polynomialorder,
+                            FT,
+                            direction,
+                            τ * 3600,
+                            7,
+                            4,
+                        )
+
+                        @test result < 1.0e-12
+
+                    end
+                end
+            end
+        end
+    end
+end
+nothing


### PR DESCRIPTION
Enable horizontal hyperdiffusion for DGFVM

### Description
This PR cleans "asserts" in dgfvm, to enable horizontal hyperdiffusion for  DGFVM (for the DG part).
In the FVM, the hyperdiffusion is set to 0, namely not vertical hyperdiffusion.

The solid body rotation 1h test, error is 1e-11.
An additional test in fvm_spherical_hyperdiffusion.jl 
"""
    initial condition is given by ρ0 = ρ0(r)
    test: ∇^4_horz ρ0(r) = 0
"""

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
