### PR TITLE
Add test to Atmos TemperatureProfiles

### DIFF
--- a/test/Atmos/TemperatureProfiles/runtests.jl
+++ b/test/Atmos/TemperatureProfiles/runtests.jl
@@ -32,6 +32,7 @@ const param_set = EarthParameterSet()
                 ),
                 DryAdiabaticProfile{FT}(param_set, _T_virt_surf, _T_min_ref),
                 IsothermalProfile(param_set, _T_virt_surf),
+                IsothermalProfile(param_set, FT),
             ]
 
             for profile in profiles


### PR DESCRIPTION
### Description

Add test for `IsothermalProfile(param_set, FT)` constructor.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
