### PR TITLE
improve diagnostic configuration interface for edmf

### DIFF
--- a/test/Atmos/EDMF/bomex_edmf.jl
+++ b/test/Atmos/EDMF/bomex_edmf.jl
@@ -10,6 +10,7 @@ using JLD2, FileIO
 const clima_dir = dirname(dirname(pathof(ClimateMachine)));
 
 include(joinpath(clima_dir, "experiments", "AtmosLES", "bomex_model.jl"))
+include(joinpath("helper_funcs", "diagnostics_configuration.jl"))
 include("edmf_model.jl")
 include("edmf_kernels.jl")
 
@@ -163,7 +164,8 @@ function main(::Type{FT}, cl_args) where {FT}
     )
     # ---
 
-    dgn_config = config_diagnostics(driver_config, timeend)
+    dgn_config =
+        config_diagnostics(driver_config, timeend; interval = "50ssecs")
 
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
         Filters.apply!(
@@ -228,40 +230,6 @@ function main(::Type{FT}, cl_args) where {FT}
     return solver_config, diag_arr, time_data
 end
 
-function config_diagnostics(driver_config, timeend)
-    FT = eltype(driver_config.grid)
-    info = driver_config.config_info
-    interval = "$(cld(timeend, 2) + 10)ssecs"
-    #interval = "10steps"
-
-    boundaries = [
-        FT(0) FT(0) FT(0)
-        FT(info.hmax) FT(info.hmax) FT(info.zmax)
-    ]
-    axes = (
-        [FT(1)],
-        [FT(1)],
-        collect(range(boundaries[1, 3], boundaries[2, 3], step = FT(50)),),
-    )
-    interpol = ClimateMachine.InterpolationConfiguration(
-        driver_config,
-        boundaries;
-        axes = axes,
-    )
-    ds_dgngrp = setup_dump_state_diagnostics(
-        SingleStackConfigType(),
-        interval,
-        driver_config.name,
-        interpol = interpol,
-    )
-    dt_dgngrp = setup_dump_tendencies_diagnostics(
-        SingleStackConfigType(),
-        interval,
-        driver_config.name,
-        interpol = interpol,
-    )
-    return ClimateMachine.DiagnosticsConfiguration([ds_dgngrp, dt_dgngrp])
-end
 
 # add a command line argument to specify the kind of surface flux
 # TODO: this will move to the future namelist functionality

--- a/test/Atmos/EDMF/helper_funcs/diagnostics_configuration.jl
+++ b/test/Atmos/EDMF/helper_funcs/diagnostics_configuration.jl
@@ -1,0 +1,42 @@
+"""
+    config_diagnostics(driver_config, timeend; interval=nothing)
+
+Returns the state and tendency diagnostic groups
+"""
+
+function config_diagnostics(driver_config, timeend; interval = nothing)
+    FT = eltype(driver_config.grid)
+    info = driver_config.config_info
+    if interval == nothing
+        interval = "$(cld(timeend, 2) + 10)ssecs"
+        #interval = "10steps"
+    end
+
+    boundaries = [
+        FT(0) FT(0) FT(0)
+        FT(info.hmax) FT(info.hmax) FT(info.zmax)
+    ]
+    axes = (
+        [FT(1)],
+        [FT(1)],
+        collect(range(boundaries[1, 3], boundaries[2, 3], step = FT(50)),),
+    )
+    interpol = ClimateMachine.InterpolationConfiguration(
+        driver_config,
+        boundaries;
+        axes = axes,
+    )
+    ds_dgngrp = setup_dump_state_diagnostics(
+        SingleStackConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+    dt_dgngrp = setup_dump_tendencies_diagnostics(
+        SingleStackConfigType(),
+        interval,
+        driver_config.name,
+        interpol = interpol,
+    )
+    return ClimateMachine.DiagnosticsConfiguration([ds_dgngrp, dt_dgngrp])
+end

--- a/test/Atmos/EDMF/helper_funcs/diagnostics_configuration.jl
+++ b/test/Atmos/EDMF/helper_funcs/diagnostics_configuration.jl
@@ -3,7 +3,6 @@
 
 Returns the state and tendency diagnostic groups
 """
-
 function config_diagnostics(driver_config, timeend; interval = nothing)
     FT = eltype(driver_config.grid)
     info = driver_config.config_info

--- a/test/Atmos/EDMF/stable_bl_edmf.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf.jl
@@ -6,6 +6,7 @@ using ClimateMachine.BalanceLaws: vars_state
 const clima_dir = dirname(dirname(pathof(ClimateMachine)));
 
 include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))
+include(joinpath("helper_funcs", "diagnostics_configuration.jl"))
 include("edmf_model.jl")
 include("edmf_kernels.jl")
 
@@ -154,7 +155,8 @@ function main(::Type{FT}, cl_args) where {FT}
     )
     # ---
 
-    dgn_config = config_diagnostics(driver_config)
+    dgn_config =
+        config_diagnostics(driver_config, timeend; interval = "10ssecs")
 
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do
         Filters.apply!(
@@ -211,6 +213,7 @@ function main(::Type{FT}, cl_args) where {FT}
 
     return solver_config, diag_arr, time_data
 end
+
 
 # add a command line argument to specify the kind of surface flux
 # TODO: this will move to the future namelist functionality


### PR DESCRIPTION
This PR adds diagnostics_configuration in edmf helper_function and enables netcdf diagnostics in bomex and sbl edmf driver.

### Description

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
