### PR TITLE
Add bounds error test to VariableTemplates

### DIFF
--- a/test/Utilities/VariableTemplates/test_complex_models.jl
+++ b/test/Utilities/VariableTemplates/test_complex_models.jl
@@ -66,6 +66,10 @@ VT = VariableTemplates
     @test v.vector_model.x == SVector{Nv, FT}(collect(1:Nv) .+ offset)
     @test v.scalar_model.x == FT(1 + Nv) + offset
 
+    # Make sure we bounds error for NTupleModel's:
+    @test_throws BoundsError m.ntuple_model[0]
+    @test_throws BoundsError m.ntuple_model[N + 1]
+
     unval(::Val{i}) where {i} = i
     @unroll_map(N) do i
         @test m.ntuple_model[i] isa NTupleModel


### PR DESCRIPTION
### Description

Closes #1789. @yairchn. We can run with `--check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)` to make sure we're not doing this anywhere.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
