### PR TITLE
Add new thermo constructor

### DIFF
--- a/docs/src/APIs/Common/Thermodynamics.md
+++ b/docs/src/APIs/Common/Thermodynamics.md
@@ -16,6 +16,7 @@ ThermodynamicState
 PhaseDry
 PhaseDry_pT
 PhaseDry_pθ
+PhaseDry_pe
 PhaseDry_ρθ
 PhaseDry_ρT
 PhaseDry_ρp
@@ -23,12 +24,14 @@ PhaseEquil
 PhaseEquil_ρTq
 PhaseEquil_pTq
 PhaseEquil_pθq
+PhaseEquil_peq
 PhaseEquil_ρθq
 PhaseEquil_ρpq
 PhaseNonEquil
 PhaseNonEquil_ρTq
 PhaseNonEquil_ρθq
 PhaseNonEquil_pθq
+PhaseNonEquil_peq
 PhaseNonEquil_ρpq
 ```
 

--- a/test/Common/Thermodynamics/runtests.jl
+++ b/test/Common/Thermodynamics/runtests.jl
@@ -666,6 +666,17 @@ end
         FT(1e-10),
     )
 
+    @test_throws ErrorException TD.saturation_adjustment_given_peq.(
+        SecantMethod,
+        param_set,
+        p,
+        e_int,
+        q_tot,
+        Ref(phase_type),
+        2,
+        FT(1e-10),
+    )
+
     T_virt = T # should not matter: testing for non-convergence
     @test_throws ErrorException TD.temperature_and_humidity_given_TᵥρRH.(
         param_set,
@@ -745,6 +756,11 @@ end
         @test all(internal_energy.(ts_pθ) .≈ internal_energy.(param_set, T))
         @test all(air_density.(ts_pθ) .≈ ρ)
 
+        p_dry = air_pressure.(param_set, T, ρ)
+        ts_pe = PhaseDry_pe.(param_set, p, e_int)
+        @test all(internal_energy.(ts_pe) .≈ internal_energy.(param_set, T))
+        @test all(air_pressure.(ts_pe) .≈ p_dry)
+
         ts_ρθ = PhaseDry_ρθ.(param_set, ρ, θ_dry)
         @test all(internal_energy.(ts_ρθ) .≈ internal_energy.(param_set, T))
         @test all(air_density.(ts_ρθ) .≈ ρ)
@@ -777,6 +793,13 @@ end
         @test all(getproperty.(PhasePartition.(ts), :tot) .≈ q_tot)
         @test all(air_density.(ts) .≈ ρ)
 
+        ts_peq = PhaseEquil_peq.(param_set, p, e_int, q_tot)
+        @test all(internal_energy.(ts_peq) .≈ e_int)
+        @test all(getproperty.(PhasePartition.(ts_peq), :tot) .≈ q_tot)
+        @test all(isapprox.(air_pressure.(ts_peq), p; rtol = rtol_pressure))
+        # TODO: investigate why increasing iterations does not decrease error:
+        # @show max(abs.(air_pressure.(ts_peq) .- p)...) # ~ 531
+
         ts = PhaseEquil_ρpq.(param_set, ρ, p, q_tot, true)
         @test all(air_density.(ts) .≈ ρ)
         @test all(air_pressure.(ts) .≈ p)
@@ -800,6 +823,11 @@ end
         @test all(internal_energy.(ts) .≈ e_int)
         @test all(compare_moisture.(ts, q_pt))
         @test all(air_density.(ts) .≈ ρ)
+
+        ts = PhaseNonEquil_peq.(param_set, p, e_int, q_pt)
+        @test all(internal_energy.(ts) .≈ e_int)
+        @test all(compare_moisture.(ts, q_pt))
+        @test all(air_pressure.(ts) .≈ p)
 
         # TD.air_temperature_given_θpq-liquid_ice_pottemp inverse
         θ_liq_ice_ =


### PR DESCRIPTION
### Description

Needed for #2021, this PR adds a new thermo constructor that accepts pressure, internal energy[, and moisture].

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
