### PR TITLE
Add FV option for EDMF stable BL

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1669,6 +1669,15 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "cpu_sbl_edmf_fvm"
+    key: "cpu_sbl_edmf_fvm"
+    command:
+      - "mpiexec julia --color=yes --project test/Atmos/EDMF/stable_bl_edmf_fvm.jl --fix-rng-seed"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: "gpu_bomex_bulk_sfc_flux"
     key: "gpu_bomex_bulk_sfc_flux"
     command:

--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -28,6 +28,8 @@ if generate_tutorials
             "Dry Idealized GCM (Held-Suarez)" => "Atmos/heldsuarez.jl",
             "Single Element Stack Experiment (Burgers Equation)" =>
                 "Atmos/burgers_single_stack.jl",
+            "Single Element Stack Experiment (Burgers Equation)" =>
+                "Atmos/burgers_single_stack_fvm.jl",
             "LES Experiment (Density Current)" => "Atmos/densitycurrent.jl",
             "LES Experiment (Rising Thermal Bubble)" =>
                 "Atmos/risingbubble.jl",

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -25,6 +25,7 @@ using ClimateMachine.Atmos
 using ClimateMachine.Orientations
 using ClimateMachine.ConfigTypes
 using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.TemperatureProfiles
 using ClimateMachine.Diagnostics
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.Mesh.Filters
@@ -190,6 +191,7 @@ function stable_bl_model(
     turbulence = ConstantKinematicViscosity(FT(0)),
     turbconv = NoTurbConv(),
     moisture_model = "dry",
+    ref_state = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),),
 ) where {FT}
 
     ics = init_problem!     # Initial conditions
@@ -317,6 +319,7 @@ function stable_bl_model(
         config_type,
         param_set;
         problem = problem,
+        ref_state = ref_state,
         turbulence = turbulence,
         moisture = moisture,
         source = source,

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -64,6 +64,7 @@ import ..BalanceLaws:
     prognostic_to_primitive!,
     primitive_to_prognostic!,
     init_state_auxiliary!,
+    construct_face_auxiliary_state!,
     init_state_prognostic!,
     update_auxiliary_state!,
     indefinite_stack_integral!,
@@ -353,6 +354,7 @@ function vars_state(m::AtmosModel, st::Primitive, FT)
         u::SVector{3, FT}
         p::FT
         moisture::vars_state(m.moisture, st, FT)
+        turbconv::vars_state(m.turbconv, st, FT)
     end
 end
 

--- a/src/BalanceLaws/prog_prim_conversion.jl
+++ b/src/BalanceLaws/prog_prim_conversion.jl
@@ -43,3 +43,28 @@ function primitive_to_prognostic!(bl, prog::Vars, prim::Vars, aux)
     prog_arr = parent(prog)
     prog_arr .= prim_arr
 end
+
+
+"""
+    construct_face_auxiliary_state!(
+        bl::BalanceLaw,
+        aux_face::AbstractArray,
+        aux_cell::AbstractArray,
+        Δz::FT
+    )
+
+Default constructor
+ - `bl` balance law
+ - `aux_face` face auxiliary variables to be constructed
+ - `aux_cell` cell center auxiliary variable
+ - `Δz` cell vertical size
+"""
+function construct_face_auxiliary_state!(
+    bl,
+    aux_face::AbstractArray,
+    aux_cell::AbstractArray,
+    Δz::FT,
+) where {FT <: Real}
+    # TODO: is this safe/correct?
+    aux_face .= aux_cell
+end

--- a/src/Common/TurbulenceConvection/TurbulenceConvection.jl
+++ b/src/Common/TurbulenceConvection/TurbulenceConvection.jl
@@ -18,6 +18,8 @@ import ..BalanceLaws:
     vars_state,
     eq_tends,
     source!,
+    prognostic_to_primitive!,
+    primitive_to_prognostic!,
     precompute,
     prognostic_vars,
     init_state_prognostic!,
@@ -151,6 +153,9 @@ function init_state_prognostic!(
     localgeo,
     t,
 ) end
+
+prognostic_to_primitive!(::NoTurbConv, _...) = nothing
+primitive_to_prognostic!(::NoTurbConv, _...) = nothing
 
 include("boundary_conditions.jl")
 include("source.jl")

--- a/src/Numerics/DGMethods/DGFVModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGFVModel_kernels.jl
@@ -1,6 +1,9 @@
 import .FVReconstructions: FVConstant, FVLinear
+using ..BalanceLaws: Primitive
 import ..BalanceLaws:
-    prognostic_to_primitive!, primitive_to_prognostic!, Primitive
+    prognostic_to_primitive!,
+    primitive_to_prognostic!,
+    construct_face_auxiliary_state!
 import .FVReconstructions: width
 import StaticArrays: SUnitRange
 
@@ -111,8 +114,15 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
         local_state_face_prognostic_neighbor =
             MArray{Tuple{num_state_prognostic}, FT}(undef)
 
+        local_state_face_auxiliary_neighbor =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
+
         local_state_face_primitive = ntuple(Val(2)) do _
             MArray{Tuple{num_state_primitive}, FT}(undef)
+        end
+
+        local_state_face_auxiliary = ntuple(Val(2)) do _
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
         end
 
         # Storage for all the values in the stencil
@@ -154,11 +164,6 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
         # Storage for the tendency
         local_tendency = MArray{Tuple{num_state_prognostic}, FT}(undef)
         local_source = MArray{Tuple{num_state_prognostic}, FT}(undef)
-
-        # XXX: will revisit this later for FVM
-        fill!(local_state_prognostic_bottom1, NaN)
-        fill!(local_state_gradient_flux_bottom1, NaN)
-        fill!(local_state_auxiliary_bottom1, NaN)
 
         # The remainder model needs to know which direction of face the model is
         # being evaluated for. In this case we only have `VerticalDirection()`
@@ -257,6 +262,19 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                 local_cell_weights[rng],
             )
 
+            construct_face_auxiliary_state!(
+                balance_law,
+                local_state_face_auxiliary[1],
+                local_state_auxiliary[stencil_center],
+                -local_cell_weights[stencil_center],
+            )
+            construct_face_auxiliary_state!(
+                balance_law,
+                local_state_face_auxiliary[2],
+                local_state_auxiliary[stencil_center],
+                local_cell_weights[stencil_center],
+            )
+
             # Transform the values back to prognostic state
             @unroll for f in 1:2
                 primitive_to_prognostic!(
@@ -264,7 +282,7 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                     local_state_face_prognostic[f],
                     local_state_face_primitive[f],
                     # Use the cell auxiliary data
-                    local_state_auxiliary[stencil_center],
+                    local_state_face_auxiliary[f],
                 )
             end
 
@@ -292,14 +310,27 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                 local_cell_weights[rng],
             )
 
+
+            construct_face_auxiliary_state!(
+                balance_law,
+                local_state_face_auxiliary[1],
+                local_state_auxiliary[stencil_center],
+                -local_cell_weights[stencil_center],
+            )
+            construct_face_auxiliary_state!(
+                balance_law,
+                local_state_face_auxiliary[2],
+                local_state_auxiliary[stencil_center],
+                local_cell_weights[stencil_center],
+            )
+
             # Transform the values back to prognostic state
             @unroll for k in 1:2
                 primitive_to_prognostic!(
                     balance_law,
                     local_state_face_prognostic[k],
                     local_state_face_primitive[k],
-                    # Use the cell auxiliary data
-                    local_state_auxiliary[stencil_center],
+                    local_state_face_auxiliary[k],
                 )
             end
 
