### PR TITLE
Fix flux pads so that empty fluxes work

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -535,13 +535,14 @@ equations.
     direction,
 )
 
-    flux_pad = SVector(1, 1, 1)
+    vec_pad = SVector(1, 1, 1)
+    tens_pad = SArray{Tuple{3, 3}}(ntuple(i -> 1, 9))
     tend = Flux{FirstOrder}()
     _args = (; state, aux, t, direction)
     args = merge(_args, (precomputed = precompute(atmos, _args, tend),))
-    flux.ρ = Σfluxes(eq_tends(Mass(), atmos, tend), atmos, args) .* flux_pad
+    flux.ρ = Σfluxes(eq_tends(Mass(), atmos, tend), atmos, args) .* vec_pad
     flux.ρu =
-        Σfluxes(eq_tends(Momentum(), atmos, tend), atmos, args) .* flux_pad
+        Σfluxes(eq_tends(Momentum(), atmos, tend), atmos, args) .* tens_pad
 
     flux_first_order!(atmos.energy, atmos, flux, args)
     flux_first_order!(atmos.moisture, atmos, flux, args)
@@ -679,16 +680,17 @@ function. Contributions from subcomponents are then assembled (pointwise).
     aux::Vars,
     t::Real,
 )
-    flux_pad = SVector(1, 1, 1)
+    vec_pad = SVector(1, 1, 1)
+    tens_pad = SArray{Tuple{3, 3}}(ntuple(i -> 1, 9))
     tend = Flux{SecondOrder}()
 
     _args = (; state, aux, t, diffusive, hyperdiffusive)
 
     args = merge(_args, (precomputed = precompute(atmos, _args, tend),))
 
-    flux.ρ = Σfluxes(eq_tends(Mass(), atmos, tend), atmos, args) .* flux_pad
+    flux.ρ = Σfluxes(eq_tends(Mass(), atmos, tend), atmos, args) .* vec_pad
     flux.ρu =
-        Σfluxes(eq_tends(Momentum(), atmos, tend), atmos, args) .* flux_pad
+        Σfluxes(eq_tends(Momentum(), atmos, tend), atmos, args) .* tens_pad
 
     flux_second_order!(atmos.energy, flux, atmos, args)
     flux_second_order!(atmos.moisture, flux, atmos, args)
@@ -871,7 +873,7 @@ function source!(
     t::Real,
     direction,
 )
-    ρu_pad = SVector(1, 1, 1)
+    vec_pad = SVector(1, 1, 1)
     tend = Source()
 
     _args = (; state, aux, t, direction, diffusive)
