### PR TITLE
Fix access to ArgParser from command line in EDMF experiments

### DIFF
--- a/test/Atmos/EDMF/report_mse_sbl_fv.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_fv.jl
@@ -13,14 +13,14 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
 
 #! format: off
 best_mse = OrderedDict()
-best_mse["prog_ρ"] = 1.1114129013658791e-02
-best_mse["prog_ρu_1"] = 6.2901522038253152e+03
-best_mse["prog_ρu_2"] = 1.2983106287732383e-04
-best_mse["prog_turbconv_environment_ρatke"] = 2.3811480079389301e+02
-best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.7727376552999260e+01
-best_mse["prog_turbconv_updraft_1_ρa"] = 1.7950630856426049e+01
-best_mse["prog_turbconv_updraft_1_ρaw"] = 1.7799954766639789e-01
-best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 1.3315847832474324e+01
+best_mse["prog_ρ"] = 6.9637575838887369e-03
+best_mse["prog_ρu_1"] = 6.2604203232863292e+03
+best_mse["prog_ρu_2"] = 1.3200376252941846e-04
+best_mse["prog_turbconv_environment_ρatke"] = 2.3729827149654821e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.7727378291873919e+01
+best_mse["prog_turbconv_updraft_1_ρa"] = 1.7947149151486141e+01
+best_mse["prog_turbconv_updraft_1_ρaw"] = 1.7799688543526015e-01
+best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 1.3315385576514325e+01
 #! format: on
 
 computed_mse = compute_mse(

--- a/test/Atmos/EDMF/stable_bl_edmf.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf.jl
@@ -1,10 +1,5 @@
 using JLD2, FileIO
 using ClimateMachine
-ClimateMachine.init(;
-    parse_clargs = true,
-    output_dir = get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", "output"),
-    fix_rng_seed = true,
-)
 using ClimateMachine.SingleStackUtils
 using ClimateMachine.Checkpoint
 using ClimateMachine.BalanceLaws: vars_state
@@ -84,20 +79,7 @@ function init_state_prognostic!(
     return nothing
 end;
 
-function main(::Type{FT}) where {FT}
-    # add a command line argument to specify the kind of surface flux
-    # TODO: this will move to the future namelist functionality
-    sbl_args = ArgParseSettings(autofix_names = true)
-    add_arg_group!(sbl_args, "StableBoundaryLayer")
-    @add_arg_table! sbl_args begin
-        "--surface-flux"
-        help = "specify surface flux for energy and moisture"
-        metavar = "prescribed|bulk|custom_sbl"
-        arg_type = String
-        default = "custom_sbl"
-    end
-
-    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
+function main(::Type{FT}, cl_args) where {FT}
 
     surface_flux = cl_args["surface_flux"]
 
@@ -230,7 +212,26 @@ function main(::Type{FT}) where {FT}
     return solver_config, diag_arr, time_data
 end
 
-solver_config, diag_arr, time_data = main(Float64)
+# add a command line argument to specify the kind of surface flux
+# TODO: this will move to the future namelist functionality
+sbl_args = ArgParseSettings(autofix_names = true)
+add_arg_group!(sbl_args, "StableBoundaryLayer")
+@add_arg_table! sbl_args begin
+    "--surface-flux"
+    help = "specify surface flux for energy and moisture"
+    metavar = "prescribed|bulk|custom_sbl"
+    arg_type = String
+    default = "custom_sbl"
+end
+
+cl_args = ClimateMachine.init(
+    parse_clargs = true,
+    custom_clargs = sbl_args,
+    output_dir = get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", "output"),
+    fix_rng_seed = true,
+)
+
+solver_config, diag_arr, time_data = main(Float64, cl_args)
 
 ## Uncomment lines to save output using JLD2
 #

--- a/test/Atmos/EDMF/stable_bl_single_stack_implicit.jl
+++ b/test/Atmos/EDMF/stable_bl_single_stack_implicit.jl
@@ -2,12 +2,6 @@ using ClimateMachine
 using ClimateMachine.SystemSolvers
 using ClimateMachine.ODESolvers
 using ClimateMachine.MPIStateArrays
-
-ClimateMachine.init(;
-    parse_clargs = true,
-    output_dir = get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", "output"),
-    fix_rng_seed = true,
-)
 using ClimateMachine.SingleStackUtils
 using ClimateMachine.Checkpoint
 using ClimateMachine.BalanceLaws: vars_state
@@ -18,20 +12,7 @@ include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))
 include("edmf_model.jl")
 include("edmf_kernels.jl")
 
-function main(::Type{FT}) where {FT}
-    # add a command line argument to specify the kind of surface flux
-    # TODO: this will move to the future namelist functionality
-    sbl_args = ArgParseSettings(autofix_names = true)
-    add_arg_group!(sbl_args, "StableBoundaryLayer")
-    @add_arg_table! sbl_args begin
-        "--surface-flux"
-        help = "specify surface flux for energy and moisture"
-        metavar = "prescribed|bulk|custom_sbl"
-        arg_type = String
-        default = "custom_sbl"
-    end
-
-    cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
+function main(::Type{FT}, cl_args) where {FT}
 
     surface_flux = cl_args["surface_flux"]
 
@@ -224,6 +205,25 @@ function main(::Type{FT}) where {FT}
     return solver_config, diag_arr, time_data
 end
 
-solver_config, diag_arr, time_data = main(Float64)
+# add a command line argument to specify the kind of surface flux
+# TODO: this will move to the future namelist functionality
+sbl_args = ArgParseSettings(autofix_names = true)
+add_arg_group!(sbl_args, "StableBoundaryLayer")
+@add_arg_table! sbl_args begin
+    "--surface-flux"
+    help = "specify surface flux for energy and moisture"
+    metavar = "prescribed|bulk|custom_sbl"
+    arg_type = String
+    default = "custom_sbl"
+end
+
+cl_args = ClimateMachine.init(
+    parse_clargs = true,
+    custom_clargs = sbl_args,
+    output_dir = get(ENV, "CLIMATEMACHINE_SETTINGS_OUTPUT_DIR", "output"),
+    fix_rng_seed = true,
+)
+
+solver_config, diag_arr, time_data = main(Float64, cl_args)
 
 nothing


### PR DESCRIPTION
### Description

The current master branch does not allow access to the custom arguments in the ArgParser, in all EDMF experiments. The only way to change those settings right now are to hardcode the default. 

This change makes it possible to set the custom arguments from the command line, similarly to the master version of `stable_bl_les.jl`. This also allows exposition of parameters for tuning in the future. 

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
