### PR TITLE
Remove timestamps from diagnostics output filenames

### DIFF
--- a/docs/src/GettingStarted/RunningClimateMachine.md
+++ b/docs/src/GettingStarted/RunningClimateMachine.md
@@ -81,7 +81,8 @@ you can query the list of arguments understood, for example:
 $ julia --project experiments/AtmosGCM/heldsuarez.jl --help
 usage: experiments/AtmosGCM/heldsuarez.jl [--disable-gpu]
                         [--show-updates <interval>]
-                        [--diagnostics <interval>] [--vtk <interval>]
+                        [--diagnostics <interval>] [--no-overwrite]
+                        [--vtk <interval>]
                         [--vtk-number-sample-points <number>]
                         [--monitor-timestep-duration <interval>]
                         [--monitor-courant-numbers <interval>]
@@ -95,6 +96,12 @@ usage: experiments/AtmosGCM/heldsuarez.jl [--disable-gpu]
                         [--debug-init] [--integration-testing]
                         [--sim-time <number>]
                         [--fixed-number-of-steps <number>]
+                        [--degree <horizontal>,<vertical>]
+                        [--nelems <nelem_1>[,<nelem_2>[,<nelem_3>]]]
+                        [--domain-height <number>]
+                        [--resolution <Δx>,<Δy>,<Δz>]
+                        [--domain-min <xmin>,<ymin>,<zmin>]
+                        [--domain-max <xmax>,<ymax>,<zmax>]
                         [--number-of-tracers <number>] [-h]
 
 Climate Machine: an Earth System Model that automatically learns from data
@@ -113,6 +120,8 @@ ClimateMachine:
   --diagnostics <interval>
                         interval at which to collect diagnostics
                         (default: "never")
+  --no-overwrite        throw an error if an output file would be
+                        overwritten
   --vtk <interval>      interval at which to output VTK (default:
                         "never")
   --vtk-number-sample-points <number>
@@ -127,8 +136,7 @@ ClimateMachine:
                         advective, and diffusive Courant numbers
                         (default: "never")
   --adapt-timestep <interval>
-                        interval at which to adjust timestep to correspond
-                        to desired courant number
+                        interval at which to update the timestep
                         (default: "never")
   --checkpoint <interval>
                         interval at which to create a checkpoint
@@ -160,6 +168,39 @@ ClimateMachine:
   --fixed-number-of-steps <number>
                         if `≥0` perform specified number of steps
                         (type: Int64, default: -1)
+  --degree <horizontal>,<vertical>
+                        tuple of horizontal and vertical polynomial
+                        degrees for spatial discretization order (no
+                        space before/after comma) (type:
+                        Tuple{Int64,Int64}, default: (-1, -1))
+  --nelems <nelem_1>[,<nelem_2>[,<nelem_3>]]
+                        number of elements in each direction: 3 for
+                        Ocean GCM, 2 for Atmos GCM or 1 for Atmos
+                        single-stack (no space before/after comma)
+                        (type: Tuple{Int64,Int64,Int64}, default: (-1,
+                        -1, -1))
+  --domain-height <number>
+                        domain height (in meters) for GCM or
+                        single-stack configurations (type: Float64,
+                        default: -1.0)
+  --resolution <Δx>,<Δy>,<Δz>
+                        tuple of three element resolutions (in meters)
+                        for LES and MultiColumnLandModel
+                        configurations (type:
+                        Tuple{Float64,Float64,Float64}, default:
+                        (-1.0, -1.0, -1.0))
+  --domain-min <xmin>,<ymin>,<zmin>
+                        tuple of three minima for the domain size (in
+                        meters) for LES and MultiColumnLandModel
+                        configurations (type:
+                        Tuple{Float64,Float64,Float64}, default:
+                        (-1.0, -1.0, -1.0))
+  --domain-max <xmax>,<ymax>,<zmax>
+                        tuple of three maxima for the domain size (in
+                        meters) for LES and MultiColumnLandModel
+                        configurations (type:
+                        Tuple{Float64,Float64,Float64}, default:
+                        (-1.0, -1.0, -1.0))
 
 Any <interval> unless otherwise stated may be specified as:
     - 2hours or 10mins or 30secs => wall-clock time

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -49,6 +49,7 @@ Base.@kwdef mutable struct Diagnostic_Settings
     Q::Union{Nothing, MPIStateArray} = nothing
     starttime::Union{Nothing, String} = nothing
     output_dir::Union{Nothing, String} = nothing
