### PR TITLE
Add surf flux tests, expose uf to interface

### DIFF
--- a/test/Common/SurfaceFluxes/test_universal_functions.jl
+++ b/test/Common/SurfaceFluxes/test_universal_functions.jl
@@ -26,6 +26,33 @@ const param_set = EarthParameterSet()
                 end
             end
         end
+
+        # More type stability (phi/psi):
+        FT = Float32
+        ζ = (-FT(1), FT(0.5) * eps(FT), 2 * eps(FT))
+        for L in (-FT(10), FT(10))
+            args = (param_set, L)
+            for uf in (Gryanik(args...), Grachev(args...), Businger(args...))
+                for transport in (MomentumTransport(), HeatTransport())
+                    ϕ = phi.(uf, ζ, transport)
+                    @test eltype(ϕ) == FT
+                    ψ = psi.(uf, ζ, transport)
+                    @test eltype(ψ) == FT
+                end
+            end
+        end
+
+        # More type stability (Psi):
+        FT = Float32
+        ζ = (-FT(1), FT(0.5) * eps(FT), 2 * eps(FT))
+        for L in (-FT(10), FT(10))
+            args = (param_set, L)
+            uf = Businger(args...)
+            for transport in (MomentumTransport(), HeatTransport())
+                Ψ = Psi.(uf, ζ, transport)
+                @test eltype(Ψ) == FT
+            end
+        end
     end
     @testset "Conversions" begin
         FT = Float32


### PR DESCRIPTION
### Description

This PR:
 - Fixes bug (`C_exchange` was accidentally passed into `K_exchange` in `surface_conditions`) (supersedes #2025)
 - Makes `K_exchange` `similar` to the proper input for GPU compatibility
 - Exposes the universal function to the `surface_conditions` interface.
 - Adds universal function tests to improve coverage

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
