### PR TITLE
Add `--checkpoint-on-crash`

### DIFF
--- a/docs/src/APIs/Arrays/Arrays.md
+++ b/docs/src/APIs/Arrays/Arrays.md
@@ -24,4 +24,5 @@ CMBuffers.CMBuffer
 
 ```@docs
 show_not_finite_fields
+checked_wait
 ```

--- a/docs/src/GettingStarted/RunningClimateMachine.md
+++ b/docs/src/GettingStarted/RunningClimateMachine.md
@@ -146,6 +146,9 @@ ClimateMachine:
                         recent)
   --checkpoint-at-end   create a checkpoint at the end of the
                         simulation
+  --checkpoint-on-crash 
+                        create a checkpoint on a kernel crash (hurts
+                        performance!)
   --checkpoint-dir <path>
                         the directory in which to store checkpoints
                         (default: "checkpoint")

--- a/src/Driver/SolverTypes/ExplicitSolverType.jl
+++ b/src/Driver/SolverTypes/ExplicitSolverType.jl
@@ -1,4 +1,3 @@
-
 export ExplicitSolverType
 
 """
@@ -58,7 +57,6 @@ function solversetup(
     t0,
     diffusion_direction,
 )
-
     solver = ode_solver.solver_method(dg, Q; dt = dt, t0 = t0)
 
     return solver

--- a/src/Driver/SolverTypes/HEVISolverType.jl
+++ b/src/Driver/SolverTypes/HEVISolverType.jl
@@ -132,8 +132,6 @@ function solversetup(
     t0,
     diffusion_direction,
 )
-
-
     # All we need to do is create a DGModel for the
     # vertical acoustic waves (determined from the `implicit_model`)
     vdg = DGModel(
@@ -145,6 +143,7 @@ function solversetup(
         state_auxiliary = dg.state_auxiliary,
         direction = VerticalDirection(),
         diffusion_direction = VerticalDirection(),
+        check_for_crashes = dg.check_for_crashes,
     )
 
     # linear solver relative tolerance rtol which should be slightly smaller than the nonlinear solver tol
@@ -190,7 +189,6 @@ function solversetup(
         split_explicit_implicit = false,
         variant = NaiveVariant(),
     )
-
 
     return solver
 end

--- a/src/Driver/SolverTypes/IMEXSolverType.jl
+++ b/src/Driver/SolverTypes/IMEXSolverType.jl
@@ -164,6 +164,7 @@ function solversetup(
         state_gradient_flux = dg.state_gradient_flux,
         states_higher_order = dg.states_higher_order,
         direction = VerticalDirection(),
+        check_for_crashes = dg.check_for_crashes,
     )
 
     if ode_solver.split_explicit_implicit

--- a/src/Driver/SolverTypes/ImplicitSolverType.jl
+++ b/src/Driver/SolverTypes/ImplicitSolverType.jl
@@ -1,4 +1,3 @@
-
 export ImplicitSolverType
 
 """
@@ -62,7 +61,6 @@ function solversetup(
     t0,
     diffusion_direction,
 )
-
     solver = ode_solver.solver_method(dg, Q; dt = dt, t0 = t0)
 
     return solver

--- a/src/Driver/SolverTypes/MISSolverType.jl
+++ b/src/Driver/SolverTypes/MISSolverType.jl
@@ -1,4 +1,3 @@
-
 export MISSolverType
 
 """
@@ -117,7 +116,6 @@ function solversetup(
     t0,
     diffusion_direction,
 )
-
     # Extract fast model and define a DG model
     # for the fast processes (acoustic/gravity waves
     # in all spatial directions)
@@ -132,6 +130,7 @@ function solversetup(
         state_gradient_flux = dg.state_gradient_flux,
         states_higher_order = dg.states_higher_order,
         direction = EveryDirection(),
+        check_for_crashes = dg.check_for_crashes,
     )
 
     # Using the RemainderModel, we subtract away the
@@ -170,7 +169,6 @@ function solversetup(
     t0,
     diffusion_direction,
 )
-
     # Extract fast model and define a DG model
     # for the fast processes (acoustic/gravity waves
     # in all spatial directions)
@@ -186,6 +184,7 @@ function solversetup(
         state_gradient_flux = dg.state_gradient_flux,
         states_higher_order = dg.states_higher_order,
         direction = EveryDirection(),
+        check_for_crashes = dg.check_for_crashes,
     )
 
     # Using the RemainderModel, we subtract away the
@@ -214,6 +213,7 @@ function solversetup(
         state_gradient_flux = dg.state_gradient_flux,
         states_higher_order = dg.states_higher_order,
         direction = HorizontalDirection(),
+        check_for_crashes = dg.check_for_crashes,
     )
     fast_dg_v = DGModel(
         fast_model,
@@ -225,6 +225,7 @@ function solversetup(
         state_gradient_flux = dg.state_gradient_flux,
         states_higher_order = dg.states_higher_order,
         direction = VerticalDirection(),
+        check_for_crashes = dg.check_for_crashes,
     )
 
     fast_dg_tendencies = (fast_dg_h, fast_dg_v)

--- a/src/Driver/SolverTypes/MultirateSolverType.jl
+++ b/src/Driver/SolverTypes/MultirateSolverType.jl
@@ -1,4 +1,3 @@
-
 export MultirateSolverType
 
 """
