### PR TITLE
update resolutionmetric for the horizontal and vertical splitting

### DIFF
--- a/src/Numerics/Mesh/Geometry.jl
+++ b/src/Numerics/Mesh/Geometry.jl
@@ -109,7 +109,7 @@ Cartesian coordinates and `M = resolutionmetric(g)`, `sqrt(u'*M*u)` is the
 degree-of-freedom density in the direction of `u`.
 """
 function resolutionmetric(g::LocalGeometry)
-    S = g.polyorder * g.invJ / 2
+    S = SDiagonal(g.polyorder) * g.invJ / 2
     S' * S # TODO: return an eigendecomposition / symmetric object?
 end
 


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
Fix a bug in `resolutionmetric` which results in an error for the horizontal and vertical splitting.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
