### PR TITLE
remove momentum contribution to energy bulk formula

### DIFF
--- a/src/Atmos/Model/bc_momentum.jl
+++ b/src/Atmos/Model/bc_momentum.jl
@@ -165,5 +165,4 @@ function atmos_momentum_normal_boundary_flux_second_order!(
     τn = C * normu_int⁻_tan * u_int⁻_tan
     # both sides involve projections of normals, so signs are consistent
     fluxᵀn.ρu += state⁻.ρ * τn
-    fluxᵀn.energy.ρe += state⁻.ρu' * τn
 end

--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -13,17 +13,17 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Bomex.nc"), "r")
 
 #! format: off
 best_mse = OrderedDict()
-best_mse["prog_ρ"] = 3.4917543567412931e-02
-best_mse["prog_ρu_1"] = 3.0715061616086091e+03
-best_mse["prog_ρu_2"] = 1.2895273328644243e-03
-best_mse["prog_moisture_ρq_tot"] = 4.1330591681431862e-02
-best_mse["prog_turbconv_environment_ρatke"] = 6.7419793087180005e+02
-best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.5667222913342755e+01
-best_mse["prog_turbconv_environment_ρaq_tot_cv"] = 1.6435778026434528e+02
-best_mse["prog_turbconv_updraft_1_ρa"] = 7.9568648163256995e+01
-best_mse["prog_turbconv_updraft_1_ρaw"] = 8.4292074562603486e-02
-best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 9.0094974216941637e+00
-best_mse["prog_turbconv_updraft_1_ρaq_tot"] = 1.0768452320369121e+01
+best_mse["prog_ρ"] = 3.4917662870525668e-02
+best_mse["prog_ρu_1"] = 3.0715053983126782e+03
+best_mse["prog_ρu_2"] = 1.2895738234436555e-03
+best_mse["prog_moisture_ρq_tot"] = 4.1331426262591536e-02
+best_mse["prog_turbconv_environment_ρatke"] = 6.7533398950377637e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.5667223118537208e+01
+best_mse["prog_turbconv_environment_ρaq_tot_cv"] = 1.6435769054934644e+02
+best_mse["prog_turbconv_updraft_1_ρa"] = 7.9507446326773803e+01
+best_mse["prog_turbconv_updraft_1_ρaw"] = 8.4143288691582691e-02
+best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 9.0080835465027622e+00
+best_mse["prog_turbconv_updraft_1_ρaq_tot"] = 1.0766760607493566e+01
 #! format: on
 
 computed_mse = compute_mse(

--- a/test/Atmos/EDMF/report_mse_sbl_anelastic.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_anelastic.jl
@@ -13,9 +13,9 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
 
 #! format: off
 best_mse = OrderedDict()
-best_mse["prog_ρ"] = 9.3809207150466600e-03
-best_mse["prog_ρu_1"] = 6.7269974359218368e+03
-best_mse["prog_ρu_2"] = 6.8630597189221576e-01
+best_mse["prog_ρ"] = 9.3809207150296822e-03
+best_mse["prog_ρu_1"] = 6.7269975116623837e+03
+best_mse["prog_ρu_2"] = 6.8630628605220889e-01
 #! format: on
 
 computed_mse = compute_mse(

--- a/test/Atmos/EDMF/report_mse_sbl_fv.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_fv.jl
@@ -13,14 +13,14 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
 
 #! format: off
 best_mse = OrderedDict()
-best_mse["prog_ρ"] = 6.9637575838887369e-03
-best_mse["prog_ρu_1"] = 6.2604203232863292e+03
-best_mse["prog_ρu_2"] = 1.3200376252941846e-04
-best_mse["prog_turbconv_environment_ρatke"] = 2.3729827149654821e+02
-best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.7727378291873919e+01
-best_mse["prog_turbconv_updraft_1_ρa"] = 1.7947149151486141e+01
-best_mse["prog_turbconv_updraft_1_ρaw"] = 1.7799688543526015e-01
-best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 1.3315385576514325e+01
+best_mse["prog_ρ"] = 6.8766006877255519e-03
+best_mse["prog_ρu_1"] = 6.2597055026242824e+03
+best_mse["prog_ρu_2"] = 1.3231034873190784e-04
+best_mse["prog_turbconv_environment_ρatke"] = 2.3567381097766608e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.7727378309967946e+01
+best_mse["prog_turbconv_updraft_1_ρa"] = 1.7945530391906004e+01
+best_mse["prog_turbconv_updraft_1_ρaw"] = 1.7798447663638761e-01
+best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 1.3315160127630856e+01
 #! format: on
 
 computed_mse = compute_mse(


### PR DESCRIPTION
### Description
This small PR remove the contribution from momentum to surface energy flux in the bulk formula, this should not appear there - see footnote in the Energy Flux section (6.2.4) in the Design Docs

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
