### PR TITLE
Alternative balanced ref state initialization for FVM

### DIFF
--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -260,15 +260,21 @@ end
 
 function fvm_balance_init!(
     m::AtmosModel,
-    aux::Vars,
     aux_top::Vars,
+    aux::Vars,
     Δz::MArray{Tuple{2}, FT},
 ) where {FT}
-    # ρᵢ₋₁  = (pᵢ₋₁ - pᵢ - g ρᵢ Δzᵢ/2) / (g  Δzᵢ₋₁/2)
     _grav::FT = grav(m.param_set)
-    aux.ref_state.ρ =
-        (
-            aux.ref_state.p - aux_top.ref_state.p -
-            _grav * aux_top.ref_state.ρ * Δz[2] / 2
-        ) / (_grav * Δz[1] / 2)
+    _R_d::FT = R_d(m.param_set)
+
+    ref = aux.ref_state
+    topref = aux_top.ref_state
+
+    T_virt = ref.p / (_R_d * ref.ρ)
+    top_T_virt = topref.p / (_R_d * topref.ρ)
+
+    topref.ρ =
+        ref.ρ * (_R_d * T_virt - _grav * Δz[1] / 2) /
+        (_R_d * top_T_virt + _grav * Δz[2] / 2)
+    topref.p = _R_d * topref.ρ * top_T_virt
 end


### PR DESCRIPTION
This PR change the way a balanced reference state is computed for FVM in the vertical. Currently we compute
density from the discrete balance relation assuming a pressure profile. In this PR the approach is to integrate
the discrete balance relation for pressure and density assuming a virtual temperature profile. Seems to behave better
for stretched grids.

@jiahe23 Could you test ?

Closes #2018

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