@@ -307,8 +338,8 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
             fill!(local_flux, -zero(FT))
             local_state_face_prognostic_neighbor .=
                 local_state_face_prognostic[1]
-            local_state_auxiliary[stencil_center - 1] .=
-                local_state_auxiliary[stencil_center]
+            local_state_face_auxiliary_neighbor .= local_state_face_auxiliary[1]
+
 
             numerical_boundary_flux_first_order!(
                 numerical_flux_first_order,
@@ -316,14 +347,17 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                 balance_law,
                 local_flux,
                 normal,
+                # current cell
                 local_state_face_prognostic[1],
-                local_state_auxiliary[stencil_center],
+                local_state_face_auxiliary[1],
+                # ghost cell
                 local_state_face_prognostic_neighbor,
-                local_state_auxiliary[stencil_center - 1],
+                local_state_face_auxiliary_neighbor,
                 t,
                 face_direction,
-                local_state_prognostic_bottom1,
-                local_state_auxiliary_bottom1,
+                # use current cell states as bottom states
+                local_state_face_prognostic[1],
+                local_state_face_auxiliary[1],
             )
 
             # Fill / reset ghost cell data
@@ -342,19 +376,23 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                 balance_law,
                 local_flux,
                 normal,
+                # current cell
                 local_state_prognostic[stencil_center],
                 local_state_gradient_flux[stencil_center],
                 local_state_hyperdiffusive[stencil_center],
                 local_state_auxiliary[stencil_center],
+                # ghost cell
                 local_state_prognostic[stencil_center - 1],
                 local_state_gradient_flux[stencil_center - 1],
                 local_state_hyperdiffusive[stencil_center - 1],
                 local_state_auxiliary[stencil_center - 1],
                 t,
-                local_state_prognostic_bottom1,
-                local_state_gradient_flux_bottom1,
-                local_state_auxiliary_bottom1,
+                # use current cell states as bottom states
+                local_state_prognostic[stencil_center],
+                local_state_gradient_flux[stencil_center],
+                local_state_auxiliary[stencil_center],
             )
+
 
             # Compute boundary flux and add it in bottom element of the mesh
             @unroll for s in 1:num_state_prognostic
@@ -404,7 +442,7 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
             # compute flux for this face
             local_state_face_prognostic_neighbor .=
                 local_state_face_prognostic[2]
-
+            local_state_face_auxiliary_neighbor .= local_state_face_auxiliary[2]
             # Next data we need to load (assume periodic, mod1, for now  will
             # mask out below as needed for boundary conditions)
             eV_load = mod1(eV_up + stencil_width, nvertelem)
@@ -477,14 +515,26 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                     end w -> throw(BoundsError(local_state_primitive, w))
             end
 
+            construct_face_auxiliary_state!(
+                balance_law,
+                local_state_face_auxiliary[1],
+                local_state_auxiliary[stencil_center],
+                -local_cell_weights[stencil_center],
+            )
+            construct_face_auxiliary_state!(
+                balance_law,
+                local_state_face_auxiliary[2],
+                local_state_auxiliary[stencil_center],
+                local_cell_weights[stencil_center],
+            )
+
             # Transform reconstructed primitive values to prognostic
             @unroll for k in 1:2
                 primitive_to_prognostic!(
                     balance_law,
                     local_state_face_prognostic[k],
                     local_state_face_primitive[k],
-                    # Use the cell auxiliary data
-                    local_state_auxiliary[stencil_center],
+                    local_state_face_auxiliary[k],
                 )
             end
 
@@ -497,12 +547,13 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                 local_flux,
                 normal,
                 local_state_face_prognostic[1],
-                local_state_auxiliary[stencil_center],
+                local_state_face_auxiliary[1],
                 local_state_face_prognostic_neighbor,
-                local_state_auxiliary[stencil_center - 1],
+                local_state_face_auxiliary_neighbor,
                 t,
                 face_direction,
             )
+
 
             numerical_flux_second_order!(
                 numerical_flux_second_order,
@@ -520,6 +571,7 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                 t,
             )
 
+
             if add_source
                 fill!(local_source, -zero(eltype(local_source)))
                 source_arr!(
@@ -531,6 +583,8 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                     t,
                     (VerticalDirection(),),
                 )
+
+
                 @unroll for s in 1:num_state_prognostic
                     local_tendency[s] += local_source[s]
                 end
@@ -571,6 +625,8 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                         t,
                         (VerticalDirection(),),
                     )
+
+
                     @unroll for s in 1:num_state_prognostic
                         local_tendency[s] += local_source[s]
                     end
@@ -605,8 +661,8 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                     # Use the top reconstruction (since handling top face)
                     local_state_face_prognostic_neighbor .=
                         local_state_face_prognostic[2]
-                    local_state_auxiliary[stencil_center - 1] .=
-                        local_state_auxiliary[stencil_center]
+                    local_state_face_auxiliary_neighbor .=
+                        local_state_face_auxiliary[2]
                     numerical_boundary_flux_first_order!(
                         numerical_flux_first_order,
                         bctag,
@@ -614,15 +670,19 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                         local_flux,
                         normal,
                         # Use the top reconstruction (since handling top face)
+                        # current state
                         local_state_face_prognostic[2],
-                        local_state_auxiliary[stencil_center],
+                        local_state_face_auxiliary[2],
+                        # ghost state
                         local_state_face_prognostic_neighbor,
-                        local_state_auxiliary[stencil_center - 1],
+                        local_state_face_auxiliary_neighbor,
                         t,
                         face_direction,
-                        local_state_prognostic_bottom1,
-                        local_state_auxiliary_bottom1,
+                        # use current cell states as bottom states
+                        local_state_face_prognostic[2],
+                        local_state_face_auxiliary[2],
                     )
+
 
                     # Fill / reset ghost cell data
                     local_state_prognostic[stencil_center - 1] .=
@@ -639,19 +699,23 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                         balance_law,
                         local_flux,
                         normal,
+                        # current state
                         local_state_prognostic[stencil_center],
                         local_state_gradient_flux[stencil_center],
                         local_state_hyperdiffusive[stencil_center],
                         local_state_auxiliary[stencil_center],
+                        # ghost state
                         local_state_prognostic[stencil_center - 1],
                         local_state_gradient_flux[stencil_center - 1],
                         local_state_hyperdiffusive[stencil_center - 1],
                         local_state_auxiliary[stencil_center - 1],
                         t,
-                        local_state_prognostic_bottom1,
-                        local_state_gradient_flux_bottom1,
-                        local_state_auxiliary_bottom1,
+                        # use current cell states as bottom states
+                        local_state_prognostic[stencil_center],
+                        local_state_gradient_flux[stencil_center],
+                        local_state_auxiliary[stencil_center],
                     )
