### PR TITLE
Clean up AtmosModel constructor

### DIFF
--- a/docs/src/GettingStarted/Atmos.md
+++ b/docs/src/GettingStarted/Atmos.md
@@ -44,7 +44,6 @@ possible options for each subcomponent.
 ```
     ::Type{AtmosGCMConfigType},
     param_set::AbstractParameterSet;
-    orientation::O = SphericalOrientation(),
     ref_state::RS = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),)
     turbulence::T = SmagorinskyLilly{FT}(C_smag(param_set)),
     hyperdiffusion::HD = NoHyperDiffusion(),

--- a/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
+++ b/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
@@ -193,7 +193,6 @@ function config_gcm_experiment(
         AtmosGCMConfigType,
         param_set;
         problem = problem,
-        orientation = orientation,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         hyperdiffusion = hyperdiffusion,

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -209,54 +209,33 @@ struct Anelastic1D <: Compressibilty end
 """
     AtmosModel{FT}()
 
-Constructor for `AtmosModel` (where `AtmosModel <: BalanceLaw`) for LES
-and single stack configurations.
+Constructor for `AtmosModel` (where `AtmosModel <: BalanceLaw`).
 """
 function AtmosModel{FT}(
-    ::Union{Type{AtmosLESConfigType}, Type{SingleStackConfigType}},
+    orientation::Orientation,
     param_set::AbstractParameterSet;
-    init_state_prognostic::ISP = nothing,
-    problem::PR = AtmosProblem(init_state_prognostic = init_state_prognostic),
-    orientation::O = FlatOrientation(),
-    energy::E = EnergyModel(),
-    ref_state::RS = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),),
-    turbulence::T = SmagorinskyLilly{FT}(0.21),
-    turbconv::TC = NoTurbConv(),
-    hyperdiffusion::HD = NoHyperDiffusion(),
-    viscoussponge::VS = NoViscousSponge(),
-    moisture::M = EquilMoist{FT}(),
-    precipitation::P = NoPrecipitation(),
-    radiation::R = NoRadiation(),
-    source::S = (
+    init_state_prognostic = nothing,
+    problem = AtmosProblem(init_state_prognostic = init_state_prognostic),
+    energy = EnergyModel(),
+    ref_state = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),),
+    turbulence = SmagorinskyLilly{FT}(C_smag(param_set)),
+    turbconv = NoTurbConv(),
+    hyperdiffusion = NoHyperDiffusion(),
+    viscoussponge = NoViscousSponge(),
+    moisture = EquilMoist{FT}(),
+    precipitation = NoPrecipitation(),
+    radiation = NoRadiation(),
+    source = (
         Gravity(),
         Coriolis(),
         GeostrophicForcing(FT, 7.62e-5, 0, 0),
         turbconv_sources(turbconv)...,
     ),
-    tracers::TR = NoTracers(),
-    lsforcing::LF = NoLSForcing(),
-    compressibility::C = Compressible(),
-    data_config::DC = nothing,
-) where {
-    FT <: AbstractFloat,
-    ISP,
-    PR,
-    O,
-    E,
-    RS,
-    T,
-    TC,
-    HD,
-    VS,
-    M,
-    P,
-    R,
-    S,
-    TR,
-    LF,
-    C,
-    DC,
-}
+    tracers = NoTracers(),
+    lsforcing = NoLSForcing(),
+    compressibility = Compressible(),
+    data_config = nothing,
+) where {FT <: AbstractFloat}
     @assert !any(isa.(source, Tuple))
 
     atmos = (
@@ -285,73 +264,29 @@ end
 """
     AtmosModel{FT}()
 
+Constructor for `AtmosModel` (where `AtmosModel <: BalanceLaw`) for LES
+and single stack configurations.
+"""
+function AtmosModel{FT}(
+    ::Union{Type{AtmosLESConfigType}, Type{SingleStackConfigType}},
+    param_set::AbstractParameterSet;
+    kwargs...,
+) where {FT <: AbstractFloat}
+    return AtmosModel{FT}(FlatOrientation(), param_set; kwargs...)
+end
+
+"""
+    AtmosModel{FT}()
+
 Constructor for `AtmosModel` (where `AtmosModel <: BalanceLaw`) for GCM
 configurations.
 """
 function AtmosModel{FT}(
     ::Type{AtmosGCMConfigType},
     param_set::AbstractParameterSet;
-    init_state_prognostic::ISP = nothing,
-    problem::PR = AtmosProblem(init_state_prognostic = init_state_prognostic),
-    orientation::O = SphericalOrientation(),
-    energy::E = EnergyModel(),
-    ref_state::RS = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),),
-    turbulence::T = SmagorinskyLilly{FT}(C_smag(param_set)),
-    turbconv::TC = NoTurbConv(),
-    hyperdiffusion::HD = NoHyperDiffusion(),
-    viscoussponge::VS = NoViscousSponge(),
-    moisture::M = EquilMoist{FT}(),
-    precipitation::P = NoPrecipitation(),
-    radiation::R = NoRadiation(),
-    source::S = (Gravity(), Coriolis(), turbconv_sources(turbconv)...),
-    tracers::TR = NoTracers(),
-    lsforcing::LF = NoLSForcing(),
-    compressibility::C = Compressible(),
-    data_config::DC = nothing,
-) where {
-    FT <: AbstractFloat,
-    ISP,
-    PR,
-    O,
-    E,
-    RS,
-    T,
-    TC,
-    HD,
-    VS,
-    M,
-    P,
-    R,
-    S,
-    TR,
-    LF,
-    C,
-    DC,
-}
-
-    @assert !any(isa.(source, Tuple))
-
-    atmos = (
-        param_set,
-        problem,
-        orientation,
-        energy,
-        ref_state,
-        turbulence,
-        turbconv,
-        hyperdiffusion,
-        viscoussponge,
-        moisture,
-        precipitation,
-        radiation,
-        source,
-        tracers,
-        lsforcing,
-        compressibility,
-        data_config,
-    )
-
-    return AtmosModel{FT, typeof.(atmos)...}(atmos...)
+    kwargs...,
+) where {FT <: AbstractFloat}
+    return AtmosModel{FT}(SphericalOrientation(), param_set; kwargs...)
 end
 
 """

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -270,9 +270,10 @@ and single stack configurations.
 function AtmosModel{FT}(
     ::Union{Type{AtmosLESConfigType}, Type{SingleStackConfigType}},
     param_set::AbstractParameterSet;
+    orientation = FlatOrientation(),
     kwargs...,
 ) where {FT <: AbstractFloat}
-    return AtmosModel{FT}(FlatOrientation(), param_set; kwargs...)
+    return AtmosModel{FT}(orientation, param_set; kwargs...)
 end
 
 """
@@ -284,9 +285,10 @@ configurations.
 function AtmosModel{FT}(
     ::Type{AtmosGCMConfigType},
     param_set::AbstractParameterSet;
+    orientation = SphericalOrientation(),
     kwargs...,
 ) where {FT <: AbstractFloat}
-    return AtmosModel{FT}(SphericalOrientation(), param_set; kwargs...)
+    return AtmosModel{FT}(orientation, param_set; kwargs...)
 end
 
 """

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -78,14 +78,12 @@ function main()
 
     setup = AcousticWaveSetup{FT}()
     T_profile = IsothermalProfile(param_set, setup.T_ref)
-    orientation = SphericalOrientation()
     ref_state = HydrostaticState(T_profile)
     turbulence = ConstantDynamicViscosity(FT(0))
     model = AtmosModel{FT}(
         AtmosGCMConfigType,
         param_set;
         init_state_prognostic = setup,
-        orientation = orientation,
         ref_state = ref_state,
         turbulence = turbulence,
         moisture = DryModel(),

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -69,14 +69,12 @@ function main()
 
     setup = AcousticWaveSetup{FT}()
     T_profile = IsothermalProfile(param_set, setup.T_ref)
-    orientation = SphericalOrientation()
     ref_state = HydrostaticState(T_profile)
     turbulence = ConstantDynamicViscosity(FT(0))
     model = AtmosModel{FT}(
         AtmosGCMConfigType,
         param_set;
         init_state_prognostic = setup,
-        orientation = orientation,
         ref_state = ref_state,
         turbulence = turbulence,
         moisture = DryModel(),

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -117,7 +117,6 @@ function test_run(
         AtmosGCMConfigType,
         param_set;
         init_state_prognostic = setup,
-        orientation = SphericalOrientation(),
         ref_state = HydrostaticState(T_profile),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),

--- a/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
@@ -116,7 +116,6 @@ function test_run(
         AtmosGCMConfigType,
         param_set;
         init_state_prognostic = setup,
-        orientation = SphericalOrientation(),
         ref_state = HydrostaticState(T_profile),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),

--- a/test/Numerics/DGMethods/Euler/fvm_balance.jl
+++ b/test/Numerics/DGMethods/Euler/fvm_balance.jl
@@ -105,11 +105,9 @@ function test_run(
 
     if domain_type === :box
         configtype = AtmosLESConfigType
-        orientation = FlatOrientation()
         source = (Gravity(),)
     elseif domain_type === :sphere
         configtype = AtmosGCMConfigType
-        orientation = SphericalOrientation()
         source = (Gravity(), Coriolis())
     end
 
@@ -117,7 +115,6 @@ function test_run(
         configtype,
         param_set;
         problem = problem,
-        orientation = orientation,
         ref_state = ref_state,
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),

--- a/tutorials/Numerics/TimeStepping/tutorial_acousticwave_config.jl
+++ b/tutorials/Numerics/TimeStepping/tutorial_acousticwave_config.jl
@@ -77,14 +77,12 @@ function run_acousticwave(
 
     setup = AcousticWaveSetup{FT}()
     T_profile = IsothermalProfile(param_set, setup.T_ref)
-    orientation = SphericalOrientation()
     ref_state = HydrostaticState(T_profile)
     turbulence = ConstantDynamicViscosity(FT(0))
     model = AtmosModel{FT}(
         AtmosGCMConfigType,
         param_set;
         init_state_prognostic = setup,
-        orientation = orientation,
         ref_state = ref_state,
         turbulence = turbulence,
         moisture = DryModel(),


### PR DESCRIPTION
### Description

This PR
 - Unifies the GCM / SingleStack / LES constructors, since the only difference is the orientation
 - Removes the type parameters from the constructors, since there are no restrictions on the types anyway.
 - Changes `turbulence::T = SmagorinskyLilly{FT}(0.21),` to `turbulence = SmagorinskyLilly{FT}(C_smag(param_set))` for `::Union{Type{AtmosLESConfigType}, Type{SingleStackConfigType}}` constructors, since [this is the default in CLIMAParameters.jl](https://github.com/CliMA/CLIMAParameters.jl/blob/master/src/Atmos/atmos_parameters.jl#L4) anyway.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