+    no_overwrite::Bool = false
 end
 const Settings = Diagnostic_Settings()
 
@@ -65,6 +66,7 @@ function init(
     Q::MPIStateArray,
     starttime::String,
     output_dir::String,
+    no_overwrite::Bool,
 )
     Settings.mpicomm = mpicomm
     Settings.param_set = param_set
@@ -72,6 +74,7 @@ function init(
     Settings.Q = Q
     Settings.starttime = starttime
     Settings.output_dir = output_dir
+    Settings.no_overwrite = no_overwrite
 end
 
 include("variables.jl")

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -278,12 +278,7 @@ function atmos_gcm_default_init(dgngrp::DiagnosticsGroup, currtime)
         end
 
         # create the output file
-        dprefix = @sprintf(
-            "%s_%s_%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
 
         init_data(dgngrp.writer, dfilename, dims, vars)

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -280,8 +280,8 @@ function atmos_gcm_default_init(dgngrp::DiagnosticsGroup, currtime)
         # create the output file
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        noov = Settings.no_overwrite
+        init_data(dgngrp.writer, dfilename, noov, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/atmos_gcm_spectra.jl
+++ b/src/Diagnostics/atmos_gcm_spectra.jl
@@ -142,12 +142,7 @@ function atmos_gcm_spectra_init(dgngrp, currtime)
             "spectrum_2d" => (("m_t", "n", "level"), FT, Dict()),
         )
 
-        dprefix = @sprintf(
-            "%s_%s-%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
         init_data(dgngrp.writer, dfilename, dims, vars)
     end

--- a/src/Diagnostics/atmos_gcm_spectra.jl
+++ b/src/Diagnostics/atmos_gcm_spectra.jl
@@ -144,7 +144,8 @@ function atmos_gcm_spectra_init(dgngrp, currtime)
 
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        noov = Settings.no_overwrite
+        init_data(dgngrp.writer, dfilename, noov, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/atmos_les_core.jl
+++ b/src/Diagnostics/atmos_les_core.jl
@@ -197,12 +197,7 @@ function atmos_les_core_init(dgngrp::DiagnosticsGroup, currtime)
         end
 
         # create the output file
-        dprefix = @sprintf(
-            "%s_%s_%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
         init_data(dgngrp.writer, dfilename, dims, vars)
     end

--- a/src/Diagnostics/atmos_les_core.jl
+++ b/src/Diagnostics/atmos_les_core.jl
@@ -199,7 +199,8 @@ function atmos_les_core_init(dgngrp::DiagnosticsGroup, currtime)
         # create the output file
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        noov = Settings.no_overwrite
+        init_data(dgngrp.writer, dfilename, noov, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -552,7 +552,7 @@ function atmos_les_default_init(dgngrp::DiagnosticsGroup, currtime)
         # create the output file
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        init_data(dgngrp.writer, dfilename, Settings.no_overwrite, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -550,12 +550,7 @@ function atmos_les_default_init(dgngrp::DiagnosticsGroup, currtime)
         vars["swp"] = ((), FT, Variables["swp"].attrib)
 
         # create the output file
-        dprefix = @sprintf(
-            "%s_%s_%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
         init_data(dgngrp.writer, dfilename, dims, vars)
     end

--- a/src/Diagnostics/atmos_les_default_perturbations.jl
+++ b/src/Diagnostics/atmos_les_default_perturbations.jl
@@ -246,13 +246,7 @@ function atmos_les_default_perturbations_init(
         end
 
         # create the output file
-        dprefix = @sprintf(
-            "%s_%s_%s_rank%04d",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-            mpirank,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
         init_data(dgngrp.writer, dfilename, dims, vars)
     end

--- a/src/Diagnostics/atmos_les_default_perturbations.jl
+++ b/src/Diagnostics/atmos_les_default_perturbations.jl
@@ -248,7 +248,8 @@ function atmos_les_default_perturbations_init(
         # create the output file
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        noov = Settings.no_overwrite
+        init_data(dgngrp.writer, dfilename, noov, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/atmos_les_spectra.jl
+++ b/src/Diagnostics/atmos_les_spectra.jl
@@ -85,12 +85,7 @@ function atmos_les_spectra_init(dgngrp, currtime)
         dims = OrderedDict("k" => (wavenumber, Dict()))
         vars = OrderedDict("spectrum" => (("k",), FT, Dict()))
 
-        dprefix = @sprintf(
-            "%s_%s-%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
         init_data(dgngrp.writer, dfilename, dims, vars)
     end

--- a/src/Diagnostics/atmos_les_spectra.jl
+++ b/src/Diagnostics/atmos_les_spectra.jl
@@ -87,7 +87,8 @@ function atmos_les_spectra_init(dgngrp, currtime)
 
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        noov = Settings.no_overwrite
+        init_data(dgngrp.writer, dfilename, noov, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/atmos_mass_energy_loss.jl
+++ b/src/Diagnostics/atmos_mass_energy_loss.jl
@@ -82,12 +82,7 @@ function atmos_mass_energy_loss_init(dgngrp, currtime)
         )
 
         # create the output file
-        dprefix = @sprintf(
-            "%s_%s_%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
         init_data(dgngrp.writer, dfilename, dims, vars)
     end

--- a/src/Diagnostics/atmos_mass_energy_loss.jl
+++ b/src/Diagnostics/atmos_mass_energy_loss.jl
@@ -84,7 +84,8 @@ function atmos_mass_energy_loss_init(dgngrp, currtime)
         # create the output file
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        noov = Settings.no_overwrite
+        init_data(dgngrp.writer, dfilename, noov, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/atmos_refstate_perturbations.jl
+++ b/src/Diagnostics/atmos_refstate_perturbations.jl
@@ -159,7 +159,8 @@ function atmos_refstate_perturbations_init(dgngrp::DiagnosticsGroup, currtime)
         # create the output file
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        noov = Settings.no_overwrite
+        init_data(dgngrp.writer, dfilename, noov, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/atmos_refstate_perturbations.jl
+++ b/src/Diagnostics/atmos_refstate_perturbations.jl
@@ -157,13 +157,7 @@ function atmos_refstate_perturbations_init(dgngrp::DiagnosticsGroup, currtime)
         end
 
         # create the output file
-        dprefix = @sprintf(
-            "%s_%s_%s_rank%04d",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-            mpirank,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
         init_data(dgngrp.writer, dfilename, dims, vars)
     end

--- a/src/Diagnostics/atmos_turbulence_stats.jl
+++ b/src/Diagnostics/atmos_turbulence_stats.jl
@@ -78,12 +78,7 @@ function atmos_turbulence_stats_init(dgngrp, currtime)
         )
 
         # create the output file
-        dprefix = @sprintf(
-            "%s_%s_%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
         init_data(dgngrp.writer, dfilename, dims, vars)
     end

--- a/src/Diagnostics/atmos_turbulence_stats.jl
+++ b/src/Diagnostics/atmos_turbulence_stats.jl
@@ -80,7 +80,8 @@ function atmos_turbulence_stats_init(dgngrp, currtime)
         # create the output file
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        noov = Settings.no_overwrite
+        init_data(dgngrp.writer, dfilename, noov, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/dump_init.jl
+++ b/src/Diagnostics/dump_init.jl
@@ -15,12 +15,7 @@ function dump_init(dgngrp, currtime, st::AbstractStateType)
             vars[varname] = (tuple(collect(keys(dims))...), FT, Dict())
         end
 
-        dprefix = @sprintf(
-            "%s_%s-%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
         init_data(dgngrp.writer, dfilename, dims, vars)
     end

--- a/src/Diagnostics/dump_init.jl
+++ b/src/Diagnostics/dump_init.jl
@@ -17,7 +17,8 @@ function dump_init(dgngrp, currtime, st::AbstractStateType)
 
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        noov = Settings.no_overwrite
+        init_data(dgngrp.writer, dfilename, noov, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/dump_tendencies.jl
+++ b/src/Diagnostics/dump_tendencies.jl
@@ -140,7 +140,8 @@ function dump_tendencies_init(dgngrp, t)
 
         dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
-        init_data(dgngrp.writer, dfilename, dims, vars)
+        noov = Settings.no_overwrite
+        init_data(dgngrp.writer, dfilename, noov, dims, vars)
     end
 
     return nothing

--- a/src/Diagnostics/dump_tendencies.jl
+++ b/src/Diagnostics/dump_tendencies.jl
@@ -138,12 +138,7 @@ function dump_tendencies_init(dgngrp, t)
             end
         end
 
-        dprefix = @sprintf(
-            "%s_%s-%s",
-            dgngrp.out_prefix,
-            dgngrp.name,
-            Settings.starttime,
-        )
+        dprefix = @sprintf("%s_%s", dgngrp.out_prefix, dgngrp.name)
         dfilename = joinpath(Settings.output_dir, dprefix)
         init_data(dgngrp.writer, dfilename, dims, vars)
     end

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -540,17 +540,6 @@ function init_runtime(settings::ClimateMachine_Settings)
         end
     end
 
-    # create the output directory if needed on delegated rank
-    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-        if settings.diagnostics != "never" || settings.vtk != "never"
-            mkpath(settings.output_dir)
-        end
-        if settings.checkpoint != "never" || settings.checkpoint_at_end
-            mkpath(settings.checkpoint_dir)
-        end
-    end
-    MPI.Barrier(MPI.COMM_WORLD)
-
     # TODO: write a better MPI logging back-end and also integrate Dlog
     # for large scale
 
@@ -652,6 +641,17 @@ function invoke!(
     init_on_cpu = solver_config.init_on_cpu
     init_args = solver_config.init_args
     solver = solver_config.solver
+
+    # create the output directories if needed on delegated rank
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        if Settings.diagnostics != "never" || Settings.vtk != "never"
+            mkpath(Settings.output_dir)
+        end
+        if Settings.checkpoint != "never" || Settings.checkpoint_at_end
+            mkpath(Settings.checkpoint_dir)
+        end
+    end
+    MPI.Barrier(MPI.COMM_WORLD)
 
     # set up callbacks
     callbacks = ()

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -57,6 +57,7 @@ Base.@kwdef mutable struct ClimateMachine_Settings
     disable_gpu::Bool = false
     show_updates::String = "60secs"
     diagnostics::String = "never"
+    no_overwrite::Bool = false
     vtk::String = "never"
     vtk_number_sample_points::Int = 0
     monitor_timestep_duration::String = "never"
@@ -204,6 +205,11 @@ function parse_commandline(
         metavar = "<interval>"
         arg_type = String
         default = get_setting(:diagnostics, defaults, global_defaults)
+        "--no-overwrite"
+        help = "throw an error if an output file would be overwritten"
+        action = :store_const
+        constant = true
+        default = get_setting(:no_overwrite, defaults, global_defaults)
         "--vtk"
         help = "interval at which to output VTK"
         metavar = "<interval>"
@@ -370,6 +376,8 @@ Recognized keyword arguments are:
         interval at which to show simulation updates
 - `diagnostics::String = "never"`:
         interval at which to collect diagnostics"
+- `no_overwrite::Bool = false`:
+        throw an error if an output file would be overwritten
 - `vtk::String = "never"`:
         interval at which to write simulation vtk output
 - `vtk-number-sample-points::Int` = 0:
@@ -676,6 +684,7 @@ function invoke!(
             Q,
             dgn_starttime,
             Settings.output_dir,
+            Settings.no_overwrite,
         )
 
         dgncbs = Callbacks.diagnostics(

--- a/src/InputOutput/Writers/Writers.jl
+++ b/src/InputOutput/Writers/Writers.jl
@@ -26,6 +26,7 @@ function full_name end
     init_data(
         writer,
         filename,
+        no_overwrite,
         dims,
         vars,
     )
@@ -38,6 +39,8 @@ specified variables are also defined. This function must be called before
 # Arguments:
 # - `writer`: instance of a subtype of `AbstractWriter`.
 # - `filename`: into which to write data (without extension).
+# - `no_overwrite`: if `true`, throw an error if `filename` exists and
+#   would be overwritten.
 # - `dims`: Dict of dimension name to 2-tuple of dimension values and Dict
 #   of attributes.
 # - `vars`: Dict of variable name to 3-tuple of a k-tuple of dimension

--- a/src/InputOutput/Writers/netcdf_writer.jl
+++ b/src/InputOutput/Writers/netcdf_writer.jl
@@ -18,8 +18,16 @@ function full_name(writer::NetCDFWriter, filename = nothing)
     end
 end
 
-function init_data(nc::NetCDFWriter, filename, dims, vars)
-    Dataset(full_name(nc, filename), "c") do ds
+function init_data(nc::NetCDFWriter, filename, no_overwrite, dims, vars)
+    nm = full_name(nc, filename)
+    if ispath(nm)
+        if no_overwrite
+            error("$(nm) exists and overwriting is forbidden.")
+        else
+            @warn "$(nm) exists and will be overwritten."
+        end
+    end
+    Dataset(nm, "c") do ds
         # define spatial and time dimensions
         for (dn, (dv, da)) in dims
             defDim(ds, dn, length(dv))

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -156,7 +156,7 @@ function main()
     outdir = mktempdir()
     currtime = ODESolvers.gettime(solver)
     starttime = replace(string(now()), ":" => ".")
-    Diagnostics.init(mpicomm, param_set, dg, Q, starttime, outdir)
+    Diagnostics.init(mpicomm, param_set, dg, Q, starttime, outdir, false)
     GenericCallbacks.init!(
         dgn_config.groups[1],
         nothing,

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -171,12 +171,7 @@ function main()
     mpirank = MPI.Comm_rank(mpicomm)
     if mpirank == 0
         dgngrp = dgn_config.groups[1]
-        nm = @sprintf(
-            "%s_%s_%s.nc",
-            replace(dgngrp.out_prefix, " " => "_"),
-            dgngrp.name,
-            starttime,
-        )
+        nm = @sprintf("%s_%s.nc", dgngrp.out_prefix, dgngrp.name)
         ds = NCDataset(joinpath(outdir, nm), "r")
         ds_u = ds["u"][:]
         ds_cov_w_u = ds["cov_w_u"][:]

--- a/test/InputOutput/Writers/runtests.jl
+++ b/test/InputOutput/Writers/runtests.jl
@@ -23,7 +23,11 @@ using ClimateMachine.Writers
     nfn, _ = mktemp()
     nfull = full_name(nc, nfn)
 
-    init_data(nc, nfn, odims, ovartypes)
+    touch(nfull)
+    @test_throws ErrorException init_data(nc, nfn, true, odims, ovartypes)
+    rm(nfull)
+
+    init_data(nc, nfn, false, odims, ovartypes)
     append_data(nc, OrderedDict("v1" => vals1, "v2" => vals2), 2.0)
 
     NCDataset(nfull, "r") do nds


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
Now, any previously existing output files will be overwritten. Use `--output-dir` (or the environment variable or the keyword argument to `init`) to change the output directory if you don't want files overwritten.

Closes #1765.

<!-- Check all the boxes below before taking the PR out of draft -->

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
