### PR TITLE
Better docstring for --cutoff-degree CL option

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -314,7 +314,7 @@ function parse_commandline(
         arg_type = NTuple{2, Int}
         default = get_setting(:degree, defaults, global_defaults)
         "--cutoff-degree"
-        help = "tuple of horizontal and vertical polynomial degrees for cutoff filter (no space before/after comma)"
+        help = "tuple of horizontal and vertical polynomial degrees to keep when applying a cutoff filter (no space before/after comma)"
         metavar = "<horizontal>,<vertical>"
         arg_type = NTuple{2, Int}
         default = get_setting(:cutoff_degree, defaults, global_defaults)


### PR DESCRIPTION
### Description
Will this close #2047  ? 
cc: @jkozdon , @simonbyrne 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
