### PR TITLE
Remove unused recover_thermo_state methods

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -960,12 +960,7 @@ function numerical_flux_first_order!(
     ρ⁻ = state_prognostic⁻.ρ
     ρu⁻ = state_prognostic⁻.ρu
     ρe⁻ = state_prognostic⁻.energy.ρe
-    ts⁻ = recover_thermo_state(
-        balance_law,
-        balance_law.moisture,
-        state_prognostic⁻,
-        state_auxiliary⁻,
-    )
+    ts⁻ = recover_thermo_state(balance_law, state_prognostic⁻, state_auxiliary⁻)
 
     u⁻ = ρu⁻ / ρ⁻
     uᵀn⁻ = u⁻' * normal_vector
@@ -980,12 +975,7 @@ function numerical_flux_first_order!(
 
     # TODO: state_auxiliary⁺ is not up-to-date
     # with state_prognostic⁺ on the boundaries
-    ts⁺ = recover_thermo_state(
-        balance_law,
-        balance_law.moisture,
-        state_prognostic⁺,
-        state_auxiliary⁺,
-    )
+    ts⁺ = recover_thermo_state(balance_law, state_prognostic⁺, state_auxiliary⁺)
 
     u⁺ = ρu⁺ / ρ⁺
     uᵀn⁺ = u⁺' * normal_vector
@@ -1114,12 +1104,7 @@ function numerical_flux_first_order!(
     ρ⁻ = state_prognostic⁻.ρ
     ρu⁻ = state_prognostic⁻.ρu
     ρe⁻ = state_prognostic⁻.energy.ρe
-    ts⁻ = recover_thermo_state(
-        balance_law,
-        balance_law.moisture,
-        state_prognostic⁻,
-        state_auxiliary⁻,
-    )
+    ts⁻ = recover_thermo_state(balance_law, state_prognostic⁻, state_auxiliary⁻)
 
     u⁻ = ρu⁻ / ρ⁻
     c⁻ = soundspeed_air(ts⁻)
@@ -1131,12 +1116,7 @@ function numerical_flux_first_order!(
     ρ⁺ = state_prognostic⁺.ρ
     ρu⁺ = state_prognostic⁺.ρu
     ρe⁺ = state_prognostic⁺.energy.ρe
-    ts⁺ = recover_thermo_state(
-        balance_law,
-        balance_law.moisture,
-        state_prognostic⁺,
-        state_auxiliary⁺,
-    )
+    ts⁺ = recover_thermo_state(balance_law, state_prognostic⁺, state_auxiliary⁺)
 
     u⁺ = ρu⁺ / ρ⁺
     uᵀn⁺ = u⁺' * normal_vector
@@ -1459,12 +1439,7 @@ function numerical_flux_first_order!(
     ρ⁻ = state_prognostic⁻.ρ
     ρu⁻ = state_prognostic⁻.ρu
     ρe⁻ = state_prognostic⁻.energy.ρe
-    ts⁻ = recover_thermo_state(
-        balance_law,
-        balance_law.moisture,
-        state_prognostic⁻,
-        state_auxiliary⁻,
-    )
+    ts⁻ = recover_thermo_state(balance_law, state_prognostic⁻, state_auxiliary⁻)
 
     u⁻ = ρu⁻ / ρ⁻
     e⁻ = ρe⁻ / ρ⁻
@@ -1480,12 +1455,7 @@ function numerical_flux_first_order!(
     ρ⁺ = state_prognostic⁺.ρ
     ρu⁺ = state_prognostic⁺.ρu
     ρe⁺ = state_prognostic⁺.energy.ρe
-    ts⁺ = recover_thermo_state(
-        balance_law,
-        balance_law.moisture,
-        state_prognostic⁺,
-        state_auxiliary⁺,
-    )
+    ts⁺ = recover_thermo_state(balance_law, state_prognostic⁺, state_auxiliary⁺)
     u⁺ = ρu⁺ / ρ⁺
     e⁺ = ρe⁺ / ρ⁺
     uᵀn⁺ = u⁺' * normal_vector

--- a/src/Atmos/Model/bc_energy.jl
+++ b/src/Atmos/Model/bc_energy.jl
@@ -192,7 +192,7 @@ function atmos_energy_normal_boundary_flux_second_order!(
 
     # calculate MSE from the states at the boundary and at the interior point
     ts = PhaseEquil_ρTq(atmos.param_set, state⁻.ρ, T, q_tot)
-    ts_int = recover_thermo_state(atmos, atmos.moisture, state_int⁻, aux_int⁻)
+    ts_int = recover_thermo_state(atmos, state_int⁻, aux_int⁻)
     e_pot = gravitational_potential(atmos.orientation, aux⁻)
     e_pot_int = gravitational_potential(atmos.orientation, aux_int⁻)
     MSE = moist_static_energy(ts, e_pot)

--- a/src/Atmos/Model/thermo_states.jl
+++ b/src/Atmos/Model/thermo_states.jl
@@ -123,61 +123,12 @@ end
 An atmospheric thermodynamic state.
 
 !!! warn
-    While recover_thermo_state is an ideal long-term solution,
-    right now we are directly calling new_thermo_state to avoid
+    For now, we are directly calling new_thermo_state to avoid
     inconsistent aux states in kernels where the aux states are
     out of sync with the boundary state.
 
-# TODO:
-    - Allow a safe way to call
-    `recover_thermo_state(state, moist::EquilMoist, ...)`
+# TODO: Define/call `recover_thermo_state` when it's safely implemented
+  (see https://github.com/CliMA/ClimateMachine.jl/issues/1648)
 """
 recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
     new_thermo_state(atmos, atmos.energy, atmos.moisture, state, aux)
-
-function recover_thermo_state(
-    atmos::AtmosModel,
-    moist::DryModel,
-    state::Vars,
-    aux::Vars,
-)
-    e_int = internal_energy(atmos, state, aux)
-    return PhaseDry(atmos.param_set, e_int, state.ρ)
-end
-
-function recover_thermo_state(
-    atmos::AtmosModel,
-    moist::EquilMoist,
-    state::Vars,
-    aux::Vars,
-)
-    e_int = internal_energy(atmos, state, aux)
-    return PhaseEquil{eltype(state), typeof(atmos.param_set)}(
-        atmos.param_set,
-        e_int,
-        state.ρ,
-        state.moisture.ρq_tot / state.ρ,
-        aux.moisture.temperature,
-    )
-end
-
-function recover_thermo_state(
-    atmos::AtmosModel,
-    moist::NonEquilMoist,
-    state::Vars,
-    aux::Vars,
-)
-    e_int = internal_energy(atmos, state, aux)
-    q = PhasePartition(
-        state.moisture.ρq_tot / state.ρ,
-        state.moisture.ρq_liq / state.ρ,
-        state.moisture.ρq_ice / state.ρ,
-    )
-
-    return PhaseNonEquil{eltype(state), typeof(atmos.param_set)}(
-        atmos.param_set,
-        e_int,
-        state.ρ,
-        q,
-    )
-end


### PR DESCRIPTION
### Description

To avoid confusion, I'm removing the `recover_thermo_state` implementations, since they're unused (and already slightly stale). I've copied the implementations to the issue that needs to be fixed for the implementations to be added back in (#1648).

Glad I decided to remove this. It turns out that `bc_energy.jl` was sneakily calling the lower-level implementation. Fortunately, this is called on the first interior, so this PR should still be non-behavior changing (regarding #1648).

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
