### PR TITLE
Fix call to f_h

### DIFF
--- a/src/Common/SurfaceFluxes/UniversalFunctions.jl
+++ b/src/Common/SurfaceFluxes/UniversalFunctions.jl
@@ -207,11 +207,11 @@ function Psi(uf::Businger, ζ, tt::HeatTransport)
             return -9 * ζ / 4
         end
     else
-        f_h = f_heat(uf, ζ)
-        if uf.L >= 0
+        if ζ >= 0
             _π_group = FT(π_group(uf, tt))
             return -_a_h * ζ / (2 * _π_group)
         else
+            f_h = f_heat(uf, ζ)
             log_term = 2 * log((1 + f_h) / 2)
             return log_term + 2 * (1 - f_h) / (9 * ζ) - 1
         end


### PR DESCRIPTION
### Description

This PR fixes a small bug regarding the universal function `Psi_h`. `f_h` is only needed in conditions of `ζ<0`, and can be ill-defined otherwise. This PR moves the call to that function to the appropriate conditional block.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
