### PR TITLE
Fix SBL energy boundary conditions

### DIFF
--- a/experiments/AtmosLES/stable_bl_les.jl
+++ b/experiments/AtmosLES/stable_bl_les.jl
@@ -101,9 +101,9 @@ add_arg_group!(sbl_args, "StableBoundaryLayer")
 
     "--surface-flux"
     help = "specify surface flux for energy and moisture"
-    metavar = "prescribed|bulk"
+    metavar = "prescribed|bulk|custom_sbl"
     arg_type = String
-    default = "bulk"
+    default = "custom_sbl"
 end
 
 cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -177,7 +177,7 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
 end
 
-function surface_temperature_variation(bl, state, t)
+function surface_temperature_variation(state, t)
     FT = eltype(state)
     return FT(265) - FT(1 / 4) * (t / 3600)
 end
@@ -255,7 +255,15 @@ function stable_bl_model(
         energy_bc = BulkFormulaEnergy(
             (bl, state, aux, t, normPu_int) -> C_drag_,
             (bl, state, aux, t) ->
-                (surface_temperature_variation(bl, state, t), q_sfc),
+                (surface_temperature_variation(state, t), q_sfc),
+        )
+        moisture_bc = BulkFormulaMoisture(
+            (state, aux, t, normPu_int) -> C_drag_,
+            (state, aux, t) -> q_sfc,
+        )
+    elseif surface_flux == "custom_sbl"
+        energy_bc = PrescribedTemperature(
+            (state, aux, t) -> surface_temperature_variation(state, t),
         )
         moisture_bc = BulkFormulaMoisture(
             (state, aux, t, normPu_int) -> C_drag_,

--- a/test/Atmos/EDMF/stable_bl_edmf.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf.jl
@@ -92,9 +92,9 @@ function main(::Type{FT}) where {FT}
     @add_arg_table! sbl_args begin
         "--surface-flux"
         help = "specify surface flux for energy and moisture"
-        metavar = "prescribed|bulk"
+        metavar = "prescribed|bulk|custom_sbl"
         arg_type = String
-        default = "bulk"
+        default = "custom_sbl"
     end
 
     cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)

--- a/test/Atmos/EDMF/stable_bl_single_stack_implicit.jl
+++ b/test/Atmos/EDMF/stable_bl_single_stack_implicit.jl
@@ -26,9 +26,9 @@ function main(::Type{FT}) where {FT}
     @add_arg_table! sbl_args begin
         "--surface-flux"
         help = "specify surface flux for energy and moisture"
-        metavar = "prescribed|bulk"
+        metavar = "prescribed|bulk|custom_sbl"
         arg_type = String
-        default = "bulk"
+        default = "custom_sbl"
     end
 
     cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
@@ -201,10 +201,8 @@ function main(::Type{FT}) where {FT}
             nothing
         end
 
-    check_cons = (
-        ClimateMachine.ConservationCheck("ρ", "3000steps", FT(0.001)),
-        ClimateMachine.ConservationCheck("energy.ρe", "3000steps", FT(0.1)),
-    )
+    check_cons =
+        (ClimateMachine.ConservationCheck("ρ", "3000steps", FT(0.001)),)
 
     cb_print_step = GenericCallbacks.EveryXSimulationSteps(100) do
         @show getsteps(solver_config.solver)


### PR DESCRIPTION
### Description

The boundary conditions are now consistent with the original GABLS experiment. The default `energy_bc` is now set to `PrescribedTemperature`, although the bulk formula is still available through command line arguments.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
