### PR TITLE
MIS method docstrings

### DIFF
--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -345,6 +345,17 @@
   year = {2014}
 }
 
+@article{KnothWolke1998,
+  title = "Implicit-explicit Runge-Kutta methods for computing atmospheric reactive flows",
+  journal = "Applied Numerical Mathematics",
+  volume = "28",
+  number = "2",
+  pages = "327--341",
+  year = "1998",
+  doi = "https://doi.org/10.1016/S0168-9274(98)00051-8",
+  author = "Oswald Knoth and Ralf Wolke"
+}
+
 @article{Kopriva2006,
   title = {Metric identities and the discontinuous spectral element method on curvilinear meshes},
   author = {Kopriva, David A},

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -102,17 +102,17 @@
 }
 
 @article {Chen2013,
-      author = "Xi Chen and Natalia Andronova and Bram Van Leer and Joyce E. Penner and John P. Boyd and Christiane Jablonowski and Shian-Jiann Lin",
-      title = "A Control-Volume Model of the Compressible Euler Equations with a Vertical Lagrangian Coordinate",
-      journal = "Monthly Weather Review",
-      year = "01 Jul. 2013",
-      publisher = "American Meteorological Society",
-      address = "Boston MA, USA",
-      volume = "141",
-      number = "7",
-      doi = "10.1175/MWR-D-12-00129.1",
-      pages=      "2526 - 2544",
-      url = "https://journals.ametsoc.org/view/journals/mwre/141/7/mwr-d-12-00129.1.xml"
+  author = "Xi Chen and Natalia Andronova and Bram Van Leer and Joyce E. Penner and John P. Boyd and Christiane Jablonowski and Shian-Jiann Lin",
+  title = "A Control-Volume Model of the Compressible Euler Equations with a Vertical Lagrangian Coordinate",
+  journal = "Monthly Weather Review",
+  year = "01 Jul. 2013",
+  publisher = "American Meteorological Society",
+  address = "Boston MA, USA",
+  volume = "141",
+  number = "7",
+  doi = "10.1175/MWR-D-12-00129.1",
+  pages=      "2526 - 2544",
+  url = "https://journals.ametsoc.org/view/journals/mwre/141/7/mwr-d-12-00129.1.xml"
 }
 
 
