### PR TITLE
Add incompressible single stack model and driver configuration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1678,6 +1678,16 @@ steps:
       queue: central
       slurm_ntasks: 1
 
+  - label: "gpu_sbl_an1d"
+    key: "gpu_sbl_an1d"
+    command:
+      - "mpiexec julia --color=yes --project test/Atmos/EDMF/stable_bl_anelastic1d.jl --fix-rng-seed"
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
   - label: "gpu_bomex_bulk_sfc_flux"
     key: "gpu_bomex_bulk_sfc_flux"
     command:

--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -26,6 +26,13 @@ ClimateMachine.BalanceLaws.source!(m::AtmosModel, source::Vars, state::Vars, dif
 ClimateMachine.BalanceLaws.init_state_prognostic!(m::AtmosModel, state::Vars, aux::Vars, localgeo, t, args...)
 ```
 
+## Compressibility
+
+```@docs
+ClimateMachine.Atmos.Compressible
+ClimateMachine.Atmos.Anelastic1D
+```
+
 ## Reference states
 
 ```@docs
@@ -40,6 +47,8 @@ ClimateMachine.Atmos.NoReferenceState
 ```@docs
 ClimateMachine.Atmos.recover_thermo_state
 ClimateMachine.Atmos.new_thermo_state
+ClimateMachine.Atmos.recover_thermo_state_anelastic
+ClimateMachine.Atmos.new_thermo_state_anelastic
 ```
 
 ## Moisture and Precipitation

--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -23,6 +23,7 @@ Source
 TendencyDef
 eq_tends
 prognostic_vars
+projection
 precompute
 fluxes
 sources

--- a/experiments/AtmosGCM/GCMDriver/gcm_bcs.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_bcs.jl
@@ -73,7 +73,7 @@ function (st::Varying_SST_TJ16)(state, aux, t)
     q_tot = state.moisture.ρq_tot / ρ
     q = PhasePartition(q_tot)
 
-    e_int = internal_energy(st.moisture, st.orientation, state, aux)
+    e_int = internal_energy(st.orientation, state, aux)
     T = air_temperature(st.param_set, e_int, q)
     p = air_pressure(st.param_set, T, ρ, q)
 

--- a/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
+++ b/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
@@ -196,7 +196,7 @@ function (st::Varying_SST_TJ16)(state, aux, t)
     q_tot = state.moisture.ρq_tot / ρ
     q = PhasePartition(q_tot)
 
-    e_int = internal_energy(st.moisture, st.orientation, state, aux)
+    e_int = internal_energy(st.orientation, state, aux)
     T = air_temperature(st.param_set, e_int, q)
     p = air_pressure(st.param_set, T, ρ, q)
 

--- a/experiments/AtmosLES/stable_bl_les.jl
+++ b/experiments/AtmosLES/stable_bl_les.jl
@@ -77,10 +77,7 @@ function main(cl_args)
     )
     dgn_config = config_diagnostics(driver_config)
 
-    check_cons = (
-        ClimateMachine.ConservationCheck("ρ", "1mins", FT(0.0001)),
-        ClimateMachine.ConservationCheck("energy.ρe", "1mins", FT(0.0025)),
-    )
+    check_cons = (ClimateMachine.ConservationCheck("ρ", "1mins", FT(0.0001)),)
 
     result = ClimateMachine.invoke!(
         solver_config;

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -6,7 +6,9 @@ export AtmosModel,
     HLLCNumericalFlux,
     RoeNumericalFlux,
     RoeNumericalFluxMoist,
-    LMARSNumericalFlux
+    LMARSNumericalFlux,
+    Compressible,
+    Anelastic1D
 
 using UnPack
 using CLIMAParameters
@@ -34,7 +36,7 @@ using ..TurbulenceClosures
 import ..TurbulenceClosures: turbulence_tensors
 using ..TurbulenceConvection
 
-import ..Thermodynamics: internal_energy
+import ..Thermodynamics: internal_energy, soundspeed_air
 using ..MPIStateArrays: MPIStateArray
 using ..Mesh.Grids:
     VerticalDirection,
@@ -48,6 +50,7 @@ using ClimateMachine.Problems
 
 import ..BalanceLaws:
     vars_state,
+    projection,
     flux_first_order!,
     flux_second_order!,
     source!,
@@ -119,6 +122,7 @@ default values for each field.
         radiation,
         source,
         tracers,
+        compressibility,
         data_config,
     )
 
