### PR TITLE
Enable custom suffix for LES default diagnostics

### DIFF
--- a/experiments/AtmosLES/stable_bl_les.jl
+++ b/experiments/AtmosLES/stable_bl_les.jl
@@ -75,7 +75,8 @@ function main(cl_args)
         init_on_cpu = true,
         Courant_number = CFLmax,
     )
-    dgn_config = config_diagnostics(driver_config)
+    dgn_config =
+        config_diagnostics(driver_config, out_suffix = cl_args["cparam_file"])
 
     check_cons = (
         ClimateMachine.ConservationCheck("ρ", "1mins", FT(0.0001)),

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -318,11 +318,12 @@ function stable_bl_model(
     return model
 end
 
-function config_diagnostics(driver_config)
+function config_diagnostics(driver_config; out_suffix = nothing)
     default_dgngrp = setup_atmos_default_diagnostics(
         AtmosLESConfigType(),
         "2500steps",
-        driver_config.name,
+        driver_config.name;
+        out_suffix = out_suffix,
     )
     core_dgngrp = setup_atmos_core_diagnostics(
         AtmosLESConfigType(),

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -11,6 +11,7 @@ using LinearAlgebra
         ::AtmosLESConfigType,
         interval::String,
         out_prefix::String;
+        out_suffix::Union{String, Nothing} = nothing,
         writer = NetCDFWriter(),
         interpol = nothing,
     )
@@ -74,6 +75,7 @@ function setup_atmos_default_diagnostics(
     ::AtmosLESConfigType,
     interval::String,
     out_prefix::String;
+    out_suffix::Union{String, Nothing} = nothing,
     writer = NetCDFWriter(),
     interpol = nothing,
 )
@@ -89,7 +91,12 @@ function setup_atmos_default_diagnostics(
         out_prefix,
         writer,
         interpol,
+        AtmosLESDefaultDiagnosticsParams(out_suffix),
     )
+end
+
+struct AtmosLESDefaultDiagnosticsParams <: DiagnosticsGroupParams
+    suffix::Union{String, Nothing}
 end
 
 # Simple horizontal averages
@@ -554,6 +561,7 @@ function atmos_les_default_init(dgngrp::DiagnosticsGroup, currtime)
             "%s_%s_%s",
             dgngrp.out_prefix,
             dgngrp.name,
+            !isnothing(dgngrp.params.suffix) ? dgngrp.params.suffix :
             Settings.starttime,
         )
         dfilename = joinpath(Settings.output_dir, dprefix)


### PR DESCRIPTION
### Description

This PR enables appending a suffix to the name of the LES default diagnostics netcdf file. The suffix is passed as an optional argument to the setup of the diagnostics, and is contained in the `DiagnosticsParams` structure. If `!nothing`, the suffix substitutes the default timestamp suffix.

This feature is very useful for handling batches of simulations that are performed in parallel, where the timestamp-based suffix is not informative.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
