### PR TITLE
Fix `InterpolationConfiguration` for grid stretching

### DIFF
--- a/experiments/TestCase/solid_body_rotation_fvm.jl
+++ b/experiments/TestCase/solid_body_rotation_fvm.jl
@@ -80,7 +80,7 @@ function config_solid_body_rotation(
         model = model,
         numerical_flux_first_order = RoeNumericalFlux(),
         fv_reconstruction = HBFVReconstruction(model, fv_reconstruction),
-        #grid_stretching = SingleExponentialStretching(FT(2.0)),
+        #grid_stretching = (SingleExponentialStretching(FT(2.0)),),
     )
 
     return config

--- a/src/Driver/diagnostics_configs.jl
+++ b/src/Driver/diagnostics_configs.jl
@@ -33,21 +33,11 @@ function InterpolationConfiguration(
     axes;
     nr_toler = nothing,
 )
-    FT = eltype(driver_config.grid)
-    param_set = driver_config.bl.param_set
     grid = driver_config.grid
     info = driver_config.config_info
-
-    _planet_radius::FT = planet_radius(param_set)
-    vert_range = grid1d(
-        _planet_radius,
-        FT(_planet_radius + info.domain_height),
-        nelem = info.nelem_vert,
-    )
-
     return InterpolationCubedSphere(
         grid,
-        collect(vert_range),
+        info.vert_range,
         info.nelem_horz,
         axes[1],
         axes[2],


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
Quick fix to use the DG grid's vertical range in `InterpolationConfiguration`.

<!-- Check all the boxes below before taking the PR out of draft -->

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
