### PR TITLE
Enable call to SurfaceFluxes from boundary conditions, clean up SurfaceFluxes

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -70,6 +70,7 @@ ClimateMachine.Atmos.BulkFormulaMoisture
 ClimateMachine.Atmos.FreeSlip
 ClimateMachine.Atmos.PrescribedTemperature
 ClimateMachine.Atmos.PrescribedEnergyFlux
+ClimateMachine.Atmos.NishizawaEnergyFlux
 ClimateMachine.Atmos.Adiabaticθ
 ClimateMachine.Atmos.BulkFormulaEnergy
 ClimateMachine.Atmos.OutflowPrecipitation

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -198,6 +198,7 @@ function stable_bl_model(
 
     C_drag_::FT = C_drag(param_set) # FT(0.001)    # Momentum exchange coefficient
     u_star = FT(0.30)
+    z_0 = FT(0.1)          # Roughness height
 
     z_sponge = FT(300)     # Start of sponge layer
     α_max = FT(0.75)       # Strength of sponge layer (timescale)
@@ -271,6 +272,13 @@ function stable_bl_model(
             (state, aux, t, normPu_int) -> C_drag_,
             (state, aux, t) -> q_sfc,
         )
+    elseif surface_flux == "Nishizawa2018"
+        energy_bc = NishizawaEnergyFlux(
+            (bl, state, aux, t, normPu_int) -> z_0,
+            (bl, state, aux, t) ->
+                (surface_temperature_variation(state, t), q_sfc),
+        )
+        moisture_bc = PrescribedMoistureFlux((state, aux, t) -> moisture_flux)
     else
         @warn @sprintf(
             """

--- a/src/Atmos/Model/bc_energy.jl
+++ b/src/Atmos/Model/bc_energy.jl
@@ -3,7 +3,7 @@ abstract type EnergyBC end
 using ..TurbulenceClosures
 using ClimateMachine.SurfaceFluxes:
     get_energy_flux, surface_conditions, DGScheme
-using ClimateMachine.Atmos: altitude
+
 """
     Insulating() :: EnergyBC
 No energy flux across the boundary.

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -17,7 +17,8 @@ export AtmosBC,
     ImpermeableTracer,
     PrescribedMoistureFlux,
     BulkFormulaMoisture,
-    PrescribedTracerFlux
+    PrescribedTracerFlux,
+    NishizawaEnergyFlux
 
 export average_density_sfc_int
 

--- a/test/Common/SurfaceFluxes/runtests.jl
+++ b/test/Common/SurfaceFluxes/runtests.jl
@@ -99,7 +99,7 @@ const param_set = EarthParameterSet()
         u_star_init = FT(0.1)
         th_star_init = -FT(0.1)
         qt_star_init = -FT(1e-5)
-        x_init =
+        MO_param_guess =
             ArrayType(FT[LMO_init, u_star_init, th_star_init, qt_star_init])
 
         # Surface values for variables
@@ -115,19 +115,13 @@ const param_set = EarthParameterSet()
         # Constants
         Δz = Tuple(z)[ii]
 
-        # F_exchange
-        F_exchange = ArrayType(FT[0.01, -0.01, -0.000001])
-
         args = (
             param_set,
-            x_init,
+            MO_param_guess,
             x_ave,
             x_s,
             z_rough,
-            F_exchange,
             vdse_ave,
-            qt_ave,
-            Δz,
             z_ave / 2,
         )
 


### PR DESCRIPTION
### Description

This PR makes two main changes:

- Cleans up SurfaceFluxes and makes use of more standard notation for some of its arguments.
- Corrects the description of the height at which the SurfaceFluxes functions are evaluated, which is different for DG and FV simulations.
- Enables the use of the output of `surface_conditions` (`SurfaceFluxes` module) in a new type of boundary condition set that can be specified in an experiment setup script. 

The boundary condition specification takes as input functional forms for the temperature and moisture at the ground (similar to `BulkFormulaEnergy`) and for the roughness lengths (Float or Array of floats). The output is the energy flux (for this EnergyBC).

**Disclaimer:** This PR does not add BC based on SurfaceFluxes for momentum and moisture yet. This is because we want to cache the results from the SurfaceFluxes call and use them for all BCs in the future. 

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
