### PR TITLE
Add analytics to CI doc build

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -20,12 +20,8 @@ jobs:
         access_token: ${{ github.token }}
 
     - uses: actions/checkout@v2.2.0
-      with:
-        fetch-depth: 0
 
-    - run: git fetch origin
-    
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v2.9.1
       id: filter
       with:
         filters: |
@@ -35,7 +31,7 @@ jobs:
     - uses: julia-actions/setup-julia@latest
       if: steps.filter.outputs.julia_file_change == 'true'
       with:
-        version: 1.5.2
+        version: 1.5.3
 
     - name: Apply JuliaFormatter
       if: steps.filter.outputs.julia_file_change == 'true'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -46,9 +46,10 @@ mathengine = MathJax(Dict(
 ))
 
 format = Documenter.HTML(
-    prettyurls = get(ENV, "CI", "") == "true",
+    prettyurls = get(ENV, "CI", "") != "" ? true : false,
     mathengine = mathengine,
     collapselevel = 1,
+    analytics = get(ENV, "CI", "") != "" ? "UA-191640394-1" : "",
 )
 
 makedocs(


### PR DESCRIPTION
### Description

Add analytics to published doc build to track engagement with project documentation. 

cc @valeriabarra 

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