@@ -142,7 +141,6 @@ function solversetup(
     t0,
     diffusion_direction,
 )
-
     # Extract fast model and define a DG model
     # for the fast processes (acoustic/gravity waves
     # in all spatial directions)
@@ -157,6 +155,7 @@ function solversetup(
         state_gradient_flux = dg.state_gradient_flux,
         states_higher_order = dg.states_higher_order,
         direction = EveryDirection(),
+        check_for_crashes = dg.check_for_crashes,
     )
 
     # Using the RemainderModel, we subtract away the
@@ -225,7 +224,6 @@ function solversetup(
     t0,
     diffusion_direction,
 )
-
     # Extract fast model and define a DG model
     # for the fast processes
     fast_model = ode_solver.fast_model(dg.balance_law)
@@ -241,6 +239,7 @@ function solversetup(
         state_gradient_flux = dg.state_gradient_flux,
         states_higher_order = dg.states_higher_order,
         direction = EveryDirection(),
+        check_for_crashes = dg.check_for_crashes,
     )
 
     # DG model for the vertical acoustic waves only
@@ -254,6 +253,7 @@ function solversetup(
         state_gradient_flux = dg.state_gradient_flux,
         states_higher_order = dg.states_higher_order,
         direction = VerticalDirection(),
+        check_for_crashes = dg.check_for_crashes,
     )
 
     # Compute fast time-step size from target ratio

--- a/src/Driver/SolverTypes/SolverTypes.jl
+++ b/src/Driver/SolverTypes/SolverTypes.jl
@@ -1,4 +1,3 @@
-
 export AbstractSolverType
 export DiscreteSplittingType, HEVISplitting
 export getdtmodel

