### PR TITLE
Add Vars wrapper for `transform_post_gradient_laplacian!`

### DIFF
--- a/src/BalanceLaws/vars_wrappers.jl
+++ b/src/BalanceLaws/vars_wrappers.jl
@@ -174,3 +174,23 @@ function reverse_integral_set_auxiliary_state_arr!(
         Vars{vars_state(balance_law, DownwardIntegrals(), FT)}(l_V),
     )
 end
+
+function transform_post_gradient_laplacian_arr!(
+    balance_law,
+    hyperdiffusion::AbstractArray,
+    l_grad_lap::AbstractArray,
+    prognostic::AbstractArray,
+    auxiliary::AbstractArray,
+    t,
+)
+
+    FT = eltype(prognostic)
+    transform_post_gradient_laplacian!(
+        balance_law,
+        Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(hyperdiffusion),
+        Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad_lap),
+        Vars{vars_state(balance_law, Prognostic(), FT)}(prognostic),
+        Vars{vars_state(balance_law, Auxiliary(), FT)}(auxiliary),
+        t,
+    )
+end

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -33,7 +33,7 @@ import ..BalanceLaws:
     compute_gradient_flux_arr!,
     compute_gradient_argument_arr!,
     source_arr!,
-    transform_post_gradient_laplacian!,
+    transform_post_gradient_laplacian_arr!,
     wavespeed,
     boundary_conditions,
     boundary_state!,

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -2637,24 +2637,12 @@ D is the differentiation matrix and ΔG is the laplacian
             )
 
             # Applies a linear transformation of gradients to the hyperdiffusive variables
-            transform_post_gradient_laplacian!(
+            transform_post_gradient_laplacian_arr!(
                 balance_law,
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion,
-                ),
-                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad_lap[
-                    :,
-                    :,
-                    k,
-                ]),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[
-                    :,
-                    k,
-                ]),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[
-                    :,
-                    k,
-                ]),
+                local_state_hyperdiffusion,
+                l_grad_lap[:, :, k],
+                local_state_prognostic[:, k],
+                local_state_auxiliary[:, k],
                 t,
             )
 
@@ -2801,24 +2789,12 @@ end
             )
 
             # Applies a linear transformation of gradients to the hyperdiffusive variables
-            transform_post_gradient_laplacian!(
+            transform_post_gradient_laplacian_arr!(
                 balance_law,
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion,
-                ),
-                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad_lap[
-                    :,
-                    :,
-                    k,
-                ]),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_state_prognostic[
-                    :,
-                    k,
-                ]),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(local_state_auxiliary[
-                    :,
-                    k,
-                ]),
+                local_state_hyperdiffusion,
+                l_grad_lap[:, :, k],
+                local_state_prognostic[:, k],
+                local_state_auxiliary[:, k],
                 t,
             )
 


### PR DESCRIPTION
### Description

I missed one last wrapper in #1979 for `transform_post_gradient_laplacian!`. It's amazing that these wrappers are actually _trimming_ lines 😄 

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
