### PR TITLE
Refactor BCs - Add `BCDef` and `bc_val` to BalanceLaws

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -85,7 +85,6 @@ ClimateMachine.Atmos.Adiabaticθ
 ClimateMachine.Atmos.BulkFormulaEnergy
 ClimateMachine.Atmos.OutflowPrecipitation
 ClimateMachine.Atmos.ImpermeableTracer
-ClimateMachine.Atmos.Impenetrable
 ClimateMachine.Atmos.Insulating
 ClimateMachine.Atmos.average_density
 ```

--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -72,11 +72,12 @@ ClimateMachine.Atmos.RayleighSponge
 
 ```@docs
 ClimateMachine.Atmos.AtmosBC
-ClimateMachine.Atmos.DragLaw
 ClimateMachine.Atmos.Impermeable
+ClimateMachine.Atmos.ImpenetrableDragLaw
+ClimateMachine.Atmos.ImpenetrableNoSlip
+ClimateMachine.Atmos.ImpenetrableFreeSlip
 ClimateMachine.Atmos.PrescribedMoistureFlux
 ClimateMachine.Atmos.BulkFormulaMoisture
-ClimateMachine.Atmos.FreeSlip
 ClimateMachine.Atmos.PrescribedTemperature
 ClimateMachine.Atmos.PrescribedEnergyFlux
 ClimateMachine.Atmos.NishizawaEnergyFlux
@@ -86,7 +87,6 @@ ClimateMachine.Atmos.OutflowPrecipitation
 ClimateMachine.Atmos.ImpermeableTracer
 ClimateMachine.Atmos.Impenetrable
 ClimateMachine.Atmos.Insulating
-ClimateMachine.Atmos.NoSlip
 ClimateMachine.Atmos.average_density
 ```
 

--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -98,6 +98,9 @@ transform_post_gradient_laplacian!
 ## Boundary conditions
 
 ```@docs