+
 
                     @unroll for s in 1:num_state_prognostic
                         local_tendency[s] -= α * sM * vMI[2] * local_flux[s]

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -469,6 +469,9 @@ function get_z(
     Nvert = N[end]
     Nph = (Nhoriz + 1)^2
     Np = Nph * (Nvert + 1)
+    if last(polynomialorders(grid)) == 0
+        rm_dupes = false # no duplicates in FVM
+    end
     if rm_dupes
         ijk_range = (1:Nph:(Np - Nph))
         vgeo = Array(grid.vgeo)

--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -539,6 +539,9 @@ struct NodalStack{N, BL, G, S, VR, TI, TJ, CI, IN}
         vrange = 1:size(prognostic, 3)
         grid_info = basic_grid_info(grid)
         @unpack Nqk = grid_info
+        if last(polynomialorders(grid)) == 0
+            interp = false
+        end
         # Store cartesian indices, so we can map the iter_state
         # to the cartesian space `Q[i, var, j]`
         if interp

--- a/test/Atmos/EDMF/Artifacts.toml
+++ b/test/Atmos/EDMF/Artifacts.toml
@@ -1,5 +1,2 @@
 [PyCLES_output]
-git-tree-sha1 = "2855ea3b737aa771bea0de60aa7ecda3577c1905"
-
-[bomex_edmf]
-git-tree-sha1 = "c7b2a1f03b06f3f3e4d06b3112c90c543082b471"
+git-tree-sha1 = "61af161b398cb0daabeb2eb1d3c57c7ba3629514"

--- a/test/Atmos/EDMF/closures/mixing_length.jl
+++ b/test/Atmos/EDMF/closures/mixing_length.jl
@@ -72,7 +72,7 @@ function mixing_length(
         m.turbconv.surface.zLL,
     )
 
-    L_W = ml.κ * z / (sqrt(m.turbconv.surface.κ_star²) * ml.c_m)
+    L_W = ml.κ * max(z, 5) / (sqrt(m.turbconv.surface.κ_star²) * ml.c_m)
     if obukhov_length < -eps(FT)
         L_W *= min((FT(1) - ml.a2 * z / obukhov_length)^ml.a1, 1 / ml.κ)
     end

--- a/test/Atmos/EDMF/compute_mse.jl
+++ b/test/Atmos/EDMF/compute_mse.jl
@@ -20,7 +20,7 @@ PyCLES_output_dataset = ArtifactWrapper(
     "PyCLES_output",
     ArtifactFile[
     # ArtifactFile(url = "https://caltech.box.com/shared/static/johlutwhohvr66wn38cdo7a6rluvz708.nc", filename = "Rico.nc",),
-    # ArtifactFile(url = "https://caltech.box.com/shared/static/zraeiftuzlgmykzhppqwrym2upqsiwyb.nc", filename = "Gabls.nc",),
+    ArtifactFile(url = "https://caltech.box.com/shared/static/zraeiftuzlgmykzhppqwrym2upqsiwyb.nc", filename = "Gabls.nc",),
     # ArtifactFile(url = "https://caltech.box.com/shared/static/toyvhbwmow3nz5bfa145m5fmcb2qbfuz.nc", filename = "DYCOMS_RF01.nc",),
     # ArtifactFile(url = "https://caltech.box.com/shared/static/ivo4751camlph6u3k68ftmb1dl4z7uox.nc", filename = "TRMM_LBA.nc",),
     # ArtifactFile(url = "https://caltech.box.com/shared/static/4osqp0jpt4cny8fq2ukimgfnyi787vsy.nc", filename = "ARM_SGP.nc",),
@@ -30,13 +30,6 @@ PyCLES_output_dataset = ArtifactWrapper(
     ],
 )
 PyCLES_output_dataset_path = get_data_folder(PyCLES_output_dataset)
-# data_files[:Rico] = Dataset(joinpath(PyCLES_output_dataset_path, "Rico.nc"), "r")
-# data_files[:Gabls] = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
-# data_files[:DYCOMS_RF01] = Dataset(joinpath(PyCLES_output_dataset_path, "DYCOMS_RF01.nc"), "r")
-# data_files[:TRMM_LBA] = Dataset(joinpath(PyCLES_output_dataset_path, "TRMM_LBA.nc"), "r")
-# data_files[:ARM_SGP] = Dataset(joinpath(PyCLES_output_dataset_path, "ARM_SGP.nc"), "r")
-# data_files[:Soares] = Dataset(joinpath(PyCLES_output_dataset_path, "Soares.nc"), "r")
-# data_files[:Nieuwstadt] = Dataset(joinpath(PyCLES_output_dataset_path, "Nieuwstadt.nc"), "r")
 #! format: on
 
 include("variable_map.jl")
@@ -49,6 +42,7 @@ function compute_mse(
     ds,
     experiment,
     best_mse,
+    t_compare,
     plot_dir = nothing,
 )
     mse = Dict()
@@ -67,9 +61,9 @@ function compute_mse(
 
     # Accidentally running a short simulation
     # could improve MSE. So, let's test that
-    # we run for at least 400. We should increase
-    # this as we can reach higher CFL.
-    @test t_cmp >= 400
+    # we run for at least t_compare. We should
+    # increase this as we can reach higher CFL.
+    @test t_cmp >= t_compare
 
     # Ensure z_cm and dons_arr fields are consistent lengths:
     @test length(z_cm) == length(dons_arr[1][first(keys(dons_arr[1]))])

--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -13,17 +13,17 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Bomex.nc"), "r")
 
 #! format: off
 best_mse = OrderedDict()
-best_mse["prog_ρ"] = 3.4917543567414361e-02
-best_mse["prog_ρu_1"] = 3.0715061616086055e+03
-best_mse["prog_ρu_2"] = 1.2895273328642526e-03
-best_mse["prog_moisture_ρq_tot"] = 4.1330591681431349e-02
-best_mse["prog_turbconv_environment_ρatke"] = 6.6415719930220473e+02
-best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.5667223192884450e+01
-best_mse["prog_turbconv_environment_ρaq_tot_cv"] = 1.6435555166434060e+02
-best_mse["prog_turbconv_updraft_1_ρa"] = 7.9564915637753856e+01
-best_mse["prog_turbconv_updraft_1_ρaw"] = 8.4288782179220159e-02
-best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 9.0095910670416632e+00
-best_mse["prog_turbconv_updraft_1_ρaq_tot"] = 1.0768554319426404e+01
+best_mse["prog_ρ"] = 3.4917543567412931e-02
+best_mse["prog_ρu_1"] = 3.0715061616086091e+03
+best_mse["prog_ρu_2"] = 1.2895273328644243e-03
+best_mse["prog_moisture_ρq_tot"] = 4.1330591681431862e-02
+best_mse["prog_turbconv_environment_ρatke"] = 6.7419793087180005e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.5667222913342755e+01
+best_mse["prog_turbconv_environment_ρaq_tot_cv"] = 1.6435778026434528e+02
+best_mse["prog_turbconv_updraft_1_ρa"] = 7.9568648163256995e+01
+best_mse["prog_turbconv_updraft_1_ρaw"] = 8.4292074562603486e-02
+best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 9.0094974216941637e+00
+best_mse["prog_turbconv_updraft_1_ρaq_tot"] = 1.0768452320369121e+01
 #! format: on
 
 computed_mse = compute_mse(
@@ -34,6 +34,7 @@ computed_mse = compute_mse(
     data_file,
     "Bomex",
     best_mse,
+    400,
     plot_dir,
 )
 
@@ -41,13 +42,14 @@ computed_mse = compute_mse(
     #! format: off
     test_mse(computed_mse, best_mse, "prog_ρ")
     test_mse(computed_mse, best_mse, "prog_ρu_1")
+    test_mse(computed_mse, best_mse, "prog_ρu_2")
     test_mse(computed_mse, best_mse, "prog_moisture_ρq_tot")
+    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρatke")
+    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρaθ_liq_cv")
+    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρaq_tot_cv")
     test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρa")
     test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρaw")
     test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρaθ_liq")
     test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρaq_tot")
-    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρatke")
-    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρaθ_liq_cv")
-    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρaq_tot_cv")
     #! format: on
 end

--- a/test/Atmos/EDMF/report_mse_sbl_fv.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_fv.jl
@@ -1,0 +1,49 @@
+using ClimateMachine
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+
+if parse(Bool, get(ENV, "CLIMATEMACHINE_PLOT_EDMF_COMPARISON", "false"))
+    plot_dir = joinpath(clima_dir, "output", "sbl_edmf", "pycles_comparison")
+else
+    plot_dir = nothing
+end
+
+include(joinpath(@__DIR__, "compute_mse.jl"))
+
+data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
+
+#! format: off
+best_mse = OrderedDict()
+best_mse["prog_ρ"] = 8.3506586610224455e-03
+best_mse["prog_ρu_1"] = 6.2714070693454869e+03
+best_mse["prog_ρu_2"] = 1.2793997157719300e-04
+best_mse["prog_turbconv_environment_ρatke"] = 2.3701966316184664e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.7727376552999260e+01
+best_mse["prog_turbconv_updraft_1_ρa"] = 1.7950630856426049e+01
+best_mse["prog_turbconv_updraft_1_ρaw"] = 1.7799954766639789e-01
+best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 1.3315847832474324e+01
+#! format: on
+
+computed_mse = compute_mse(
+    solver_config.dg.grid,
+    solver_config.dg.balance_law,
+    time_data,
+    dons_arr,
+    data_file,
+    "Gabls",
+    best_mse,
+    60,
+    plot_dir,
+)
+
+@testset "SBL EDMF Solution Quality Assurance (QA) tests" begin
+    #! format: off
+    test_mse(computed_mse, best_mse, "prog_ρ")
+    test_mse(computed_mse, best_mse, "prog_ρu_1")
+    test_mse(computed_mse, best_mse, "prog_ρu_2")
+    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρatke")
+    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρaθ_liq_cv")
+    test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρa")
+    test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρaw")
+    test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρaθ_liq")
+    #! format: on
+end

--- a/test/Atmos/EDMF/stable_bl_edmf_fvm.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf_fvm.jl
@@ -1,0 +1,246 @@
+using JLD2, FileIO
+using ClimateMachine
+ClimateMachine.init(;
+    parse_clargs = true,
+    output_dir = get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", "output"),
+    fix_rng_seed = true,
+)
+using ClimateMachine.SingleStackUtils
+using ClimateMachine.Checkpoint
+using ClimateMachine.BalanceLaws: vars_state
+import ClimateMachine.DGMethods.FVReconstructions: FVLinear
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+
+include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))
+include("edmf_model.jl")
+include("edmf_kernels.jl")
+
+"""
+    init_state_prognostic!(
+            turbconv::EDMF{FT},
+            m::AtmosModel{FT},
+            state::Vars,
+            aux::Vars,
+            localgeo,
+            t::Real,
+        ) where {FT}
+
+Initialize EDMF state variables.
+This method is only called at `t=0`.
+"""
+function init_state_prognostic!(
+    turbconv::EDMF{FT},
+    m::AtmosModel{FT},
+    state::Vars,
+    aux::Vars,
+    localgeo,
+    t::Real,
+) where {FT}
+    # Aliases:
+    gm = state
+    en = state.turbconv.environment
+    up = state.turbconv.updraft
+    N_up = n_updrafts(turbconv)
+    # GCM setting - Initialize the grid mean profiles of prognostic variables (ρ,e_int,q_tot,u,v,w)
+    z = altitude(m, aux)
+
+    # SCM setting - need to have separate cases coded and called from a folder - see what LES does
+    # a thermo state is used here to convert the input θ to e_int profile
+    e_int = internal_energy(m, state, aux)
+
+    ts = PhaseDry(m.param_set, e_int, state.ρ)
+    T = air_temperature(ts)
+    p = air_pressure(ts)
+    q = PhasePartition(ts)
+    θ_liq = liquid_ice_pottemp(ts)
+
+    a_min = turbconv.subdomains.a_min
+    @unroll_map(N_up) do i
+        up[i].ρa = gm.ρ * a_min
+        up[i].ρaw = gm.ρu[3] * a_min
+        up[i].ρaθ_liq = gm.ρ * a_min * θ_liq
+        up[i].ρaq_tot = FT(0)
+    end
+
+    # initialize environment covariance with zero for now
+    if z <= FT(250)
+        en.ρatke =
+            gm.ρ *
+            FT(0.4) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0)
+        en.ρaθ_liq_cv =
+            gm.ρ *
+            FT(0.4) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0)
+    else
+        en.ρatke = FT(0)
+        en.ρaθ_liq_cv = FT(0)
+    end
+    en.ρaq_tot_cv = FT(0)
+    en.ρaθ_liq_q_tot_cv = FT(0)
+    return nothing
+end;
+
+function main(::Type{FT}) where {FT}
+    # add a command line argument to specify the kind of surface flux
+    # TODO: this will move to the future namelist functionality
+    sbl_args = ArgParseSettings(autofix_names = true)
+    add_arg_group!(sbl_args, "StableBoundaryLayer")
+    @add_arg_table! sbl_args begin
+        "--surface-flux"
+        help = "specify surface flux for energy and moisture"
+        metavar = "prescribed|bulk"
+        arg_type = String
+        default = "bulk"
+    end
+
+    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
+
+    surface_flux = cl_args["surface_flux"]
+
+    # DG polynomial order
+    N = (1, 0)
+    nelem_vert = 80
+
+    # Prescribe domain parameters
+    zmax = FT(400)
+
+    t0 = FT(0)
+
+    # Simulation time
+    timeend = FT(60)
+    CFLmax = FT(0.50)
+
+    config_type = SingleStackConfigType
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        # solver_method = LSRK144NiegemannDiehlBusch,
+        solver_method = LSRK54CarpenterKennedy,
+    )
+
+    N_updrafts = 1
+    N_quad = 3 # Using N_quad = 1 leads to norm(Q) = NaN at init.
+    turbconv = EDMF(FT, N_updrafts, N_quad)
+
+    model = stable_bl_model(
+        FT,
+        config_type,
+        zmax,
+        surface_flux;
+        turbconv = turbconv,
+        ref_state = HydrostaticState(
+            DecayingTemperatureProfile{FT}(param_set);
+            subtract_off = false,
+        ),
+    )
+
+    # Assemble configuration
+    driver_config = ClimateMachine.SingleStackConfiguration(
+        "SBL_EDMF",
+        N,
+        nelem_vert,
+        zmax,
+        param_set,
+        model;
+        hmax = FT(40),
+        solver_type = ode_solver_type,
+        numerical_flux_first_order = RoeNumericalFlux(),
+        fv_reconstruction = HBFVReconstruction(model, FVLinear()),
+    )
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+    )
+
+    # --- Zero-out horizontal variations:
+    vsp = vars_state(model, Prognostic(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :turbconv),
+    )
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :energy, :ρe),
+    )
+    vsa = vars_state(model, Auxiliary(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.dg.state_auxiliary,
+        varsindex(vsa, :turbconv),
+    )
+    # ---
+
+    dgn_config = config_diagnostics(driver_config)
+
+    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(100) do
+        nstep = getsteps(solver_config.solver)
+        Filters.apply!(
+            solver_config.Q,
+            (turbconv_filters(turbconv)...,),
+            solver_config.dg.grid,
+            TMARFilter(),
+        )
+        nothing
+    end
+
+    diag_arr = [single_stack_diagnostics(solver_config)]
+    time_data = FT[0]
+
+    # Define the number of outputs from `t0` to `timeend`
+    n_outputs = 5
+    # This equates to exports every ceil(Int, timeend/n_outputs) time-step:
+    every_x_simulation_time = ceil(Int, timeend / n_outputs)
+
+    cb_data_vs_time =
+        GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
+            diag_vs_z = single_stack_diagnostics(solver_config)
+
+            nstep = getsteps(solver_config.solver)
+            # Save to disc (for debugging):
+            # @save "bomex_edmf_nstep=$nstep.jld2" diag_vs_z
+
+            push!(diag_arr, diag_vs_z)
+            push!(time_data, gettime(solver_config.solver))
+            nothing
+        end
+
+    check_cons = (
+        ClimateMachine.ConservationCheck("ρ", "3000steps", FT(0.001)),
+        ClimateMachine.ConservationCheck("energy.ρe", "3000steps", FT(0.1)),
+    )
+
+    cb_print_step = GenericCallbacks.EveryXSimulationSteps(500) do
+        @show getsteps(solver_config.solver)
+        nothing
+    end
+
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        check_cons = check_cons,
+        user_callbacks = (cbtmarfilter, cb_data_vs_time, cb_print_step),
+        check_euclidean_distance = true,
+    )
+
+    diag_vs_z = single_stack_diagnostics(solver_config)
+    push!(diag_arr, diag_vs_z)
+    push!(time_data, gettime(solver_config.solver))
+
+    return solver_config, diag_arr, time_data
+end
+
+solver_config, diag_arr, time_data = main(Float64)
+
+include(joinpath(@__DIR__, "report_mse_sbl_fv.jl"))
+
+nothing

