### PR TITLE
Pass bc arguments with NamedTuple

### DIFF
--- a/src/Atmos/Model/bc_energy.jl
+++ b/src/Atmos/Model/bc_energy.jl
@@ -9,12 +9,12 @@ using ClimateMachine.SurfaceFluxes:
 No energy flux across the boundary.
 """
 struct Insulating <: EnergyBC end
-function atmos_energy_boundary_state!(nf, bc_energy::Insulating, atmos, args...) end
+function atmos_energy_boundary_state!(nf, bc_energy::Insulating, atmos, _...) end
 function atmos_energy_normal_boundary_flux_second_order!(
     nf,
     bc_energy::Insulating,
     atmos,
-    args...,
+    _...,
 ) end
 
 
@@ -31,13 +31,9 @@ function atmos_energy_boundary_state!(
     bc_energy::PrescribedTemperature,
     atmos,
     state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
+    args,
 )
+    @unpack aux⁻, state⁻, t = args
     FT = eltype(aux⁻)
     _T_0::FT = T_0(atmos.param_set)
     _cv_d::FT = cv_d(atmos.param_set)
@@ -52,18 +48,9 @@ function atmos_energy_normal_boundary_flux_second_order!(
     bc_energy::PrescribedTemperature,
     atmos,
     fluxᵀn,
-    n⁻,
-    state⁻,
-    diffusive⁻,
-    hyperdiffusive⁻,
-    aux⁻,
-    state⁺,
-    diffusive⁺,
-    hyperdiffusive⁺,
-    aux⁺,
-    t,
-    args...,
+    args,
 )
+    @unpack state⁻, aux⁻, diffusive⁻, t, n⁻ = args
 
     # TODO: figure out a better way...
     ν, D_t, _ = turbulence_tensors(atmos, state⁻, diffusive⁻, aux⁻, t)
@@ -86,25 +73,16 @@ function atmos_energy_boundary_state!(
     nf,
     bc_energy::PrescribedEnergyFlux,
     atmos,
-    args...,
+    _...,
 ) end
 function atmos_energy_normal_boundary_flux_second_order!(
     nf,
     bc_energy::PrescribedEnergyFlux,
     atmos,
     fluxᵀn,
-    n⁻,
-    state⁻,
-    diffusive⁻,
-    hyperdiffusive⁻,
-    aux⁻,
-    state⁺,
-    diffusive⁺,
-    hyperdiffusive⁺,
-    aux⁺,
-    t,
-    args...,
+    args,
 )
+    @unpack state⁻, aux⁻, t = args
 
     # DG normal is defined in the outward direction
     # we want to prescribe the inward flux
@@ -120,24 +98,16 @@ across the boundary by `fn`, a function with signature
 struct Adiabaticθ{FN} <: EnergyBC
     fn::FN
 end
-function atmos_energy_boundary_state!(nf, bc_energy::Adiabaticθ, atmos, args...) end
+function atmos_energy_boundary_state!(nf, bc_energy::Adiabaticθ, atmos, _...) end
 function atmos_energy_normal_boundary_flux_second_order!(
     nf,
     bc_energy::Adiabaticθ,
     atmos,
     fluxᵀn,
-    n⁻,
-    state⁻,
-    diffusive⁻,
-    hyperdiffusive⁻,
-    aux⁻,
-    state⁺,
-    diffusive⁺,
-    hyperdiffusive⁺,
-    aux⁺,
-    t,
-    args...,
+    args,
 )
+    @unpack state⁻, aux⁻, t = args
+
     # DG normal is defined in the outward direction
     # we want to prescribe the inward flux
     fluxᵀn.energy.ρθ_liq_ice -= bc_energy.fn(state⁻, aux⁻, t)
@@ -158,27 +128,16 @@ function atmos_energy_boundary_state!(
     nf,
     bc_energy::BulkFormulaEnergy,
     atmos,
-    args...,
+    _...,
 ) end
 function atmos_energy_normal_boundary_flux_second_order!(
     nf,
     bc_energy::BulkFormulaEnergy,
     atmos,
     fluxᵀn,
-    n⁻,
-    state⁻,
-    diffusive⁻,
-    hyperdiffusive⁻,
-    aux⁻,
-    state⁺,
-    diffusive⁺,
-    hyperdiffusive⁺,
-    aux⁺,
-    t,
-    state_int⁻,
-    diffusive_int⁻,
-    aux_int⁻,
+    args,
 )
+    @unpack state⁻, aux⁻, t, state_int⁻, aux_int⁻ = args
 
     u_int⁻ = state_int⁻.ρu / state_int⁻.ρ
     u_int⁻_tan = projection_tangential(atmos, aux_int⁻, u_int⁻)
@@ -213,27 +172,17 @@ function atmos_energy_boundary_state!(
     nf,
     bc_energy::NishizawaEnergyFlux,
     atmos,
-    args...,
+    _...,
 ) end
 function atmos_energy_normal_boundary_flux_second_order!(
     nf,
     bc_energy::NishizawaEnergyFlux,
     atmos,
     fluxᵀn,
-    n⁻,
-    state⁻,
-    diffusive⁻,
-    hyperdiffusive⁻,
-    aux⁻,
-    state⁺,
-    diffusive⁺,
-    hyperdiffusive⁺,
-    aux⁺,
-    t,
-    state_int⁻,
-    diffusive_int⁻,
-    aux_int⁻,
+    args,
 )
+    @unpack state⁻, aux⁻, t, aux_int⁻, state_int⁻ = args
+
     FT = eltype(state⁻)
     # Interior state
     u_int⁻ = state_int⁻.ρu / state_int⁻.ρ

--- a/src/Atmos/Model/bc_moisture.jl
+++ b/src/Atmos/Model/bc_moisture.jl
@@ -10,13 +10,13 @@ function atmos_moisture_boundary_state!(
     nf,
     bc_moisture::Impermeable,
     atmos,
-    args...,
+    _...,
 ) end
 function atmos_moisture_normal_boundary_flux_second_order!(
     nf,
     bc_moisture::Impermeable,
     atmos,
-    args...,
+    _...,
 ) end
 
 
@@ -33,25 +33,16 @@ function atmos_moisture_boundary_state!(
     nf,
     bc_moisture::PrescribedMoistureFlux,
     atmos,
-    args...,
+    _...,
 ) end
 function atmos_moisture_normal_boundary_flux_second_order!(
     nf,
     bc_moisture::PrescribedMoistureFlux,
     atmos,
     fluxᵀn,
-    n⁻,
-    state⁻,
-    diffusive⁻,
-    hyperdiffusive⁻,
-    aux⁻,
-    state⁺,
-    diffusive⁺,
-    hyperdiffusive⁺,
-    aux⁺,
-    t,
-    args...,
+    args,
 )
+    @unpack state⁻, aux⁻, t = args
 
     nρd_q_tot = -bc_moisture.fn(state⁻, aux⁻, t)
     fluxᵀn.ρ += nρd_q_tot
@@ -78,27 +69,16 @@ function atmos_moisture_boundary_state!(
     nf,
     bc_moisture::BulkFormulaMoisture,
     atmos,
-    args...,
+    _...,
 ) end
 function atmos_moisture_normal_boundary_flux_second_order!(
     nf,
     bc_moisture::BulkFormulaMoisture,
     atmos,
     fluxᵀn,
-    n⁻,
-    state⁻,
-    diffusive⁻,
-    hyperdiffusive⁻,
-    aux⁻,
-    state⁺,
-    diffusive⁺,
-    hyperdiffusive⁺,
-    aux⁺,
-    t,
-    state_int⁻,
-    diffusive_int⁻,
-    aux_int⁻,
+    args,
 )
+    @unpack state⁻, aux⁻, t, aux_int⁻, state_int⁻ = args
 
     u_int⁻ = state_int⁻.ρu / state_int⁻.ρ
     u_int⁻_tan = projection_tangential(atmos, aux_int⁻, u_int⁻)

--- a/src/Atmos/Model/bc_momentum.jl
+++ b/src/Atmos/Model/bc_momentum.jl
@@ -26,13 +26,9 @@ function atmos_momentum_boundary_state!(
     bc_momentum::Impenetrable{FreeSlip},
     atmos,
     state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
+    args,
 )
+    @unpack state⁻, n = args
     state⁺.ρu -= 2 * dot(state⁻.ρu, n) .* SVector(n)
 end
 function atmos_momentum_boundary_state!(
@@ -40,20 +36,16 @@ function atmos_momentum_boundary_state!(
     bc_momentum::Impenetrable{FreeSlip},
     atmos,
     state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
+    args,
 )
+    @unpack state⁻, n = args
     state⁺.ρu -= dot(state⁻.ρu, n) .* SVector(n)
 end
 function atmos_momentum_normal_boundary_flux_second_order!(
     nf,
     bc_momentum::Impenetrable{FreeSlip},
     atmos,
-    args...,
+    _...,
 ) end
 
 
@@ -70,13 +62,9 @@ function atmos_momentum_boundary_state!(
     bc_momentum::Impenetrable{NoSlip},
     atmos,
     state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
+    args,
 )
+    @unpack state⁻ = args
     state⁺.ρu = -state⁻.ρu
 end
 function atmos_momentum_boundary_state!(
@@ -84,12 +72,7 @@ function atmos_momentum_boundary_state!(
     bc_momentum::Impenetrable{NoSlip},
     atmos,
     state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
+    args,
 )
     state⁺.ρu = zero(state⁺.ρu)
 end
@@ -97,7 +80,7 @@ function atmos_momentum_normal_boundary_flux_second_order!(
     nf,
     bc_momentum::Impenetrable{NoSlip},
     atmos,
-    args...,
+    _...,
 ) end
 
 
@@ -117,24 +100,14 @@ function atmos_momentum_boundary_state!(
     bc_momentum::Impenetrable{DL},
     atmos,
     state⁺,
-    aux⁺,
-    n,
-    state⁻,
-    aux⁻,
-    t,
-    args...,
+    args,
 ) where {DL <: DragLaw}
     atmos_momentum_boundary_state!(
         nf,
         Impenetrable(FreeSlip()),
         atmos,
         state⁺,
-        aux⁺,
-        n,
-        state⁻,
-        aux⁻,
-        t,
-        args...,
+        args,
     )
 end
 function atmos_momentum_normal_boundary_flux_second_order!(
@@ -142,23 +115,12 @@ function atmos_momentum_normal_boundary_flux_second_order!(
     bc_momentum::Impenetrable{DL},
     atmos,
     fluxᵀn,
-    n,
-    state⁻,
-    diffusive⁻,
-    hyperdiffusive⁻,
-    aux⁻,
-    state⁺,
-    diffusive⁺,
-    hyperdiffusive⁺,
-    aux⁺,
-    t,
-    state_int⁻,
-    diffusive_int⁻,
-    aux_int⁻,
+    args,
 ) where {DL <: DragLaw}
+    @unpack state⁻, aux⁻, n⁻, t, aux_int⁻, state_int⁻ = args
 
     u1⁻ = state_int⁻.ρu / state_int⁻.ρ
-    u_int⁻_tan = u1⁻ - dot(u1⁻, n) .* SVector(n)
+    u_int⁻_tan = u1⁻ - dot(u1⁻, n⁻) .* SVector(n⁻)
     normu_int⁻_tan = norm(u_int⁻_tan)
     # NOTE: difference from design docs since normal points outwards
     C = bc_momentum.drag.fn(state⁻, aux⁻, t, normu_int⁻_tan)

--- a/src/Atmos/Model/bc_precipitation.jl
+++ b/src/Atmos/Model/bc_precipitation.jl
@@ -10,11 +10,11 @@ function atmos_precipitation_boundary_state!(
     nf,
     bc_precipitation::OutflowPrecipitation,
     atmos,
-    args...,
+    _...,
 ) end
 function atmos_precipitation_normal_boundary_flux_second_order!(
     nf,
     bc_precipitation::OutflowPrecipitation,
     atmos,
-    args...,
+    _...,
 ) end

--- a/src/Atmos/Model/bc_tracer.jl
+++ b/src/Atmos/Model/bc_tracer.jl
@@ -10,7 +10,7 @@ function atmos_tracer_boundary_state!(
     nf,
     bc_tracer::ImpermeableTracer,
     atmos,
-    args...,
+    _...,
 )
     nothing
 end
@@ -18,7 +18,7 @@ function atmos_tracer_normal_boundary_flux_second_order!(
     nf,
     bc_tracer::ImpermeableTracer,
     atmos,
-    args...,
+    _...,
 )
     nothing
 end

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -53,20 +53,13 @@ function boundary_state!(
     state⁻,
     aux⁻,
     t,
-    args...,
+    state_int⁻,
+    aux_int⁻,
 )
-    atmos_boundary_state!(
-        nf,
-        bc,
-        atmos,
-        state⁺,
-        aux⁺,
-        n,
-        state⁻,
-        aux⁻,
-        t,
-        args...,
-    )
+
+    args = (; aux⁺, state⁻, aux⁻, t, n, state_int⁻, aux_int⁻)
+
+    atmos_boundary_state!(nf, bc, atmos, state⁺, args)
     # update moisture auxiliary variables (perform saturation adjustment, if necessary)
     # to make thermodynamic quantities consistent with the boundary state
     atmos_nodal_update_auxiliary_state!(atmos.moisture, atmos, state⁺, aux⁺, t)
@@ -81,13 +74,19 @@ function boundary_state!(
     nothing
 end
 
-function atmos_boundary_state!(nf, bc::AtmosBC, atmos, args...)
-    atmos_momentum_boundary_state!(nf, bc.momentum, atmos, args...)
-    atmos_energy_boundary_state!(nf, bc.energy, atmos, args...)
-    atmos_moisture_boundary_state!(nf, bc.moisture, atmos, args...)
-    atmos_precipitation_boundary_state!(nf, bc.precipitation, atmos, args...)
-    atmos_tracer_boundary_state!(nf, bc.tracer, atmos, args...)
-    turbconv_boundary_state!(nf, bc.turbconv, atmos, args...)
+function atmos_boundary_state!(nf, bc::AtmosBC, atmos, state⁺, args)
+    atmos_momentum_boundary_state!(nf, bc.momentum, atmos, state⁺, args)
+    atmos_energy_boundary_state!(nf, bc.energy, atmos, state⁺, args)
+    atmos_moisture_boundary_state!(nf, bc.moisture, atmos, state⁺, args)
+    atmos_precipitation_boundary_state!(
+        nf,
+        bc.precipitation,
+        atmos,
+        state⁺,
+        args,
+    )
+    atmos_tracer_boundary_state!(nf, bc.tracer, atmos, state⁺, args)
+    turbconv_boundary_state!(nf, bc.turbconv, atmos, state⁺, args)
 end
 
 
@@ -98,33 +97,32 @@ function normal_boundary_flux_second_order!(
     fluxᵀn::Vars{S},
     n⁻,
     state⁻,
-    diff⁻,
+    diffusive⁻,
     hyperdiff⁻,
     aux⁻,
     state⁺,
-    diff⁺,
+    diffusive⁺,
     hyperdiff⁺,
     aux⁺,
     t,
-    args...,
+    state_int⁻,
+    diffusive_int⁻,
+    aux_int⁻,
 ) where {S}
-    atmos_normal_boundary_flux_second_order!(
-        nf,
-        bc,
-        atmos,
-        fluxᵀn,
+
+    args = (;
         n⁻,
         state⁻,
-        diff⁻,
+        diffusive⁻,
         hyperdiff⁻,
         aux⁻,
-        state⁺,
-        diff⁺,
-        hyperdiff⁺,
-        aux⁺,
         t,
-        args...,
+        state_int⁻,
+        diffusive_int⁻,
+        aux_int⁻,
     )
+
+    atmos_normal_boundary_flux_second_order!(nf, bc, atmos, fluxᵀn, args)
 end
 
 function atmos_normal_boundary_flux_second_order!(

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -173,15 +173,25 @@ function boundary_state!(
     nf::NumericalFluxFirstOrder,
     bc,
     atmoslm::AtmosLinearModel,
-    args...,
+    state⁺,
+    aux⁺,
+    n,
+    state⁻,
+    aux⁻,
+    t,
+    state_int⁻,
+    aux_int⁻,
 )
-    atmos_boundary_state!(nf, bc, atmoslm, args...)
+
+    args = (; aux⁺, state⁻, aux⁻, t, n, state_int⁻, aux_int⁻)
+
+    atmos_boundary_state!(nf, bc, atmoslm, state⁺, args)
 end
 function boundary_state!(
     nf::NumericalFluxSecondOrder,
     bc,
     atmoslm::AtmosLinearModel,
-    args...,
+    _...,
 )
     nothing
 end

--- a/src/Common/TurbulenceConvection/boundary_conditions.jl
+++ b/src/Common/TurbulenceConvection/boundary_conditions.jl
@@ -17,7 +17,7 @@ struct NoTurbConvBC <: TurbConvBC end
 
 turbconv_bcs(::NoTurbConv) = (NoTurbConvBC(), NoTurbConvBC())
 
-function turbconv_boundary_state!(nf, bc_turbulence::NoTurbConvBC, bl, args...)
+function turbconv_boundary_state!(nf, bc_turbulence::NoTurbConvBC, bl, _...)
     nothing
 end
 
@@ -25,7 +25,7 @@ function turbconv_normal_boundary_flux_second_order!(
     nf,
     bc_turbulence::NoTurbConvBC,
     bl,
-    args...,
+    _...,
 )
     nothing
 end


### PR DESCRIPTION
### Description

In this PR, a NamedTuple is constructed with most arguments in `boundary_state!` and `normal_boundary_flux_second_order!`, and only parameters needed are `@unpack`ed in the bc implementation functions.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
