### PR TITLE
Remove parameter type in Impenetrable

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -72,11 +72,9 @@ ClimateMachine.Atmos.RayleighSponge
 
 ```@docs
 ClimateMachine.Atmos.AtmosBC
-ClimateMachine.Atmos.DragLaw
 ClimateMachine.Atmos.Impermeable
 ClimateMachine.Atmos.PrescribedMoistureFlux
 ClimateMachine.Atmos.BulkFormulaMoisture
-ClimateMachine.Atmos.FreeSlip
 ClimateMachine.Atmos.PrescribedTemperature
 ClimateMachine.Atmos.PrescribedEnergyFlux
 ClimateMachine.Atmos.NishizawaEnergyFlux
@@ -84,9 +82,10 @@ ClimateMachine.Atmos.Adiabaticθ
 ClimateMachine.Atmos.BulkFormulaEnergy
 ClimateMachine.Atmos.OutflowPrecipitation
 ClimateMachine.Atmos.ImpermeableTracer
-ClimateMachine.Atmos.Impenetrable
+ClimateMachine.Atmos.ImpenetrableFreeSlip
+ClimateMachine.Atmos.ImpenetrableNoSlip
+ClimateMachine.Atmos.ImpenetrableDragLaw
 ClimateMachine.Atmos.Insulating
-ClimateMachine.Atmos.NoSlip
 ClimateMachine.Atmos.average_density
 ```
 

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -456,11 +456,11 @@ function bomex_model(
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
-                momentum = Impenetrable(DragLaw(
+                momentum = ImpenetrableDragLaw(
                     # normPu_int is the internal horizontal speed
                     # P represents the projection onto the horizontal
                     (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
-                )),
+                ),
                 energy = energy_bc,
                 moisture = moisture_bc,
                 turbconv = turbconv_bcs(turbconv)[1],

--- a/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
+++ b/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
@@ -412,9 +412,9 @@ function config_cfsites(
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
-                momentum = Impenetrable(DragLaw(
+                momentum = ImpenetrableDragLaw(
                     (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
-                )),
+                ),
                 energy = PrescribedEnergyFlux((state, aux, t) -> hfls + hfss),
                 moisture = PrescribedMoistureFlux(
                     (state, aux, t) ->

--- a/experiments/AtmosLES/convective_bl_model.jl
+++ b/experiments/AtmosLES/convective_bl_model.jl
@@ -275,11 +275,11 @@ function convective_bl_model(
     moisture_bcs = moisture_model == "dry" ? () : (; moisture = moisture_bc)
     boundary_conditions = (
         AtmosBC(;
-            momentum = Impenetrable(DragLaw(
+            momentum = ImpenetrableDragLaw(
                 # normPu_int is the internal horizontal speed
                 # P represents the projection onto the horizontal
                 (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
-            )),
+            ),
             energy = energy_bc,
             moisture_bcs...,
             turbconv = turbconv_bcs(turbconv)[1],

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -350,9 +350,9 @@ function config_dycoms(
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
-                momentum = Impenetrable(DragLaw(
+                momentum = ImpenetrableDragLaw(
                     (state, aux, t, normPu) -> C_drag,
-                )),
+                ),
                 energy = PrescribedEnergyFlux((state, aux, t) -> LHF + SHF),
                 moisture = PrescribedMoistureFlux(
                     (state, aux, t) -> moisture_flux,

--- a/experiments/AtmosLES/rising_bubble_bryan.jl
+++ b/experiments/AtmosLES/rising_bubble_bryan.jl
@@ -29,7 +29,7 @@ const param_set = EarthParameterSet()
 
 # ------------------------ Description ------------------------- #
 # 1) Dry Rising Bubble (circular potential temperature perturbation)
-# 2) Boundaries - `All Walls` : Impenetrable(FreeSlip())
+# 2) Boundaries - `All Walls` : ImpenetrableFreeSlip()
 #                               Laterally periodic
 # 3) Domain - 20000m[horizontal] x 10000m[vertical] (2-dimensional)
 # 4) Timeend - 1000s

--- a/experiments/AtmosLES/rising_bubble_theta_formulation.jl
+++ b/experiments/AtmosLES/rising_bubble_theta_formulation.jl
@@ -13,7 +13,7 @@
 # 1) Dry Rising Bubble (circular potential temperature perturbation)
 # 2) Boundaries
 #    Top and Bottom boundaries:
-#    - `Impenetrable(FreeSlip())` - Top and bottom: no momentum flux, no mass flux through
+#    - `ImpenetrableFreeSlip()` - Top and bottom: no momentum flux, no mass flux through
 #      walls.
 #    - `Impermeable()` - non-porous walls, i.e. no diffusive fluxes through
 #       walls.
@@ -226,11 +226,11 @@ function config_risingbubble(
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
-                momentum = Impenetrable(FreeSlip()),
+                momentum = ImpenetrableFreeSlip(),
                 energy = Adiabaticθ((state, aux, t) -> FT(0)),
             ),
             AtmosBC(
-                momentum = Impenetrable(FreeSlip()),
+                momentum = ImpenetrableFreeSlip(),
                 energy = Adiabaticθ((state, aux, t) -> FT(0)),
             ),
         ),

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -294,11 +294,11 @@ function stable_bl_model(
     moisture_bcs = moisture_model == "dry" ? () : (; moisture = moisture_bc)
     boundary_conditions = (
         AtmosBC(;
-            momentum = Impenetrable(DragLaw(
+            momentum = ImpenetrableDragLaw(
                 # normPu_int is the internal horizontal speed
                 # P represents the projection onto the horizontal
                 (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
-            )),
+            ),
             energy = energy_bc,
             moisture_bcs...,
             turbconv = turbconv_bcs(turbconv)[1],

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -30,7 +30,7 @@ const param_set = EarthParameterSet()
 # 1) Boundary Conditions:
 #       Laterally periodic with no flow penetration through top
 #       and bottom wall boundaries.
-#       Momentum: Impenetrable(FreeSlip())
+#       Momentum: ImpenetrableFreeSlip()
 #       Energy:   Spatially varying non-zero heat flux up to time t₁
 # 2) Domain: 1250m × 1250m × 1000m
 # Configuration defaults are in `src/Driver/Configurations.jl`

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -3,10 +3,9 @@ using CLIMAParameters.Planet: cv_d, T_0
 export InitStateBC
 
 export AtmosBC,
-    Impenetrable,
-    FreeSlip,
-    NoSlip,
-    DragLaw,
+    ImpenetrableFreeSlip,
+    ImpenetrableNoSlip,
+    ImpenetrableDragLaw,
     Insulating,
     PrescribedTemperature,
     PrescribedEnergyFlux,
@@ -23,7 +22,7 @@ export AtmosBC,
 export average_density_sfc_int
 
 """
-    AtmosBC(momentum = Impenetrable(FreeSlip())
+    AtmosBC(momentum = ImpenetrableFreeSlip()
             energy   = Insulating()
             moisture = Impermeable()
             precipitation = OutflowPrecipitation()
@@ -32,7 +31,7 @@ export average_density_sfc_int
 The standard boundary condition for [`AtmosModel`](@ref). The default options imply a "no flux" boundary condition.
 """
 Base.@kwdef struct AtmosBC{M, E, Q, P, TR, TC}
-    momentum::M = Impenetrable(FreeSlip())
+    momentum::M = ImpenetrableFreeSlip()
     energy::E = Insulating()
     moisture::Q = Impermeable()
     precipitation::P = OutflowPrecipitation()

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -29,7 +29,7 @@ import ClimateMachine.VariableTemplates.varsindex
 
 # ------------------------ Description ------------------------- #
 # 1) Dry Rising Bubble (circular potential temperature perturbation)
-# 2) Boundaries - `All Walls` : Impenetrable(FreeSlip())
+# 2) Boundaries - `All Walls` : ImpenetrableFreeSlip()
 #                               Laterally periodic
 # 3) Domain - 2500m[horizontal] x 2500m[horizontal] x 2500m[vertical]
 # 4) Timeend - 1000s

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -39,7 +39,7 @@
 # ```
 #
 # 2) Boundaries
-#    - `Impenetrable(FreeSlip())` - Top and bottom: no momentum flux, no mass flux through
+#    - `ImpenetrableFreeSlip()` - Top and bottom: no momentum flux, no mass flux through
 #      walls.
 #    - `Impermeable()` - non-porous walls, i.e. no diffusive fluxes through
 #       walls.

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -37,7 +37,7 @@
 # and $T = \theta \pi$
 #
 # 2) Boundaries
-#    - `Impenetrable(FreeSlip())` - Top and bottom: no momentum flux, no mass flux through
+#    - `ImpenetrableFreeSlip()` - Top and bottom: no momentum flux, no mass flux through
 #      walls.
 #    - `Impermeable()` - non-porous walls, i.e. no diffusive fluxes through
 #       walls.

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -14,7 +14,7 @@
 #
 # 1) Dry Density Current (circular potential temperature perturbation)
 # 2) Boundaries
-#    - `Impenetrable(FreeSlip())` - no momentum flux, no mass flux through
+#    - `ImpenetrableFreeSlip()` - no momentum flux, no mass flux through
 #      walls.
 #    - `Impermeable()` - non-porous walls, i.e. no diffusive fluxes through
 #       walls.

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -139,11 +139,11 @@ function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
-                momentum = Impenetrable(NoSlip()),
+                momentum = ImpenetrableNoSlip(),
                 energy = PrescribedTemperature((state, aux, t) -> T_bot),
             ),
             AtmosBC(
-                momentum = Impenetrable(NoSlip()),
+                momentum = ImpenetrableNoSlip(),
                 energy = PrescribedTemperature((state, aux, t) -> T_top),
             ),
         ),

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -13,7 +13,7 @@
 # 1) Dry Rising Bubble (circular potential temperature perturbation)
 # 2) Boundaries
 #    Top and Bottom boundaries:
-#    - `Impenetrable(FreeSlip())` - Top and bottom: no momentum flux, no mass flux through
+#    - `ImpenetrableFreeSlip()` - Top and bottom: no momentum flux, no mass flux through
 #      walls.
 #    - `Impermeable()` - non-porous walls, i.e. no diffusive fluxes through
 #       walls.


### PR DESCRIPTION
### Description

When trying to refactor the balance law boundary conditions, it's difficult to work with `Impenetrable` because, without the parameter, it only specifies BCs on a single component of the momentum. @blallen, mind if I spread these changes to the ocean, too?

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
