### PR TITLE
Add WrapVars type, and use to remove arr suffix

### DIFF
--- a/src/Numerics/DGMethods/NumericalFluxes.jl
+++ b/src/Numerics/DGMethods/NumericalFluxes.jl
@@ -790,7 +790,7 @@ function numerical_flux_first_order!(
     )
 end
 
-function numerical_boundary_flux_first_order!(
+function numerical_boundary_flux_first_order_loop!(
     numerical_flux_first_order,
     bctag::Int,
     balance_law,
@@ -869,7 +869,7 @@ function numerical_flux_second_order!(
     )
 end
 
-function numerical_boundary_flux_second_order!(
+function numerical_boundary_flux_second_order_loop!(
     numerical_flux_second_order,
     bctag::Int,
     balance_law,
@@ -929,7 +929,7 @@ function numerical_boundary_flux_second_order!(
     end d -> throw(BoundsError(bcs, bctag))
 end
 
-function numerical_boundary_flux_gradient!(
+function numerical_boundary_flux_gradient_loop!(
     numerical_flux_gradient,
     bctag::Int,
     balance_law,


### PR DESCRIPTION
### Description

I started working on the Vars wrapper in numerical fluxes, but then realized that we have multiple methods that would accept arrays (e.g., `numerical_boundary_flux_first_order!`) and the wrapper would have the same interface as the caller, which makes the `_arr` suffix much less appealing/clear. This PR adds a type `WrapVars` to the balance law, and uses this as a first argument whenever we want to wrap the arrays in `Vars`. This should also avoid the method ambiguity problem (since `WrapVars` is an extra argument).

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
