### PR TITLE
Implement SurfaceFluxes in EDMF

### DIFF
--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -35,6 +35,7 @@ using ClimateMachine.TurbulenceClosures
 using ClimateMachine.TurbulenceConvection
 using ClimateMachine.VariableTemplates
 using ClimateMachine.BalanceLaws
+using ClimateMachine.SurfaceFluxes
 import ClimateMachine.BalanceLaws: source
 
 using CLIMAParameters
@@ -259,6 +260,9 @@ function stable_bl_model(
             (state, aux, t, normPu_int) -> C_drag,
             (state, aux, t) -> q_sfc,
         )
+        # elseif surface_flux == "Nishizawa2018"
+        #     energy_bc = PrescribedEnergyFlux((state, aux, t) -> LHF + SHF)
+        #     moisture_bc = PrescribedMoistureFlux((state, aux, t) -> moisture_flux)
     else
         @warn @sprintf(
             """

--- a/src/Common/SurfaceFluxes/SurfaceFluxes.jl
+++ b/src/Common/SurfaceFluxes/SurfaceFluxes.jl
@@ -114,10 +114,8 @@ Surface conditions given
  - `x_ave` volume-averaged value for variable `x`
  - `x_s` surface value for variable `x`
  - `z_0` roughness length for variable `x`
- - `F_exchange` flux at the top for variable `x`
  - `VDSE_scale` virtual dry static energy (i.e., basic potential temperature)
- - `Δz` layer thickness (not spatial discretization)
- - `z` coordinate axis
+ - `Δz` layer thickness
  - `VDSE_flux_star` potential temperature flux (optional)
 
 If `VDSE_flux_star` is not given, then it is computed by iteration
@@ -129,11 +127,8 @@ function surface_conditions(
     x_ave::AbstractVector,
     x_s::AbstractVector,
     z_0::AbstractVector,
-    F_exchange::AbstractVector,
     VDSE_scale::FT,
-    qt_bar::FT,
     Δz::FT,
-    z::FT,
     scheme,
     VDSE_flux_star::Union{Nothing, FT} = nothing,
 ) where {FT <: AbstractFloat, AbstractEarthParameterSet}
@@ -143,7 +138,6 @@ function surface_conditions(
     @assert length(x_ave) == n_vars
     @assert length(x_s) == n_vars
     @assert length(z_0) == n_vars
-    @assert length(F_exchange) == n_vars
     local sol
 
     args = (;
@@ -181,17 +175,8 @@ function surface_conditions(
     VDSE_flux_star = -u_star^3 * VDSE_scale / (_von_karman_const * _grav * L_MO)
     flux = -u_star * x_star
 
-    K_exchange = exchange_coefficients(
-        param_set,
-        z,
-        F_exchange,
-        x_star,
-        VDSE_scale,
-        L_MO,
-    )
-
     C_exchange =
-        get_flux_coefficients(param_set, z, x_star, VDSE_scale, L_MO, z_0)
+        get_flux_coefficients(param_set, Δz, x_star, VDSE_scale, L_MO, z_0)
 
     VFT = typeof(flux)
     return SurfaceFluxConditions{FT, VFT}(

--- a/test/Atmos/EDMF/closures/mixing_length.jl
+++ b/test/Atmos/EDMF/closures/mixing_length.jl
@@ -49,10 +49,6 @@ function mixing_length(
     tke_en = max(en.ρatke, 0) * ρinv / env.a
 
     # buoyancy related functions
-    # compute obukhov_length and ustar from SurfaceFlux.jl here
-    ustar = m.turbconv.surface.ustar
-    obukhov_length = m.turbconv.surface.obukhov_length
-
     ∂b∂z, Nˢ_eff = compute_buoyancy_gradients(m, args, ts_gm, ts_en)
     Grad_Ri = ∇Richardson_number(∂b∂z, Shear², 1 / ml.max_length, ml.Ri_c)
     Pr_t = turbulent_Prandtl_number(ml.Pr_n, Grad_Ri, ml.ω_pr)
@@ -63,14 +59,8 @@ function mixing_length(
     L_Nˢ = coeff * Nˢ_fact + ml.max_length * (FT(1) - Nˢ_fact)
 
     # compute L2 - law of the wall
-    surf_vals = subdomain_surface_values(
-        m.turbconv.surface,
-        m.turbconv,
-        m,
-        gm,
-        gm_aux,
-        m.turbconv.surface.zLL,
-    )
+    # compute obukhov_length from SurfaceFlux.jl here
+    obukhov_length = FT(0)
 
     L_W = ml.κ * z / (sqrt(m.turbconv.surface.κ_star²) * ml.c_m)
     if obukhov_length < -eps(FT)

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -1156,8 +1156,18 @@ function turbconv_boundary_state!(
     θ_liq_cv,
     q_tot_cv,
     θ_liq_q_tot_cv,
-    tke =
-        subdomain_surface_values(turbconv.surface, turbconv, m, gm⁻, gm_a⁻, zLL)
+    tke,
+    _,
+    _ = subdomain_surface_values(
+        turbconv.surface,
+        turbconv,
+        m,
+        gm⁻,
+        gm_a⁻,
+        state_int,
+        aux_int,
+        zLL,
+    )
 
     @unroll_map(N_up) do i
         up⁺[i].ρaw = FT(0)

--- a/test/Atmos/EDMF/edmf_model.jl
+++ b/test/Atmos/EDMF/edmf_model.jl
@@ -80,30 +80,16 @@ values and parameters needed by the model.
 $(DocStringExtensions.FIELDS)
 """
 Base.@kwdef struct SurfaceModel{FT <: AbstractFloat, SV}
-    "Temperature ‵[k]‵"
-    T::FT = 300.4
-    "Liquid water potential temperature ‵[k]‵"
-    θ_liq::FT = 299.1
-    "Specific humidity ‵[kg/kg]‵"
-    q_tot::FT = 22.45e-3
-    "Sensible heat flux ‵[w/m^2]‵"
-    shf::FT = 9.5
-    "Latent heat flux ‵[w/m^2]‵"
-    lhf::FT = 147.2
     "Area"
     a::FT
     "Scalar coefficient"
     scalar_coeff::SV = 0
-    "Friction velocity"
-    ustar::FT = 0.28
-    "Monin - Obukhov length"
-    obukhov_length::FT = 0
     "Surface covariance stability coefficient"
     ψϕ_stab::FT = 8.3
     "Square ratio of rms turbulent velocity to friction velocity"
     κ_star²::FT = 3.75
-    "Height of the lowest level"
-    zLL::FT = 60
+    "Roughness height"
+    z_0::FT = 0.1
 end
 
 """

--- a/test/Common/SurfaceFluxes/runtests.jl
+++ b/test/Common/SurfaceFluxes/runtests.jl
@@ -115,21 +115,7 @@ const param_set = EarthParameterSet()
         # Constants
         Δz = Tuple(z)[ii]
 
-        # F_exchange
-        F_exchange = ArrayType(FT[0.01, -0.01, -0.000001])
-
-        args = (
-            param_set,
-            x_init,
-            x_ave,
-            x_s,
-            z_rough,
-            F_exchange,
-            vdse_ave,
-            qt_ave,
-            Δz,
-            z_ave / 2,
-        )
+        args = (param_set, x_init, x_ave, x_s, z_rough, vdse_ave, Δz)
 
         ## Assuming surface fluxes are not given
         result = surface_conditions(args..., SF.DGScheme())


### PR DESCRIPTION
### Description

This PR makes use of the SurfaceFluxes module for EDMF single stack simulations. The necessary changes with respect to the previous implementation are:

- Diagnostic of friction velocity and Obuhkov length, instead of hardcoding their values.
- Diagnostic of heat, momentum and moisture surface fluxes following Monin Obukhov Similarity Theory and Nishizawa et al (2018). These fluxes have to be passed to the grid mean and to the surface functions in the EDMF scheme.

It would probably be useful to cache the results of the iterative solver somewhere so that they do not have to be recomputed in different places. They are needed right now in the model files (e.g. `stable_bl_model.jl`), `surface_functions.jl` and the obukhov length should be accessible to `mixing_length.jl`.

There is also the need to pass the boundary state and the first interior point state to SurfaceFluxes. This is easy for the pass in `surface_functions.jl`, but not for `stable_bl_model.jl`.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