@@ -880,7 +882,7 @@ function source!(
 
     source.ρ = Σsources(eq_tends(Mass(), atmos, tend), atmos, args)
     source.ρu =
-        Σsources(eq_tends(Momentum(), atmos, tend), atmos, args) .* ρu_pad
+        Σsources(eq_tends(Momentum(), atmos, tend), atmos, args) .* vec_pad
     source!(atmos.energy, source, atmos, args)
     source!(atmos.moisture, source, atmos, args)
     source!(atmos.precipitation, source, atmos, args)

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -218,7 +218,8 @@ function flux_first_order!(
     t::Real,
     direction,
 )
-    flux_pad = SVector(1, 1, 1)
+    tens_pad = SArray{Tuple{3, 3}}(ntuple(i -> 1, 9))
+    vec_pad = SVector(1, 1, 1)
     tend = Flux{FirstOrder}()
     _args = (; state, aux, t, direction)
 
@@ -228,9 +229,9 @@ function flux_first_order!(
     # TODO: look into this
     args = _args
     # args = merge(_args, (precomputed = precompute(lm.atmos, _args, tend),))
-    flux.ρ = Σfluxes(eq_tends(Mass(), lm, tend), lm, args) .* flux_pad
-    flux.ρu = Σfluxes(eq_tends(Momentum(), lm, tend), lm, args) .* flux_pad
-    flux.energy.ρe = Σfluxes(eq_tends(Energy(), lm, tend), lm, args) .* flux_pad
+    flux.ρ = Σfluxes(eq_tends(Mass(), lm, tend), lm, args) .* vec_pad
+    flux.ρu = Σfluxes(eq_tends(Momentum(), lm, tend), lm, args) .* tens_pad
+    flux.energy.ρe = Σfluxes(eq_tends(Energy(), lm, tend), lm, args) .* vec_pad
     nothing
 end
 
@@ -254,7 +255,7 @@ function source!(
     ::NTuple{1, Dir},
 ) where {Dir <: Direction}
 
-    ρu_pad = SVector(1, 1, 1)
+    vec_pad = SVector(1, 1, 1)
     tend = Source()
     _args = (; state, aux, t, direction = Dir, diffusive)
 
@@ -266,7 +267,7 @@ function source!(
     # args = merge(_args, (precomputed = precompute(lm.atmos, _args, tend),))
 
     # Sources for the linear atmos model only appear in the momentum equation
-    source.ρu = Σsources(eq_tends(Momentum(), lm, tend), lm, args) .* ρu_pad
+    source.ρu = Σsources(eq_tends(Momentum(), lm, tend), lm, args) .* vec_pad
     nothing
 end
 

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -785,25 +785,36 @@ function flux_first_order!(
     N_up = n_updrafts(turbconv)
     # in future GCM implementations we need to think about grid mean advection
     tend = Flux{FirstOrder}()
+    vec_pad = SVector(1, 1, 1)
 
     @unroll_map(N_up) do i
-        up_flx[i].ρa = Σfluxes(eq_tends(up_ρa{i}(), atmos, tend), atmos, args)
-        up_flx[i].ρaw = Σfluxes(eq_tends(up_ρaw{i}(), atmos, tend), atmos, args)
+        up_flx[i].ρa =
+            Σfluxes(eq_tends(up_ρa{i}(), atmos, tend), atmos, args) .* vec_pad
+        up_flx[i].ρaw =
+            Σfluxes(eq_tends(up_ρaw{i}(), atmos, tend), atmos, args) .* vec_pad
         up_flx[i].ρaθ_liq =
-            Σfluxes(eq_tends(up_ρaθ_liq{i}(), atmos, tend), atmos, args)
+            Σfluxes(eq_tends(up_ρaθ_liq{i}(), atmos, tend), atmos, args) .*
+            vec_pad
         if !(atmos.moisture isa DryModel)
             up_flx[i].ρaq_tot =
-                Σfluxes(eq_tends(up_ρaq_tot{i}(), atmos, tend), atmos, args)
+                Σfluxes(eq_tends(up_ρaq_tot{i}(), atmos, tend), atmos, args) .*
+                vec_pad
         end
     end
-    en_flx.ρatke = Σfluxes(eq_tends(en_ρatke(), atmos, tend), atmos, args)
+    en_flx.ρatke =
+        Σfluxes(eq_tends(en_ρatke(), atmos, tend), atmos, args) .* vec_pad
     en_flx.ρaθ_liq_cv =
-        Σfluxes(eq_tends(en_ρaθ_liq_cv(), atmos, tend), atmos, args)
+        Σfluxes(eq_tends(en_ρaθ_liq_cv(), atmos, tend), atmos, args) .* vec_pad
     if !(atmos.moisture isa DryModel)
         en_flx.ρaq_tot_cv =
-            Σfluxes(eq_tends(en_ρaq_tot_cv(), atmos, tend), atmos, args)
+            Σfluxes(eq_tends(en_ρaq_tot_cv(), atmos, tend), atmos, args) .*
+            vec_pad
         en_flx.ρaθ_liq_q_tot_cv =
-            Σfluxes(eq_tends(en_ρaθ_liq_q_tot_cv(), atmos, tend), atmos, args)
+            Σfluxes(
+                eq_tends(en_ρaθ_liq_q_tot_cv(), atmos, tend),
+                atmos,
+                args,
+            ) .* vec_pad
     end
 end;
 
@@ -1132,25 +1143,25 @@ function flux_second_order!(
 
     # Aliases:
     en_flx = flux.turbconv.environment
-    flux_pad = SVector(1, 1, 1)
+    vec_pad = SVector(1, 1, 1)
     # in future GCM implementations we need to think about grid mean advection
     tend = Flux{SecondOrder}()
     en_flx.ρatke =
-        Σfluxes(eq_tends(en_ρatke(), atmos, tend), atmos, args) .* flux_pad
+        Σfluxes(eq_tends(en_ρatke(), atmos, tend), atmos, args) .* vec_pad
     # in the EDMF second order (diffusive) fluxes
     # exist only in the grid mean and the environment
     en_flx.ρaθ_liq_cv =
-        Σfluxes(eq_tends(en_ρaθ_liq_cv(), atmos, tend), atmos, args) .* flux_pad
+        Σfluxes(eq_tends(en_ρaθ_liq_cv(), atmos, tend), atmos, args) .* vec_pad
     if !(atmos.moisture isa DryModel)
         en_flx.ρaq_tot_cv =
             Σfluxes(eq_tends(en_ρaq_tot_cv(), atmos, tend), atmos, args) .*
-            flux_pad
+            vec_pad
         en_flx.ρaθ_liq_q_tot_cv =
             Σfluxes(
                 eq_tends(en_ρaθ_liq_q_tot_cv(), atmos, tend),
                 atmos,
                 args,
-            ) .* flux_pad
+            ) .* vec_pad
     end
 end;
 


### PR DESCRIPTION
### Description

I wasn't really thorough with the pads the first time around. This PR cleans up the flux pads so that we can use empty `eq_tends` for (all 🤞🏻 ) fluxes. We could alternatively handle this inside `Σfluxes`/`Σsources`, but we'd need to pass the prognostic variable to it, and I'd rather make that transition in #1921 if that materializes.

Thanks @dennisYatunin for pointing this out.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