--- a/src/Driver/SolverTypes/SplitExplicitSolverType.jl
+++ b/src/Driver/SolverTypes/SplitExplicitSolverType.jl
@@ -1,4 +1,3 @@
-
 export SplitExplicitSolverType
 
 """

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -132,6 +132,7 @@ function SolverConfiguration(
                 direction = direction,
                 diffusion_direction = diffdir,
                 modeldata = modeldata,
+                check_for_crashes = Settings.checkpoint_on_crash,
             )
         end
 
@@ -151,6 +152,7 @@ function SolverConfiguration(
                 direction = direction,
                 diffusion_direction = diffdir,
                 modeldata = modeldata,
+                check_for_crashes = Settings.checkpoint_on_crash,
             )
         end
 

--- a/src/Numerics/DGMethods/DGModel.jl
+++ b/src/Numerics/DGMethods/DGModel.jl
@@ -30,6 +30,7 @@ struct DGFVModel{BL, G, FVR, NFND, NFD, GNF, AS, DS, HDS, D, DD, MD, GF, TF} <:
     modeldata::MD
     gradient_filter::GF
     tendency_filter::TF
+    check_for_crashes::Bool
 end
 
 function DGFVModel(
@@ -40,6 +41,7 @@ function DGFVModel(
     numerical_flux_second_order,
     numerical_flux_gradient;
     fill_nan = false,
+    check_for_crashes = false,
     state_auxiliary = create_state(
         balance_law,
         grid,
@@ -77,6 +79,7 @@ function DGFVModel(
         modeldata,
         gradient_filter,
         tendency_filter,
+        check_for_crashes,
     )
 end
 
@@ -95,6 +98,7 @@ struct DGModel{BL, G, NFND, NFD, GNF, AS, DS, HDS, D, DD, MD, GF, TF} <:
     modeldata::MD
     gradient_filter::GF
     tendency_filter::TF
+    check_for_crashes::Bool
 end
 
 function DGModel(
@@ -104,6 +108,7 @@ function DGModel(
     numerical_flux_second_order,
     numerical_flux_gradient;
     fill_nan = false,
+    check_for_crashes = false,
     state_auxiliary = create_state(
         balance_law,
         grid,
@@ -137,6 +142,7 @@ function DGModel(
         modeldata,
         gradient_filter,
         tendency_filter,
+        check_for_crashes,
     )
 end
 
@@ -283,11 +289,17 @@ function (dgfvm::DGFVModel)(tendency, state_prognostic, _, t, α, β)
             exchange_state_prognostic = MPIStateArrays.end_ghost_exchange!(
                 state_prognostic;
                 dependencies = exchange_state_prognostic,
+                check_for_crashes = dgfvm.check_for_crashes,
             )
 
             # Update_aux may start asynchronous work on the compute device and
             # we synchronize those here through a device event.
-            wait(device, exchange_state_prognostic)
+            checked_wait(
+                device,
+                exchange_state_prognostic,
+                nothing,
+                dgfvm.check_for_crashes,
+            )
             update_auxiliary_state!(
                 dgfvm,
                 dgfvm.balance_law,
@@ -330,7 +342,7 @@ function (dgfvm::DGFVModel)(tendency, state_prognostic, _, t, α, β)
         if num_state_gradient_flux > 0
             # Update_aux_diffusive may start asynchronous work on the compute device
             # and we synchronize those here through a device event.
-            wait(device, comp_stream)
+            checked_wait(device, comp_stream, nothing, dgfvm.check_for_crashes)
             update_auxiliary_state_gradient!(
                 dgfvm,
                 dgfvm.balance_law,
@@ -371,12 +383,18 @@ function (dgfvm::DGFVModel)(tendency, state_prognostic, _, t, α, β)
             exchange_state_gradient_flux = MPIStateArrays.end_ghost_exchange!(
                 dgfvm.state_gradient_flux;
                 dependencies = exchange_state_gradient_flux,
+                check_for_crashes = dgfvm.check_for_crashes,
             )
 
             # Update_aux_diffusive may start asynchronous work on the
             # compute device and we synchronize those here through a device
             # event.
-            wait(device, exchange_state_gradient_flux)
+            checked_wait(
+                device,
+                exchange_state_gradient_flux,
+                nothing,
+                dgfvm.check_for_crashes,
+            )
             update_auxiliary_state_gradient!(
                 dgfvm,
                 dgfvm.balance_law,
@@ -389,11 +407,17 @@ function (dgfvm::DGFVModel)(tendency, state_prognostic, _, t, α, β)
             exchange_state_prognostic = MPIStateArrays.end_ghost_exchange!(
                 state_prognostic;
                 dependencies = exchange_state_prognostic,
+                check_for_crashes = dgfvm.check_for_crashes,
             )
 
             # Update_aux may start asynchronous work on the compute device and
             # we synchronize those here through a device event.
-            wait(device, exchange_state_prognostic)
+            checked_wait(
+                device,
+                exchange_state_prognostic,
+                nothing,
+                dgfvm.check_for_crashes,
+            )
             update_auxiliary_state!(
                 dgfvm,
                 dgfvm.balance_law,
@@ -434,7 +458,7 @@ function (dgfvm::DGFVModel)(tendency, state_prognostic, _, t, α, β)
     # The synchronization here through a device event prevents CuArray based and
     # other default stream kernels from launching before the work scheduled in
     # this function is finished.
-    wait(device, comp_stream)
+    checked_wait(device, comp_stream, nothing, dgfvm.check_for_crashes)
 end
 
 """
@@ -522,11 +546,17 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             exchange_state_prognostic = MPIStateArrays.end_ghost_exchange!(
                 state_prognostic;
                 dependencies = exchange_state_prognostic,
+                check_for_crashes = dg.check_for_crashes,
             )
 
             # Update_aux may start asynchronous work on the compute device and
             # we synchronize those here through a device event.
