### PR TITLE
Improve TurbulenceClosures names, mv some abstract types to balance law

### DIFF
--- a/docs/src/APIs/Common/TurbulenceClosures.md
+++ b/docs/src/APIs/Common/TurbulenceClosures.md
@@ -12,8 +12,6 @@ TurbulenceClosures
 
 ```@docs
 TurbulenceClosureModel
-hyperdiff_enthalpy_and_momentum_flux
-hyperdiff_momentum_flux
 WithDivergence
 WithoutDivergence
 ConstantViscosity

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -89,7 +89,7 @@ eq_tends(pv::PV, m::AtmosModel, tt::Flux{SecondOrder}) where {PV <: Momentum} =
         ViscousStress{PV}(),
         eq_tends(pv, m.moisture, tt)...,
         eq_tends(pv, m.turbconv, tt)...,
-        hyperdiff_momentum_flux(pv, m.hyperdiffusion, tt)...,
+        eq_tends(pv, m.hyperdiffusion, tt)...,
     )
 
 # Energy
@@ -106,7 +106,7 @@ eq_tends(
 ) where {PV <: AbstractEnergy} = (
     eq_tends(pv, m.energy, tt)...,
     eq_tends(pv, m.turbconv, tt)...,
-    hyperdiff_enthalpy_and_momentum_flux(pv, m.hyperdiffusion, tt)...,
+    eq_tends(pv, m.hyperdiffusion, tt)...,
 )
 
 # Moisture
@@ -114,7 +114,7 @@ eq_tends(pv::PV, m::AtmosModel, tt::Flux{SecondOrder}) where {PV <: Moisture} =
     (
         eq_tends(pv, m.moisture, tt)...,
         eq_tends(pv, m.turbconv, tt)...,
-        hyperdiff_momentum_flux(pv, m.hyperdiffusion, tt)...,
+        eq_tends(pv, m.hyperdiffusion, tt)...,
     )
 
 # Precipitation

--- a/src/Atmos/Model/declare_prognostic_vars.jl
+++ b/src/Atmos/Model/declare_prognostic_vars.jl
@@ -1,23 +1,20 @@
 ##### Prognostic variable
 
 export Mass, Momentum, Energy, ρθ_liq_ice
-export Moisture, TotalMoisture, LiquidMoisture, IceMoisture
-export Precipitation, Rain, Snow
+export TotalMoisture, LiquidMoisture, IceMoisture
+export Rain, Snow
 export Tracers
 
 struct Mass <: PrognosticVariable end
-struct Momentum <: PrognosticVariable end
+struct Momentum <: AbstractMomentum end
 
-abstract type AbstractEnergy <: PrognosticVariable end
 struct Energy <: AbstractEnergy end
 struct ρθ_liq_ice <: AbstractEnergy end
 
-abstract type Moisture <: PrognosticVariable end
 struct TotalMoisture <: Moisture end
 struct LiquidMoisture <: Moisture end
 struct IceMoisture <: Moisture end
 
-abstract type Precipitation <: PrognosticVariable end
 struct Rain <: Precipitation end
 struct Snow <: Precipitation end
 

--- a/src/BalanceLaws/tendency_types.jl
+++ b/src/BalanceLaws/tendency_types.jl
@@ -15,7 +15,9 @@
 #  - `T₂` - the second order flux divergence (column vector)
 #  - `S` - the non-conservative source (column vector)
 
-export PrognosticVariable
+export PrognosticVariable,
+    AbstractMomentum, AbstractEnergy, Moisture, Precipitation
+
 export FirstOrder, SecondOrder
 export AbstractTendencyType, Flux, Source
 export TendencyDef
@@ -27,6 +29,12 @@ Subtypes are used for specifying
 each prognostic variable.
 """
 abstract type PrognosticVariable end
+
+abstract type AbstractMomentum <: PrognosticVariable end
+abstract type AbstractEnergy <: PrognosticVariable end
+abstract type Moisture <: PrognosticVariable end
+abstract type Precipitation <: PrognosticVariable end
+
 
 """
     AbstractOrder

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -73,7 +73,9 @@ export TurbulenceClosureModel,
     turbulence_tensors,
     init_aux_turbulence!,
     init_aux_hyperdiffusion!,
-    sponge_viscosity_modifier
+    sponge_viscosity_modifier,
+    HyperdiffEnthalpyFlux,
+    HyperdiffViscousFlux
 
 # ### Abstract Type
 # We define a `TurbulenceClosureModel` abstract type and
@@ -1015,63 +1017,25 @@ end
 
 const Biharmonic = Union{EquilMoistBiharmonic, DryBiharmonic}
 
-export HyperdiffEnthalpyFlux
 struct HyperdiffEnthalpyFlux{PV} <: TendencyDef{Flux{SecondOrder}, PV} end
-
-export HyperdiffViscousFlux
 struct HyperdiffViscousFlux{PV} <: TendencyDef{Flux{SecondOrder}, PV} end
 
-export hyperdiff_enthalpy_and_momentum_flux
-
-"""
-    hyperdiff_enthalpy_and_momentum_flux(
-        ::PrognosticVariable,
-        ::HyperDiffusion,
-        ::AbstractTendencyType,
-    )
-
-A tuple of the hyperdiffusive enthalpy
-and viscous flux types based on the
-diffusive model.
-"""
-function hyperdiff_enthalpy_and_momentum_flux end
-
-# empty tuple by default
-hyperdiff_enthalpy_and_momentum_flux(
-    pv::PV,
-    ::HyperDiffusion,
-    ::Flux{SecondOrder},
-) where {PV} = ()
+# empty by default
+eq_tends(pv::PV, ::HyperDiffusion, ::AbstractTendencyType) where {PV} = ()
 
 # Enthalpy and viscous for Biharmonic model
-hyperdiff_enthalpy_and_momentum_flux(
+eq_tends(
     pv::PV,
     ::Biharmonic,
     ::Flux{SecondOrder},
-) where {PV} = (HyperdiffEnthalpyFlux{PV}(), HyperdiffViscousFlux{PV}())
-
-export hyperdiff_momentum_flux
-"""
-    hyperdiff_momentum_flux(
-        ::PrognosticVariable,
-        ::HyperDiffusion,
-        ::AbstractTendencyType,
-    )
-
-A tuple of the hyperdiffusive viscous
-flux types based on the diffusive model.
-"""
-function hyperdiff_momentum_flux end
-
-# empty tuple by default
-hyperdiff_momentum_flux(
-    pv::PV,
-    ::HyperDiffusion,
-    ::Flux{SecondOrder},
-) where {PV} = ()
+) where {PV <: AbstractEnergy} =
+    (HyperdiffEnthalpyFlux{PV}(), HyperdiffViscousFlux{PV}())
 
 # Viscous for Biharmonic model
-hyperdiff_momentum_flux(pv::PV, ::Biharmonic, ::Flux{SecondOrder}) where {PV} =
-    (HyperdiffViscousFlux{PV}(),)
+eq_tends(
+    pv::PV,
+    ::Biharmonic,
+    ::Flux{SecondOrder},
+) where {PV <: AbstractMomentum} = (HyperdiffViscousFlux{PV}(),)
 
 end #module TurbulenceClosures.jl


### PR DESCRIPTION
### Description

This PR renames `hyperdiff_momentum_flux` and `hyperdiff_enthalpy_and_momentum_flux` to `eq_tends`, because that's basically what they are--they return a tuple of tendency definition types. To make this work, we need to move some Atmos abstract prognostic variable types to the balance law, so that Atmos submodel's can use these types to distinguish between some variables. Thanks to @kpamnany for this suggestion!

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