--- a/tutorials/Atmos/burgers_single_stack_fvm.jl
+++ b/tutorials/Atmos/burgers_single_stack_fvm.jl
@@ -1,0 +1,729 @@
+# # Single stack tutorial based on the 3D Burgers + tracer equations
+
+# This tutorial implements the Burgers equations with a tracer field
+# in a single element stack. The flow is initialized with a horizontally
+# uniform profile of horizontal velocity and uniform initial temperature. The fluid
+# is heated from the bottom surface. Gaussian noise is imposed to the horizontal
+# velocity field at each node at the start of the simulation. The tutorial demonstrates how to
+#
+#   * Initialize a [`BalanceLaw`](@ref ClimateMachine.BalanceLaws.BalanceLaw) in a single stack configuration;
+#   * Return the horizontal velocity field to a given profile (e.g., large-scale advection);
+#   * Remove any horizontal inhomogeneities or noise from the flow.
+#
+# The second and third bullet points are demonstrated imposing Rayleigh friction, horizontal
+# diffusion and 2D divergence damping to the horizontal momentum prognostic equation.
+
+# Equations solved in balance law form:
+
+# ```math
+# \begin{align}
+# \frac{∂ ρ}{∂ t} =& - ∇ ⋅ (ρ\mathbf{u}) \\
+# \frac{∂ ρ\mathbf{u}}{∂ t} =& - ∇ ⋅ (-μ ∇\mathbf{u}) - ∇ ⋅ (ρ\mathbf{u} \mathbf{u}') - γ[ (ρ\mathbf{u}-ρ̄\mathbf{ū}) - (ρ\mathbf{u}-ρ̄\mathbf{ū})⋅ẑ ẑ] - ν_d ∇_h (∇_h ⋅ ρ\mathbf{u}) \\
+# \frac{∂ ρcT}{∂ t} =& - ∇ ⋅ (-α ∇ρcT) - ∇ ⋅ (\mathbf{u} ρcT)
+# \end{align}
+# ```
+
+# Boundary conditions:
+# ```math
+# \begin{align}
+# z_{\mathrm{min}}: & ρ = 1 \\
+# z_{\mathrm{min}}: & ρ\mathbf{u} = \mathbf{0} \\
+# z_{\mathrm{min}}: & ρcT = ρc T_{\mathrm{fixed}} \\
+# z_{\mathrm{max}}: & ρ = 1 \\
+# z_{\mathrm{max}}: & ρ\mathbf{u} = \mathbf{0} \\
+# z_{\mathrm{max}}: & -α∇ρcT = 0
+# \end{align}
+# ```
+
+# where
+#  - ``t`` is time
+#  - ``ρ`` is the density
+#  - ``\mathbf{u}`` is the velocity (vector)
+#  - ``\mathbf{ū}`` is the horizontally averaged velocity (vector)
+#  - ``μ`` is the dynamic viscosity tensor
+#  - ``γ`` is the Rayleigh friction frequency
+#  - ``ν_d`` is the horizontal divergence damping coefficient
+#  - ``T`` is the temperature
+#  - ``α`` is the thermal diffusivity tensor
+#  - ``c`` is the heat capacity
+#  - ``ρcT`` is the thermal energy
+
+# Solving these equations is broken down into the following steps:
+# 1) Preliminary configuration
+# 2) PDEs
+# 3) Space discretization
+# 4) Time discretization
+# 5) Solver hooks / callbacks
+# 6) Solve
+# 7) Post-processing
+
+# # Preliminary configuration
+
+# ## [Loading code](@id Loading-code-burgers-fvm)
+
+# First, we'll load our pre-requisites
+#  - load external packages:
+using MPI
+using Distributions
+using OrderedCollections
+using Plots
+using StaticArrays
+using LinearAlgebra: Diagonal, tr
+
+#  - load CLIMAParameters and set up to use it:
+using CLIMAParameters
+using CLIMAParameters.Planet: grav
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+#  - load necessary ClimateMachine modules:
+using ClimateMachine
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.Writers
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux
+
+using ClimateMachine.Mesh.Geometry: LocalGeometry
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.ODESolvers
+using ClimateMachine.VariableTemplates
+using ClimateMachine.SingleStackUtils
+import ClimateMachine.DGMethods.FVReconstructions: FVLinear
+
+#  - import necessary ClimateMachine modules: (`import`ing enables us to
+#  provide implementations of these structs/methods)
+using ClimateMachine.Orientations:
+    Orientation,
+    NoOrientation,
+    FlatOrientation,
+    init_aux!,
+    vertical_unit_vector,
+    projection_tangential
+
+import ClimateMachine.BalanceLaws:
+    vars_state,
+    source!,
+    flux_second_order!,
+    flux_first_order!,
+    compute_gradient_argument!,
+    compute_gradient_flux!,
+    init_state_auxiliary!,
+    init_state_prognostic!,
+    construct_face_auxiliary_state!,
+    BoundaryCondition,
+    boundary_conditions,
+    boundary_state!
+
+# ## Initialization
+
+# Define the float type (`Float64` or `Float32`)
+const FT = Float64;
+# Initialize ClimateMachine for CPU.
+ClimateMachine.init(; disable_gpu = true);
+
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+
+# Load some helper functions for plotting
+include(joinpath(clima_dir, "docs", "plothelpers.jl"));
+
+# # Define the set of Partial Differential Equations (PDEs)
+
+# ## Define the model
+
+# Model parameters can be stored in the particular [`BalanceLaw`](@ref
+# ClimateMachine.BalanceLaws.BalanceLaw), in this case, the `BurgersEquation`:
+
+Base.@kwdef struct BurgersEquation{FT, APS, O} <: BalanceLaw
+    "Parameters"
+    param_set::APS
+    "Orientation model"
+    orientation::O
+    "Heat capacity"
+    c::FT = 1
+    "Vertical dynamic viscosity"
+    μv::FT = 1e-4
+    "Horizontal dynamic viscosity"
+    μh::FT = 1
+    "Vertical thermal diffusivity"
+    αv::FT = 1e-2
+    "Horizontal thermal diffusivity"
+    αh::FT = 1
+    "IC Gaussian noise standard deviation"
+    σ::FT = 5e-2
+    "Rayleigh damping"
+    γ::FT = 5
+    "Domain height"
+    zmax::FT = 1
+    "Initial conditions for temperature"
+    initialT::FT = 295.15
+    "Bottom boundary value for temperature (Dirichlet boundary conditions)"
+    T_bottom::FT = 300.0
+    "Top flux (α∇ρcT) at top boundary (Neumann boundary conditions)"
+    flux_top::FT = 0.0
+    "Divergence damping coefficient (horizontal)"
+    νd::FT = 1
+end
+
+# Create an instance of the `BurgersEquation`:
+orientation = FlatOrientation()
+
+m = BurgersEquation{FT, typeof(param_set), typeof(orientation)}(
+    param_set = param_set,
+    orientation = orientation,
+);
+
+# This model dictates the flow control, using [Dynamic Multiple
+# Dispatch](https://en.wikipedia.org/wiki/Multiple_dispatch), for which
+# kernels are executed.
+
+# ## Define the variables
+
+# All of the methods defined in this section were `import`ed in
+# [Loading code](@ref Loading-code-burgers) to let us provide
+# implementations for our `BurgersEquation` as they will be used
+# by the solver.
+
+# Specify auxiliary variables for `BurgersEquation`
+function vars_state(m::BurgersEquation, st::Auxiliary, FT)
+    @vars begin
+        coord::SVector{3, FT}
+        orientation::vars_state(m.orientation, st, FT)
+    end
+end
+
+# Specify prognostic variables, the variables solved for in the PDEs, for
+# `BurgersEquation`
+vars_state(::BurgersEquation, ::Prognostic, FT) =
+    @vars(ρ::FT, ρu::SVector{3, FT}, ρcT::FT);
+
+# Specify state variables whose gradients are needed for `BurgersEquation`
+vars_state(::BurgersEquation, ::Gradient, FT) =
+    @vars(u::SVector{3, FT}, ρcT::FT, ρu::SVector{3, FT});
+
+# Specify gradient variables for `BurgersEquation`
+vars_state(::BurgersEquation, ::GradientFlux, FT) = @vars(
+    μ∇u::SMatrix{3, 3, FT, 9},
+    α∇ρcT::SVector{3, FT},
+    νd∇D::SMatrix{3, 3, FT, 9}
+);
+
+# ## Define the compute kernels
+
+# Specify the initial values in `aux::Vars`, which are available in
+# `init_state_prognostic!`. Note that
+# - this method is only called at `t=0`.
+# - `aux.coord` is available here because we've specified `coord` in `vars_state(m, aux, FT)`.
+function nodal_init_state_auxiliary!(
+    m::BurgersEquation,
+    aux::Vars,
+    tmp::Vars,
+    geom::LocalGeometry,
+)
+    aux.coord = geom.coord
+end;
+
+# `init_aux!` initializes the auxiliary gravitational potential field needed for vertical projections
+function init_state_auxiliary!(
+    m::BurgersEquation,
+    state_auxiliary::MPIStateArray,
+    grid,
+    direction,
+)
+    init_aux!(m, m.orientation, state_auxiliary, grid, direction)
+
+    init_state_auxiliary!(
+        m,
+        nodal_init_state_auxiliary!,
+        state_auxiliary,
+        grid,
+        direction,
+    )
+end;
+
+# Specify the initial values in `state::Vars`. Note that
+# - this method is only called at `t=0`.
+# - `state.ρ`, `state.ρu` and`state.ρcT` are available here because we've specified `ρ`, `ρu` and `ρcT` in `vars_state(m, state, FT)`.
+function init_state_prognostic!(
+    m::BurgersEquation,
+    state::Vars,
+    aux::Vars,
+    localgeo,
+    t::Real,
+)
+    z = aux.coord[3]
+    ε1 = rand(Normal(0, m.σ))
+    ε2 = rand(Normal(0, m.σ))
+    state.ρ = 1
+    ρu = 1 - 4 * (z - m.zmax / 2)^2 + ε1
+    ρv = 1 - 4 * (z - m.zmax / 2)^2 + ε2
+    ρw = 0
+    state.ρu = SVector(ρu, ρv, ρw)
+
+    state.ρcT = state.ρ * m.c * m.initialT
+end;
+
+function construct_face_auxiliary_state!(
+    bl::BurgersEquation,
+    aux_face::AbstractArray,
+    aux_cell::AbstractArray,
+    Δz::FT,
+) where {FT <: Real}
+    _grav = FT(grav(bl.param_set))
+    var_aux = Vars{vars_state(bl, Auxiliary(), FT)}
+    aux_face .= aux_cell
+
+    if !(bl.orientation isa NoOrientation)
+        var_aux(aux_face).orientation.Φ =
+            var_aux(aux_cell).orientation.Φ + _grav * Δz / 2
+    end
+end
+
+
+# The remaining methods, defined in this section, are called at every
+# time-step in the solver by the [`BalanceLaw`](@ref
+# ClimateMachine.BalanceLaws.BalanceLaw) framework.
+
+# Since we have second-order fluxes, we must tell `ClimateMachine` to compute
+# the gradient of `ρcT`, `u` and `ρu`. Here, we specify how `ρcT`, `u` and `ρu` are computed. Note that
+# e.g. `transform.ρcT` is available here because we've specified `ρcT` in `vars_state(m, ::Gradient, FT)`.
+function compute_gradient_argument!(
+    m::BurgersEquation,
+    transform::Vars,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    transform.ρcT = state.ρcT
+    transform.u = state.ρu / state.ρ
+    transform.ρu = state.ρu
+end;
+
+# Specify where in `diffusive::Vars` to store the computed gradient from
+# `compute_gradient_argument!`. Note that:
+#  - `diffusive.μ∇u` is available here because we've specified `μ∇u` in `vars_state(m, ::GradientFlux, FT)`.
+#  - `∇transform.u` is available here because we've specified `u` in `vars_state(m, ::Gradient, FT)`.
+#  - `diffusive.μ∇u` is built using an anisotropic diffusivity tensor.
+#  - The `divergence` may be computed from the trace of tensor `∇ρu`.
+function compute_gradient_flux!(
+    m::BurgersEquation{FT},
+    diffusive::Vars,
+    ∇transform::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) where {FT}
+    ∇ρu = ∇transform.ρu
+    ẑ = vertical_unit_vector(m.orientation, m.param_set, aux)
+    divergence = tr(∇ρu) - ẑ' * ∇ρu * ẑ
+    diffusive.α∇ρcT = Diagonal(SVector(m.αh, m.αh, m.αv)) * ∇transform.ρcT
+    diffusive.μ∇u = Diagonal(SVector(m.μh, m.μh, m.μv)) * ∇transform.u
+    diffusive.νd∇D =
+        Diagonal(SVector(m.νd, m.νd, FT(0))) *
+        Diagonal(SVector(divergence, divergence, FT(0)))
+end;
+
+# Introduce Rayleigh friction towards a target profile as a source.
+# Note that:
+# - Rayleigh damping is only applied in the horizontal using the `projection_tangential` method.
+function source!(
+    m::BurgersEquation{FT},
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    args...,
+) where {FT}
+    ẑ = vertical_unit_vector(m.orientation, m.param_set, aux)
+    z = aux.coord[3]
+    ρ̄ū =
+        state.ρ * SVector{3, FT}(
+            0.5 - 2 * (z - m.zmax / 2)^2,
+            0.5 - 2 * (z - m.zmax / 2)^2,
+            0.0,
+        )
+    ρu_p = state.ρu - ρ̄ū
+    source.ρu -=
+        m.γ * projection_tangential(m.orientation, m.param_set, aux, ρu_p)
+end;
+
+# Compute advective flux.
+# Note that:
+# - `state.ρu` is available here because we've specified `ρu` in `vars_state(m, state, FT)`.
+function flux_first_order!(
+    m::BurgersEquation,
+    flux::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+    _...,
+)
+    flux.ρ = state.ρu
+
+    u = state.ρu / state.ρ
+    flux.ρu = state.ρu * u'
+    flux.ρcT = u * state.ρcT
+end;
+
+# Compute diffusive flux (e.g. ``F(μ, \mathbf{u}, t) = -μ∇\mathbf{u}`` in the original PDE).
+# Note that:
+# - `diffusive.μ∇u` is available here because we've specified `μ∇u` in `vars_state(m, ::GradientFlux, FT)`.
+# - The divergence gradient can be written as a diffusive flux using a divergence diagonal tensor.
+function flux_second_order!(
+    m::BurgersEquation,
+    flux::Grad,
+    state::Vars,
+    diffusive::Vars,
+    hyperdiffusive::Vars,
+    aux::Vars,
+    t::Real,
+)
+    flux.ρcT -= diffusive.α∇ρcT
+    flux.ρu -= diffusive.μ∇u
+    flux.ρu -= diffusive.νd∇D
+end;
+
+# ### Boundary conditions
+
+# Second-order terms in our equations, ``∇⋅(G)`` where ``G = μ∇\mathbf{u}``, are
+# internally reformulated to first-order unknowns.
+# Boundary conditions must be specified for all unknowns, both first-order and
+# second-order unknowns which have been reformulated.
+
+struct TopBC <: BoundaryCondition end;
+struct BottomBC <: BoundaryCondition end;
+boundary_conditions(::BurgersEquation) = (BottomBC(), TopBC());
+
+# The boundary conditions for `ρ`, `ρu` and `ρcT` (first order unknowns)
+function boundary_state!(
+    nf,
+    bc::BottomBC,
+    m::BurgersEquation,
+    state⁺::Vars,
+    aux⁺::Vars,
+    n⁻,
+    _...,
+)
+    state⁺.ρ = 1
+    state⁺.ρu = SVector(0, 0, 0)
+    state⁺.ρcT = state⁺.ρ * m.c * m.T_bottom
+end;
+function boundary_state!(
+    nf,
+    bc::TopBC,
+    m::BurgersEquation,
+    state⁺::Vars,
+    aux⁺::Vars,
+    n⁻,
+    _...,
+)
+    state⁺.ρ = 1
+    state⁺.ρu = SVector(0, 0, 0)
+end;
+
+# The boundary conditions for `ρ`, `ρu` and `ρcT` are specified here for
+# second-order unknowns
+function boundary_state!(
+    nf,
+    bc::BottomBC,
+    m::BurgersEquation,
+    state⁺::Vars,
+    diff⁺::Vars,
+    aux⁺::Vars,
+    n⁻,
+    _...,
+)
+    state⁺.ρ = 1
+    state⁺.ρu = SVector(0, 0, 0)
+    state⁺.ρcT = state⁺.ρ * m.c * m.T_bottom
+end;
+function boundary_state!(
+    nf,
+    bc::TopBC,
+    m::BurgersEquation,
+    state⁺::Vars,
+    diff⁺::Vars,
+    aux⁺::Vars,
+    n⁻,
+    _...,
+)
+    state⁺.ρ = 1
+    state⁺.ρu = SVector(0, 0, 0)
+    diff⁺.α∇ρcT = -n⁻ * m.flux_top
+end;
+
+# # Spatial discretization
+
+# Prescribe polynomial order of basis functions in finite elements
+N_poly = (1, 0);
+
+# Specify the number of vertical elements
+nelem_vert = 50;
+
+# Specify the domain height
+zmax = m.zmax;
+
+# Establish a `ClimateMachine` single stack configuration
+driver_config = ClimateMachine.SingleStackConfiguration(
+    "BurgersEquation",
+    N_poly,
+    nelem_vert,
+    zmax,
+    param_set,
+    m,
+    numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
+    fv_reconstruction = FVLinear(),
+);
+
+# # Time discretization
+
+# Specify simulation time (SI units)
+t0 = FT(0);
+timeend = FT(1);
+
+# We'll define the time-step based on the Fourier
+# number and the [Courant number](https://en.wikipedia.org/wiki/Courant–Friedrichs–Lewy_condition)
+# of the flow
+Δ = min_node_distance(driver_config.grid)
+
+given_Fourier = FT(0.5);
+Fourier_bound = given_Fourier * Δ^2 / max(m.αh, m.μh, m.νd);
+Courant_bound = FT(0.5) * Δ;
+dt = min(Fourier_bound, Courant_bound)
+
+# # Configure a `ClimateMachine` solver.
+
+# This initializes the state vector and allocates memory for the solution in
+# space (`dg` has the model `m`, which describes the PDEs as well as the
+# function used for initialization). This additionally initializes the ODE
+# solver, by default an explicit Low-Storage
+# [Runge-Kutta](https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods)
+# method.
+
+solver_config =
+    ClimateMachine.SolverConfiguration(t0, timeend, driver_config, ode_dt = dt);
+
+# ## Inspect the initial conditions for a single nodal stack
+
+# Let's export plots of the initial state
+output_dir = @__DIR__;
+
+mkpath(output_dir);
+
+z_scale = 100 # convert from meters to cm
+z_key = "z"
+z_label = "z [cm]"
+z = get_z(driver_config.grid; z_scale = z_scale)
+state_vars = get_vars_from_nodal_stack(
+    driver_config.grid,
+    solver_config.Q,
+    vars_state(m, Prognostic(), FT),
+);
+
+# Create an array to store the solution:
+state_data = Dict[state_vars]  # store initial condition at ``t=0``
+time_data = FT[0]                                      # store time data
+
+# Generate plots of initial conditions for the southwest nodal stack
+export_plot(
+    z,
+    time_data,
+    state_data,
+    ("ρcT",),
+    joinpath(output_dir, "initial_condition_T_nodal.png");
+    xlabel = "ρcT at southwest node",
+    ylabel = z_label,
+);
+export_plot(
+    z,
+    time_data,
+    state_data,
+    ("ρu[1]",),
+    joinpath(output_dir, "initial_condition_u_nodal.png");
+    xlabel = "ρu at southwest node",
+    ylabel = z_label,
+);
+export_plot(
+    z,
+    time_data,
+    state_data,
+    ("ρu[2]",),
+    joinpath(output_dir, "initial_condition_v_nodal.png");
+    xlabel = "ρv at southwest node",
+    ylabel = z_label,
+);
+
+# ![](initial_condition_T_nodal.png)
+# ![](initial_condition_u_nodal.png)
+
+# ## Inspect the initial conditions for the horizontal averages
+
+# Horizontal statistics of variables
+
+state_vars_var = get_horizontal_variance(
+    driver_config.grid,
+    solver_config.Q,
+    vars_state(m, Prognostic(), FT),
+);
+
+state_vars_avg = get_horizontal_mean(
+    driver_config.grid,
+    solver_config.Q,
+    vars_state(m, Prognostic(), FT),
+);
+
+data_avg = Dict[state_vars_avg]
+data_var = Dict[state_vars_var]
+
+export_plot(
+    z,
+    time_data,
+    data_avg,
+    ("ρu[1]",),
+    joinpath(output_dir, "initial_condition_avg_u.png");
+    xlabel = "Horizontal mean of ρu",
+    ylabel = z_label,
+);
+export_plot(
+    z,
+    time_data,
+    data_var,
+    ("ρu[1]",),
+    joinpath(output_dir, "initial_condition_variance_u.png");
+    xlabel = "Horizontal variance of ρu",
+    ylabel = z_label,
+);
+
+# ![](initial_condition_avg_u.png)
+# ![](initial_condition_variance_u.png)
+
+# # Solver hooks / callbacks
+
+# Define the number of outputs from `t0` to `timeend`
+const n_outputs = 5;
+const every_x_simulation_time = timeend / n_outputs;
+
+# Create a dictionary for `z` coordinate (and convert to cm) NCDatasets IO:
+dims = OrderedDict(z_key => collect(z));
+
+# Create dictionaries to store outputs:
+data_var = Dict[Dict([k => Dict() for k in 0:n_outputs]...),]
+data_var[1] = state_vars_var
+
+data_avg = Dict[Dict([k => Dict() for k in 0:n_outputs]...),]
+data_avg[1] = state_vars_avg
+
+data_nodal = Dict[Dict([k => Dict() for k in 0:n_outputs]...),]
+data_nodal[1] = state_vars
+
+# The `ClimateMachine`'s time-steppers provide hooks, or callbacks, which
+# allow users to inject code to be executed at specified intervals. In this
+# callback, the state variables are collected, combined into a single
+# `OrderedDict` and written to a NetCDF file (for each output step).
+callback = GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
+    state_vars_var = get_horizontal_variance(
+        driver_config.grid,
+        solver_config.Q,
+        vars_state(m, Prognostic(), FT),
+    )
+    state_vars_avg = get_horizontal_mean(
+        driver_config.grid,
+        solver_config.Q,
+        vars_state(m, Prognostic(), FT),
+    )
+    state_vars = get_vars_from_nodal_stack(
+        driver_config.grid,
+        solver_config.Q,
+        vars_state(m, Prognostic(), FT),
+        i = 1,
+        j = 1,
+    )
+    push!(data_var, state_vars_var)
+    push!(data_avg, state_vars_avg)
+    push!(data_nodal, state_vars)
+    push!(time_data, gettime(solver_config.solver))
+    nothing
+end;
+
+# # Solve
+
+# This is the main `ClimateMachine` solver invocation. While users do not have
+# access to the time-stepping loop, code may be injected via `user_callbacks`,
+# which is a `Tuple` of [`GenericCallbacks`](@ref ClimateMachine.GenericCallbacks).
+ClimateMachine.invoke!(solver_config; user_callbacks = (callback,))
+
+# # Post-processing
+
+# Our solution has now been calculated and exported to NetCDF files in
+# `output_dir`.
+
+# Let's plot the horizontal statistics of `ρu` and `ρcT`, as well as the evolution of
+# `ρu` for the southwest nodal stack:
+export_plot(
+    z,
+    time_data,
+    data_avg,
+    ("ρu[1]"),
+    joinpath(output_dir, "solution_vs_time_u_avg.png");
+    xlabel = "Horizontal mean of ρu",
+    ylabel = z_label,
+);
+export_plot(
+    z,
+    time_data,
+    data_var,
+    ("ρu[1]"),
+    joinpath(output_dir, "variance_vs_time_u.png");
+    xlabel = "Horizontal variance of ρu",
+    ylabel = z_label,
+);
+export_plot(
+    z,
+    time_data,
+    data_avg,
+    ("ρcT"),
+    joinpath(output_dir, "solution_vs_time_T_avg.png");
+    xlabel = "Horizontal mean of ρcT",
+    ylabel = z_label,
+);
+export_plot(
+    z,
+    time_data,
+    data_var,
+    ("ρcT"),
+    joinpath(output_dir, "variance_vs_time_T.png");
+    xlabel = "Horizontal variance of ρcT",
+    ylabel = z_label,
+);
+export_plot(
+    z,
+    time_data,
+    data_nodal,
+    ("ρu[1]"),
+    joinpath(output_dir, "solution_vs_time_u_nodal.png");
+    xlabel = "ρu at southwest node",
+    ylabel = z_label,
+);
+# ![](solution_vs_time_u_avg.png)
+# ![](variance_vs_time_u.png)
+# ![](solution_vs_time_T_avg.png)
+# ![](variance_vs_time_T.png)
+# ![](solution_vs_time_u_nodal.png)
+
+# Rayleigh friction returns the horizontal velocity to the objective
+# profile on the timescale of the simulation (1 second), since `γ`∼1. The horizontal viscosity
+# and 2D divergence damping act to reduce the horizontal variance over the same timescale.
+# The initial Gaussian noise is propagated to the temperature field through advection.
+# The horizontal diffusivity acts to reduce this `ρcT` variance in time, although in a longer
+# timescale.
+
+# To run this file, and
+# inspect the solution, include this tutorial in the Julia REPL
+# with:
+
+# ```julia
+# include(joinpath("tutorials", "Atmos", "burgers_single_stack.jl"))
+# ```


### PR DESCRIPTION
This branch adds a Finite Volume driver for the stable boundary layer EDMF experiment. 
This new driver has a MSE test file to track its progress compared with LES data. 
In a future PR the stable BL drivers of DG and FV will be unified to a single driver with a flag.


- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
