### PR TITLE
add C_drag to the surface_condition struct

### DIFF
--- a/src/Common/SurfaceFluxes/SurfaceFluxes.jl
+++ b/src/Common/SurfaceFluxes/SurfaceFluxes.jl
@@ -51,6 +51,7 @@ struct SurfaceFluxConditions{FT, VFT}
     flux::VFT
     x_star::VFT
     K_exchange::VFT
+    C_exchange::VFT
 end
 
 function Base.show(io::IO, sfc::SurfaceFluxConditions)
@@ -60,6 +61,7 @@ function Base.show(io::IO, sfc::SurfaceFluxConditions)
     println(io, "flux           = ", sfc.flux)
     println(io, "x_star         = ", sfc.x_star)
     println(io, "K_exchange     = ", sfc.K_exchange)
+    println(io, "C_exchange     = ", sfc.C_exchange)
     println(io, "-----------------------")
 end
 
@@ -199,6 +201,7 @@ function surface_conditions(
         VDSE_flux_star,
         flux,
         x_star,
+        K_exchange,
         C_exchange,
     )
 end


### PR DESCRIPTION
### Description

This PR adds the drag coefficient to `surface_conditions` output in `SurfaceFluxes.jl`. 

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
