### PR TITLE
Change the length scale in hyperdiffusion to horizontal nodal distance

### DIFF
--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -50,6 +50,7 @@ Topologies.grid1d
 Geometry.LocalGeometry
 Geometry.lengthscale
 Geometry.resolutionmetric
+Geometry.lengthscale_horizontal
 ```
 
 ## Brick Mesh

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -44,7 +44,7 @@ using CLIMAParameters.Atmos.SubgridScale: inv_Pr_turb
 
 using ClimateMachine
 
-import ..Mesh.Geometry: LocalGeometry, resolutionmetric, lengthscale
+import ..Mesh.Geometry: LocalGeometry, lengthscale, lengthscale_horizontal
 
 using ..Orientations
 using ..VariableTemplates
@@ -837,7 +837,7 @@ function init_aux_hyperdiffusion!(
     aux::Vars,
     geom::LocalGeometry,
 )
-    aux.hyperdiffusion.Δ = lengthscale(geom)
+    aux.hyperdiffusion.Δ = lengthscale_horizontal(geom)
 end
 
 function compute_gradient_argument!(
@@ -909,7 +909,7 @@ function init_aux_hyperdiffusion!(
     aux::Vars,
     geom::LocalGeometry,
 )
-    aux.hyperdiffusion.Δ = lengthscale(geom)
+    aux.hyperdiffusion.Δ = lengthscale_horizontal(geom)
 end
 
 function compute_gradient_argument!(

--- a/test/Numerics/Mesh/Geometry.jl
+++ b/test/Numerics/Mesh/Geometry.jl
@@ -45,15 +45,16 @@ MPI.Initialized() || MPI.Init()
         (zmax - zmin) / (polynomialorder * Ne[3]),
     )
     Savg = cbrt(prod(S))
+    Shoriavg = (S[1] + S[2]) / 2
     M = SDiagonal(S .^ -2)
 
-    N = polynomialorder
-    Np = (N + 1)^3
+    N = (polynomialorder, polynomialorder)
+    Np = (polynomialorder + 1)^3
     for e in 1:size(grid.vgeo, 3)
         for n in 1:size(grid.vgeo, 1)
             g = LocalGeometry{Np, N}(grid.vgeo, n, e)
             @test lengthscale(g) ≈ Savg
-            @test Geometry.resolutionmetric(g) ≈ M
+            @test lengthscale_horizontal(g) ≈ Shoriavg
         end
     end
 end


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
Co-authored-by: @akshaysridhar 

This PR :

- Adds a function to calculate the horizontal effective resolution in Geometry.jl
- Changes the length scale in hyperdiffusion(`DryBiharmonic` and `EquilMoistBiharmonic`) to the horizontal effective resolution. 

The parameters in the hyperdiffusion are e.g. `(ν₄, aux.hyperdiffusion.Δ, τ_timescale) = (3.359104202786882e15, 235880.1990528821, 28800.0)`, which are reasonable.

Thank @jkozdon for his help on the calculation of horizontal nodal distance!

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