@@ -781,15 +781,27 @@
 }
 
 @article{Webb2017,
-    author = {Webb, M. J. and Andrews, T. and Bodas-Salcedo, A. and Bony, S. and Bretherton, C. S. and Chadwick, R. and Chepfer, H. and Douville, H. and Good, P. and Kay, J. E. and Klein, S. A. and Marchand, R. and Medeiros, B. and Siebesma, A. P. and Skinner, C. B. and Stevens, B. and Tselioudis, G. and Tsushima, Y. and Watanabe, M.},
-    title = {The Cloud Feedback Model Intercomparison Project (CFMIP) contribution to CMIP6},
-    journal = {Geoscientific Model Development},
-    volume = {10},
-    year = {2017},
-    number = {1},
-    pages = {359--384},
-    url = {https://www.geosci-model-dev.net/10/359/2017/},
-    doi = {10.5194/gmd-10-359-2017},
+  author = {Webb, M. J. and Andrews, T. and Bodas-Salcedo, A. and Bony, S. and Bretherton, C. S. and Chadwick, R. and Chepfer, H. and Douville, H. and Good, P. and Kay, J. E. and Klein, S. A. and Marchand, R. and Medeiros, B. and Siebesma, A. P. and Skinner, C. B. and Stevens, B. and Tselioudis, G. and Tsushima, Y. and Watanabe, M.},
+  title = {The Cloud Feedback Model Intercomparison Project (CFMIP) contribution to CMIP6},
+  journal = {Geoscientific Model Development},
+  volume = {10},
+  year = {2017},
+  number = {1},
+  pages = {359--384},
+  url = {https://www.geosci-model-dev.net/10/359/2017/},
+  doi = {10.5194/gmd-10-359-2017},
+}
+
+@article {WickerSkamarock2002,
+  author = "Louis J. Wicker and William C. Skamarock",
+  title = "Time-Splitting Methods for Elastic Models Using Forward Time Schemes",
+  journal = "Monthly Weather Review",
+  year = "2002",
+  publisher = "American Meteorological Society",
+  volume = "130",
+  number = "8",
+  doi = "10.1175/1520-0493(2002)130<2088:TSMFEM>2.0.CO;2",
+  pages= "2088--2097",
 }
 
 @article{Wiin1967,
@@ -838,4 +850,5 @@
   doi = {10.1007/BF00223393},
   publisher = {Springer}
 }
+
 

--- a/docs/src/APIs/Numerics/ODESolvers/ODESolvers.md
+++ b/docs/src/APIs/Numerics/ODESolvers/ODESolvers.md
@@ -55,6 +55,8 @@ ODESolvers.MultirateRungeKutta
 ## Multi-rate Infinitesimal Step Methods
 
 ```@docs
+ODESolvers.TimeScaledRHS
+ODESolvers.MultirateInfinitesimalStep
 ODESolvers.MISRK1
 ODESolvers.MIS2
 ODESolvers.MISRK2a

--- a/docs/src/APIs/Numerics/ODESolvers/ODESolvers.md
+++ b/docs/src/APIs/Numerics/ODESolvers/ODESolvers.md
@@ -55,8 +55,6 @@ ODESolvers.MultirateRungeKutta
 ## Multi-rate Infinitesimal Step Methods
 
 ```@docs
-ODESolvers.TimeScaledRHS
-ODESolvers.MultirateInfinitesimalStep
 ODESolvers.MISRK1
 ODESolvers.MIS2
 ODESolvers.MISRK2a

--- a/docs/src/APIs/Numerics/ODESolvers/ODESolvers.md
+++ b/docs/src/APIs/Numerics/ODESolvers/ODESolvers.md
@@ -57,6 +57,17 @@ ODESolvers.MultirateRungeKutta
 ```@docs
 ODESolvers.TimeScaledRHS
 ODESolvers.MultirateInfinitesimalStep
+ODESolvers.MISRK1
+ODESolvers.MIS2
+ODESolvers.MISRK2a
+ODESolvers.MISRK2b
+ODESolvers.MIS3C
+ODESolvers.MISRK3
+ODESolvers.MIS4
+ODESolvers.MIS4a
+ODESolvers.MISKWRK43
+ODESolvers.TVDMISA
+ODESolvers.TVDMISB
 ```
 
 ## Split-explicit methods

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalGARKExplicit.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalGARKExplicit.jl
@@ -44,21 +44,23 @@ Construct an explicit MultiRate Infinitesimal General-structure Additive
 Runge--Kutta (MRI-GARK) scheme to solve
 
 ```math
-    \\dot{y} = f(y, t) + g(y, t)
+    \\dot{y} = f_{slow}(y, t) + f_{fast}(y, t)
 ```
 
-where `f` is the slow tendency function and `g` is the fast tendency function;
+where `f_{slow}` is the slow tendency function and `f_{fast}` is the fast tendency function;
 see Sandu (2019).
 
 The fast tendency is integrated using the `fastsolver` and the slow tendency
 using the MRI-GARK scheme. Namely, at each stage the scheme solves
 
 ```math
+\\begin{aligned}
                v(T_i) &= Y_i \\\\
              \\dot{v} &= f(v, t) + \\sum_{j=1}^{i} \\bar{γ}_{ij}(t) R_j \\\\
     \\bar{γ}_{ijk}(t) &= \\sum_{k=0}^{NΓ-1} γ_{ijk} τ(t)^k / Δc_s \\\\
                  τ(t) &= (t - t_s) / Δt \\\\
               Y_{i+1} &= v(T_i + c_s * Δt)
+\\end{aligned}
 ```
 
 where ``Y_1 = y_n`` and ``y_{n+1} = Y_{Nstages+1}``.

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalStepMethod.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalStepMethod.jl
@@ -65,7 +65,7 @@ This is a time stepping object for explicitly time stepping the partitioned diff
 equation given by right-hand-side functions `f_fast` and `f_slow` with the state `Q`, i.e.,
 
 ```math
-  \\dot{Q} = f_fast(Q, t) + f_slow(Q, t)
+  \\dot{Q} = f_{fast}(Q, t) + f_{slow}(Q, t)
 ```
 
 with the required time step size `dt` and optional initial time `t0`.  This
@@ -91,6 +91,8 @@ The available concrete implementations are:
 
 ### References
  - [KnothWensch2014](@cite)
+ - [WickerSkamarock2002](@cite)
+ - [KnothWolke1998](@cite)
 """
 mutable struct MultirateInfinitesimalStep{
     T,
@@ -453,8 +455,9 @@ end
 """
     MISRK2a(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
 
-The `MISRK2a` method is a 2nd-order accurate, 2-stage method
-based on the approach detailed by Wicker and Skamarock.
+The `MISRK2a` method is a 2nd-order accurate, 2-stage MIS method
+based on the approach detailed by Wicker and Skamarock in
+[WickerSkamarock2002](@cite).
 
 ### References
  - [WickerSkamarock2002](@cite)
@@ -506,10 +509,12 @@ end
 """
     MISRK2b(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
 
-
+The `MISRK2b` method is a 2nd-order accurate, 2-stage MIS method and a
+variant of the `MISRK2a` method based on the approach detailed by Wicker
+and Skamarock in [WickerSkamarock2002](@cite).
 
 ### References
- -
+ - [WickerSkamarock2002](@cite)
 """
 function MISRK2b(
     slowrhs!,
@@ -618,11 +623,12 @@ end
 """
     MISRK3(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
 
-The `MISRK3` method is a 3rd-order accurate, 3-stage method
-based on the approach detailed by Wicker and Skamarock.
+The `MISRK3` method is a 3rd-order accurate, 3-stage MIS method
+based on the approach detailed by Wicker and Skamarock in
+[WickerSkamarock2002](@cite).
 
 ### References
- - [WickerSkamarock](@cite)
+ - [WickerSkamarock2002](@cite)
 """
 function MISRK3(
     slowrhs!,
@@ -792,10 +798,12 @@ end
 """
     MISKWRK43(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
 
-
+The `MISKWRK43` method is a 3rd-order accurate, 4-stage MIS method. It is the
+MIS analog of an RK43 method, based on the approach detailed in
+[KnothWolke1998](@cite).
 
 ### References
- -
+ - [KnothWolke1998](@cite)
 """
 function MISKWRK43(
     slowrhs!,

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalStepMethod.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalStepMethod.jl
@@ -57,9 +57,9 @@ function (o::OffsetRHS{AT} where {AT})(dQ, Q, params, tau; increment)
 end
 
 """
-MultirateInfinitesimalStep(slowrhs!, fastrhs!, fastmethod,
-                           α, β, γ,
-                           Q::AT; dt=0, t0=0) where {AT<:AbstractArray}
+    MultirateInfinitesimalStep(slowrhs!, fastrhs!, fastmethod,
+                               α, β, γ,
+                               Q::AT; dt=0, t0=0) where {AT<:AbstractArray}
 
 This is a time stepping object for explicitly time stepping the partitioned differential
 equation given by right-hand-side functions `f_fast` and `f_slow` with the state `Q`, i.e.,
@@ -74,6 +74,20 @@ time stepping object is intended to be passed to the `solve!` command.
 The constructor builds a multirate infinitesimal step Runge-Kutta scheme
 based on the provided `α`, `β` and `γ` tableaux and `fastmethod` for solving
 the fast modes.
+
+The available concrete implementations are:
+
+  - [`MISRK1`](@ref)
+  - [`MIS2`](@ref)
+  - [`MISRK2a`](@ref)
+  - [`MISRK2b`](@ref)
+  - [`MIS3C`](@ref)
+  - [`MISRK3`](@ref)
+  - [`MIS4`](@ref)
+  - [`MIS4a`](@ref)
+  - [`MISKWRK43`](@ref)
+  - [`TVDMISA`](@ref)
+  - [`TVDMISB`](@ref)
 
 ### References
  - [KnothWensch2014](@cite)
@@ -332,6 +346,15 @@ end
     end
 end
 
+"""
+    MISRK1(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+The `MISRK1` method is a 1st-order accurate MIS method based
+on the RK1 (explicit Euler) method.
+
+### References
+ - [KnothWensch2014](@cite)
+"""
 function MISRK1(
     slowrhs!,
     fastrhs!,
@@ -367,6 +390,15 @@ function beta(::typeof(MISRK1), RT::DataType)
     ]
 end
 
+"""
+    MIS2(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+The `MIS2` method is a 2nd-order accurate, 3-stage MIS method whose
+construction is summarized in Table 1 of [KnothWensch2014](@cite).
+
+### References
+ - [KnothWensch2014](@cite)
+"""
 function MIS2(
     slowrhs!,
     fastrhs!,
@@ -418,6 +450,15 @@ function beta(::typeof(MIS2), RT::DataType)
     ]
 end
 
+"""
+    MISRK2a(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+The `MISRK2a` method is a 2nd-order accurate, 2-stage method
+based on the approach detailed by Wicker and Skamarock.
+
+### References
+ - [WickerSkamarock2002](@cite)
+"""
 function MISRK2a(
     slowrhs!,
     fastrhs!,
@@ -462,6 +503,14 @@ function beta(::typeof(MISRK2a), RT::DataType)
     ]
 end
 
+"""
+    MISRK2b(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+
+
+### References
+ -
+"""
 function MISRK2b(
     slowrhs!,
     fastrhs!,
@@ -506,6 +555,15 @@ function beta(::typeof(MISRK2b), RT::DataType)
     ]
 end
 
+"""
+    MIS3C(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+The `MIS3C` method is a 3rd-order accurate, 3-stage MIS method whose
+construction is summarized in Table 2 of [KnothWensch2014](@cite).
+
+### References
+ - [KnothWensch2014](@cite)
+"""
 function MIS3C(
     slowrhs!,
     fastrhs!,
@@ -557,6 +615,15 @@ function beta(::typeof(MIS3C), RT::DataType)
     ]
 end
 
+"""
+    MISRK3(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+The `MISRK3` method is a 3rd-order accurate, 3-stage method
+based on the approach detailed by Wicker and Skamarock.
+
+### References
+ - [WickerSkamarock](@cite)
+"""
 function MISRK3(
     slowrhs!,
     fastrhs!,
@@ -594,6 +661,15 @@ function beta(::typeof(MISRK3), RT::DataType)
     ]
 end
 
+"""
+    MIS4(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+The `MIS4` method is a 3rd-order accurate, 4-stage MIS method whose
+construction is summarized in Table 3 of [KnothWensch2014](@cite).
+
+### References
+ - [KnothWensch2014](@cite)
+"""
 function MIS4(
     slowrhs!,
     fastrhs!,
@@ -648,6 +724,15 @@ function beta(::typeof(MIS4), RT::DataType)
     ]
 end
 
+"""
+    MIS4a(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+The `MIS4a` method is a 3rd-order accurate, 4-stage MIS method whose
+construction is summarized in Table 4 of [KnothWensch2014](@cite).
+
+### References
+ - [KnothWensch2014](@cite)
+"""
 function MIS4a(
     slowrhs!,
     fastrhs!,
@@ -704,6 +789,14 @@ function beta(::typeof(MIS4a), RT::DataType)
     ]
 end
 
+"""
+    MISKWRK43(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+
+
+### References
+ -
+"""
 function MISKWRK43(
     slowrhs!,
     fastrhs!,
@@ -752,6 +845,15 @@ function beta(::typeof(MISKWRK43), RT::DataType)
     ]
 end
 
+"""
+    TVDMISA(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+The `TVDMISA` method is a 3rd-order accurate, 3-stage MIS method whose
+construction is summarized in Table 6 of [KnothWensch2014](@cite).
+
+### References
+ - [KnothWensch2014](@cite)
+"""
 function TVDMISA(
     slowrhs!,
     fastrhs!,
@@ -803,6 +905,15 @@ function beta(::typeof(TVDMISA), RT::DataType)
     ]
 end
 
+"""
+    TVDMISB(slowrhs!, fastrhs!, fastmethod, nsubsteps, Q; dt = 0, t0 = 0)
+
+The `TVDMISB` method is a 3rd-order accurate, 3-stage MIS method whose
+construction is summarized in Table 7 of [KnothWensch2014](@cite).
+
+### References
+ - [KnothWensch2014](@cite)
+"""
 function TVDMISB(
     slowrhs!,
     fastrhs!,

--- a/src/Numerics/ODESolvers/SplitExplicitMethod.jl
+++ b/src/Numerics/ODESolvers/SplitExplicitMethod.jl
@@ -15,8 +15,8 @@ This is a time stepping object for explicitly time stepping the differential
 equation given by the right-hand-side function `f` with the state `Q`, i.e.,
 
 ```math
-  \\dot{Q_fast} = f_fast(Q_fast, Q_slow, t)
-  \\dot{Q_slow} = f_slow(Q_slow, Q_fast, t)
+  \\dot{Q_{fast}} = f_{fast}(Q_{fast}, Q_{slow}, t)
+  \\dot{Q_{slow}} = f_{slow}(Q_{slow}, Q_{fast}, t)
 ```
 
 with the required time step size `dt` and optional initial time `t0`.  This


### PR DESCRIPTION
### Description
This PR adds some MIS Time Stepping method docstrings that were missing, so that they can show up in our API docs. 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
