### PR TITLE
add standard sbatch submission script for Caltech Central cluster

### DIFF
--- a/contrib/caltech.sh
+++ b/contrib/caltech.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#SBATCH --ntasks=1
+#SBATCH --gres=gpu:1
+#SBATCH --time=01:00:00
+
+if [[ -z "${SLURM_JOB_ID}" ]]; then
+    cat << EOF
+This script should be used as an sbatch submission script. Usage:
+
+  sbatch [options...] contrib/caltech.sh script [arguments...]
+
+where:
+  [options...]: sbatch options. Default are "--ntasks=1 --gres=gpu:1 --time=01:00:00"
+  script: is the julia script to run
+  [arguments...]: options to be passed to the script
+EOF
+    exit
+fi
+
+set -euo pipefail # kill the job if anything fails
+set -x # echo script
+
+module purge
+module load julia/1.5.2 hdf5/1.10.1 netcdf-c/4.6.1
+if [[ -z "${SLURM_JOB_GPUS}" ]]; then
+    # no GPUs allocated to job
+    module load openmpi/4.0.4
+else
+    module load cuda/10.2 openmpi/4.0.4_cuda-10.2
+fi
+
+export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK:=1}
+export JULIA_MPI_BINARY=system
+export JULIA_CUDA_USE_BINARYBUILDER=false
+
+julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
+julia --project -e 'using Pkg; Pkg.precompile()'
+mpiexec julia --project "$@"


### PR DESCRIPTION
### Description

This adds a standard job submission script for the Caltech Central HPC cluster

I'm not 100% convinced this is a good idea: we've so far tried to avoid keeping site-specific job submission scripts in the repo, instead keeping the info in the wiki. The downside of this is that the information can easily get out-of-date. Thoughts or alternative suggestions are appreciated.

I've tried to condense the logic into one script. This uses GPUs by default, but also supports CPU-only operation. 

I know that some people use more complicated scripts, e.g. https://github.com/CliMA/ClimateMachine.jl/wiki/Bash-Run-Scripts, so would appreciate some input to see if we can accommodate those workflows.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
