### PR TITLE
Equidistant cubed-sphere

### DIFF
--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -492,6 +492,18 @@
   publisher = {American Meteorological Society}
 }
 
+@article{Nair2005,
+  title = {A Discontinuous Galerkin Transport Scheme on the Cubed Sphere},
+  author = {Nair, Ramachandran D and Thomas, Stephen J and Loft, Richard D},
+  journal = {Monthly Weather Review},
+  volume = {133},
+  number = {4},
+  doi = {doi:10.1175/MWR2890.1},
+  pages = {814--828},
+  year = {2005},
+  publisher = {American Meteorological Society}
+}
+
 @article{Niegemann2012,
   title = {Efficient low-storage Runge--Kutta schemes with optimized stability regions},
   author = {Niegemann, Jens and Diehl, Richard and Busch, Kurt},
@@ -543,6 +555,17 @@
   pages = {431--437},
   year = {1962},
   doi = {10.1090/S0025-5718-1962-0150954-0}
+}
+
+@article{Rancic1996,
+  title = {A global shallow-water model using an expanded spherical cube: Gnomonic versus conformal coordinates},
+  author = {Ran\v{c}i\'{c}, M. and Purser, R. J. and Mesinger, F.},
+  journal = {Quarterly Journal of the Royal Meteorological Society},
+  volume = {122},
+  number = {532},
+  pages = {959--982},
+  year = {1996},
+  doi = {10.1002/qj.49712253209}
 }
 
 @article{Roberts2018,

--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -38,8 +38,10 @@ Topologies.StackedCubedSphereTopology(mpicomm, Nhorz, Rrange)
 ```@docs
 Topologies.cubedshellmesh
 Topologies.equiangular_cubed_shell_warp
-Topologies.hasboundary
 Topologies.equiangular_cubed_shell_unwarp
+Topologies.equidistant_cubed_shell_warp
+Topologies.equidistant_cubed_shell_unwarp
+Topologies.hasboundary
 Topologies.compute_lat_long
 Topologies.cubedshelltopowarp
 Topologies.grid1d

--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -37,10 +37,12 @@ Topologies.StackedCubedSphereTopology(mpicomm, Nhorz, Rrange)
 
 ```@docs
 Topologies.cubedshellmesh
-Topologies.equiangular_cubed_shell_warp
-Topologies.equiangular_cubed_shell_unwarp
-Topologies.equidistant_cubed_shell_warp
-Topologies.equidistant_cubed_shell_unwarp
+Topologies.cubed_sphere_warp
+Topologies.cubed_sphere_unwarp
+Topologies.equiangular_cubed_sphere_warp
+Topologies.equiangular_cubed_sphere_unwarp
+Topologies.equidistant_cubed_sphere_warp
+Topologies.equidistant_cubed_sphere_unwarp
 Topologies.hasboundary
 Topologies.compute_lat_long
 Topologies.cubedshelltopowarp

--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -37,9 +37,9 @@ Topologies.StackedCubedSphereTopology(mpicomm, Nhorz, Rrange)
 
 ```@docs
 Topologies.cubedshellmesh
-Topologies.cubedshellwarp
+Topologies.equiangular_cubed_shell_warp
 Topologies.hasboundary
-Topologies.cubedshellunwarp
+Topologies.equiangular_cubed_shell_unwarp
 Topologies.compute_lat_long
 Topologies.cubedshelltopowarp
 Topologies.grid1d

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -355,7 +355,7 @@ function AtmosGCMConfiguration(
     ),
     mpicomm = MPI.COMM_WORLD,
     grid_stretching = (nothing,),
-    meshwarp::Function = cubedshellwarp,
+    meshwarp::Function = equiangular_cubed_shell_warp,
     numerical_flux_first_order = RusanovNumericalFlux(),
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
     numerical_flux_gradient = CentralNumericalFluxGradient(),

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -355,7 +355,7 @@ function AtmosGCMConfiguration(
     ),
     mpicomm = MPI.COMM_WORLD,
     grid_stretching = (nothing,),
-    meshwarp::Function = equiangular_cubed_shell_warp,
+    meshwarp::Function = equiangular_cubed_sphere_warp,
     numerical_flux_first_order = RusanovNumericalFlux(),
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
     numerical_flux_gradient = CentralNumericalFluxGradient(),

--- a/src/Numerics/Mesh/Interpolation.jl
+++ b/src/Numerics/Mesh/Interpolation.jl
@@ -787,7 +787,11 @@ struct InterpolationCubedSphere{
                         rad * cosd(lat_grd[j]) * sind(long_grd[k]) # inclination -> latitude; azimuthal -> longitude.
 
                     uw_grd[1], uw_grd[2], uw_grd[3] =
-                        Topologies.cubedshellunwarp(x1_grd, x2_grd, x3_grd) # unwarping from sphere to cubed shell
+                        Topologies.equiangular_cubed_shell_unwarp(
+                            x1_grd,
+                            x2_grd,
+                            x3_grd,
+                        ) # unwarping from sphere to cubed shell
 
                     x1_uw2_grd = uw_grd[1] / rad # unwrapping cubed shell on to a 2D grid (in 3D space, -1 to 1 cube)
                     x2_uw2_grd = uw_grd[2] / rad

--- a/src/Numerics/Mesh/Interpolation.jl
+++ b/src/Numerics/Mesh/Interpolation.jl
@@ -787,7 +787,8 @@ struct InterpolationCubedSphere{
                         rad * cosd(lat_grd[j]) * sind(long_grd[k]) # inclination -> latitude; azimuthal -> longitude.
 
                     uw_grd[1], uw_grd[2], uw_grd[3] =
-                        Topologies.equiangular_cubed_shell_unwarp(
+                        Topologies.cubed_sphere_unwarp(
+                            EquiangularCubedSphere(),
                             x1_grd,
                             x2_grd,
                             x3_grd,

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -1,7 +1,7 @@
 using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
-    StackedCubedSphereTopology, equiangular_cubed_shell_warp, grid1d
+    StackedCubedSphereTopology, equiangular_cubed_sphere_warp, grid1d
 using ClimateMachine.Mesh.Grids:
     DiscontinuousSpectralElementGrid, VerticalDirection
 using ClimateMachine.Mesh.Filters
@@ -107,7 +107,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = polynomialorder,
-        meshwarp = equiangular_cubed_shell_warp,
+        meshwarp = equiangular_cubed_sphere_warp,
     )
 
     T_profile = IsothermalProfile(param_set, setup.T_ref)

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -1,7 +1,7 @@
 using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
-    StackedCubedSphereTopology, cubedshellwarp, grid1d
+    StackedCubedSphereTopology, equiangular_cubed_shell_warp, grid1d
 using ClimateMachine.Mesh.Grids:
     DiscontinuousSpectralElementGrid, VerticalDirection
 using ClimateMachine.Mesh.Filters
@@ -107,7 +107,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = polynomialorder,
-        meshwarp = cubedshellwarp,
+        meshwarp = equiangular_cubed_shell_warp,
     )
 
     T_profile = IsothermalProfile(param_set, setup.T_ref)

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -1,7 +1,7 @@
 using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
-    StackedCubedSphereTopology, cubedshellwarp, grid1d
+    StackedCubedSphereTopology, equiangular_cubed_shell_warp, grid1d
 using ClimateMachine.Mesh.Grids:
     DiscontinuousSpectralElementGrid,
     VerticalDirection,
@@ -114,7 +114,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = polynomialorder,
-        meshwarp = cubedshellwarp,
+        meshwarp = equiangular_cubed_shell_warp,
     )
     hmnd = min_node_distance(grid, HorizontalDirection())
     vmnd = min_node_distance(grid, VerticalDirection())

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -1,7 +1,7 @@
 using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
-    StackedCubedSphereTopology, equiangular_cubed_shell_warp, grid1d
+    StackedCubedSphereTopology, equiangular_cubed_sphere_warp, grid1d
 using ClimateMachine.Mesh.Grids:
     DiscontinuousSpectralElementGrid,
     VerticalDirection,
@@ -114,7 +114,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = polynomialorder,
-        meshwarp = equiangular_cubed_shell_warp,
+        meshwarp = equiangular_cubed_sphere_warp,
     )
     hmnd = min_node_distance(grid, HorizontalDirection())
     vmnd = min_node_distance(grid, VerticalDirection())

--- a/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
@@ -1,7 +1,7 @@
 using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
-    StackedCubedSphereTopology, cubedshellwarp, grid1d
+    StackedCubedSphereTopology, equiangular_cubed_shell_warp, grid1d
 using ClimateMachine.Mesh.Grids:
     DiscontinuousSpectralElementGrid, VerticalDirection
 using ClimateMachine.Mesh.Filters
@@ -106,7 +106,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = polynomialorder,
-        meshwarp = cubedshellwarp,
+        meshwarp = equiangular_cubed_shell_warp,
     )
 
     T_profile = IsothermalProfile(param_set, setup.T_ref)

--- a/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
@@ -1,7 +1,7 @@
 using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
-    StackedCubedSphereTopology, equiangular_cubed_shell_warp, grid1d
+    StackedCubedSphereTopology, equiangular_cubed_sphere_warp, grid1d
 using ClimateMachine.Mesh.Grids:
     DiscontinuousSpectralElementGrid, VerticalDirection
 using ClimateMachine.Mesh.Filters
@@ -106,7 +106,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = polynomialorder,
-        meshwarp = equiangular_cubed_shell_warp,
+        meshwarp = equiangular_cubed_sphere_warp,
     )
 
     T_profile = IsothermalProfile(param_set, setup.T_ref)

--- a/test/Numerics/DGMethods/Euler/fvm_balance.jl
+++ b/test/Numerics/DGMethods/Euler/fvm_balance.jl
@@ -86,7 +86,7 @@ function test_run(
             nelem = numelem_vert,
         )
         topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)
-        meshwarp = equiangular_cubed_shell_warp
+        meshwarp = equiangular_cubed_sphere_warp
     end
 
     grid = DiscontinuousSpectralElementGrid(

--- a/test/Numerics/DGMethods/Euler/fvm_balance.jl
+++ b/test/Numerics/DGMethods/Euler/fvm_balance.jl
@@ -86,7 +86,7 @@ function test_run(
             nelem = numelem_vert,
         )
         topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)
-        meshwarp = cubedshellwarp
+        meshwarp = equiangular_cubed_shell_warp
     end
 
     grid = DiscontinuousSpectralElementGrid(
@@ -174,8 +174,8 @@ function test_run(
                               simtime = %.16e
                               runtime = %s
                               ρu = %.16e, %.16e
-                              ρv = %.16e, %.16e 
-                              ρw = %.16e, %.16e 
+                              ρv = %.16e, %.16e
+                              ρw = %.16e, %.16e
                               norm(Q) = %.16e
                               """ gettime(lsrk) runtime ρu... ρv... ρw... energy
         end

--- a/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
@@ -185,7 +185,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = N,
-        meshwarp = cubedshellwarp,
+        meshwarp = equiangular_cubed_shell_warp,
     )
 
     dx = min_node_distance(grid, HorizontalDirection())

--- a/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
@@ -185,7 +185,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = N,
-        meshwarp = equiangular_cubed_shell_warp,
+        meshwarp = equiangular_cubed_sphere_warp,
     )
 
     dx = min_node_distance(grid, HorizontalDirection())

--- a/test/Numerics/DGMethods/advection_diffusion/diffusion_hyperdiffusion_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/diffusion_hyperdiffusion_sphere.jl
@@ -100,7 +100,7 @@ function run(mpicomm, ArrayType, topl, N, timeend, FT, vtkdir, outputtime)
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = N,
-        meshwarp = cubedshellwarp,
+        meshwarp = equiangular_cubed_shell_warp,
     )
 
     dx = min_node_distance(grid)

--- a/test/Numerics/DGMethods/advection_diffusion/diffusion_hyperdiffusion_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/diffusion_hyperdiffusion_sphere.jl
@@ -100,7 +100,7 @@ function run(mpicomm, ArrayType, topl, N, timeend, FT, vtkdir, outputtime)
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = N,
-        meshwarp = equiangular_cubed_shell_warp,
+        meshwarp = equiangular_cubed_sphere_warp,
     )
 
     dx = min_node_distance(grid)

--- a/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
@@ -110,7 +110,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = polynomialorder,
-        meshwarp = topo == Sphere ? equiangular_cubed_shell_warp :
+        meshwarp = topo == Sphere ? equiangular_cubed_sphere_warp :
                    (x...) -> identity(x),
     )
 

--- a/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
@@ -110,7 +110,8 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = polynomialorder,
-        meshwarp = topo == Sphere ? cubedshellwarp : (x...) -> identity(x),
+        meshwarp = topo == Sphere ? equiangular_cubed_shell_warp :
+                   (x...) -> identity(x),
     )
 
     problems = (

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl
@@ -205,7 +205,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = (N, 0),
-        meshwarp = equiangular_cubed_shell_warp,
+        meshwarp = equiangular_cubed_sphere_warp,
     )
 
     dx = min_node_distance(grid, HorizontalDirection())

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl
@@ -205,7 +205,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = (N, 0),
-        meshwarp = cubedshellwarp,
+        meshwarp = equiangular_cubed_shell_warp,
     )
 
     dx = min_node_distance(grid, HorizontalDirection())

--- a/test/Numerics/DGMethods/compressible_navier_stokes_equations/three_dimensional/config_sphere.jl
+++ b/test/Numerics/DGMethods/compressible_navier_stokes_equations/three_dimensional/config_sphere.jl
@@ -38,7 +38,7 @@ function Config(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = resolution.N + Nover,
-        meshwarp = equiangular_cubed_shell_warp,
+        meshwarp = equiangular_cubed_sphere_warp,
     )
 
     model = CNSE3D{FT}(

--- a/test/Numerics/DGMethods/compressible_navier_stokes_equations/three_dimensional/config_sphere.jl
+++ b/test/Numerics/DGMethods/compressible_navier_stokes_equations/three_dimensional/config_sphere.jl
@@ -38,7 +38,7 @@ function Config(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = resolution.N + Nover,
-        meshwarp = cubedshellwarp,
+        meshwarp = equiangular_cubed_shell_warp,
     )
 
     model = CNSE3D{FT}(

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -166,7 +166,7 @@ function test_run(mpicomm, ArrayType, N, Nhorz, Rrange, timeend, FT, dt)
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = N,
-        meshwarp = Topologies.cubedshellwarp,
+        meshwarp = Topologies.equiangular_cubed_shell_warp,
     )
     dg = DGModel(
         ConservationTestModel(),

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -166,7 +166,7 @@ function test_run(mpicomm, ArrayType, N, Nhorz, Rrange, timeend, FT, dt)
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = N,
-        meshwarp = Topologies.equiangular_cubed_shell_warp,
+        meshwarp = Topologies.equiangular_cubed_sphere_warp,
     )
     dg = DGModel(
         ConservationTestModel(),

--- a/test/Numerics/DGMethods/grad_test_sphere.jl
+++ b/test/Numerics/DGMethods/grad_test_sphere.jl
@@ -57,7 +57,7 @@ function test_run(mpicomm, Ne_horz, Ne_vert, N, FT, ArrayType, direction)
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = N,
-        meshwarp = Topologies.equiangular_cubed_shell_warp,
+        meshwarp = Topologies.equiangular_cubed_sphere_warp,
     )
 
     model = GradSphereTestModel{direction}()

--- a/test/Numerics/DGMethods/grad_test_sphere.jl
+++ b/test/Numerics/DGMethods/grad_test_sphere.jl
@@ -57,7 +57,7 @@ function test_run(mpicomm, Ne_horz, Ne_vert, N, FT, ArrayType, direction)
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = N,
-        meshwarp = Topologies.cubedshellwarp,
+        meshwarp = Topologies.equiangular_cubed_shell_warp,
     )
 
     model = GradSphereTestModel{direction}()

--- a/test/Numerics/DGMethods/horizontal_integral_test.jl
+++ b/test/Numerics/DGMethods/horizontal_integral_test.jl
@@ -169,7 +169,7 @@ function run_test3(mpicomm, dim, Ne, N, FT, ArrayType)
             FloatType = FT,
             DeviceArray = ArrayType,
             polynomialorder = N,
-            meshwarp = Topologies.cubedshellwarp,
+            meshwarp = Topologies.equiangular_cubed_shell_warp,
         )
 
         nrealelem = length(topl.realelems)

--- a/test/Numerics/DGMethods/horizontal_integral_test.jl
+++ b/test/Numerics/DGMethods/horizontal_integral_test.jl
@@ -169,7 +169,7 @@ function run_test3(mpicomm, dim, Ne, N, FT, ArrayType)
             FloatType = FT,
             DeviceArray = ArrayType,
             polynomialorder = N,
-            meshwarp = Topologies.equiangular_cubed_shell_warp,
+            meshwarp = Topologies.equiangular_cubed_sphere_warp,
         )
 
         nrealelem = length(topl.realelems)

--- a/test/Numerics/DGMethods/integral_test_sphere.jl
+++ b/test/Numerics/DGMethods/integral_test_sphere.jl
@@ -150,7 +150,7 @@ function test_run(mpicomm, topl, ArrayType, N, FT, Rinner, Router)
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = N,
-        meshwarp = Topologies.cubedshellwarp,
+        meshwarp = Topologies.equiangular_cubed_shell_warp,
     )
     dg = DGModel(
         IntegralTestSphereModel(Rinner, Router),

--- a/test/Numerics/DGMethods/integral_test_sphere.jl
+++ b/test/Numerics/DGMethods/integral_test_sphere.jl
@@ -150,7 +150,7 @@ function test_run(mpicomm, topl, ArrayType, N, FT, Rinner, Router)
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = N,
-        meshwarp = Topologies.equiangular_cubed_shell_warp,
+        meshwarp = Topologies.equiangular_cubed_sphere_warp,
     )
     dg = DGModel(
         IntegralTestSphereModel(Rinner, Router),

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -77,7 +77,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = polynomialorder,
-        meshwarp = cubedshellwarp,
+        meshwarp = equiangular_cubed_shell_warp,
     )
     T_profile = IsothermalProfile(param_set, setup.T_ref)
 

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -77,7 +77,7 @@ function test_run(
         FloatType = FT,
         DeviceArray = ArrayType,
         polynomialorder = polynomialorder,
-        meshwarp = equiangular_cubed_shell_warp,
+        meshwarp = equiangular_cubed_sphere_warp,
     )
     T_profile = IsothermalProfile(param_set, setup.T_ref)
 

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -271,7 +271,7 @@ function run_cubed_sphere_interpolation_test(
         FloatType = FT,
         DeviceArray = DA,
         polynomialorder = polynomialorders,
-        meshwarp = ClimateMachine.Mesh.Topologies.cubedshellwarp,
+        meshwarp = ClimateMachine.Mesh.Topologies.equiangular_cubed_shell_warp,
     )
 
     model = AtmosModel{FT}(

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -271,7 +271,7 @@ function run_cubed_sphere_interpolation_test(
         FloatType = FT,
         DeviceArray = DA,
         polynomialorder = polynomialorders,
-        meshwarp = ClimateMachine.Mesh.Topologies.equiangular_cubed_shell_warp,
+        meshwarp = ClimateMachine.Mesh.Topologies.equiangular_cubed_sphere_warp,
     )
 
     model = AtmosModel{FT}(

--- a/test/Numerics/Mesh/mpi_connect_sphere.jl
+++ b/test/Numerics/Mesh/mpi_connect_sphere.jl
@@ -31,7 +31,7 @@ function main()
         FloatType = FT,
         DeviceArray = DA,
         polynomialorder = N,
-        meshwarp = Topologies.equiangular_cubed_shell_warp,
+        meshwarp = Topologies.equiangular_cubed_sphere_warp,
     )
 
     let

--- a/test/Numerics/Mesh/mpi_connect_sphere.jl
+++ b/test/Numerics/Mesh/mpi_connect_sphere.jl
@@ -31,7 +31,7 @@ function main()
         FloatType = FT,
         DeviceArray = DA,
         polynomialorder = N,
-        meshwarp = Topologies.cubedshellwarp,
+        meshwarp = Topologies.equiangular_cubed_shell_warp,
     )
 
     let

--- a/test/Numerics/Mesh/topology.jl
+++ b/test/Numerics/Mesh/topology.jl
@@ -4,25 +4,37 @@ using Combinatorics, MPI
 
 MPI.Initialized() || MPI.Init()
 
-@testset "cubedshellwarp tests" begin
-    import ClimateMachine.Mesh.Topologies: cubedshellwarp
+@testset "equiangular_cubed_shell_warp tests" begin
+    import ClimateMachine.Mesh.Topologies: equiangular_cubed_shell_warp
 
     @testset "check radius" begin
-        @test hypot(cubedshellwarp(3.0, -2.2, 1.3)...) ≈ 3.0 rtol = eps()
-        @test hypot(cubedshellwarp(-3.0, -2.2, 1.3)...) ≈ 3.0 rtol = eps()
-        @test hypot(cubedshellwarp(1.1, -2.2, 3.0)...) ≈ 3.0 rtol = eps()
-        @test hypot(cubedshellwarp(1.1, -2.2, -3.0)...) ≈ 3.0 rtol = eps()
-        @test hypot(cubedshellwarp(1.1, 3.0, 0.0)...) ≈ 3.0 rtol = eps()
-        @test hypot(cubedshellwarp(1.1, -3.0, 0.0)...) ≈ 3.0 rtol = eps()
+        @test hypot(equiangular_cubed_shell_warp(3.0, -2.2, 1.3)...) ≈ 3.0 rtol =
+            eps()
+        @test hypot(equiangular_cubed_shell_warp(-3.0, -2.2, 1.3)...) ≈ 3.0 rtol =
+            eps()
+        @test hypot(equiangular_cubed_shell_warp(1.1, -2.2, 3.0)...) ≈ 3.0 rtol =
+            eps()
+        @test hypot(equiangular_cubed_shell_warp(1.1, -2.2, -3.0)...) ≈ 3.0 rtol =
+            eps()
+        @test hypot(equiangular_cubed_shell_warp(1.1, 3.0, 0.0)...) ≈ 3.0 rtol =
+            eps()
+        @test hypot(equiangular_cubed_shell_warp(1.1, -3.0, 0.0)...) ≈ 3.0 rtol =
+            eps()
     end
 
     @testset "check sign" begin
-        @test sign.(cubedshellwarp(3.0, -2.2, 1.3)) == sign.((3.0, -2.2, 1.3))
-        @test sign.(cubedshellwarp(-3.0, -2.2, 1.3)) == sign.((-3.0, -2.2, 1.3))
-        @test sign.(cubedshellwarp(1.1, -2.2, 3.0)) == sign.((1.1, -2.2, 3.0))
-        @test sign.(cubedshellwarp(1.1, -2.2, -3.0)) == sign.((1.1, -2.2, -3.0))
-        @test sign.(cubedshellwarp(1.1, 3.0, 0.0)) == sign.((1.1, 3.0, 0.0))
-        @test sign.(cubedshellwarp(1.1, -3.0, 0.0)) == sign.((1.1, -3.0, 0.0))
+        @test sign.(equiangular_cubed_shell_warp(3.0, -2.2, 1.3)) ==
+              sign.((3.0, -2.2, 1.3))
+        @test sign.(equiangular_cubed_shell_warp(-3.0, -2.2, 1.3)) ==
+              sign.((-3.0, -2.2, 1.3))
+        @test sign.(equiangular_cubed_shell_warp(1.1, -2.2, 3.0)) ==
+              sign.((1.1, -2.2, 3.0))
+        @test sign.(equiangular_cubed_shell_warp(1.1, -2.2, -3.0)) ==
+              sign.((1.1, -2.2, -3.0))
+        @test sign.(equiangular_cubed_shell_warp(1.1, 3.0, 0.0)) ==
+              sign.((1.1, 3.0, 0.0))
+        @test sign.(equiangular_cubed_shell_warp(1.1, -3.0, 0.0)) ==
+              sign.((1.1, -3.0, 0.0))
     end
 
     @testset "check continuity" begin
@@ -30,43 +42,68 @@ MPI.Initialized() || MPI.Init()
             permutations([3.0, 2.999999999, 1.3]),
             permutations([2.999999999, 3.0, 1.3]),
         )
-            @test all(cubedshellwarp(u...) .≈ cubedshellwarp(v...))
+            @test all(
+                equiangular_cubed_shell_warp(u...) .≈
+                equiangular_cubed_shell_warp(v...),
+            )
         end
         for (u, v) in zip(
             permutations([3.0, -2.999999999, 1.3]),
             permutations([2.999999999, -3.0, 1.3]),
         )
-            @test all(cubedshellwarp(u...) .≈ cubedshellwarp(v...))
+            @test all(
+                equiangular_cubed_shell_warp(u...) .≈
+                equiangular_cubed_shell_warp(v...),
+            )
         end
         for (u, v) in zip(
             permutations([-3.0, 2.999999999, 1.3]),
             permutations([-2.999999999, 3.0, 1.3]),
         )
-            @test all(cubedshellwarp(u...) .≈ cubedshellwarp(v...))
+            @test all(
+                equiangular_cubed_shell_warp(u...) .≈
+                equiangular_cubed_shell_warp(v...),
+            )
         end
         for (u, v) in zip(
             permutations([-3.0, -2.999999999, 1.3]),
             permutations([-2.999999999, -3.0, 1.3]),
         )
-            @test all(cubedshellwarp(u...) .≈ cubedshellwarp(v...))
+            @test all(
+                equiangular_cubed_shell_warp(u...) .≈
+                equiangular_cubed_shell_warp(v...),
+            )
         end
     end
 end
 
-@testset "cubedshellunwarp" begin
-    import ClimateMachine.Mesh.Topologies: cubedshellwarp, cubedshellunwarp
+@testset "equiangular_cubed_shell_unwarp" begin
+    import ClimateMachine.Mesh.Topologies:
+        equiangular_cubed_shell_warp, equiangular_cubed_shell_unwarp
 
     for u in permutations([3.0, 2.999999999, 1.3])
-        @test all(cubedshellunwarp(cubedshellwarp(u...)...) .≈ u)
+        @test all(
+            equiangular_cubed_shell_unwarp(equiangular_cubed_shell_warp(u...)...) .≈
+            u,
+        )
     end
     for u in permutations([3.0, -2.999999999, 1.3])
-        @test all(cubedshellunwarp(cubedshellwarp(u...)...) .≈ u)
+        @test all(
+            equiangular_cubed_shell_unwarp(equiangular_cubed_shell_warp(u...)...) .≈
+            u,
+        )
     end
     for u in permutations([-3.0, 2.999999999, 1.3])
-        @test all(cubedshellunwarp(cubedshellwarp(u...)...) .≈ u)
+        @test all(
+            equiangular_cubed_shell_unwarp(equiangular_cubed_shell_warp(u...)...) .≈
+            u,
+        )
     end
     for u in permutations([-3.0, -2.999999999, 1.3])
-        @test all(cubedshellunwarp(cubedshellwarp(u...)...) .≈ u)
+        @test all(
+            equiangular_cubed_shell_unwarp(equiangular_cubed_shell_warp(u...)...) .≈
+            u,
+        )
     end
 end
 

--- a/test/Numerics/Mesh/topology.jl
+++ b/test/Numerics/Mesh/topology.jl
@@ -107,6 +107,109 @@ end
     end
 end
 
+@testset "equidistant_cubed_shell_warp tests" begin
+    import ClimateMachine.Mesh.Topologies: equidistant_cubed_shell_warp
+
+    @testset "check radius" begin
+        @test hypot(equidistant_cubed_shell_warp(3.0, -2.2, 1.3)...) ≈ 3.0 rtol =
+            eps()
+        @test hypot(equidistant_cubed_shell_warp(-3.0, -2.2, 1.3)...) ≈ 3.0 rtol =
+            eps()
+        @test hypot(equidistant_cubed_shell_warp(1.1, -2.2, 3.0)...) ≈ 3.0 rtol =
+            eps()
+        @test hypot(equidistant_cubed_shell_warp(1.1, -2.2, -3.0)...) ≈ 3.0 rtol =
+            eps()
+        @test hypot(equidistant_cubed_shell_warp(1.1, 3.0, 0.0)...) ≈ 3.0 rtol =
+            eps()
+        @test hypot(equidistant_cubed_shell_warp(1.1, -3.0, 0.0)...) ≈ 3.0 rtol =
+            eps()
+    end
+
+    @testset "check sign" begin
+        @test sign.(equidistant_cubed_shell_warp(3.0, -2.2, 1.3)) ==
+              sign.((3.0, -2.2, 1.3))
+        @test sign.(equidistant_cubed_shell_warp(-3.0, -2.2, 1.3)) ==
+              sign.((-3.0, -2.2, 1.3))
+        @test sign.(equidistant_cubed_shell_warp(1.1, -2.2, 3.0)) ==
+              sign.((1.1, -2.2, 3.0))
+        @test sign.(equidistant_cubed_shell_warp(1.1, -2.2, -3.0)) ==
+              sign.((1.1, -2.2, -3.0))
+        @test sign.(equidistant_cubed_shell_warp(1.1, 3.0, 0.0)) ==
+              sign.((1.1, 3.0, 0.0))
+        @test sign.(equidistant_cubed_shell_warp(1.1, -3.0, 0.0)) ==
+              sign.((1.1, -3.0, 0.0))
+    end
+
+    @testset "check continuity" begin
+        for (u, v) in zip(
+            permutations([3.0, 2.999999999, 1.3]),
+            permutations([2.999999999, 3.0, 1.3]),
+        )
+            @test all(
+                equidistant_cubed_shell_warp(u...) .≈
+                equidistant_cubed_shell_warp(v...),
+            )
+        end
+        for (u, v) in zip(
+            permutations([3.0, -2.999999999, 1.3]),
+            permutations([2.999999999, -3.0, 1.3]),
+        )
+            @test all(
+                equidistant_cubed_shell_warp(u...) .≈
+                equidistant_cubed_shell_warp(v...),
+            )
+        end
+        for (u, v) in zip(
+            permutations([-3.0, 2.999999999, 1.3]),
+            permutations([-2.999999999, 3.0, 1.3]),
+        )
+            @test all(
+                equidistant_cubed_shell_warp(u...) .≈
+                equidistant_cubed_shell_warp(v...),
+            )
+        end
+        for (u, v) in zip(
+            permutations([-3.0, -2.999999999, 1.3]),
+            permutations([-2.999999999, -3.0, 1.3]),
+        )
+            @test all(
+                equidistant_cubed_shell_warp(u...) .≈
+                equidistant_cubed_shell_warp(v...),
+            )
+        end
+    end
+end
+
+@testset "equidistant_cubed_shell_unwarp" begin
+    import ClimateMachine.Mesh.Topologies:
+        equidistant_cubed_shell_warp, equidistant_cubed_shell_unwarp
+
+    for u in permutations([3.0, 2.999999999, 1.3])
+        @test all(
+            equidistant_cubed_shell_unwarp(equidistant_cubed_shell_warp(u...)...) .≈
+            u,
+        )
+    end
+    for u in permutations([3.0, -2.999999999, 1.3])
+        @test all(
+            equidistant_cubed_shell_unwarp(equidistant_cubed_shell_warp(u...)...) .≈
+            u,
+        )
+    end
+    for u in permutations([-3.0, 2.999999999, 1.3])
+        @test all(
+            equidistant_cubed_shell_unwarp(equidistant_cubed_shell_warp(u...)...) .≈
+            u,
+        )
+    end
+    for u in permutations([-3.0, -2.999999999, 1.3])
+        @test all(
+            equidistant_cubed_shell_unwarp(equidistant_cubed_shell_warp(u...)...) .≈
+            u,
+        )
+    end
+end
+
 @testset "grid1d" begin
     g = grid1d(0, 10, nelem = 10)
     @test eltype(g) == Float64

--- a/test/Numerics/Mesh/topology.jl
+++ b/test/Numerics/Mesh/topology.jl
@@ -4,37 +4,28 @@ using Combinatorics, MPI
 
 MPI.Initialized() || MPI.Init()
 
-@testset "equiangular_cubed_shell_warp tests" begin
-    import ClimateMachine.Mesh.Topologies: equiangular_cubed_shell_warp
+@testset "Equiangular cubed_sphere_warp tests" begin
+    import ClimateMachine.Mesh.Topologies: equiangular_cubed_sphere_warp
+
+    # Create function alias for shorter formatting
+    eacsw = equiangular_cubed_sphere_warp
 
     @testset "check radius" begin
-        @test hypot(equiangular_cubed_shell_warp(3.0, -2.2, 1.3)...) ≈ 3.0 rtol =
-            eps()
-        @test hypot(equiangular_cubed_shell_warp(-3.0, -2.2, 1.3)...) ≈ 3.0 rtol =
-            eps()
-        @test hypot(equiangular_cubed_shell_warp(1.1, -2.2, 3.0)...) ≈ 3.0 rtol =
-            eps()
-        @test hypot(equiangular_cubed_shell_warp(1.1, -2.2, -3.0)...) ≈ 3.0 rtol =
-            eps()
-        @test hypot(equiangular_cubed_shell_warp(1.1, 3.0, 0.0)...) ≈ 3.0 rtol =
-            eps()
-        @test hypot(equiangular_cubed_shell_warp(1.1, -3.0, 0.0)...) ≈ 3.0 rtol =
-            eps()
+        @test hypot(eacsw(3.0, -2.2, 1.3)...) ≈ 3.0 rtol = eps()
+        @test hypot(eacsw(-3.0, -2.2, 1.3)...) ≈ 3.0 rtol = eps()
+        @test hypot(eacsw(1.1, -2.2, 3.0)...) ≈ 3.0 rtol = eps()
+        @test hypot(eacsw(1.1, -2.2, -3.0)...) ≈ 3.0 rtol = eps()
+        @test hypot(eacsw(1.1, 3.0, 0.0)...) ≈ 3.0 rtol = eps()
+        @test hypot(eacsw(1.1, -3.0, 0.0)...) ≈ 3.0 rtol = eps()
     end
 
     @testset "check sign" begin
-        @test sign.(equiangular_cubed_shell_warp(3.0, -2.2, 1.3)) ==
-              sign.((3.0, -2.2, 1.3))
-        @test sign.(equiangular_cubed_shell_warp(-3.0, -2.2, 1.3)) ==
-              sign.((-3.0, -2.2, 1.3))
-        @test sign.(equiangular_cubed_shell_warp(1.1, -2.2, 3.0)) ==
-              sign.((1.1, -2.2, 3.0))
-        @test sign.(equiangular_cubed_shell_warp(1.1, -2.2, -3.0)) ==
-              sign.((1.1, -2.2, -3.0))
-        @test sign.(equiangular_cubed_shell_warp(1.1, 3.0, 0.0)) ==
-              sign.((1.1, 3.0, 0.0))
-        @test sign.(equiangular_cubed_shell_warp(1.1, -3.0, 0.0)) ==
-              sign.((1.1, -3.0, 0.0))
+        @test sign.(eacsw(3.0, -2.2, 1.3)) == sign.((3.0, -2.2, 1.3))
+        @test sign.(eacsw(-3.0, -2.2, 1.3)) == sign.((-3.0, -2.2, 1.3))
+        @test sign.(eacsw(1.1, -2.2, 3.0)) == sign.((1.1, -2.2, 3.0))
+        @test sign.(eacsw(1.1, -2.2, -3.0)) == sign.((1.1, -2.2, -3.0))
+        @test sign.(eacsw(1.1, 3.0, 0.0)) == sign.((1.1, 3.0, 0.0))
+        @test sign.(eacsw(1.1, -3.0, 0.0)) == sign.((1.1, -3.0, 0.0))
     end
 
     @testset "check continuity" begin
@@ -42,102 +33,73 @@ MPI.Initialized() || MPI.Init()
             permutations([3.0, 2.999999999, 1.3]),
             permutations([2.999999999, 3.0, 1.3]),
         )
-            @test all(
-                equiangular_cubed_shell_warp(u...) .≈
-                equiangular_cubed_shell_warp(v...),
-            )
+            @test all(eacsw(u...) .≈ eacsw(v...))
         end
         for (u, v) in zip(
             permutations([3.0, -2.999999999, 1.3]),
             permutations([2.999999999, -3.0, 1.3]),
         )
-            @test all(
-                equiangular_cubed_shell_warp(u...) .≈
-                equiangular_cubed_shell_warp(v...),
-            )
+            @test all(eacsw(u...) .≈ eacsw(v...))
         end
         for (u, v) in zip(
             permutations([-3.0, 2.999999999, 1.3]),
             permutations([-2.999999999, 3.0, 1.3]),
         )
-            @test all(
-                equiangular_cubed_shell_warp(u...) .≈
-                equiangular_cubed_shell_warp(v...),
-            )
+            @test all(eacsw(u...) .≈ eacsw(v...))
         end
         for (u, v) in zip(
             permutations([-3.0, -2.999999999, 1.3]),
             permutations([-2.999999999, -3.0, 1.3]),
         )
-            @test all(
-                equiangular_cubed_shell_warp(u...) .≈
-                equiangular_cubed_shell_warp(v...),
-            )
+            @test all(eacsw(u...) .≈ eacsw(v...))
         end
     end
 end
 
-@testset "equiangular_cubed_shell_unwarp" begin
+@testset "Equiangular cubed_sphere_unwarp tests" begin
     import ClimateMachine.Mesh.Topologies:
-        equiangular_cubed_shell_warp, equiangular_cubed_shell_unwarp
+        cubed_sphere_warp, equiangular_cubed_sphere_unwarp
+
+    # Create function aliases for shorter formatting
+    eacsw = equiangular_cubed_sphere_warp
+    eacsu = equiangular_cubed_sphere_unwarp
 
     for u in permutations([3.0, 2.999999999, 1.3])
-        @test all(
-            equiangular_cubed_shell_unwarp(equiangular_cubed_shell_warp(u...)...) .≈
-            u,
-        )
+        @test all(eacsu(eacsw(u...)...) .≈ u)
     end
     for u in permutations([3.0, -2.999999999, 1.3])
-        @test all(
-            equiangular_cubed_shell_unwarp(equiangular_cubed_shell_warp(u...)...) .≈
-            u,
-        )
+        @test all(eacsu(eacsw(u...)...) .≈ u)
     end
     for u in permutations([-3.0, 2.999999999, 1.3])
-        @test all(
-            equiangular_cubed_shell_unwarp(equiangular_cubed_shell_warp(u...)...) .≈
-            u,
-        )
+        @test all(eacsu(eacsw(u...)...) .≈ u)
     end
     for u in permutations([-3.0, -2.999999999, 1.3])
-        @test all(
-            equiangular_cubed_shell_unwarp(equiangular_cubed_shell_warp(u...)...) .≈
-            u,
-        )
+        @test all(eacsu(eacsw(u...)...) .≈ u)
     end
 end
 
-@testset "equidistant_cubed_shell_warp tests" begin
-    import ClimateMachine.Mesh.Topologies: equidistant_cubed_shell_warp
+@testset "Equidistant cubed_sphere_warp tests" begin
+    import ClimateMachine.Mesh.Topologies: equidistant_cubed_sphere_warp
+
+    # Create function alias for shorter formatting
+    edcsw = equidistant_cubed_sphere_warp
 
     @testset "check radius" begin
-        @test hypot(equidistant_cubed_shell_warp(3.0, -2.2, 1.3)...) ≈ 3.0 rtol =
-            eps()
-        @test hypot(equidistant_cubed_shell_warp(-3.0, -2.2, 1.3)...) ≈ 3.0 rtol =
-            eps()
-        @test hypot(equidistant_cubed_shell_warp(1.1, -2.2, 3.0)...) ≈ 3.0 rtol =
-            eps()
-        @test hypot(equidistant_cubed_shell_warp(1.1, -2.2, -3.0)...) ≈ 3.0 rtol =
-            eps()
-        @test hypot(equidistant_cubed_shell_warp(1.1, 3.0, 0.0)...) ≈ 3.0 rtol =
-            eps()
-        @test hypot(equidistant_cubed_shell_warp(1.1, -3.0, 0.0)...) ≈ 3.0 rtol =
-            eps()
+        @test hypot(edcsw(3.0, -2.2, 1.3)...) ≈ 3.0 rtol = eps()
+        @test hypot(edcsw(-3.0, -2.2, 1.3)...) ≈ 3.0 rtol = eps()
+        @test hypot(edcsw(1.1, -2.2, 3.0)...) ≈ 3.0 rtol = eps()
+        @test hypot(edcsw(1.1, -2.2, -3.0)...) ≈ 3.0 rtol = eps()
+        @test hypot(edcsw(1.1, 3.0, 0.0)...) ≈ 3.0 rtol = eps()
+        @test hypot(edcsw(1.1, -3.0, 0.0)...) ≈ 3.0 rtol = eps()
     end
 
     @testset "check sign" begin
-        @test sign.(equidistant_cubed_shell_warp(3.0, -2.2, 1.3)) ==
-              sign.((3.0, -2.2, 1.3))
-        @test sign.(equidistant_cubed_shell_warp(-3.0, -2.2, 1.3)) ==
-              sign.((-3.0, -2.2, 1.3))
-        @test sign.(equidistant_cubed_shell_warp(1.1, -2.2, 3.0)) ==
-              sign.((1.1, -2.2, 3.0))
-        @test sign.(equidistant_cubed_shell_warp(1.1, -2.2, -3.0)) ==
-              sign.((1.1, -2.2, -3.0))
-        @test sign.(equidistant_cubed_shell_warp(1.1, 3.0, 0.0)) ==
-              sign.((1.1, 3.0, 0.0))
-        @test sign.(equidistant_cubed_shell_warp(1.1, -3.0, 0.0)) ==
-              sign.((1.1, -3.0, 0.0))
+        @test sign.(edcsw(3.0, -2.2, 1.3)) == sign.((3.0, -2.2, 1.3))
+        @test sign.(edcsw(-3.0, -2.2, 1.3)) == sign.((-3.0, -2.2, 1.3))
+        @test sign.(edcsw(1.1, -2.2, 3.0)) == sign.((1.1, -2.2, 3.0))
+        @test sign.(edcsw(1.1, -2.2, -3.0)) == sign.((1.1, -2.2, -3.0))
+        @test sign.(edcsw(1.1, 3.0, 0.0)) == sign.((1.1, 3.0, 0.0))
+        @test sign.(edcsw(1.1, -3.0, 0.0)) == sign.((1.1, -3.0, 0.0))
     end
 
     @testset "check continuity" begin
@@ -145,68 +107,48 @@ end
             permutations([3.0, 2.999999999, 1.3]),
             permutations([2.999999999, 3.0, 1.3]),
         )
-            @test all(
-                equidistant_cubed_shell_warp(u...) .≈
-                equidistant_cubed_shell_warp(v...),
-            )
+            @test all(edcsw(u...) .≈ edcsw(v...))
         end
         for (u, v) in zip(
             permutations([3.0, -2.999999999, 1.3]),
             permutations([2.999999999, -3.0, 1.3]),
         )
-            @test all(
-                equidistant_cubed_shell_warp(u...) .≈
-                equidistant_cubed_shell_warp(v...),
-            )
+            @test all(edcsw(u...) .≈ edcsw(v...))
         end
         for (u, v) in zip(
             permutations([-3.0, 2.999999999, 1.3]),
             permutations([-2.999999999, 3.0, 1.3]),
         )
-            @test all(
-                equidistant_cubed_shell_warp(u...) .≈
-                equidistant_cubed_shell_warp(v...),
-            )
+            @test all(edcsw(u...) .≈ edcsw(v...))
         end
         for (u, v) in zip(
             permutations([-3.0, -2.999999999, 1.3]),
             permutations([-2.999999999, -3.0, 1.3]),
         )
-            @test all(
-                equidistant_cubed_shell_warp(u...) .≈
-                equidistant_cubed_shell_warp(v...),
-            )
+            @test all(edcsw(u...) .≈ edcsw(v...))
         end
     end
 end
 
-@testset "equidistant_cubed_shell_unwarp" begin
+@testset "Equidistant cubed_sphere_unwarp tests" begin
     import ClimateMachine.Mesh.Topologies:
-        equidistant_cubed_shell_warp, equidistant_cubed_shell_unwarp
+        equidistant_cubed_sphere_warp, equidistant_cubed_sphere_unwarp
+
+    # Create function aliases for shorter formatting
+    edcsw = equidistant_cubed_sphere_warp
+    edcsu = equidistant_cubed_sphere_unwarp
 
     for u in permutations([3.0, 2.999999999, 1.3])
-        @test all(
-            equidistant_cubed_shell_unwarp(equidistant_cubed_shell_warp(u...)...) .≈
-            u,
-        )
+        @test all(edcsu(edcsw(u...)...) .≈ u)
     end
     for u in permutations([3.0, -2.999999999, 1.3])
-        @test all(
-            equidistant_cubed_shell_unwarp(equidistant_cubed_shell_warp(u...)...) .≈
-            u,
-        )
+        @test all(edcsu(edcsw(u...)...) .≈ u)
     end
     for u in permutations([-3.0, 2.999999999, 1.3])
-        @test all(
-            equidistant_cubed_shell_unwarp(equidistant_cubed_shell_warp(u...)...) .≈
-            u,
-        )
+        @test all(edcsu(edcsw(u...)...) .≈ u)
     end
     for u in permutations([-3.0, -2.999999999, 1.3])
-        @test all(
-            equidistant_cubed_shell_unwarp(equidistant_cubed_shell_warp(u...)...) .≈
-            u,
-        )
+        @test all(edcsu(edcsw(u...)...) .≈ u)
     end
 end
 


### PR DESCRIPTION
### Description

This PR adds support for an equidistant cubed-sphere (as defined in [Rancic at al](https://doi.org/10.1002/qj.49712253209) and [Nair et al](https://doi.org/10.1175/MWR2890.1) ). 

Things done in this PR so far: 
- [x] Renamed existing `cubedshellwarp` -> `cubed_sphere_warp` (changed shell to sphere and used snake case, for better readability and accessibility). Similarly, renamed `cubedshellunwarp` -> `cubed_sphere_unwarp`. For assignments of functors, I then needed to create different specialized wrappers: `equiangular_cubed_sphere_warp`, `equiangular_cubed_sphere_unwarp`, `equidistant_cubed_sphere_warp`, and `equidistant_cubed_sphere_unwarp`.
- [x] Tests for the equidistant cubed-sphere warp/unwarp functions have been added (the same as for the equiangular case). 

This will close #1778. 

Things to think about/do: 
- [x] How to change the interface to give the user the possibility to choose between one or the other cubed-sphere? Perhaps @charleskawczynski can give me a hint.
~~- [ ] Confirm that using the equidistant cubed-sphere in an experiment should improve the CFL condition.~~ <-- Edit: This is actually not the case with the equidistant cubed sphere, my bad for misinterpreting Rancic's paper.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