@@ -142,6 +146,7 @@ struct AtmosModel{
     S,
     TR,
     LF,
+    C,
     DC,
 } <: BalanceLaw
     "Parameter Set (type to dispatch on, e.g., planet parameters. See CLIMAParameters.jl package)"
@@ -174,9 +179,32 @@ struct AtmosModel{
     tracers::TR
     "Large-scale forcing (Forcing information from GCMs, reanalyses, or observations)"
     lsforcing::LF
+    "Compressibility switch"
+    compressibility::C
     "Data Configuration (Helper field for experiment configuration)"
     data_config::DC
 end
+
+abstract type Compressibilty end
+
+"""
+    Compressible <: Compressibilty
+
+Dispatch on compressible model (default)
+
+ - Density is prognostic
+"""
+struct Compressible <: Compressibilty end
+
+"""
+    Anelastic1D <: Compressibilty
+
+Dispatch on Anelastic1D model
+
+ - Density is constant in time
+ - Remove momentum z-component tendencies
+"""
+struct Anelastic1D <: Compressibilty end
 
 """
     AtmosModel{FT}()
@@ -207,6 +235,7 @@ function AtmosModel{FT}(
     ),
     tracers::TR = NoTracers(),
     lsforcing::LF = NoLSForcing(),
+    compressibility::C = Compressible(),
     data_config::DC = nothing,
 ) where {
     FT <: AbstractFloat,
@@ -225,6 +254,7 @@ function AtmosModel{FT}(
     S,
     TR,
     LF,
+    C,
     DC,
 }
     @assert !any(isa.(source, Tuple))
@@ -245,6 +275,7 @@ function AtmosModel{FT}(
         source,
         tracers,
         lsforcing,
+        compressibility,
         data_config,
     )
 
@@ -275,6 +306,7 @@ function AtmosModel{FT}(
     source::S = (Gravity(), Coriolis(), turbconv_sources(turbconv)...),
     tracers::TR = NoTracers(),
     lsforcing::LF = NoLSForcing(),
+    compressibility::C = Compressible(),
     data_config::DC = nothing,
 ) where {
     FT <: AbstractFloat,
@@ -293,6 +325,7 @@ function AtmosModel{FT}(
     S,
     TR,
     LF,
+    C,
     DC,
 }
 
@@ -314,6 +347,7 @@ function AtmosModel{FT}(
         source,
         tracers,
         lsforcing,
+        compressibility,
         data_config,
     )
 
@@ -480,6 +514,22 @@ gravitational_potential(bl, aux) = gravitational_potential(bl.orientation, aux)
 turbulence_tensors(atmos::AtmosModel, args...) =
     turbulence_tensors(atmos.turbulence, atmos, args...)
 
+"""
+    density(atmos::AtmosModel, state::Vars, aux::Vars)
+
+In the Anelastic1D state, `state.ρ` that is used to
+extract intrinsic values (i.e. `e=state.energy.ρe/state.ρ`)
+is time invariant (by eliminating the tendencies) while
+`ref_state.ρ` is used to construct a thermodynamic state.
+`density` will get the `ref_state.ρ` for thermodynamic state
+when the model is Anelastic1D.
+"""
+density(atmos::AtmosModel, state::Vars, aux::Vars) =
+    density(atmos.compressibility, state, aux)
+density(::Compressible, state, aux) = state.ρ
+density(::Anelastic1D, state, aux) = aux.ref_state.ρ
+
+
 include("declare_prognostic_vars.jl") # declare prognostic variables
 include("multiphysics_types.jl")      # types for multi-physics tendencies
 include("tendencies_mass.jl")         # specify mass tendencies
@@ -495,6 +545,7 @@ include("moisture.jl")
 include("energy.jl")
 include("precipitation.jl")
 include("thermo_states.jl")
+include("thermo_states_anelastic.jl")
 include("radiation.jl")
 include("tracers.jl")
 include("lsforcing.jl")
@@ -503,6 +554,7 @@ include("courant.jl")
 include("filters.jl")
 include("prog_prim_conversion.jl")   # prognostic<->primitive conversion
 include("reconstructions.jl")   # finite-volume method reconstructions
+include("projections.jl")            # include term-by-term projectinos
 
 include("linear_tendencies.jl")
 include("linear_atmos_tendencies.jl")
@@ -689,6 +741,8 @@ function. Contributions from subcomponents are then assembled (pointwise).
     nothing
 end
 
+soundspeed_air(ts::ThermodynamicState, ::Anelastic1D) = 0
+soundspeed_air(ts::ThermodynamicState, ::Compressible) = soundspeed_air(ts)
 @inline function wavespeed(
     m::AtmosModel,
     nM,
@@ -701,7 +755,7 @@ end
     u = ρinv * state.ρu
     uN = abs(dot(nM, u))
     ts = recover_thermo_state(m, state, aux)
-    ss = soundspeed_air(ts)
+    ss = soundspeed_air(ts, m.compressibility)
     FT = typeof(state.ρ)
     ws = fill(uN + ss, MVector{number_states(m, Prognostic()), FT})
     vars_ws = Vars{vars_state(m, Prognostic(), FT)}(ws)

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -24,13 +24,23 @@ eq_tends(pv::PrognosticVariable, m::AtmosModel, tt::Source) =
 ##### First order fluxes
 #####
 
-# Mass
-eq_tends(pv::PV, ::AtmosModel, ::Flux{FirstOrder}) where {PV <: Mass} =
+eq_tends(pv::PV, ::Anelastic1D, ::Flux{FirstOrder}) where {PV <: Mass} = ()
+
+eq_tends(pv::PV, ::Compressible, ::Flux{FirstOrder}) where {PV <: Mass} =
     (Advect{PV}(),)
 
+# Mass
+eq_tends(pv::PV, atmos::AtmosModel, tt::Flux{FirstOrder}) where {PV <: Mass} =
+    (eq_tends(pv, atmos.compressibility, tt))
+
 # Momentum
-eq_tends(pv::PV, m::AtmosModel, ::Flux{FirstOrder}) where {PV <: Momentum} =
-    (Advect{PV}(), PressureGradient{PV}())
+eq_tends(pv::PV, ::Compressible, ::Flux{FirstOrder}) where {PV <: Momentum} =
+    (PressureGradient{PV}(),)
+
+eq_tends(pv::PV, ::Anelastic1D, ::Flux{FirstOrder}) where {PV <: Momentum} = ()
+
+eq_tends(pv::PV, m::AtmosModel, tt::Flux{FirstOrder}) where {PV <: Momentum} =
+    (Advect{PV}(), eq_tends(pv, m.compressibility, tt)...)
 
 # Energy
 eq_tends(pv::PV, m::EnergyModel, tt::Flux{FirstOrder}) where {PV <: Energy} =

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -30,16 +30,16 @@ function compute_gradient_argument!(
 ) end
 
 internal_energy(atmos::AtmosModel, state::Vars, aux::Vars) =
-    internal_energy(atmos.moisture, atmos.orientation, state, aux)
+    internal_energy(atmos, atmos.orientation, state, aux)
 
 @inline function internal_energy(
-    moist::MoistureModel,
+    atmos::AtmosModel,
     orientation::Orientation,
     state::Vars,
     aux::Vars,
 )
     Thermodynamics.internal_energy(
-        state.ρ,
+        density(atmos, state, aux),
         state.energy.ρe,
         state.ρu,
         gravitational_potential(orientation, aux),

--- a/src/Atmos/Model/projections.jl
+++ b/src/Atmos/Model/projections.jl
@@ -1,0 +1,31 @@
+import ..BalanceLaws: projection
+
+# Zero-out vertical momentum tendencies based on compressibility
+function projection(
+    atmos::AtmosModel,
+    td::TendencyDef{TT, PV},
+    args,
+    x,
+) where {TT, PV <: Momentum}
+    return projection(atmos.compressibility, td, args, x)
+end
+
+# Zero-out vertical momentum fluxes for Anelastic1D:
+function projection(
+    ::Anelastic1D,
+    ::TendencyDef{Flux{O}, PV},
+    args,
+    x,
+) where {O, PV <: Momentum}
+    return x .* SArray{Tuple{3, 3}}(1, 1, 1, 1, 1, 1, 0, 0, 0)
+end
+
+# Zero-out vertical momentum sources for Anelastic1D:
+function projection(
+    ::Anelastic1D,
+    ::TendencyDef{Source, PV},
+    args,
+    x,
+) where {PV <: Momentum}
+    return x .* SVector(1, 1, 0)
+end

--- a/src/Atmos/Model/thermo_states.jl
+++ b/src/Atmos/Model/thermo_states.jl
@@ -12,8 +12,45 @@ the `aux` state.
     This method calls the iterative saturation adjustment
     procedure for EquilMoist models.
 """
+function new_thermo_state end
+
+# First dispatch on compressibility
 new_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
+    new_thermo_state(atmos.compressibility, atmos, state, aux)
+
+new_thermo_state(::Compressible, atmos::AtmosModel, state::Vars, aux::Vars) =
     new_thermo_state(atmos, atmos.energy, atmos.moisture, state, aux)
+new_thermo_state(::Anelastic1D, atmos::AtmosModel, state::Vars, aux::Vars) =
+    new_thermo_state_anelastic(atmos, state, aux)
+
+"""
+    recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars)
+
+An atmospheric thermodynamic state.
+
+!!! warn
+    For now, we are directly calling new_thermo_state to avoid
+    inconsistent aux states in kernels where the aux states are
+    out of sync with the boundary state.
+
+# TODO: Define/call `recover_thermo_state` when it's safely implemented
+  (see https://github.com/CliMA/ClimateMachine.jl/issues/1648)
+"""
+function recover_thermo_state end
+
+# First dispatch on compressibility
+recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
+    new_thermo_state(atmos.compressibility, atmos, state, aux)
+
+recover_thermo_state(
+    ::Compressible,
+    atmos::AtmosModel,
+    state::Vars,
+    aux::Vars,
+) = new_thermo_state(atmos, atmos.energy, atmos.moisture, state, aux)
+
+recover_thermo_state(::Anelastic1D, atmos::AtmosModel, state::Vars, aux::Vars) =
+    new_thermo_state_anelastic(atmos, state, aux)
 
 function new_thermo_state(
     atmos::AtmosModel,
@@ -116,19 +153,3 @@ function new_thermo_state(
         q,
     )
 end
-
-"""
-    recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars)
-
-An atmospheric thermodynamic state.
-
-!!! warn
-    For now, we are directly calling new_thermo_state to avoid
-    inconsistent aux states in kernels where the aux states are
-    out of sync with the boundary state.
-
-# TODO: Define/call `recover_thermo_state` when it's safely implemented
-  (see https://github.com/CliMA/ClimateMachine.jl/issues/1648)
-"""
-recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
-    new_thermo_state(atmos, atmos.energy, atmos.moisture, state, aux)

--- a/src/Atmos/Model/thermo_states_anelastic.jl
+++ b/src/Atmos/Model/thermo_states_anelastic.jl
@@ -1,0 +1,87 @@
+#### thermodynamics
+
+export new_thermo_state_anelastic, recover_thermo_state_anelastic
+
+"""
+    new_thermo_state_anelastic(atmos::AtmosModel, state::Vars, aux::Vars)
+
+Create a new thermodynamic state, based on the `state`, and _not_
+the `aux` state.
+
+!!! note
+    This method calls the iterative saturation adjustment
+    procedure for EquilMoist models.
+"""
+new_thermo_state_anelastic(atmos::AtmosModel, state::Vars, aux::Vars) =
+    new_thermo_state_anelastic(atmos, atmos.energy, atmos.moisture, state, aux)
+
+"""
+    recover_thermo_state_anelastic(atmos::AtmosModel, state::Vars, aux::Vars)
+
+An atmospheric thermodynamic state.
+
+!!! warn
+    For now, we are directly calling new_thermo_state_anelastic to avoid
+    inconsistent aux states in kernels where the aux states are
+    out of sync with the boundary state.
+
+# TODO: Define/call `recover_thermo_state_anelastic` when it's safely implemented
+  (see https://github.com/CliMA/ClimateMachine.jl/issues/1648)
+"""
+recover_thermo_state_anelastic(atmos::AtmosModel, state::Vars, aux::Vars) =
+    new_thermo_state_anelastic(atmos, atmos.energy, atmos.moisture, state, aux)
+
+function new_thermo_state_anelastic(
+    atmos::AtmosModel,
+    energy::EnergyModel,
+    moist::DryModel,
+    state::Vars,
+    aux::Vars,
+)
+    e_int = internal_energy(atmos, state, aux)
+    p = aux.ref_state.p
+    return PhaseDry_pe(atmos.param_set, p, e_int)
+end
+
+function new_thermo_state_anelastic(
+    atmos::AtmosModel,
+    energy::EnergyModel,
+    moist::EquilMoist,
+    state::Vars,
+    aux::Vars,
+)
+    e_int = internal_energy(atmos, state, aux)
+    p = aux.ref_state.p
+    ρ = density(atmos, state, aux)
+    return PhaseEquil_peq(
+        atmos.param_set,
+        p,
+        e_int,
+        state.moisture.ρq_tot / ρ,
+        moist.maxiter,
+        moist.tolerance,
+    )
+end
+
+function new_thermo_state_anelastic(
+    atmos::AtmosModel,
+    energy::EnergyModel,
+    moist::NonEquilMoist,
+    state::Vars,
+    aux::Vars,
+)
+    e_int = internal_energy(atmos, state, aux)
+    ρ = density(atmos, state, aux)
+    q = PhasePartition(
+        state.moisture.ρq_tot / ρ,
+        state.moisture.ρq_liq / ρ,
+        state.moisture.ρq_ice / ρ,
+    )
+
+    return PhaseNonEquil_peq{eltype(state), typeof(atmos.param_set)}(
+        atmos.param_set,
+        p,
+        e_int,
+        q,
+    )
+end

--- a/src/BalanceLaws/sum_tendencies.jl
+++ b/src/BalanceLaws/sum_tendencies.jl
@@ -29,19 +29,24 @@ runs to help improve debugging.
 ntuple_sum(nt::NTuple{N, T}) where {N, T} = sum(nt)
 
 """
-    Σfluxes(fluxes::NTuple, args...)
+    Σfluxes(fluxes::NTuple, bl, args)
 
 Sum of the fluxes where
  - `fluxes` is an `NTuple{N, TendencyDef{Flux{O}, PV}} where {N, PV, O}`
+ - `bl` is the balance law
+ - `args` are the arguments passed to the individual `flux` functions
 """
 function Σfluxes(
     pv::PV,
     fluxes::NTuple{N, TendencyDef{Flux{O}, PV}},
-    args...,
+    bl,
+    args,
 ) where {N, O, PV}
-    return ntuple_sum(ntuple(Val(N)) do i
-        flux(fluxes[i], args...)
-    end)
+    return ntuple_sum(
+        ntuple(Val(N)) do i
+            projection(bl, fluxes[i], args, flux(fluxes[i], bl, args))
+        end,
+    )
 end
 
 # Emptry scalar case:
@@ -72,19 +77,24 @@ function Σfluxes(
 end
 
 """
-    Σsources(sources::NTuple, args...)
+    Σsources(sources::NTuple, bl, args)
 
 Sum of the sources where
  - `sources` is an `NTuple{N, TendencyDef{Source, PV}} where {N, PV}`
+ - `bl` is the balance law
+ - `args` are the arguments passed to the individual `source` functions
 """
 function Σsources(
     pv::PV,
     sources::NTuple{N, TendencyDef{Source, PV}},
-    args...,
+    bl,
+    args,
 ) where {N, PV}
-    return ntuple_sum(ntuple(Val(N)) do i
-        source(sources[i], args...)
-    end)
+    return ntuple_sum(
+        ntuple(Val(N)) do i
+            projection(bl, sources[i], args, source(sources[i], bl, args))
+        end,
+    )
 end
 
 # Emptry scalar case:

--- a/src/BalanceLaws/tendency_types.jl
+++ b/src/BalanceLaws/tendency_types.jl
@@ -122,6 +122,14 @@ corresponding to the column-vector `Yᵢ` in:
 prognostic_vars(::BalanceLaw) = ()
 
 """
+    projection(bl, ::TendencyDef, args, x)
+
+Provide a hook to project individual tendencies.
+Return identity by defualt
+"""
+projection(bl, ::TendencyDef{TT, PV}, args, x) where {TT, PV} = x
+
+"""
     var, name = get_prog_state(state::Union{Vars, Grad}, pv::PrognosticVariable)
 
 Returns a tuple of two elements. `var` is a `Vars` or `Grad`

--- a/test/Atmos/EDMF/report_mse_sbl_anelastic.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_anelastic.jl
@@ -13,14 +13,9 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
 
 #! format: off
 best_mse = OrderedDict()
-best_mse["prog_ρ"] = 1.1114129013658791e-02
-best_mse["prog_ρu_1"] = 6.2901522038253152e+03
-best_mse["prog_ρu_2"] = 1.2983106287732383e-04
-best_mse["prog_turbconv_environment_ρatke"] = 2.3811480079389301e+02
-best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.7727376552999260e+01
-best_mse["prog_turbconv_updraft_1_ρa"] = 1.7950630856426049e+01
-best_mse["prog_turbconv_updraft_1_ρaw"] = 1.7799954766639789e-01
-best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 1.3315847832474324e+01
+best_mse["prog_ρ"] = 9.3809207150466600e-03
+best_mse["prog_ρu_1"] = 6.7269974359218368e+03
+best_mse["prog_ρu_2"] = 6.8630597189221576e-01
 #! format: on
 
 computed_mse = compute_mse(
@@ -31,7 +26,7 @@ computed_mse = compute_mse(
     data_file,
     "Gabls",
     best_mse,
-    60,
+    1800,
     plot_dir,
 )
 
@@ -40,10 +35,5 @@ computed_mse = compute_mse(
     test_mse(computed_mse, best_mse, "prog_ρ")
     test_mse(computed_mse, best_mse, "prog_ρu_1")
     test_mse(computed_mse, best_mse, "prog_ρu_2")
-    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρatke")
-    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρaθ_liq_cv")
-    test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρa")
-    test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρaw")
-    test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρaθ_liq")
     #! format: on
 end

--- a/test/Atmos/EDMF/stable_bl_anelastic1d.jl
+++ b/test/Atmos/EDMF/stable_bl_anelastic1d.jl
@@ -1,0 +1,252 @@
+using JLD2, FileIO
+using ClimateMachine
+ClimateMachine.init(;
+    parse_clargs = true,
+    output_dir = get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", "output"),
+    fix_rng_seed = true,
+)
+using ClimateMachine.SingleStackUtils
+using ClimateMachine.Checkpoint
+using ClimateMachine.BalanceLaws: vars_state
+import ClimateMachine.BalanceLaws: projection
+import ClimateMachine.DGMethods
+using ClimateMachine.Atmos
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+import CLIMAParameters
+
+include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))
+include("edmf_model.jl")
+include("edmf_kernels.jl")
+
+# CLIMAParameters.Planet.T_surf_ref(::EarthParameterSet) = 290.0 # default
+CLIMAParameters.Planet.T_surf_ref(::EarthParameterSet) = 265
+
+"""
+    init_state_prognostic!(
+            turbconv::EDMF{FT},
+            m::AtmosModel{FT},
+            state::Vars,
+            aux::Vars,
+            localgeo,
+            t::Real,
+        ) where {FT}
+
+Initialize EDMF state variables.
+This method is only called at `t=0`.
+"""
+function init_state_prognostic!(
+    turbconv::EDMF{FT},
+    m::AtmosModel{FT},
+    state::Vars,
+    aux::Vars,
+    localgeo,
+    t::Real,
+) where {FT}
+    # Aliases:
+    gm = state
+    en = state.turbconv.environment
+    up = state.turbconv.updraft
+    N_up = n_updrafts(turbconv)
+    # GCM setting - Initialize the grid mean profiles of prognostic variables (ρ,e_int,q_tot,u,v,w)
+    z = altitude(m, aux)
+
+    # SCM setting - need to have separate cases coded and called from a folder - see what LES does
+    # a thermo state is used here to convert the input θ to e_int profile
+    e_int = internal_energy(m, state, aux)
+
+    ts = PhaseDry(m.param_set, e_int, state.ρ)
+    T = air_temperature(ts)
+    p = air_pressure(ts)
+    q = PhasePartition(ts)
+    θ_liq = liquid_ice_pottemp(ts)
+
+    a_min = turbconv.subdomains.a_min
+    @unroll_map(N_up) do i
+        up[i].ρa = gm.ρ * a_min
+        up[i].ρaw = gm.ρu[3] * a_min
+        up[i].ρaθ_liq = gm.ρ * a_min * θ_liq
+        up[i].ρaq_tot = FT(0)
+    end
+
+    # initialize environment covariance with zero for now
+    if z <= FT(250)
+        en.ρatke =
+            gm.ρ *
+            FT(0.4) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0)
+        en.ρaθ_liq_cv =
+            gm.ρ *
+            FT(0.4) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0)
+    else
+        en.ρatke = FT(0)
+        en.ρaθ_liq_cv = FT(0)
+    end
+    en.ρaq_tot_cv = FT(0)
+    en.ρaθ_liq_q_tot_cv = FT(0)
+    return nothing
+end;
+
+function main(::Type{FT}) where {FT}
+    # add a command line argument to specify the kind of surface flux
+    # TODO: this will move to the future namelist functionality
+    sbl_args = ArgParseSettings(autofix_names = true)
+    add_arg_group!(sbl_args, "StableBoundaryLayer")
+    @add_arg_table! sbl_args begin
+        "--surface-flux"
+        help = "specify surface flux for energy and moisture"
+        metavar = "prescribed|bulk|custom_sbl"
+        arg_type = String
+        default = "custom_sbl"
+    end
+
+    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
+
+    surface_flux = cl_args["surface_flux"]
+
+    # DG polynomial order
+    N = 4
+    nelem_vert = 20
+
+    # Prescribe domain parameters
+    zmax = FT(400)
+
+    t0 = FT(0)
+
+    # Simulation time
+    timeend = FT(1800 * 1)
+    CFLmax = FT(100)
+
+    config_type = SingleStackConfigType
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
+    N_updrafts = 1
+    N_quad = 3
+    turbconv = NoTurbConv()
+    # turbconv = EDMF(FT, N_updrafts, N_quad)
+    # compressibility = Compressible()
+    compressibility = Anelastic1D()
+
+    model = stable_bl_model(
+        FT,
+        config_type,
+        zmax,
+        surface_flux;
+        turbulence = SmagorinskyLilly{FT}(0.21),
+        turbconv = turbconv,
+        compressibility = compressibility,
+    )
+
+    # Assemble configuration
+    driver_config = ClimateMachine.SingleStackConfiguration(
+        "SBL_ANELASTIC_1D",
+        N,
+        nelem_vert,
+        zmax,
+        param_set,
+        model;
+        hmax = FT(40),
+        solver_type = ode_solver_type,
+    )
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+    )
+
+    # --- Zero-out horizontal variations:
+    vsp = vars_state(model, Prognostic(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :turbconv),
+    )
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :energy, :ρe),
+    )
+    vsa = vars_state(model, Auxiliary(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.dg.state_auxiliary,
+        varsindex(vsa, :turbconv),
+    )
+    # ---
+
+    dgn_config = config_diagnostics(driver_config)
+
+    # boyd vandeven filter
+    cb_boyd = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            ("energy.ρe",),
+            solver_config.dg.grid,
+            BoydVandevenFilter(
+                solver_config.dg.grid,
+                1, #default=0
+                4, #default=32
+            ),
+        )
+        nothing
+    end
+
+    diag_arr = [single_stack_diagnostics(solver_config)]
+    time_data = FT[0]
+
+    # Define the number of outputs from `t0` to `timeend`
+    n_outputs = 5
+    # This equates to exports every ceil(Int, timeend/n_outputs) time-step:
+    every_x_simulation_time = ceil(Int, timeend / n_outputs)
+
+    cb_data_vs_time =
+        GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
+            diag_vs_z = single_stack_diagnostics(solver_config)
+
+            nstep = getsteps(solver_config.solver)
+
+            push!(diag_arr, diag_vs_z)
+            push!(time_data, gettime(solver_config.solver))
+            nothing
+        end
+
+    # Mass tendencies = 0 for Anelastic1D model,
+    # so mass should be completely conserved:
+    check_cons =
+        (ClimateMachine.ConservationCheck("ρ", "3000steps", FT(0.00000001)),)
+
+    cb_print_step = GenericCallbacks.EveryXSimulationSteps(100) do
+        @show getsteps(solver_config.solver)
+        nothing
+    end
+
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        check_cons = check_cons,
+        user_callbacks = (cb_boyd, cb_data_vs_time, cb_print_step),
+        check_euclidean_distance = true,
+    )
+
+    diag_vs_z = single_stack_diagnostics(solver_config)
+    push!(diag_arr, diag_vs_z)
+    push!(time_data, gettime(solver_config.solver))
+
+    return solver_config, diag_arr, time_data
+end
+
+solver_config, diag_arr, time_data = main(Float64)
+
+include(joinpath(@__DIR__, "report_mse_sbl_anelastic.jl"))
+
+nothing


### PR DESCRIPTION
### Description

This PR:
 - Adds a `compressibility` submodel to the AtmosModel
 - Adds some thermo wrappers which use the (anelastic) reference state for density
 - Modify equation tendencies for the `Anelastic1D` submodel
 - Adds a `projection` hook to the balance law

It seems like we can take timesteps of at least 15 seconds 🎉 

It would be nice to more elegantly (i.e., by default) handle `g = compressibility isa Compressible ? (Gravity(),) : ()`. I think that using `g = compressibility isa Compressible ? (Gravity(),) : ()` is the simplest existing solution based on how sources are currently passed to the atmos model. We can decide later if the sources should be handled differently, but this would touch many experiments and should be addressed in a separate PR.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
