### PR TITLE
enable netcdf diagnostics for stable boundary layer case in EDMF set up

### DIFF
--- a/test/Atmos/EDMF/stable_bl_edmf.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf.jl
@@ -154,7 +154,7 @@ function main(::Type{FT}, cl_args) where {FT}
     )
     # ---
 
-    dgn_config = config_diagnostics(driver_config)
+    dgn_config = config_diagnostics(driver_config, timeend)
 
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
         Filters.apply!(
@@ -210,6 +210,41 @@ function main(::Type{FT}, cl_args) where {FT}
     push!(time_data, gettime(solver_config.solver))
 
     return solver_config, diag_arr, time_data
+end
+
+function config_diagnostics(driver_config, timeend)
+    FT = eltype(driver_config.grid)
+    info = driver_config.config_info
+    interval = "$(cld(timeend, 2) + 10)ssecs"
+    #interval = "10steps"
+
+    boundaries = [
+        FT(0) FT(0) FT(0)
+        FT(info.hmax) FT(info.hmax) FT(info.zmax)
+    ]
+    axes = (
+        [FT(1)],
+        [FT(1)],
+        collect(range(boundaries[1, 3], boundaries[2, 3], step = FT(50)),),
+    )
+    interpol = ClimateMachine.InterpolationConfiguration(
+        driver_config,
+        boundaries;
+        axes = axes,
+    )
+    ds_dgngrp = setup_dump_state_diagnostics(
+        SingleStackConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+    dt_dgngrp = setup_dump_tendencies_diagnostics(
+        SingleStackConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+    return ClimateMachine.DiagnosticsConfiguration([ds_dgngrp, dt_dgngrp])
 end
 
 # add a command line argument to specify the kind of surface flux


### PR DESCRIPTION
### Description

This PR adds a single stack diagnostic configuration for the `stable_bl_edmf.jl` driver that enables the netcdf output for the experiment.

```
CLIMA_OUTPUT='/central/scratch/jiahe/edmf_sbl'
julia --project --diagnostics default --output-dir $CLIMA_OUTPUT
```
dumps the following two data
```
SBL_EDMF_DumpState.nc
SBL_EDMF_DumpTendencies.nc
```

vars in `SBL_EDMF_DumpState.nc`
```
netcdf SBL_EDMF_DumpState {
dimensions:
	x = 1 ;
	y = 1 ;
	z = 9 ;
	time = UNLIMITED ; // (1 currently)
variables:
	double x(x) ;
	double y(y) ;
	double z(z) ;
	double time(time) ;
		time:units = "seconds since 1900-01-01 00:00:00" ;
		time:long_name = "time" ;
	double ρ(time, z, y, x) ;
	double ρu\[1\](time, z, y, x) ;
	double ρu\[2\](time, z, y, x) ;
	double ρu\[3\](time, z, y, x) ;
	double energy.ρe(time, z, y, x) ;
	double turbconv.environment.ρatke(time, z, y, x) ;
	double turbconv.environment.ρaθ_liq_cv(time, z, y, x) ;
	double turbconv.environment.ρaq_tot_cv(time, z, y, x) ;
	double turbconv.environment.ρaθ_liq_q_tot_cv(time, z, y, x) ;
	double turbconv.updraft\[1\].ρa(time, z, y, x) ;
	double turbconv.updraft\[1\].ρaw(time, z, y, x) ;
	double turbconv.updraft\[1\].ρaθ_liq(time, z, y, x) ;
	double turbconv.updraft\[1\].ρaq_tot(time, z, y, x) ;
}
```

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
