### PR TITLE
Remove vars from numerical flux gradient

### DIFF
--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -1509,21 +1509,13 @@ auxiliary gradient flux, and G* is the associated numerical flux.
                 numerical_flux_gradient,
                 balance_law,
                 local_transform_gradient,
-                SVector(normal_vector),
-                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁻),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, Gradient(), FT)}(local_transform⁺),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺,
-                ),
+                normal_vector,
+                local_transform⁻,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_transform⁺,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
                 t,
             )
             if num_state_gradient_flux > 0

--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -68,19 +68,18 @@ function numerical_flux_gradient!(
     ::CentralNumericalFluxGradient,
     balance_law::BalanceLaw,
     transform_gradient::MMatrix,
-    normal_vector::SVector,
-    state_gradient⁻::Vars{T},
-    state_prognostic⁻::Vars{S},
-    state_auxiliary⁻::Vars{A},
-    state_gradient⁺::Vars{T},
-    state_prognostic⁺::Vars{S},
-    state_auxiliary⁺::Vars{A},
+    normal_vector::AbstractArray,
+    state_gradient⁻::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    state_gradient⁺::AbstractArray,
+    state_prognostic⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
     t,
-) where {T, S, A}
+)
 
     transform_gradient .=
-        normal_vector .*
-        (parent(state_gradient⁺) .+ parent(state_gradient⁻))' ./ 2
+        SVector(normal_vector) .* (state_gradient⁺ .+ state_gradient⁻)' ./ 2
 end
 
 function numerical_boundary_flux_gradient!(


### PR DESCRIPTION
### Description

This PR removes the `Vars` wrap around `numerical_flux_gradient!`, which does not seem to require a `Vars` method definition.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
