### PR TITLE
Enable the removal of condensate in the moist BW driver

### DIFF
--- a/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
+++ b/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
@@ -231,9 +231,11 @@ function config_baroclinic_wave(
     if with_moisture
         hyperdiffusion = EquilMoistBiharmonic(FT(8 * 3600))
         moisture = EquilMoist{FT}()
+        source = (Gravity(), Coriolis(), RemovePrecipitation(true)...) # precipitation is default to NoPrecipitation() as 0M microphysics
     else
         hyperdiffusion = DryBiharmonic(FT(8 * 3600))
         moisture = DryModel()
+        source = (Gravity(), Coriolis())
     end
 
     _C_drag = C_drag(param_set)::FT
@@ -266,7 +268,7 @@ function config_baroclinic_wave(
         turbulence = ConstantKinematicViscosity(FT(0)),
         hyperdiffusion = hyperdiffusion,
         moisture = moisture,
-        source = (Gravity(), Coriolis()),
+        source = source,
     )
 
     config = ClimateMachine.AtmosGCMConfiguration(

--- a/experiments/TestCase/baroclinic_wave.jl
+++ b/experiments/TestCase/baroclinic_wave.jl
@@ -173,7 +173,7 @@ function config_baroclinic_wave(FT, poly_order, resolution, with_moisture)
     if with_moisture
         hyperdiffusion = EquilMoistBiharmonic(FT(8 * 3600))
         moisture = EquilMoist{FT}()
-        source = (Gravity(), Coriolis())
+        source = (Gravity(), Coriolis(), RemovePrecipitation(true)...) # precipitation is default to NoPrecipitation() as 0M microphysics
     else
         hyperdiffusion = DryBiharmonic(FT(8 * 3600))
         moisture = DryModel()


### PR DESCRIPTION
### Description

This PR adds the `RemovePrecipitation(true)` to the source terms in the moist baroclinic wave driver, and enables the removal of condensates thru the 0M microphysics scheme. 

It has been tested that the two experiment drivers can run successfully with the changes, and the `RemovePrecipitation` keyword is added to the Mass, Energy, and TotalMoisture in the tendency table.

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