+BCDef
+DefaultBC
+set_bcs!
 boundary_conditions
 boundary_state!
 ```

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -453,17 +453,15 @@ function bomex_model(
         )
     end
 
-    drag_law = DragLaw(
-        # normPu_int is the internal horizontal speed
-        # P represents the projection onto the horizontal
-        (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
-    )
+    # normPu_int is the internal horizontal speed
+    # P represents the projection onto the horizontal
+    drag_law = (state, aux, t, normPu_int) -> (u_star / normPu_int)^2
 
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
-                tup = (Impenetrable(drag_law)...,),
-                momentum = Impenetrable{Momentum}(drag_law),
+                tup = (ImpenetrableDragLaw(drag_law)...,),
+                momentum = ImpenetrableDragLaw{Momentum}(drag_law),
                 energy = energy_bc,
                 moisture = moisture_bc,
                 turbconv = turbconv_bcs(turbconv)[1],

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -453,14 +453,17 @@ function bomex_model(
         )
     end
 
+    drag_law = DragLaw(
+        # normPu_int is the internal horizontal speed
+        # P represents the projection onto the horizontal
+        (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
+    )
+
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
-                momentum = Impenetrable(DragLaw(
-                    # normPu_int is the internal horizontal speed
-                    # P represents the projection onto the horizontal
-                    (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
-                )),
+                tup = (Impenetrable(drag_law)...,),
+                momentum = Impenetrable{Momentum}(drag_law),
                 energy = energy_bc,
                 moisture = moisture_bc,
                 turbconv = turbconv_bcs(turbconv)[1],

--- a/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
+++ b/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
@@ -408,12 +408,12 @@ function config_cfsites(
 ) where {FT}
     # Boundary Conditions
     u_star = FT(0.28)
-    drag_law = DragLaw((state, aux, t, normPu_int) -> (u_star / normPu_int)^2)
+    drag_law = (state, aux, t, normPu_int) -> (u_star / normPu_int)^2
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
-                tup = (Impenetrable(drag_law)...,),
-                momentum = Impenetrable{Momentum}(drag_law),
+                tup = (ImpenetrableDragLaw(drag_law)...,),
+                momentum = ImpenetrableDragLaw{Momentum}(drag_law),
                 energy = PrescribedEnergyFlux((state, aux, t) -> hfls + hfss),
                 moisture = PrescribedMoistureFlux(
                     (state, aux, t) ->

--- a/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
+++ b/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
@@ -408,13 +408,12 @@ function config_cfsites(
 ) where {FT}
     # Boundary Conditions
     u_star = FT(0.28)
-
+    drag_law = DragLaw((state, aux, t, normPu_int) -> (u_star / normPu_int)^2)
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
-                momentum = Impenetrable(DragLaw(
-                    (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
-                )),
+                tup = (Impenetrable(drag_law)...,),
+                momentum = Impenetrable{Momentum}(drag_law),
                 energy = PrescribedEnergyFlux((state, aux, t) -> hfls + hfss),
                 moisture = PrescribedMoistureFlux(
                     (state, aux, t) ->

--- a/experiments/AtmosLES/convective_bl_model.jl
+++ b/experiments/AtmosLES/convective_bl_model.jl
@@ -273,15 +273,15 @@ function convective_bl_model(
     end
 
     moisture_bcs = moisture_model == "dry" ? () : (; moisture = moisture_bc)
-    drag_law = DragLaw(
-        # normPu_int is the internal horizontal speed
-        # P represents the projection onto the horizontal
-        (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
-    )
+
+    # normPu_int is the internal horizontal speed
+    # P represents the projection onto the horizontal
+    drag_law = (state, aux, t, normPu_int) -> (u_star / normPu_int)^2
+
     boundary_conditions = (
         AtmosBC(;
-            tup = (Impenetrable(drag_law)...,),
-            momentum = Impenetrable{Momentum}(drag_law),
+            tup = (ImpenetrableDragLaw(drag_law)...,),
+            momentum = ImpenetrableDragLaw{Momentum}(drag_law),
             energy = energy_bc,
             moisture_bcs...,
             turbconv = turbconv_bcs(turbconv)[1],

--- a/experiments/AtmosLES/convective_bl_model.jl
+++ b/experiments/AtmosLES/convective_bl_model.jl
@@ -273,13 +273,15 @@ function convective_bl_model(
     end
 
     moisture_bcs = moisture_model == "dry" ? () : (; moisture = moisture_bc)
+    drag_law = DragLaw(
+        # normPu_int is the internal horizontal speed
+        # P represents the projection onto the horizontal
+        (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
+    )
     boundary_conditions = (
         AtmosBC(;
-            momentum = Impenetrable(DragLaw(
-                # normPu_int is the internal horizontal speed
-                # P represents the projection onto the horizontal
-                (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
-            )),
+            tup = (Impenetrable(drag_law)...,),
+            momentum = Impenetrable{Momentum}(drag_law),
             energy = energy_bc,
             moisture_bcs...,
             turbconv = turbconv_bcs(turbconv)[1],

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -347,13 +347,13 @@ function config_dycoms(
         precipitation = NoPrecipitation()
     end
 
-    drag_law = DragLaw((state, aux, t, normPu) -> C_drag)
+    drag_law = (state, aux, t, normPu) -> C_drag
 
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(;
-                tup = (Impenetrable(drag_law)...,),
-                momentum = Impenetrable{Momentum}(drag_law),
+                tup = (ImpenetrableDragLaw(drag_law)...,),
+                momentum = ImpenetrableDragLaw{Momentum}(drag_law),
                 energy = PrescribedEnergyFlux((state, aux, t) -> LHF + SHF),
                 moisture = PrescribedMoistureFlux(
                     (state, aux, t) -> moisture_flux,

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -347,12 +347,13 @@ function config_dycoms(
         precipitation = NoPrecipitation()
     end
 
+    drag_law = DragLaw((state, aux, t, normPu) -> C_drag)
+
     problem = AtmosProblem(
         boundaryconditions = (
-            AtmosBC(
-                momentum = Impenetrable(DragLaw(
-                    (state, aux, t, normPu) -> C_drag,
-                )),
+            AtmosBC(;
+                tup = (Impenetrable(drag_law)...,),
+                momentum = Impenetrable{Momentum}(drag_law),
                 energy = PrescribedEnergyFlux((state, aux, t) -> LHF + SHF),
                 moisture = PrescribedMoistureFlux(
                     (state, aux, t) -> moisture_flux,

--- a/experiments/AtmosLES/rising_bubble_bryan.jl
+++ b/experiments/AtmosLES/rising_bubble_bryan.jl
@@ -29,7 +29,7 @@ const param_set = EarthParameterSet()
 
 # ------------------------ Description ------------------------- #
 # 1) Dry Rising Bubble (circular potential temperature perturbation)
-# 2) Boundaries - `All Walls` : Impenetrable(FreeSlip())
+# 2) Boundaries - `All Walls` : ImpenetrableFreeSlip()
 #                               Laterally periodic
 # 3) Domain - 20000m[horizontal] x 10000m[vertical] (2-dimensional)
 # 4) Timeend - 1000s

--- a/experiments/AtmosLES/rising_bubble_theta_formulation.jl
+++ b/experiments/AtmosLES/rising_bubble_theta_formulation.jl
@@ -13,7 +13,7 @@
 # 1) Dry Rising Bubble (circular potential temperature perturbation)
 # 2) Boundaries
 #    Top and Bottom boundaries:
-#    - `Impenetrable(FreeSlip())` - Top and bottom: no momentum flux, no mass flux through
+#    - `ImpenetrableFreeSlip()` - Top and bottom: no momentum flux, no mass flux through
 #      walls.
 #    - `Impermeable()` - non-porous walls, i.e. no diffusive fluxes through
 #       walls.
@@ -226,13 +226,13 @@ function config_risingbubble(
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(;
-                tup = (Impenetrable{Momentum}(FreeSlip()),),
-                momentum = Impenetrable{Momentum}(FreeSlip()),
+                tup = (ImpenetrableFreeSlip{Momentum}(),),
+                momentum = ImpenetrableFreeSlip{Momentum}(),
                 energy = Adiabaticθ((state, aux, t) -> FT(0)),
             ),
             AtmosBC(
-                tup = (Impenetrable{Momentum}(FreeSlip()),),
-                momentum = Impenetrable{Momentum}(FreeSlip()),
+                tup = (ImpenetrableFreeSlip{Momentum}(),),
+                momentum = ImpenetrableFreeSlip{Momentum}(),
                 energy = Adiabaticθ((state, aux, t) -> FT(0)),
             ),
         ),

--- a/experiments/AtmosLES/rising_bubble_theta_formulation.jl
+++ b/experiments/AtmosLES/rising_bubble_theta_formulation.jl
@@ -225,12 +225,14 @@ function config_risingbubble(
 
     problem = AtmosProblem(
         boundaryconditions = (
-            AtmosBC(
-                momentum = Impenetrable(FreeSlip()),
+            AtmosBC(;
+                tup = (Impenetrable{Momentum}(FreeSlip()),),
+                momentum = Impenetrable{Momentum}(FreeSlip()),
                 energy = Adiabaticθ((state, aux, t) -> FT(0)),
             ),
             AtmosBC(
-                momentum = Impenetrable(FreeSlip()),
+                tup = (Impenetrable{Momentum}(FreeSlip()),),
+                momentum = Impenetrable{Momentum}(FreeSlip()),
                 energy = Adiabaticθ((state, aux, t) -> FT(0)),
             ),
         ),

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -292,13 +292,14 @@ function stable_bl_model(
     end
 
     moisture_bcs = moisture_model == "dry" ? () : (; moisture = moisture_bc)
+
+    # normPu_int is the internal horizontal speed
+    # P represents the projection onto the horizontal
+    drag_law = (state, aux, t, normPu_int) -> (u_star / normPu_int)^2
+
     boundary_conditions = (
         AtmosBC(;
-            momentum = Impenetrable{Momentum}(DragLaw(
-                # normPu_int is the internal horizontal speed
-                # P represents the projection onto the horizontal
-                (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
-            )),
+            momentum = ImpenetrableDragLaw{Momentum}(drag_law),
             energy = energy_bc,
             moisture_bcs...,
             turbconv = turbconv_bcs(turbconv)[1],

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -294,7 +294,7 @@ function stable_bl_model(
     moisture_bcs = moisture_model == "dry" ? () : (; moisture = moisture_bc)
     boundary_conditions = (
         AtmosBC(;
-            momentum = Impenetrable(DragLaw(
+            momentum = Impenetrable{Momentum}(DragLaw(
                 # normPu_int is the internal horizontal speed
                 # P represents the projection onto the horizontal
                 (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -30,7 +30,7 @@ const param_set = EarthParameterSet()
 # 1) Boundary Conditions:
 #       Laterally periodic with no flow penetration through top
 #       and bottom wall boundaries.
-#       Momentum: Impenetrable(FreeSlip())
+#       Momentum: ImpenetrableFreeSlip()
 #       Energy:   Spatially varying non-zero heat flux up to time t₁
 # 2) Domain: 1250m × 1250m × 1000m
 # Configuration defaults are in `src/Driver/Configurations.jl`

--- a/src/Atmos/Model/bc_momentum.jl
+++ b/src/Atmos/Model/bc_momentum.jl
@@ -8,9 +8,13 @@ Defines an impenetrable wall model for momentum. This implies:
   - no flow in the direction normal to the boundary, and
   - flow parallel to the boundary is subject to the `drag` condition.
 """
-struct Impenetrable{D <: MomentumDragBC} <: MomentumBC
+struct Impenetrable{D, PV <: Union{Momentum, Energy}} <: BCDef{PV}
     drag::D
 end
+
+Impenetrable{PV}(drag::D) where {D, PV} = Impenetrable{D, PV}(drag)
+Impenetrable(drag::D) where {D} =
+    (Impenetrable{D, Momentum}(drag), Impenetrable{D, Energy}(drag))
 
 """
     FreeSlip() :: MomentumDragBC
@@ -19,36 +23,16 @@ No surface drag on momentum parallel to the boundary.
 """
 struct FreeSlip <: MomentumDragBC end
 
-
-
-function atmos_momentum_boundary_state!(
-    nf::NumericalFluxFirstOrder,
-    bc_momentum::Impenetrable{FreeSlip},
-    atmos,
-    state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
-)
-    state⁺.ρu -= 2 * dot(state⁻.ρu, n) .* SVector(n)
+function bc_val(::Impenetrable{FreeSlip, Momentum}, ::AtmosModel, ::NF1, args)
+    @unpack state, n = args
+    return state.ρu - 2 * dot(state.ρu, n) .* SVector(n)
 end
-function atmos_momentum_boundary_state!(
-    nf::NumericalFluxGradient,
-    bc_momentum::Impenetrable{FreeSlip},
-    atmos,
-    state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
-)
-    state⁺.ρu -= dot(state⁻.ρu, n) .* SVector(n)
+
+function bc_val(::Impenetrable{FreeSlip, Momentum}, ::AtmosModel, ::NF∇, args)
+    @unpack state, n = args
+    return state.ρu - dot(state.ρu, n) .* SVector(n)
 end
+
 function atmos_momentum_normal_boundary_flux_second_order!(
     nf,
     bc_momentum::Impenetrable{FreeSlip},
@@ -65,34 +49,19 @@ Zero momentum at the boundary.
 """
 struct NoSlip <: MomentumDragBC end
 
-function atmos_momentum_boundary_state!(
-    nf::NumericalFluxFirstOrder,
-    bc_momentum::Impenetrable{NoSlip},
-    atmos,
-    state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
-)
-    state⁺.ρu = -state⁻.ρu
+function bc_val(::Impenetrable{NoSlip, Momentum}, ::AtmosModel, ::NF1, args)
+    return -args.state⁻.ρu
 end
-function atmos_momentum_boundary_state!(
-    nf::NumericalFluxGradient,
-    bc_momentum::Impenetrable{NoSlip},
-    atmos,
-    state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
-)
-    state⁺.ρu = zero(state⁺.ρu)
+
+function bc_val(::Impenetrable{NoSlip, Momentum}, ::AtmosModel, ::NF2, args)
+    @unpack state, n = args
+    return state.ρu - dot(state.ρu, n) .* SVector(n)
 end
+
+function bc_val(::Impenetrable{NoSlip, Momentum}, ::AtmosModel, ::NF∇, args)
+    return zero(args.state.ρu)
+end
+
 function atmos_momentum_normal_boundary_flux_second_order!(
     nf,
     bc_momentum::Impenetrable{NoSlip},
@@ -111,31 +80,6 @@ parallel to the boundary.
 """
 struct DragLaw{FN} <: MomentumDragBC
     fn::FN
-end
-function atmos_momentum_boundary_state!(
-    nf::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
-    bc_momentum::Impenetrable{DL},
-    atmos,
-    state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
-) where {DL <: DragLaw}
-    atmos_momentum_boundary_state!(
-        nf,
-        Impenetrable(FreeSlip()),
-        atmos,
-        state⁺,
-        aux⁺,
-        n,
-        state⁻,
-        aux⁻,
-        t,
-        args...,
-    )
 end
 function atmos_momentum_normal_boundary_flux_second_order!(
     nf,
@@ -166,4 +110,49 @@ function atmos_momentum_normal_boundary_flux_second_order!(
     # both sides involve projections of normals, so signs are consistent
     fluxᵀn.ρu += state⁻.ρ * τn
     fluxᵀn.energy.ρe += state⁻.ρu' * τn
+end
+
+function bc_val(
+    bc::Impenetrable{D, Momentum},
+    atmos::AtmosModel,
+    nf::Union{NF1, NF∇},
+    args,
+) where {D <: DragLaw}
+    return bc_val(Impenetrable{FreeSlip, Momentum}(FreeSlip()), atmos, nf, args)
+end
+
+function compute_τn(bc, args)
+    @unpack state, state_int, n = args
+
+    u1⁻ = state_int.ρu / state_int.ρ
+    u_int_tan = u1 - dot(u1, n) .* SVector(n)
+    normu_int_tan = norm(u_int_tan)
+    # NOTE: difference from design docs since normal points outwards
+    C = bc.drag.fn(state, aux, t, normu_int_tan)
+    τn = C * normu_int_tan * u_int_tan
+end
+
+function bc_val(
+    bc::Impenetrable{D, Momentum},
+    ::AtmosModel,
+    ::NF2,
+    args,
+) where {D <: DragLaw}
+    @unpack state = args
+    τn = compute_τn(bc, args)
+    # both sides involve projections of normals, so signs are consistent
+    return state.ρ + state.ρ * τn
+end
+
+function bc_val(
+    ::Impenetrable{D, Energy},
+    ::AtmosModel,
+    ::NF2,
+    args,
+) where {D <: DragLaw}
+    @unpack state = args
+
+    τn = compute_τn(bc, args)
+    # both sides involve projections of normals, so signs are consistent
+    return state.energy.ρe + state.ρu' * τn
 end

--- a/src/Atmos/Model/bc_momentum.jl
+++ b/src/Atmos/Model/bc_momentum.jl
@@ -40,7 +40,7 @@ struct ImpenetrableNoSlip{PV <: Union{Momentum, Energy}} <: BCDef{PV} end
 ImpenetrableNoSlip() = (ImpenetrableNoSlip{Momentum}(),)
 
 function bc_val(::ImpenetrableNoSlip{Momentum}, ::AtmosModel, ::NF1, args)
-    return -args.state⁻.ρu
+    return -args.state.ρu
 end
 
 function bc_val(::ImpenetrableNoSlip{Momentum}, ::AtmosModel, ::NF2, args)

--- a/src/Atmos/Model/bc_momentum.jl
+++ b/src/Atmos/Model/bc_momentum.jl
@@ -130,6 +130,7 @@ function compute_τn(bc, args)
     # NOTE: difference from design docs since normal points outwards
     C = bc.drag.fn(state, aux, t, normu_int_tan)
     τn = C * normu_int_tan * u_int_tan
+    return τn
 end
 
 function bc_val(

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -28,7 +28,9 @@ export AtmosBC,
 export average_density_sfc_int
 
 """
-    AtmosBC(momentum = Impenetrable(FreeSlip())
+    AtmosBC(;
+            tup      = (Impenetrable{Momentum}(FreeSlip()),)
+            momentum = Impenetrable{Momentum}(FreeSlip())
             energy   = Insulating()
             moisture = Impermeable()
             precipitation = OutflowPrecipitation()

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -8,10 +8,9 @@ const NF2 = NumericalFluxSecondOrder
 const NF∇ = NumericalFluxGradient
 
 export AtmosBC,
-    Impenetrable,
-    FreeSlip,
-    NoSlip,
-    DragLaw,
+    ImpenetrableFreeSlip,
+    ImpenetrableNoSlip,
+    ImpenetrableDragLaw,
     Insulating,
     PrescribedTemperature,
     PrescribedEnergyFlux,
@@ -29,8 +28,8 @@ export average_density_sfc_int
 
 """
     AtmosBC(;
-            tup      = (Impenetrable{Momentum}(FreeSlip()),)
-            momentum = Impenetrable{Momentum}(FreeSlip())
+            tup      = (ImpenetrableFreeSlip{Momentum}(),)
+            momentum = ImpenetrableFreeSlip{Momentum}()
             energy   = Insulating()
             moisture = Impermeable()
             precipitation = OutflowPrecipitation()
@@ -39,13 +38,13 @@ export average_density_sfc_int
 The standard boundary condition for [`AtmosModel`](@ref). The default options imply a "no flux" boundary condition.
 """
 Base.@kwdef struct AtmosBC{M, E, Q, P, TR, TC, T}
-    momentum::M = Impenetrable{Momentum}(FreeSlip())
+    momentum::M = ImpenetrableFreeSlip{Momentum}()
     energy::E = Insulating()
     moisture::Q = Impermeable()
     precipitation::P = OutflowPrecipitation()
     tracer::TR = ImpermeableTracer()
     turbconv::TC = NoTurbConvBC()
-    tup::T = (Impenetrable(FreeSlip())...,)
+    tup::T = (ImpenetrableFreeSlip()...,)
 end
 
 boundary_conditions(atmos::AtmosModel) = atmos.problem.boundaryconditions

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -173,9 +173,32 @@ function boundary_state!(
     nf::NumericalFluxFirstOrder,
     bc,
     atmoslm::AtmosLinearModel,
+    state⁺,
+    aux⁺,
+    n,
+    state⁻,
+    aux⁻,
+    t,
     args...,
 )
-    atmos_boundary_state!(nf, bc, atmoslm, args...)
+
+    ntargs = (; n, state = state⁻, aux = aux⁻, t, args)
+
+    set_bcs!(state⁺, atmoslm.atmos, nf, bc, ntargs, prognostic_vars(atmoslm))
+
+    atmos_boundary_state!(
+        nf,
+        bc,
+        atmoslm,
+        state⁺,
+        aux⁺,
+        n,
+        state⁻,
+        aux⁻,
+        t,
+        args...,
+    )
+
 end
 function boundary_state!(
     nf::NumericalFluxSecondOrder,

--- a/src/BalanceLaws/BalanceLaws.jl
+++ b/src/BalanceLaws/BalanceLaws.jl
@@ -36,5 +36,7 @@ include("show_tendencies.jl")
 include("sum_tendencies.jl")
 include("prog_prim_conversion.jl")
 include("vars_wrappers.jl")
+include("bc_types.jl")
+include("show_bcs.jl")
 
 end

--- a/src/BalanceLaws/bc_types.jl
+++ b/src/BalanceLaws/bc_types.jl
@@ -49,7 +49,7 @@ function set_bcs!(state⁺, bl, nf, bc, ntargs, prog_vars = prognostic_vars(bl))
         var⁺, name = get_prog_state(state⁺, prog)
         var⁻, name = get_prog_state(state⁻, prog)
         var_bcs = bcs_per_prog_var(bc.tup, prog)
-        bcvals = map(bcs_per_prog_var(bc.tup, prog)) do bc_pv
+        bcvals = map(var_bcs) do bc_pv
             bc_val(bc_pv, bl, nf, ntargs)
         end
         set_bc!(var⁺, name, bcvals)

--- a/src/BalanceLaws/bc_types.jl
+++ b/src/BalanceLaws/bc_types.jl
@@ -1,6 +1,6 @@
 ##### Boundary condition types
 
-export DefaultBC, set_bcs!
+export BCDef, DefaultBC, set_bcs!
 
 """
     BCDef
@@ -31,10 +31,7 @@ bc_val(::BCDef{PV}, bl, nf, args) where {PV} = DefaultBC{PV}()
 """
     set_bcs!(state⁺, bl, nf, bc, ntargs, prog_vars = prognostic_vars(bl))
 
-A convenience method for setting `state⁺` such that numerical fluxes,
-computed in `flux_first_order!`, enforces boundary conditions.
-
-This method is to be called in `boundary_state!`.
+A convenience method for setting `state⁺` inside `boundary_state!`.
 
 Arguments:
  - `state⁺` the exterior state

--- a/src/BalanceLaws/bc_types.jl
+++ b/src/BalanceLaws/bc_types.jl
@@ -1,0 +1,76 @@
+##### Boundary condition types
+
+export DefaultBC, set_bcs!
+
+"""
+    BCDef
+
+Subtypes are used for specifying
+each boundary condition.
+"""
+abstract type BCDef{PV <: PrognosticVariable} end
+
+"""
+    DefaultBC
+
+The default boundary condition
+"""
+struct DefaultBC{PV} <: BCDef{PV} end
+
+"""
+    bc_val(::BCDef{PV}, bl, nf, args)
+
+Return the value of the boundary condition, given
+ - `bcd::BCDef` the boundary condition definition type
+ - `bl` the balance law
+ - `nf` the numerical flux
+ - `args` top-level arguments, packed into a NamedTuple
+"""
+bc_val(::BCDef{PV}, bl, nf, args) where {PV} = DefaultBC{PV}()
+
+"""
+    set_bcs!(state⁺, bl, nf, bc, ntargs, prog_vars = prognostic_vars(bl))
+
+A convenience method for setting `state⁺` such that numerical fluxes,
+computed in `flux_first_order!`, enforces boundary conditions.
+
+This method is to be called in `boundary_state!`.
+
+Arguments:
+ - `state⁺` the exterior state
+ - `bl` the balance law
+ - `nf::Union{NumericalFluxFirstOrder,NumericalFluxGradient}` the numerical flux
+ - `ntargs` the top-level arguments
+ - `prog_vars` (optional) the balance law's prognostic variables
+"""
+function set_bcs!(state⁺, bl, nf, bc, ntargs, prog_vars = prognostic_vars(bl))
+    state⁻ = ntargs.state
+    map(prog_vars) do prog
+        var⁺, name = get_prog_state(state⁺, prog)
+        var⁻, name = get_prog_state(state⁻, prog)
+        var_bcs = bcs_per_prog_var(bc.tup, prog)
+        bcvals = map(bcs_per_prog_var(bc.tup, prog)) do bc_pv
+            bc_val(bc_pv, bl, nf, ntargs)
+        end
+        set_bc!(var⁺, name, bcvals)
+    end
+end
+
+#####
+##### Internal methods for setting/diagonalizing boundary conditions
+#####
+
+diag_bc(::PVA, ::BCDef{PVB}) where {PVA, PVB} = nothing
+diag_bc(::PV, bcd::BCDef{PV}) where {PV} = bcd
+
+filter_bcs(t::Tuple) = filter(x -> !(x == nothing), t)
+diag_bc(tup, pv) = filter_bcs(map(bc -> diag_bc(pv, bc), tup))
+
+prog_var_bcs(::Tuple{}, ::PV) where {PV} = (DefaultBC{PV}(),)
+prog_var_bcs(t::Tuple, ::PV) where {PV} = t
+
+bcs_per_prog_var(tup, pv::PrognosticVariable) =
+    prog_var_bcs(diag_bc(tup, pv), pv)
+
+set_bc!(var⁺, name, bcvals::Tuple{DefaultBC}) = nothing
+set_bc!(var⁺, name, bcvals) = setproperty!(var⁺, name, sum(bcvals))

--- a/src/BalanceLaws/show_bcs.jl
+++ b/src/BalanceLaws/show_bcs.jl
@@ -15,6 +15,7 @@ function show_bcs(
     bl::BalanceLaw;
     include_params = false,
     include_module = false,
+    table_complete = false,
 )
 
     prog_vars = prognostic_vars(bl)
@@ -36,6 +37,8 @@ function show_bcs(
                 end)
             end
         end
+
+        table_complete || @warn "This BC table is temporarily incomplete"
 
         data = hcat(eqs, collect.(bcs_entries)...)
         pretty_table(

--- a/src/BalanceLaws/show_bcs.jl
+++ b/src/BalanceLaws/show_bcs.jl
@@ -1,0 +1,55 @@
+##### Show boundary conditions
+
+export show_bcs
+
+type_param(::BCDef{PV}) where {PV} = PV
+
+function fmt_bc(t_in, include_params)
+    t = "$(nameof(typeof(t_in)))"
+    return include_params ? t * "{$(type_param(t_in))}" : t
+end
+
+fmt_bcs(bcs) = "($(join(bcs, ", ")))"
+
+function show_bcs(
+    bl::BalanceLaw;
+    include_params = false,
+    include_module = false,
+)
+
+    prog_vars = prognostic_vars(bl)
+    if !isempty(prog_vars)
+        all_bcs = boundary_conditions(bl)
+        header = hcat(
+            ["Equation"; "(Y_i)"],
+            hcat(map(i -> ["BC"; "$i"], 1:length(all_bcs))...),
+        )
+        if include_module
+            eqs = collect(string.(typeof.(prog_vars)))
+        else
+            eqs = collect(last.(split.(string.(typeof.(prog_vars)), ".")))
+        end
+        bcs_entries = map(all_bcs) do bc
+            map(prognostic_vars(bl)) do prog
+                fmt_bcs(map(bcs_per_prog_var(bc.tup, prog)) do bc_pv
+                    fmt_bc(bc_pv, include_params)
+                end)
+            end
+        end
+
+        data = hcat(eqs, collect.(bcs_entries)...)
+        pretty_table(
+            data,
+            header,
+            header_crayon = crayon"yellow bold",
+            subheader_crayon = crayon"green bold",
+            crop = :none,
+        )
+    else
+        msg = "Defining `prognostic_vars` and\n"
+        msg *= "`bcs_per_prog_var` for $(nameof(typeof(bl))) will\n"
+        msg *= "enable printing a table of boundary conditions."
+        @info msg
+    end
+
+end

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -181,6 +181,7 @@ function print_model_info(model, mpicomm)
         end
         @info msg
         show_tendencies(model; table_complete = model isa AtmosModel)
+        show_bcs(model)
     end
 end
 

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -29,7 +29,7 @@ import ClimateMachine.VariableTemplates.varsindex
 
 # ------------------------ Description ------------------------- #
 # 1) Dry Rising Bubble (circular potential temperature perturbation)
-# 2) Boundaries - `All Walls` : Impenetrable(FreeSlip())
+# 2) Boundaries - `All Walls` : ImpenetrableFreeSlip()
 #                               Laterally periodic
 # 3) Domain - 2500m[horizontal] x 2500m[horizontal] x 2500m[vertical]
 # 4) Timeend - 1000s

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -39,7 +39,7 @@
 # ```
 #
 # 2) Boundaries
