### PR TITLE
Add --nelems for Ocean config

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -77,7 +77,7 @@ Base.@kwdef mutable struct ClimateMachine_Settings
     sim_time::Float64 = NaN
     fixed_number_of_steps::Int = -1
     degree::NTuple{2, Int} = (-1, -1)
-    nelems::NTuple{2, Int} = (-1, -1)
+    nelems::NTuple{3, Int} = (-1, -1, -1)
     domain_height::Float64 = -1
     resolution::NTuple{3, Float64} = (-1, -1, -1)
     domain_min::NTuple{3, Float64} = (-1, -1, -1)
@@ -307,9 +307,9 @@ function parse_commandline(
         arg_type = NTuple{2, Int}
         default = get_setting(:degree, defaults, global_defaults)
         "--nelems"
-        help = "tuple of number of elements in each direction: 2 for GCM or 1 for single-stack (no space before/after comma)"
-        metavar = "<nelem_1>,<nelem_2>"
-        arg_type = NTuple{2, Int}
+        help = "number of elements in each direction: 3 for Ocean GCM, 2 for Atmos GCM or 1 for Atmos single-stack (no space before/after comma)"
+        metavar = "<nelem_1>[,<nelem_2>[,<nelem_3>]]"
+        arg_type = NTuple{3, Int}
         default = get_setting(:nelems, defaults, global_defaults)
         "--domain-height"
         help = "domain height (in meters) for GCM or single-stack configurations"
@@ -408,8 +408,8 @@ Recognized keyword arguments are:
         if `≥0` perform specified number of steps
 - `degree::NTuple{2, Int} = (-1, -1)`:
         tuple of horizontal and vertical polynomial degrees for spatial discretization order
-- `nelems::NTuple{2, Int} = (-1, -1)`:
-        tuple of number of elements in each direction: 2 for GCM or 1 for single-stack
+- `nelems::NTuple{3, Int} = (-1, -1, -1)`:
+        tuple of number of elements in each direction: 3 for Ocean, 2 for GCM or 1 for single-stack
 - `domain_height::Float64 = -1`:
         domain height (in meters) for GCM or single-stack configurations
 - `resolution::NTuple{3, Float64} = (-1, -1, -1)`:

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -6,6 +6,7 @@
 # - AtmosGCMConfiguration
 # - OceanBoxGCMConfiguration
 # - SingleStackConfiguration
+# - MultiColumnLandModel
 #
 # User-customized configurations can use these as templates.
 

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -27,15 +27,16 @@ include("SolverTypes/SolverTypes.jl")
 """
     ArgParse.parse_item
 
-Parses custom command line option for tuples of two integers.
+Parses custom command line option for tuples of three or fewer integers.
 """
-function ArgParse.parse_item(::Type{NTuple{2, Int}}, s::AbstractString)
+function ArgParse.parse_item(::Type{NTuple{3, Int}}, s::AbstractString)
 
     str_array = split(s, ",")
     int_1 = length(str_array) > 0 ? parse(Int, str_array[1]) : 0
     int_2 = length(str_array) > 1 ? parse(Int, str_array[2]) : 0
+    int_3 = length(str_array) > 2 ? parse(Int, str_array[3]) : 0
 
-    return (int_1, int_2)
+    return (int_1, int_2, int_3)
 end
 
 """
@@ -321,7 +322,7 @@ function AtmosGCMConfiguration(
     (polyorder_horz, polyorder_vert) = get_polyorders(N)
 
     # Check if the number of elements was passed as a CL option
-    if ClimateMachine.Settings.nelems != (-1, -1)
+    if ClimateMachine.Settings.nelems != (-1, -1, -1)
         (nelem_horz, nelem_vert) = ClimateMachine.Settings.nelems
     end
 
@@ -420,6 +421,11 @@ function OceanBoxGCMConfiguration(
 
     (polyorder_horz, polyorder_vert) = get_polyorders(N)
 
+    # Check if the number of elements was passed as a CL option
+    if ClimateMachine.Settings.nelems != (-1, -1, -1)
+        (Nˣ, Nʸ, Nᶻ) = ClimateMachine.Settings.nelems
+    end
+
     brickrange = (
         range(FT(0); length = Nˣ + 1, stop = model.problem.Lˣ),
         range(FT(0); length = Nʸ + 1, stop = model.problem.Lʸ),
@@ -438,6 +444,28 @@ function OceanBoxGCMConfiguration(
         FloatType = FT,
         DeviceArray = array_type,
         polynomialorder = (polyorder_horz, polyorder_vert),
+    )
+
+    @info @sprintf(
+        """
+Establishing Ocean Box GCM configuration for %s
+    precision               = %s
+    horiz polynomial order  = %d
+    vert polynomial order   = %d
+    Nˣ # elems              = %d
+    Nʸ # elems              = %d
+    Nᶻ # elems              = %d
+    domain depth            = %.2e m
+    MPI ranks               = %d""",
+        name,
+        FT,
+        polyorder_horz,
+        polyorder_vert,
+        Nˣ,
+        Nʸ,
+        Nᶻ,
+        -model.problem.H,
+        MPI.Comm_size(mpicomm)
     )
 
     return DriverConfiguration(
@@ -483,7 +511,7 @@ function SingleStackConfiguration(
     (polyorder_horz, polyorder_vert) = get_polyorders(N)
 
     # Check if the number of elements was passed as a CL option
-    if ClimateMachine.Settings.nelems != (-1, -1)
+    if ClimateMachine.Settings.nelems != (-1, -1, -1)
         nE = ClimateMachine.Settings.nelems
         nelem_vert = nE[1]
     end


### PR DESCRIPTION
This is a quick patch of PR #1946 to add the `--nelems` CL option also for the Ocean configuration. 

While at it, I also printed the same `@info` that is printed in the other configs and added a missing config to the doc summary at the top of the file. 

I tested this with 

```
$ julia --project test/Ocean/HydrostaticBoussinesq/test_3D_spindown.jl --nelems 4,4,7
```
and the relevant output is:

```
┌ Info: Establishing Ocean configuration for hydrostatic_spindown
│     precision               = Float64
│     horiz polynomial order  = 4
│     vert polynomial order   = 4
│     Nˣ # elems              = 4
│     Nʸ # elems              = 4
│     Nᶻ # elems              = 7
│     domain depth            = -4.00e+02 m
└     MPI ranks               = 1
```

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