-            wait(device, exchange_state_prognostic)
+            checked_wait(
+                device,
+                exchange_state_prognostic,
+                nothing,
+                dg.check_for_crashes,
+            )
             update_auxiliary_state!(
                 dg,
                 dg.balance_law,
@@ -574,7 +604,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
         if num_state_gradient_flux > 0
             # Update_aux_diffusive may start asynchronous work on the compute device
             # and we synchronize those here through a device event.
-            wait(device, comp_stream)
+            checked_wait(device, comp_stream, nothing, dg.check_for_crashes)
             update_auxiliary_state_gradient!(
                 dg,
                 dg.balance_law,
@@ -610,6 +640,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             exchange_Qhypervisc_grad = MPIStateArrays.end_ghost_exchange!(
                 Qhypervisc_grad,
                 dependencies = exchange_Qhypervisc_grad,
+                check_for_crashes = dg.check_for_crashes,
             )
         end
 
@@ -651,6 +682,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             exchange_Qhypervisc_div = MPIStateArrays.end_ghost_exchange!(
                 Qhypervisc_div,
                 dependencies = exchange_Qhypervisc_div,
+                check_for_crashes = dg.check_for_crashes,
             )
         end
 
@@ -702,12 +734,18 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
                     MPIStateArrays.end_ghost_exchange!(
                         dg.state_gradient_flux;
                         dependencies = exchange_state_gradient_flux,
+                        check_for_crashes = dg.check_for_crashes,
                     )
 
                 # Update_aux_diffusive may start asynchronous work on the
                 # compute device and we synchronize those here through a device
                 # event.
-                wait(device, exchange_state_gradient_flux)
+                checked_wait(
+                    device,
+                    exchange_state_gradient_flux,
+                    nothing,
+                    dg.check_for_crashes,
+                )
                 update_auxiliary_state_gradient!(
                     dg,
                     dg.balance_law,
@@ -721,17 +759,24 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
                 exchange_Qhypervisc_grad = MPIStateArrays.end_ghost_exchange!(
                     Qhypervisc_grad;
                     dependencies = exchange_Qhypervisc_grad,
+                    check_for_crashes = dg.check_for_crashes,
                 )
             end
         else
             exchange_state_prognostic = MPIStateArrays.end_ghost_exchange!(
                 state_prognostic;
                 dependencies = exchange_state_prognostic,
+                check_for_crashes = dg.check_for_crashes,
             )
 
             # Update_aux may start asynchronous work on the compute device and
             # we synchronize those here through a device event.
-            wait(device, exchange_state_prognostic)
+            checked_wait(
+                device,
+                exchange_state_prognostic,
+                nothing,
+                dg.check_for_crashes,
+            )
             update_auxiliary_state!(
                 dg,
                 dg.balance_law,
@@ -771,7 +816,7 @@ function (dg::DGModel)(tendency, state_prognostic, _, t, α, β)
             dependencies = comp_stream,
         )
     end
-    wait(device, comp_stream)
+    checked_wait(device, comp_stream, nothing, dg.check_for_crashes)
 end
 
 function init_ode_state(
@@ -826,7 +871,7 @@ function init_ode_state(
             args...;
             ndrange = Np * nrealelem,
         )
-        wait(event) # XXX: This could be `wait(device, event)` once KA supports that.
+        wait(event)
         state_prognostic .= h_state_prognostic
         state_auxiliary .= h_state_auxiliary
     end
@@ -972,7 +1017,7 @@ function indefinite_stack_integral!(
         ndrange = (length(horzelems) * Nq[1], Nqj),
         dependencies = (event,),
     )
-    wait(device, event)
+    checked_wait(device, event, nothing, dg.check_for_crashes)
 end
 
 function reverse_indefinite_stack_integral!(
@@ -1013,7 +1058,7 @@ function reverse_indefinite_stack_integral!(
         ndrange = (length(horzelems) * Nq[1], Nqj),
         dependencies = (event,),
     )
-    wait(device, event)
+    checked_wait(device, event, nothing, dg.check_for_crashes)
 end
 
 # By default, we call update_auxiliary_state!, given
@@ -1075,7 +1120,7 @@ function update_auxiliary_state!(
             dependencies = (event,),
         )
     end
-    wait(device, event)
+    checked_wait(device, event, nothing, spacedisc.check_for_crashes)
 end
 
 """
@@ -1144,7 +1189,7 @@ function courant(
             ndrange = (nrealelem * Nq[1] * Nq[2] * Nqk),
             dependencies = (event,),
         )
-        wait(device, event)
+        checked_wait(device, event, nothing, dg.check_for_crashes)
 
         rank_courant_max = maximum(pointwise_courant)
     else

--- a/src/Numerics/DGMethods/remainder.jl
+++ b/src/Numerics/DGMethods/remainder.jl
@@ -105,6 +105,7 @@ function remainder_DGModel(
     modeldata = maindg.modeldata,
     gradient_filter = maindg.gradient_filter,
     tendency_filter = maindg.tendency_filter,
+    check_for_crashes = maindg.check_for_crashes,
 ) where {NumModels}
     FT = eltype(state_auxiliary)
 
@@ -160,6 +161,7 @@ function remainder_DGModel(
         modeldata,
         gradient_filter,
         tendency_filter,
+        check_for_crashes,
     )
 end
 


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
If specified, `--checkpoint-on-crash` adds exception checking to the `wait` call in `MPIStateArrays` which is where most such crashes will be detected. An `Allreduce` call is added here which notifies all MPI ranks of the crash; a checkpoint is then written.

I've tested this using the baroclinic wave experiment (with the [filter](https://github.com/CliMA/ClimateMachine.jl/blob/master/experiments/TestCase/baroclinic_wave.jl#L288) removed to force a crash) on CPU and GPU with 1, 2 and 32 MPI ranks and it seems to work fine.

Closes #1468 and #1510.

<!-- Check all the boxes below before taking the PR out of draft -->

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