-#    - `Impenetrable(FreeSlip())` - Top and bottom: no momentum flux, no mass flux through
+#    - `ImpenetrableFreeSlip()` - Top and bottom: no momentum flux, no mass flux through
 #      walls.
 #    - `Impermeable()` - non-porous walls, i.e. no diffusive fluxes through
 #       walls.

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -37,7 +37,7 @@
 # and $T = \theta \pi$
 #
 # 2) Boundaries
-#    - `Impenetrable(FreeSlip())` - Top and bottom: no momentum flux, no mass flux through
+#    - `ImpenetrableFreeSlip()` - Top and bottom: no momentum flux, no mass flux through
 #      walls.
 #    - `Impermeable()` - non-porous walls, i.e. no diffusive fluxes through
 #       walls.

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -14,7 +14,7 @@
 #
 # 1) Dry Density Current (circular potential temperature perturbation)
 # 2) Boundaries
-#    - `Impenetrable(FreeSlip())` - no momentum flux, no mass flux through
+#    - `ImpenetrableFreeSlip()` - no momentum flux, no mass flux through
 #      walls.
 #    - `Impermeable()` - non-porous walls, i.e. no diffusive fluxes through
 #       walls.

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -138,12 +138,14 @@ function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
     ## Set up the problem
     problem = AtmosProblem(
         boundaryconditions = (
-            AtmosBC(
-                momentum = Impenetrable(NoSlip()),
+            AtmosBC(;
+                tup = (Impenetrable{Momentum}(NoSlip()),),
+                momentum = Impenetrable{Momentum}(NoSlip()),
                 energy = PrescribedTemperature((state, aux, t) -> T_bot),
             ),
-            AtmosBC(
-                momentum = Impenetrable(NoSlip()),
+            AtmosBC(;
+                tup = (Impenetrable{Momentum}(NoSlip()),),
+                momentum = Impenetrable{Momentum}(NoSlip()),
                 energy = PrescribedTemperature((state, aux, t) -> T_top),
             ),
         ),

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -139,13 +139,13 @@ function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(;
-                tup = (Impenetrable{Momentum}(NoSlip()),),
-                momentum = Impenetrable{Momentum}(NoSlip()),
+                tup = (ImpenetrableNoSlip{Momentum}(),),
+                momentum = ImpenetrableNoSlip{Momentum}(),
                 energy = PrescribedTemperature((state, aux, t) -> T_bot),
             ),
             AtmosBC(;
-                tup = (Impenetrable{Momentum}(NoSlip()),),
-                momentum = Impenetrable{Momentum}(NoSlip()),
+                tup = (ImpenetrableNoSlip{Momentum}(),),
+                momentum = ImpenetrableNoSlip{Momentum}(),
                 energy = PrescribedTemperature((state, aux, t) -> T_top),
             ),
         ),

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -13,7 +13,7 @@
 # 1) Dry Rising Bubble (circular potential temperature perturbation)
 # 2) Boundaries
 #    Top and Bottom boundaries:
-#    - `Impenetrable(FreeSlip())` - Top and bottom: no momentum flux, no mass flux through
+#    - `ImpenetrableFreeSlip()` - Top and bottom: no momentum flux, no mass flux through
 #      walls.
 #    - `Impermeable()` - non-porous walls, i.e. no diffusive fluxes through
 #       walls.


### PR DESCRIPTION
### Description

This is the first PR of many to refactor the boundary conditions. This PR:

 - Changes the Atmos BC interface to accept tuples of `BCDef` types, so that we can loop over the BCs / prognostic variables
 - Individual `bc_val` function kernels will (eventually) be DG-agnostic
 - Add a BC table (similar to the tendency table)

It'll be much easier to do this incrementally, and this PR takes a small step and handles:

 - `boundary_state!` for momentum
 - some shared infrastructure in BalanceLaws

Similar to the tendency layer specification, this PR (and those more to come) will add types and hooks to add a layer on-top of the existing BC interface.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
