### PR TITLE
Fix creation of Anelastic1D thermo states with NonEquilMoist

### DIFF
--- a/src/Atmos/Model/thermo_states_anelastic.jl
+++ b/src/Atmos/Model/thermo_states_anelastic.jl
@@ -71,6 +71,7 @@ function new_thermo_state_anelastic(
     aux::Vars,
 )
     e_int = internal_energy(atmos, state, aux)
+    p = aux.ref_state.p
     ρ = density(atmos, state, aux)
     q = PhasePartition(
         state.moisture.ρq_tot / ρ,
@@ -78,10 +79,5 @@ function new_thermo_state_anelastic(
         state.moisture.ρq_ice / ρ,
     )
 
-    return PhaseNonEquil_peq{eltype(state), typeof(atmos.param_set)}(
-        atmos.param_set,
-        p,
-        e_int,
-        q,
-    )
+    return PhaseNonEquil_peq(atmos.param_set, p, e_int, q)
 end


### PR DESCRIPTION
### Update new_thermo_state_anelastic for NonEquilMoist

<!-- Provide a clear description of the content -->

Define pressure and use correct function call signature.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
