### PR TITLE
Add a radiative energy flux module to the soil model

### DIFF
--- a/docs/src/APIs/Land/LandModel.md
+++ b/docs/src/APIs/Land/LandModel.md
@@ -30,6 +30,7 @@ ClimateMachine.Land.LandDomainBC
 ClimateMachine.Land.LandComponentBC
 ClimateMachine.Land.NoBC
 ClimateMachine.Land.SurfaceDrivenWaterBoundaryConditions
+ClimateMachine.Land.SurfaceDrivenHeatBoundaryConditions
 ClimateMachine.Land.Dirichlet
 ClimateMachine.Land.Neumann
 ```

--- a/docs/src/APIs/Land/RadiativeEnergyFlux.md
+++ b/docs/src/APIs/Land/RadiativeEnergyFlux.md
@@ -1,0 +1,14 @@
+# RadiativeEnergyFlux
+
+```@meta
+CurrentModule = ClimateMachine.Land.RadiativeEnergyFlux
+```
+
+## RadiativeEnergyFlux types and functions
+```@docs
+AbstractNetSwFluxModel
+PrescribedSwFluxAndAlbedo
+PrescribedNetSwFlux
+compute_net_sw_flux
+compute_net_radiative_energy_flux
+```

--- a/src/Land/Model/LandModel.jl
+++ b/src/Land/Model/LandModel.jl
@@ -220,6 +220,8 @@ function init_state_prognostic!(
     land.init_state_prognostic(land, state, aux, coords, t, args...)
 end
 
+include("RadiativeEnergyFlux.jl")
+using .RadiativeEnergyFlux
 include("SoilWaterParameterizations.jl")
 using .SoilWaterParameterizations
 include("SoilHeatParameterizations.jl")

--- a/src/Land/Model/RadiativeEnergyFlux.jl
+++ b/src/Land/Model/RadiativeEnergyFlux.jl
@@ -1,0 +1,111 @@
+module RadiativeEnergyFlux
+
+using ...VariableTemplates
+using DocStringExtensions
+
+export AbstractNetSwFluxModel,
+    PrescribedSwFluxAndAlbedo,
+    PrescribedNetSwFlux,
+    compute_net_sw_flux,
+    compute_net_radiative_energy_flux
+
+"""
+   AbstractNetSwFluxModel{FT <: AbstractFloat}
+"""
+abstract type AbstractNetSwFluxModel{FT <: AbstractFloat} end
+
+"""
+    PrescribedSwFluxAndAlbedo{FT, FN1, FN2} <: AbstractNetSwFluxModel{FT}
+
+Structure which contains functions for shortwave albedo and
+shortwave fluxes. They are user-defined, constant across the domain
+and can be a function of time.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct PrescribedSwFluxAndAlbedo{FT, FN1, FN2} <: AbstractNetSwFluxModel{FT}
+    "Shortwave albedo in grid. No units."
+    α::FN1
+    "Shortwave flux in grid. Units of J m-2 s-1"
+    swf::FN2
+    function PrescribedSwFluxAndAlbedo(
+        ::Type{FT};
+        α::FN1 = (t) -> FT(NaN),
+        swf::FN2 = (t) -> FT(NaN),
+    ) where {FT, FN1, FN2}
+        args = (α, swf)
+        return new{FT, FN1, FN2}(args...)
+    end
+end
+
+"""
+    PrescribedNetSwFlux{FT,FN3} <: AbstractNetSwFluxModel{FT}
+
+Structure which contains net shortwave flux values. The function is
+user-defined, constant across the domain and can be a function of time.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct PrescribedNetSwFlux{FT, FN3} <: AbstractNetSwFluxModel{FT}
+    "Net shortwave flux. Units of J m-2 s-1"
+    nswf::FN3
+    function PrescribedNetSwFlux(
+        ::Type{FT};
+        nswf::FN3 = (t) -> FT(NaN),
+    ) where {FT, FN3}
+        return new{FT, FN3}(nswf)
+    end
+end
+
+"""
+    compute_net_sw_flux(
+        nswf_model::PrescribedSwFluxAndAlbedo{FT},
+        t::Real,
+    ) where {FT}
+
+Computes the net shortwave flux as a function of time.
+"""
+function compute_net_sw_flux(
+    nswf_model::PrescribedSwFluxAndAlbedo{FT},
+    t::Real,
+) where {FT}
+    net_sw_flux = (FT(1) - nswf_model.α(t)) * nswf_model.swf(t)
+    return net_sw_flux
+end
+
+"""
+    compute_net_sw_flux(
+        nswf_model:: PrescribedNetSwFlux{FT},
+        t::Real
+    ) where {FT}
+
+Computes the net shortwave flux as a function of time.
+"""
+function compute_net_sw_flux(
+    nswf_model::PrescribedNetSwFlux{FT},
+    t::Real,
+) where {FT}
+    net_sw_flux = nswf_model.nswf(t)
+    return net_sw_flux
+end
+
+"""
+    compute_net_radiative_energy_flux(
+        nswf_model::AbstractNetSwFluxModel{FT},
+        t::Real
+    )
+
+Returns the net radiative energy flux as a function of time. Will
+include long wave fluxes in future version.
+"""
+function compute_net_radiative_energy_flux(
+    nswf_model::AbstractNetSwFluxModel{FT},
+    t::Real,
+) where {FT}
+    net_radiative_flux = compute_net_sw_flux(nswf_model, t)
+    return net_radiative_flux
+end
+
+end

--- a/src/Land/Model/land_bc.jl
+++ b/src/Land/Model/land_bc.jl
@@ -3,7 +3,8 @@ export LandDomainBC,
     Dirichlet,
     Neumann,
     NoBC,
-    SurfaceDrivenWaterBoundaryConditions
+    SurfaceDrivenWaterBoundaryConditions,
+    SurfaceDrivenHeatBoundaryConditions
 
 """
    AbstractBoundaryConditions 
@@ -54,7 +55,6 @@ struct Neumann{Ff} <: AbstractBoundaryConditions
     scalar_flux_bc::Ff
 end
 
-
 """
     SurfaceDrivenWaterBoundaryConditions{FT, PD, RD} <: AbstractBoundaryConditions
 
@@ -72,7 +72,6 @@ struct SurfaceDrivenWaterBoundaryConditions{FT, PD, RD} <:
     "Runoff model"
     runoff_model::RD
 end
-
 
 """
     SurfaceDrivenWaterBoundaryConditions(
@@ -95,6 +94,42 @@ function SurfaceDrivenWaterBoundaryConditions(
     return SurfaceDrivenWaterBoundaryConditions{FT, typeof.(args)...}(args...)
 end
 
+"""
+    SurfaceDrivenHeatBoundaryConditions{FT, SWD} <: AbstractBoundaryConditions
+
+Boundary condition type to be used when the user wishes to 
+apply physical fluxes of heat at the top of the domain 
+(according to radiative energy fluxes).
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct SurfaceDrivenHeatBoundaryConditions{FT, SWD} <:
+       AbstractBoundaryConditions where {FT, SWD}
+    "Net short wave flux model"
+    nswf_model::SWD
+end
+
+"""
+    SurfaceDrivenHeatBoundaryConditions(
+        ::Type{FT};
+        nswf_model::AbstractNetSwFluxModel{FT} = PrescribedNetSwFlux{FT}()
+    ) where {FT}
+
+Constructor for the SurfaceDrivenHeatBoundaryConditions object. The default
+is no shortwave flux.
+"""
+function SurfaceDrivenHeatBoundaryConditions(
+    ::Type{FT};
+    nswf_model::AbstractNetSwFluxModel{FT} = PrescribedNetSwFlux(
+        FT;
+        nswf = t -> eltype(t)(0),
+    ),
+) where {FT}
+    return SurfaceDrivenHeatBoundaryConditions{FT, typeof(nswf_model)}(
+        nswf_model,
+    )
+end
 
 """
     LandDomainBC{TBC, BBC, LBC}
@@ -133,7 +168,6 @@ Base.@kwdef struct LandComponentBC{
     soil_heat::SH = NoBC()
 end
 
-
 """
     function boundary_conditions(land::LandModel)
 
@@ -147,8 +181,6 @@ function boundary_conditions(land::LandModel)
     # faces labeled integer 1,2,3 are bottom, top, lateral sides.
     return mytuple
 end
-
-
 
 function boundary_state!(
     nf,
@@ -176,12 +208,10 @@ function boundary_state!(
     )
 end
 
-
 function land_boundary_state!(nf, bc::LandComponentBC, land, args...)
     soil_boundary_state!(nf, bc.soil_water, land.soil.water, land, args...)
     soil_boundary_state!(nf, bc.soil_heat, land.soil.heat, land, args...)
 end
-
 
 function boundary_state!(
     nf,
@@ -214,7 +244,6 @@ function boundary_state!(
         args...,
     )
 end
-
 
 function land_boundary_flux!(nf, bc::LandComponentBC, land, args...)
     soil_boundary_flux!(nf, bc.soil_water, land.soil.water, land, args...)

--- a/src/Land/Model/soil_bc.jl
+++ b/src/Land/Model/soil_bc.jl
@@ -213,7 +213,7 @@ function soil_boundary_flux!(
 end
 
 
-# SurfaceDriven conditions for SoilWater
+# SurfaceDriven conditions for for SoilHeat and SoilWater
 
 """
     function soil_boundary_flux!(
@@ -261,4 +261,43 @@ function soil_boundary_flux!(
         t,
     )
 
+end
+
+"""
+    soil_boundary_flux!(
+        nf,
+        bc::SurfaceDrivenHeatBoundaryConditions,
+        heat::SoilHeatModel,
+        land::LandModel,
+        state⁺::Vars,
+        diff⁺::Vars,
+        aux⁺::Vars,
+        n̂,
+        state⁻::Vars,
+        diff⁻::Vars,
+        aux⁻::Vars,
+        t,
+    )
+
+The Surface Driven BC method for `soil_boundary_flux!` for the
+`SoilHeatModel`.
+"""
+function soil_boundary_flux!(
+    nf,
+    bc::SurfaceDrivenHeatBoundaryConditions,
+    heat::SoilHeatModel,
+    land::LandModel,
+    state⁺::Vars,
+    diff⁺::Vars,
+    aux⁺::Vars,
+    n̂,
+    state⁻::Vars,
+    diff⁻::Vars,
+    aux⁻::Vars,
+    t,
+    _...,
+)
+
+    net_surface_flux = compute_net_radiative_energy_flux(bc.nswf_model, t)
+    diff⁺.soil.heat.κ∇T = n̂ * (-net_surface_flux)
 end

--- a/test/Land/Model/test_radiative_energy_flux_functions.jl
+++ b/test/Land/Model/test_radiative_energy_flux_functions.jl
@@ -1,0 +1,184 @@
+# Test functions used in runoff modeling.
+using MPI
+using OrderedCollections
+using StaticArrays
+using Statistics
+using Test
+
+using CLIMAParameters
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using ClimateMachine
+using ClimateMachine.Land
+using ClimateMachine.Land.RadiativeEnergyFlux
+using ClimateMachine.Land.SoilWaterParameterizations
+using ClimateMachine.Land.SoilHeatParameterizations
+using ClimateMachine.Land.Runoff
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.DGMethods: BalanceLaw, LocalGeometry
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.ODESolvers
+using ClimateMachine.VariableTemplates
+using ClimateMachine.SingleStackUtils
+using ClimateMachine.BalanceLaws:
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, vars_state
+
+@testset "Radiative energy flux testing" begin
+    F = Float32
+    user_nswf = t -> F(2 * t)
+    user_swf = t -> F(2 * t)
+    user_α = t -> F(0.2 * t)
+    prescribed_swf_and_a =
+        PrescribedSwFluxAndAlbedo(F; α = user_α, swf = user_swf)
+    prescribed_nswf = PrescribedNetSwFlux(F; nswf = user_nswf)
+    flux_from_prescribed_swf_and_albedo =
+        compute_net_radiative_energy_flux.(
+            Ref(prescribed_swf_and_a),
+            [1, 2, 3, 4],
+        )
+
+    flux_from_prescribed_nswf =
+        compute_net_radiative_energy_flux.(Ref(prescribed_nswf), [1, 2, 3, 4])
+
+    @test flux_from_prescribed_swf_and_albedo ≈
+          F.(([0.8, 0.6, 0.4, 0.2]) .* ([2, 4, 6, 8]))
+    @test eltype(flux_from_prescribed_swf_and_albedo) == F
+
+    @test flux_from_prescribed_nswf ≈ F.([2, 4, 6, 8])
+    @test eltype(flux_from_prescribed_nswf) == F
+end
+
+@testset "Heat analytic unit test" begin
+    ClimateMachine.init()
+
+    FT = Float64
+
+    function init_soil!(land, state, aux, localgeo, time)
+        myfloat = eltype(state)
+        ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, time)
+        θ_l =
+            volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
+        ρc_s = volumetric_heat_capacity(
+            θ_l,
+            θ_i,
+            land.soil.param_functions.ρc_ds,
+            land.param_set,
+        )
+
+        state.soil.heat.ρe_int = myfloat(volumetric_internal_energy(
+            θ_i,
+            ρc_s,
+            land.soil.heat.initialT(aux),
+            land.param_set,
+        ))
+    end
+
+
+    soil_param_functions = SoilParamFunctions{FT}(
+        porosity = 0.4,
+        ν_ss_gravel = 0.2,
+        ν_ss_om = 0.2,
+        ν_ss_quartz = 0.2,
+        ρc_ds = 1.0, # diffusivity = k/ρc. When no water, ρc = ρc_ds.
+        κ_solid = 1.0,
+        ρp = 1.0,
+        κ_sat_unfrozen = 0.57,
+        κ_sat_frozen = 2.29,
+    )
+
+    #  Prescribed net short wave flux, initial temperature
+    A = FT(5)
+    prescribed_nswf = t -> FT(-A * t)
+    T_init = FT(300.0)
+    T_init_func = aux -> T_init
+
+    # Flux entering = flux leaving soil column
+    bc = LandDomainBC(
+        bottom_bc = LandComponentBC(
+            soil_heat = Neumann((aux, t) -> FT(-A * t)),
+        ),
+        surface_bc = LandComponentBC(
+            soil_heat = SurfaceDrivenHeatBoundaryConditions(
+                FT;
+                nswf_model = PrescribedNetSwFlux(FT; nswf = prescribed_nswf),
+            ),
+        ),
+    )
+
+    soil_water_model = PrescribedWaterModel()
+    soil_heat_model = SoilHeatModel(FT; initialT = T_init_func)
+
+    m_soil = SoilModel(soil_param_functions, soil_water_model, soil_heat_model)
+    sources = ()
+    m = LandModel(
+        param_set,
+        m_soil;
+        boundary_conditions = bc,
+        source = sources,
+        init_state_prognostic = init_soil!,
+    )
+
+    N_poly = 5
+    nelem_vert = 10
+
+    # Specify the domain boundaries
+    zmax = FT(1)
+    zmin = FT(0)
+
+    driver_config = ClimateMachine.SingleStackConfiguration(
+        "LandModel",
+        N_poly,
+        nelem_vert,
+        zmax,
+        param_set,
+        m;
+        zmin = zmin,
+        numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
+    )
+
+    t0 = FT(0)
+    timeend = FT(1)
+    dt = FT(1e-4)
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        ode_dt = dt,
+    )
+    mygrid = solver_config.dg.grid
+    aux = solver_config.dg.state_auxiliary
+    ClimateMachine.invoke!(solver_config)
+    t = ODESolvers.gettime(solver_config.solver)
+
+    z_ind = varsindex(vars_state(m, Auxiliary(), FT), :z)
+    z = Array(aux[:, z_ind, :][:])
+
+    T_ind = varsindex(vars_state(m, Auxiliary(), FT), :soil, :heat, :T)
+    T = Array(aux[:, T_ind, :][:])
+
+    k = k_dry(param_set, soil_param_functions)
+    diffusivity = k / soil_param_functions.ρc_ds
+
+    A = A / k # Because the flux is applied on κ∇T. κ∇T = A*t in clima, whereas ∇T = A*t in the analytic soln.
+    approx_sum_term = sum(
+        (
+            -2 * A / (diffusivity * pi^4) *
+            cos.(n * pi * z) *
+            (pi * n * sin(pi * n) + cos(pi * n) - 1) *
+            (1 - exp(-timeend * diffusivity * (pi * n)^2)) / n^4
+        ) for n in 1:100
+    )
+
+    approx_analytic_soln =
+        A * timeend .* z .+ T_init .- A * timeend / 2 .+ approx_sum_term
+
+    MSE = mean((approx_analytic_soln .- T) .^ 2.0)
+
+    @test eltype(aux) == FT
+    @test MSE < 1e-5
+end


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
This module includes structures to store albedo and short wave flux values, and functions for the user to set these values. The user can either prescribe short wave flux and albedo, or net short wave flux directly. There is no spectral dependence for the first iteration of this module. This flux is then applied at the top boundary, as a SurfaceDrivenHeatBoundaryConditions bc type. 

<!-- Check all the boxes below before taking the PR out of draft -->

- [x ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [N/A ] Unit tests are included OR N/A.
- [x ] Code is exercised in an integration test OR N/A.
- [x ] Documentation has been added/updated OR N/A.
