### PR TITLE
Add tests for ArtifactWrappers

### DIFF
--- a/test/InputOutput/ArtifactWrappers/runtests.jl
+++ b/test/InputOutput/ArtifactWrappers/runtests.jl
@@ -1,0 +1,39 @@
+module TestArtifactWrappers
+
+using Test
+using ClimateMachine.ArtifactWrappers
+
+@testset "ArtifactFile" begin
+    af = ArtifactFile(url = "url", filename = "filename")
+    @test af.url == "url"
+    @test af.filename == "filename"
+end
+
+@testset "ArtifactWrapper" begin
+    mktempdir() do path
+
+        tempfile = joinpath(path, "foo.txt")
+
+        open(tempfile, "w") do io
+            print(io, "foo")
+        end
+
+        af = ArtifactFile(url = "file://$tempfile", filename = "foo")
+
+        # Caches artifact:
+        aw = ArtifactWrapper(path, true, "test_art_wrap", ArtifactFile[af])
+        f = get_data_folder(aw)
+        @test isfile(joinpath(f, "foo"))
+
+        # Download only:
+        aw = ArtifactWrapper(path, false, "test_art_wrap", ArtifactFile[af])
+
+        # Test that "artifact_" was prepended:
+        @test occursin("artifact_", aw.artifact_dir)
+
+        f = get_data_folder(aw)
+        @test isfile(joinpath(f, "foo"))
+    end
+end
+
+end

--- a/test/InputOutput/runtests.jl
+++ b/test/InputOutput/runtests.jl
@@ -2,7 +2,7 @@ using Test, Pkg
 
 @testset "InputOutput" begin
     all_tests = isempty(ARGS) || "all" in ARGS ? true : false
-    for submodule in ["VTK", "Writers"]
+    for submodule in ["VTK", "Writers", "ArtifactWrappers"]
         if all_tests ||
            "$submodule" in ARGS ||
            "InputOutput/$submodule" in ARGS ||


### PR DESCRIPTION
### Description

Checking off a box in #1541!

I went to use [SafeTestsets.jl](https://github.com/YingboMa/SafeTestsets.jl), but I couldn't figure out how to use it without indenting all of the tests or breaking our recursive test structure call. (we can test Numerics/ or Numerics/ODESolvers).

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
