### PR TITLE
Unit tests and corrections, SurfaceFluxes module

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -726,6 +726,15 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "cpu_surface_fluxes"
+    key: "cpu_surface_fluxes"
+    command:
+      - "mpiexec julia --color=yes --project test/Common/SurfaceFluxes/runtests.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: "gpu_thermodynamics"
     key: "gpu_thermodynamics"
     command:

--- a/docs/src/APIs/Common/SurfaceFluxes.md
+++ b/docs/src/APIs/Common/SurfaceFluxes.md
@@ -27,4 +27,6 @@ ClimateMachine.SurfaceFluxes.UniversalFunctions.Psi
 ```@docs
 ClimateMachine.SurfaceFluxes.surface_conditions
 ClimateMachine.SurfaceFluxes.exchange_coefficients
+ClimateMachine.SurfaceFluxes.recover_profile
+ClimateMachine.SurfaceFluxes.monin_obukhov_length
 ```

--- a/test/Common/SurfaceFluxes/runtests.jl
+++ b/test/Common/SurfaceFluxes/runtests.jl
@@ -1,5 +1,6 @@
 module TestSurfaceFluxes
 
+using Random
 using ClimateMachine
 ClimateMachine.init()
 const ArrayType = ClimateMachine.array_type()
@@ -9,6 +10,8 @@ using NonlinearSolvers
 using ClimateMachine.SurfaceFluxes
 const SF = SurfaceFluxes
 using StaticArrays
+import ClimateMachine.MPIStateArrays: array_device
+import KernelAbstractions: CPU
 
 using CLIMAParameters: AbstractEarthParameterSet
 struct EarthParameterSet <: AbstractEarthParameterSet end
@@ -83,7 +86,6 @@ const param_set = EarthParameterSet()
         0.00428178089592372,
         0.00121229800895103,
         0.00262353784027441,
-        -0.000570314880866852,
     ])
 
     for ii in 1:length(u_star)
@@ -134,6 +136,92 @@ const param_set = EarthParameterSet()
 
         # Keeping FV-based scheme in case needed
         result = surface_conditions(args..., SF.FVScheme())
+
+    end
+end
+
+# Shuffing disabled in GPU, Tuple for scalar indexing
+cpu_shuffle(array::ArrayType) =
+    array_device(array) isa CPU ? shuffle(array) : Tuple(array)
+
+@testset "SurfaceFluxes - Recovery" begin
+    FT = Float32
+
+    # Stochastic sampling of parameter space
+    for j in 1:20
+        # Define MO parameters to be recovered
+        u_star = cpu_shuffle(ArrayType(FT[0.05, 0.1, 0.2, 0.3, 0.4]))
+        θ_star = cpu_shuffle(ArrayType(FT[0, 50, 100, 200, 300])) # Functions not robust to θ_star < 0
+
+        # Define temperature parameters
+        θ_scale = cpu_shuffle(ArrayType(FT[290, 280, 270, 260, 250]))
+        θ_s = cpu_shuffle(ArrayType(FT[290, 280, 270, 260, 250]))
+
+        # Define a set of heights
+        z = cpu_shuffle(ArrayType(FT[5, 10, 15, 20, 50]))
+        z_rough = cpu_shuffle(ArrayType(FT[0.001, 0.01, 0.1, 0.5, 1])) # Must be smaller than z
+
+        # Relative initialization of MO parameters
+        LMO_init = cpu_shuffle(ArrayType(FT[-1.0, 0.2, 0.5, 1.0, 2.0]))
+        u_star_init = cpu_shuffle(ArrayType(FT[0.2, 0.5, 1.0, 1.5, 2.0])) # Must be positive
+        θ_star_init = cpu_shuffle(ArrayType(FT[-1e-6, 1e-6, -1e-6, 1e-6, 1e-6]))
+
+        for ii in 1:length(u_star)
+            x_star_given = Tuple(ArrayType(FT[u_star[ii], θ_star[ii]]))
+            L = monin_obukhov_length(
+                param_set,
+                u_star[ii],
+                θ_scale[ii],
+                -u_star[ii] * θ_star[ii],
+            )
+            x_s = ArrayType(FT[FT(0), θ_s[ii]])
+
+            u_in = recover_profile(
+                param_set,
+                z[ii],
+                u_star[ii],
+                Tuple(x_s)[1],
+                z_rough[ii],
+                L,
+                SF.MomentumTransport(),
+                SF.DGScheme(),
+            )
+            θ_in = recover_profile(
+                param_set,
+                z[ii],
+                θ_star[ii],
+                Tuple(x_s)[2],
+                z_rough[ii],
+                L,
+                SF.HeatTransport(),
+                SF.DGScheme(),
+            )
+
+            x_in = ArrayType(FT[u_in, θ_in])
+
+            MO_param_guess = ArrayType(FT[
+                LMO_init[ii] * L,
+                u_star_init[ii] * u_star[ii],
+                θ_star_init[ii] * θ_star[ii],
+            ])
+            recovered = surface_conditions(
+                param_set,
+                MO_param_guess,
+                x_in,
+                x_s,
+                z_rough[ii],
+                θ_scale[ii],
+                z[ii],
+                SF.DGScheme(),
+            )
+
+            # Test is recovery under 5% error for all variables
+            x_star_recovered = Tuple(recovered.x_star)
+            @test abs(x_star_recovered[1] - x_star_given[1]) /
+                  (abs(x_star_given[1]) + FT(1e-3)) < FT(0.05)
+            @test abs(x_star_recovered[2] - x_star_given[2]) /
+                  (abs(x_star_given[2]) + FT(1e-3)) < FT(0.05)
+        end
     end
 end
 


### PR DESCRIPTION
### Description

This PR adds _recovery_ unit tests to the `SurfaceFluxes` module. With this motivation:

- I add a `recover_profile` function that generates u(z), θ(z) following Monin-Obukhov Similarity Theory.
- I generate profiles u(z), θ(z) from an initial set of Monin-Obukhov parameters, and test their recovery through `surface_conditions`.

In the development of the tests,

- I found and corrected a problem in the `monin_obukhov_length` function, which allowed division by zero in a physically relevant scenario (no surface fluxes).
- I found the SurfaceFluxes module to **lack robustness in conditions of surface heating** (θ*<0). There exist logarithms of functions that can take negative values in this regime (This can easily be reproduced through the unit tests).

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
