### PR TITLE
Add AtmosPhysics constructor, and use in drivers

### DIFF
--- a/docs/src/APIs/Atmos/AtmosModel.md
+++ b/docs/src/APIs/Atmos/AtmosModel.md
@@ -13,6 +13,7 @@ ClimateMachine.Atmos.AtmosProblem
 ## AtmosModel balance law
 
 ```@docs
+ClimateMachine.Atmos.AtmosPhysics
 ClimateMachine.Atmos.AtmosModel
 ```
 

--- a/docs/src/HowToGuides/Atmos/MoistureAndPrecip.md
+++ b/docs/src/HowToGuides/Atmos/MoistureAndPrecip.md
@@ -203,14 +203,17 @@ choices, along with the `param_set` `struct` have to be passed to
 the Atmos model configuration:
 
 ```julia
-model = AtmosModel{FT}(
-    AtmosLESConfigType,
+physics = AtmosPhysics{FT}(
     param_set;
-    problem = problem,
     ref_state = ref_state,
     moisture = moisture,
     precipitation = precipitation,
     turbulence = SmagorinskyLilly{FT}(C_smag),
+)
+model = AtmosModel{FT}(
+    AtmosLESConfigType,
+    physics;
+    problem = problem,
     source = source,
 )
 ```

--- a/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
+++ b/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
@@ -191,14 +191,18 @@ function config_gcm_experiment(
     )
 
     # Create the Atmosphere model
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         hyperdiffusion = hyperdiffusion,
         moisture = moisture,
+    )
+
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        problem = problem,
         source = setup_source(problem),
     )
 

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -188,16 +188,20 @@ function config_heldsuarez(FT, poly_order, resolution)
         tracers = NoTracers()
     end
 
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_heldsuarez!,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         hyperdiffusion = DryBiharmonic(FT(8 * 3600)),
         moisture = DryModel(),
-        source = (Gravity(), Coriolis(), HeldSuarezForcing()),
         tracers = tracers,
+    )
+
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = init_heldsuarez!,
+        source = (Gravity(), Coriolis(), HeldSuarezForcing()),
     )
 
     config = ClimateMachine.AtmosGCMConfiguration(

--- a/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
+++ b/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
@@ -262,14 +262,18 @@ function config_baroclinic_wave(
         init_state_prognostic = init_baroclinic_wave!,
     )
 
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         hyperdiffusion = hyperdiffusion,
         moisture = moisture,
+    )
+
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        problem = problem,
         source = source,
     )
 

--- a/experiments/AtmosGCM/nonhydrostatic_gravity_wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic_gravity_wave.jl
@@ -119,13 +119,17 @@ function config_nonhydrostatic_gravity_wave(FT, poly_order, resolution)
     # Set up the atmosphere model
     exp_name = "NonhydrostaticGravityWave"
 
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_nonhydrostatic_gravity_wave!,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         moisture = DryModel(),
+    )
+
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = init_nonhydrostatic_gravity_wave!,
         source = (Gravity(),),
     )
 

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -466,15 +466,15 @@ function bomex_model(
     )
 
     # Assemble model components
-    model = AtmosModel{FT}(
-        config_type,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
         turbulence = SmagorinskyLilly{FT}(C_smag),
         moisture = moisture,
-        source = source,
         turbconv = turbconv,
     )
+
+    model =
+        AtmosModel{FT}(config_type, physics; problem = problem, source = source)
 
     return model
 end

--- a/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
+++ b/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
@@ -412,19 +412,23 @@ function config_cfsites(
         ),
         init_state_prognostic = init_cfsites!,
     )
+    physics = AtmosPhysics{FT}(
+        param_set;
+        turbulence = Vreman{FT}(0.23),
+        moisture = EquilMoist(; maxiter = 5, tolerance = FT(2)),
+        lsforcing = HadGEMVertical(),
+    )
+
     model = AtmosModel{FT}(
         AtmosLESConfigType,
-        param_set;
+        physics;
         problem = problem,
-        turbulence = Vreman{FT}(0.23),
         source = (
             Gravity(),
             LinearSponge{FT}(zmax, zmax * 0.85, 1, 4),
             LargeScaleProcess(),
             LargeScaleSubsidence(),
         ),
-        moisture = EquilMoist(; maxiter = 5, tolerance = FT(2)),
-        lsforcing = HadGEMVertical(),
     )
 
     # Timestepper options

--- a/experiments/AtmosLES/convective_bl_model.jl
+++ b/experiments/AtmosLES/convective_bl_model.jl
@@ -291,15 +291,15 @@ function convective_bl_model(
     )
 
     # Assemble model components
-    model = AtmosModel{FT}(
-        config_type,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
         turbulence = SmagorinskyLilly{FT}(C_smag),
         moisture = moisture,
-        source = source,
         turbconv = turbconv,
     )
+
+    model =
+        AtmosModel{FT}(config_type, physics; problem = problem, source = source)
 
     return model
 end

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -363,15 +363,19 @@ function config_dycoms(
         init_state_prognostic = init_dycoms!,
     )
 
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
         ref_state = ref_state,
         turbulence = Vreman{FT}(C_smag),
         moisture = moisture,
         precipitation = precipitation,
         radiation = radiation,
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
         source = source,
     )
 

--- a/experiments/AtmosLES/ekman_layer_model.jl
+++ b/experiments/AtmosLES/ekman_layer_model.jl
@@ -250,23 +250,23 @@ function ekman_layer_model(
         AtmosBC(; turbconv = turbconv_bcs(turbconv)[2]),
     )
 
+    physics = AtmosPhysics{FT}(
+        param_set;
+        ref_state = ref_state,
+        turbulence = turbulence,
+        moisture = DryModel(),
+        turbconv = turbconv,
+        compressibility = compressibility,
+    )
+
     problem = AtmosProblem(
         init_state_prognostic = ics,
         boundaryconditions = boundary_conditions,
     )
 
     # Assemble model components
-    model = AtmosModel{FT}(
-        config_type,
-        param_set;
-        problem = problem,
-        ref_state = ref_state,
-        turbulence = turbulence,
-        moisture = DryModel(),
-        source = source,
-        turbconv = turbconv,
-        compressibility = compressibility,
-    )
+    model =
+        AtmosModel{FT}(config_type, physics; problem = problem, source = source)
 
     return model
 end

--- a/experiments/AtmosLES/rising_bubble_bryan.jl
+++ b/experiments/AtmosLES/rising_bubble_bryan.jl
@@ -153,12 +153,17 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax, fast_method)
     C_smag = FT(0.23)
     ref_state =
         HydrostaticState(DryAdiabaticProfile{FT}(param_set, FT(300), FT(0)))
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+
+    physics = AtmosPhysics{FT}(
         param_set;
         turbulence = SmagorinskyLilly{FT}(C_smag),
-        source = (Gravity(),),
         ref_state = ref_state,
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        source = (Gravity(),),
         init_state_prognostic = init_risingbubble!,
     )
 

--- a/experiments/AtmosLES/rising_bubble_theta_formulation.jl
+++ b/experiments/AtmosLES/rising_bubble_theta_formulation.jl
@@ -240,17 +240,21 @@ function config_risingbubble(
 
     ## Here we assemble the `AtmosModel`.
     _C_smag = FT(0)
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,                            ## Flow in a box, requires the AtmosLESConfigType
+    physics = AtmosPhysics{FT}(
         param_set;                                     ## Parameter set corresponding to earth parameters
-        init_state_prognostic = init_risingbubble!,    ## Apply the initial condition
-        problem = problem,                             ## Problem (boundary conditions)
         ref_state = NoReferenceState(),                ## Reference state
         energy = θModel(),                             ## Energy model
         turbulence = SmagorinskyLilly(_C_smag),        ## Turbulence closure model
         moisture = DryModel(),                         ## Exclude moisture variables
-        source = (Gravity(),),                         ## Gravity is the only source term here
         tracers = NTracers{ntracers, FT}(δ_χ),         ## Tracer model with diffusivity coefficients
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,                            ## Flow in a box, requires the AtmosLESConfigType
+        physics;                                       ## Atmos physics
+        init_state_prognostic = init_risingbubble!,    ## Apply the initial condition
+        problem = problem,                             ## Problem (boundary conditions)
+        source = (Gravity(),),                         ## Gravity is the only source term here
     )
 
     ## Finally, we pass a `Problem Name` string, the mesh information, and the

--- a/experiments/AtmosLES/schar_scalar_advection.jl
+++ b/experiments/AtmosLES/schar_scalar_advection.jl
@@ -161,15 +161,20 @@ function config_schar(FT, N, resolution, xmax, ymax, zmax)
 
     _C_smag = FT(0.21)
     _δχ = SVector{1, FT}(0)
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_schar!,
         ref_state = ref_state,
         turbulence = Vreman(_C_smag),
         moisture = DryModel(),
-        source = source,
         tracers = NTracers{1, FT}(_δχ),
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        init_state_prognostic = init_schar!,
+        source = source,
     )
 
     config = ClimateMachine.AtmosLESConfiguration(

--- a/experiments/AtmosLES/squall_line.jl
+++ b/experiments/AtmosLES/squall_line.jl
@@ -279,14 +279,18 @@ function config_squall_line(
         init_state_prognostic = ics,
     )
 
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
         ref_state = ref_state,
         moisture = moisture,
         precipitation = precipitation,
         turbulence = SmagorinskyLilly{FT}(C_smag),
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
         source = source,
     )
 

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -311,17 +311,17 @@ function stable_bl_model(
     )
 
     # Assemble model components
-    model = AtmosModel{FT}(
-        config_type,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
         ref_state = ref_state,
         turbulence = turbulence,
         moisture = moisture,
-        source = source,
         turbconv = turbconv,
         compressibility = compressibility,
     )
+
+    model =
+        AtmosModel{FT}(config_type, physics; problem = problem, source = source)
 
     return model
 end

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -105,12 +105,15 @@ function config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
         ),
         init_state_prognostic = init_surfacebubble!,
     )
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
         turbulence = SmagorinskyLilly{FT}(C_smag),
         moisture = EquilMoist(),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
         source = (Gravity(),),
     )
     config = ClimateMachine.AtmosLESConfiguration(

--- a/experiments/AtmosLES/taylor_green.jl
+++ b/experiments/AtmosLES/taylor_green.jl
@@ -94,14 +94,18 @@ function config_greenvortex(
     )
 
     _C_smag = FT(C_smag(param_set))
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,                 # Flow in a box, requires the AtmosLESConfigType
+    physics = AtmosPhysics{FT}(
         param_set;                          # Parameter set corresponding to earth parameters
-        init_state_prognostic = init_greenvortex!,
         ref_state = NoReferenceState(),
-        orientation = NoOrientation(),
         turbulence = Vreman(_C_smag),       # Turbulence closure model
         moisture = DryModel(),
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,                 # Flow in a box, requires the AtmosLESConfigType
+        physics;                            # Atmos physics
+        init_state_prognostic = init_greenvortex!,
+        orientation = NoOrientation(),
         source = (),
     )
 

--- a/experiments/TestCase/baroclinic_wave.jl
+++ b/experiments/TestCase/baroclinic_wave.jl
@@ -180,14 +180,17 @@ function config_baroclinic_wave(FT, poly_order, resolution, with_moisture)
         moisture = DryModel()
         source = (Gravity(), Coriolis())
     end
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_baroclinic_wave!,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         hyperdiffusion = hyperdiffusion,
         moisture = moisture,
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = init_baroclinic_wave!,
         source = source,
     )
 

--- a/experiments/TestCase/baroclinic_wave_fvm.jl
+++ b/experiments/TestCase/baroclinic_wave_fvm.jl
@@ -186,14 +186,17 @@ function config_baroclinic_wave(
         moisture = DryModel()
         source = (Gravity(), Coriolis())
     end
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_baroclinic_wave!,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         # hyperdiffusion = hyperdiffusion,
         moisture = moisture,
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = init_baroclinic_wave!,
         source = source,
     )
 

--- a/experiments/TestCase/isothermal_zonal_flow.jl
+++ b/experiments/TestCase/isothermal_zonal_flow.jl
@@ -93,13 +93,16 @@ function config_isothermal_zonal_flow(
     # Set up the atmosphere model
     exp_name = "IsothermalZonalFlow"
 
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_isothermal_zonal_flow!,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = init_isothermal_zonal_flow!,
         source = (Gravity(),),
     )
 

--- a/experiments/TestCase/risingbubble.jl
+++ b/experiments/TestCase/risingbubble.jl
@@ -108,15 +108,18 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax, with_moisture)
     else
         moisture = DryModel()
     end
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_risingbubble!,
         ref_state = ref_state,
         turbulence = SmagorinskyLilly(_C_smag),
         moisture = moisture,
-        source = (Gravity(),),
         tracers = NoTracers(),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        init_state_prognostic = init_risingbubble!,
+        source = (Gravity(),),
     )
 
     config = ClimateMachine.AtmosLESConfiguration(

--- a/experiments/TestCase/risingbubble_fvm.jl
+++ b/experiments/TestCase/risingbubble_fvm.jl
@@ -119,15 +119,18 @@ function config_risingbubble(
     else
         moisture = DryModel()
     end
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_risingbubble!,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         moisture = moisture,
-        source = (Gravity(),),
         tracers = NoTracers(),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        init_state_prognostic = init_risingbubble!,
+        source = (Gravity(),),
     )
 
     config = ClimateMachine.AtmosLESConfiguration(

--- a/experiments/TestCase/solid_body_rotation.jl
+++ b/experiments/TestCase/solid_body_rotation.jl
@@ -51,14 +51,17 @@ function config_solid_body_rotation(FT, poly_order, resolution, ref_state)
     exp_name = "SolidBodyRotation"
     domain_height::FT = 30e3 # distance between surface and top of atmosphere (m)
 
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_solid_body_rotation!,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         #hyperdiffusion = DryBiharmonic(FT(8 * 3600)),
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = init_solid_body_rotation!,
         source = (Gravity(), Coriolis()),
     )
 

--- a/experiments/TestCase/solid_body_rotation_fvm.jl
+++ b/experiments/TestCase/solid_body_rotation_fvm.jl
@@ -59,14 +59,17 @@ function config_solid_body_rotation(
     exp_name = "SolidBodyRotation"
     domain_height::FT = 30e3 # distance between surface and top of atmosphere (m)
 
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_solid_body_rotation!,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         #hyperdiffusion = DryBiharmonic(FT(8 * 3600)),
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = init_solid_body_rotation!,
         source = (Gravity(), Coriolis()),
     )
 

--- a/experiments/TestCase/solid_body_rotation_mountain.jl
+++ b/experiments/TestCase/solid_body_rotation_mountain.jl
@@ -68,14 +68,17 @@ function config_solid_body_rotation(FT, poly_order, resolution, ref_state)
 
     _planet_radius = FT(planet_radius(param_set))
 
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_solid_body_rotation!,
         ref_state = ref_state,
         turbulence = ConstantKinematicViscosity(FT(0)),
         #hyperdiffusion = DryBiharmonic(FT(8 * 3600)),
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = init_solid_body_rotation!,
         source = (Gravity(), Coriolis()),
     )
 

--- a/src/Atmos/Model/get_prognostic_vars.jl
+++ b/src/Atmos/Model/get_prognostic_vars.jl
@@ -15,7 +15,9 @@ prognostic_vars(::RainSnowModel) = (Rain(), Snow())
 prognostic_vars(::NoTracers) = ()
 prognostic_vars(::NTracers{N}) where {N} = (Tracers{N}(),)
 
-prognostic_vars(m::AtmosModel) = (
+prognostic_vars(atmos::AtmosModel) = prognostic_vars(atmos.physics)
+
+prognostic_vars(m::AtmosPhysics) = (
     Mass(),
     Momentum(),
     prognostic_vars(energy_model(m))...,

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -210,9 +210,10 @@ function AtmosLESConfiguration(
         implicit_solver = SingleColumnLU,
         implicit_solver_adjustable = false,
     ),
+    physics = AtmosPhysics{FT}(param_set;),
     model = AtmosModel{FT}(
         AtmosLESConfigType,
-        param_set;
+        physics;
         init_state_prognostic = init_LES!,
     ),
     mpicomm = MPI.COMM_WORLD,
@@ -357,9 +358,10 @@ function AtmosGCMConfiguration(
     init_GCM!;
     array_type = ClimateMachine.array_type(),
     solver_type = DefaultSolverType(),
+    physics = AtmosPhysics{FT}(param_set),
     model = AtmosModel{FT}(
         AtmosGCMConfigType,
-        param_set;
+        physics;
         init_state_prognostic = init_GCM!,
     ),
     mpicomm = MPI.COMM_WORLD,

--- a/test/Atmos/Model/discrete_hydrostatic_balance.jl
+++ b/test/Atmos/Model/discrete_hydrostatic_balance.jl
@@ -37,13 +37,16 @@ function config_balanced(
 )
     ref_state = HydrostaticState(temp_profile; subtract_off = false)
 
-    model = AtmosModel{FT}(
-        config_type,
+    physics = AtmosPhysics{FT}(
         param_set;
         ref_state = ref_state,
         turbulence = ConstantDynamicViscosity(FT(0)),
         hyperdiffusion = NoHyperDiffusion(),
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        config_type,
+        physics;
         source = (Gravity(),),
         init_state_prognostic = init_to_ref_state!,
     )

--- a/test/Atmos/Model/get_atmos_ref_states.jl
+++ b/test/Atmos/Model/get_atmos_ref_states.jl
@@ -19,15 +19,17 @@ ClimateMachine.init()
 function get_atmos_ref_states(nelem_vert, N_poly, RH)
 
     FT = Float64
-    model = AtmosModel{FT}(
-        SingleStackConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
         ref_state = HydrostaticState(
             DecayingTemperatureProfile{FT}(param_set),
             RH,
         ),
-        init_state_prognostic = (problem, bl, state, aux, localgeo, t) ->
-            nothing,
+    )
+    model = AtmosModel{FT}(
+        SingleStackConfigType,
+        physics;
+        init_state_prognostic = (_...) -> nothing,
     )
     driver_config = ClimateMachine.SingleStackConfiguration(
         "ref_state",

--- a/test/Atmos/prog_prim_conversion/runtests.jl
+++ b/test/Atmos/prog_prim_conversion/runtests.jl
@@ -88,11 +88,14 @@ end
     FT = Float64
     compressibility = (Anelastic1D(), Compressible())
     for comp in compressibility
-        bl = AtmosModel{FT}(
-            AtmosLESConfigType,
+        physics = AtmosPhysics{FT}(
             param_set;
             moisture = DryModel(),
             compressibility = comp,
+        )
+        bl = AtmosModel{FT}(
+            AtmosLESConfigType,
+            physics;
             init_state_prognostic = x -> x,
         )
         vs_prog = vars_state(bl, Prognostic(), FT)
@@ -132,11 +135,14 @@ end
     FT = Float64
     compressibility = (Compressible(),) # Anelastic1D() does not converge
     for comp in compressibility
-        bl = AtmosModel{FT}(
-            AtmosLESConfigType,
+        physics = AtmosPhysics{FT}(
             param_set;
             moisture = EquilMoist(; maxiter = 5), # maxiter=3 does not converge
             compressibility = comp,
+        )
+        bl = AtmosModel{FT}(
+            AtmosLESConfigType,
+            physics;
             init_state_prognostic = x -> x,
         )
         vs_prog = vars_state(bl, Prognostic(), FT)
@@ -189,10 +195,14 @@ end
     FT = Float64
     compressibility = (Anelastic1D(), Compressible())
     for comp in compressibility
-        bl = AtmosModel{FT}(
-            AtmosLESConfigType,
+        physics = AtmosPhysics{FT}(
             param_set;
             moisture = NonEquilMoist(),
+            compressibility = comp,
+        )
+        bl = AtmosModel{FT}(
+            AtmosLESConfigType,
+            physics;
             init_state_prognostic = x -> x,
         )
         vs_prog = vars_state(bl, Prognostic(), FT)
@@ -230,10 +240,10 @@ end
 
 @testset "Prognostic-Primitive conversion (array interface)" begin
     FT = Float64
+    physics = AtmosPhysics{FT}(param_set; moisture = DryModel())
     bl = AtmosModel{FT}(
         AtmosLESConfigType,
-        param_set;
-        moisture = DryModel(),
+        physics;
         init_state_prognostic = x -> x,
     )
     vs_prog = vars_state(bl, Prognostic(), FT)

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -99,12 +99,15 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
     T_profile = DryAdiabaticProfile{FT}(param_set)
     C_smag = FT(0.23)
     ref_state = HydrostaticState(T_profile)
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_risingbubble!,
         ref_state = ref_state,
         turbulence = SmagorinskyLilly{FT}(C_smag),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        init_state_prognostic = init_risingbubble!,
         source = (Gravity(),),
     )
 

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -81,13 +81,16 @@ function main()
     T_profile = IsothermalProfile(param_set, setup.T_ref)
     ref_state = HydrostaticState(T_profile)
     turbulence = ConstantDynamicViscosity(FT(0))
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = setup,
         ref_state = ref_state,
         turbulence = turbulence,
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = setup,
         source = (Gravity(),),
     )
 

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -72,13 +72,16 @@ function main()
     T_profile = IsothermalProfile(param_set, setup.T_ref)
     ref_state = HydrostaticState(T_profile)
     turbulence = ConstantDynamicViscosity(FT(0))
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = setup,
         ref_state = ref_state,
         turbulence = turbulence,
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = setup,
         source = (Gravity(),),
     )
 

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -103,14 +103,17 @@ function main()
         init_state_prognostic = mms3_init_state!,
     )
 
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
-        orientation = NoOrientation(),
         ref_state = NoReferenceState(),
         turbulence = ConstantDynamicViscosity(FT(μ_exact), WithDivergence()),
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
+        orientation = NoOrientation(),
         source = (MMSSource{3}(),),
     )
 

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -19,6 +19,7 @@ using ClimateMachine.Thermodynamics:
     air_density, soundspeed_air, internal_energy, PhaseDry_pT, PhasePartition
 using ClimateMachine.TemperatureProfiles: IsothermalProfile
 using ClimateMachine.Atmos:
+    AtmosPhysics,
     AtmosModel,
     DryModel,
     NoPrecipitation,
@@ -114,15 +115,18 @@ function test_run(
     T_profile = IsothermalProfile(param_set, setup.T_ref)
     δ_χ = @SVector [FT(ii) for ii in 1:ntracers]
 
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = setup,
         ref_state = HydrostaticState(T_profile),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = (Gravity(),),
         tracers = NTracers{length(δ_χ), FT}(δ_χ),
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = setup,
+        source = (Gravity(),),
     )
     linearmodel = AtmosAcousticGravityLinearModel(model)
 

--- a/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
@@ -19,6 +19,7 @@ using ClimateMachine.Thermodynamics:
     air_density, soundspeed_air, internal_energy, PhaseDry_pT, PhasePartition
 using ClimateMachine.TemperatureProfiles: IsothermalProfile
 using ClimateMachine.Atmos:
+    AtmosPhysics,
     AtmosModel,
     DryModel,
     NoPrecipitation,
@@ -113,15 +114,18 @@ function test_run(
     T_profile = IsothermalProfile(param_set, setup.T_ref)
     δ_χ = @SVector [FT(ii) for ii in 1:ntracers]
 
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = setup,
         ref_state = HydrostaticState(T_profile),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = (Gravity(),),
         tracers = NTracers{length(δ_χ), FT}(δ_χ),
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = setup,
+        source = (Gravity(),),
     )
 
     linearmodel = AtmosAcousticGravityLinearModel(model)

--- a/test/Numerics/DGMethods/Euler/fvm_balance.jl
+++ b/test/Numerics/DGMethods/Euler/fvm_balance.jl
@@ -111,15 +111,14 @@ function test_run(
         source = (Gravity(), Coriolis())
     end
 
-    model = AtmosModel{FT}(
-        configtype,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
         ref_state = ref_state,
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
-        source = source,
     )
+    model =
+        AtmosModel{FT}(configtype, physics; problem = problem, source = source)
 
     dg = DGFVModel(
         model,

--- a/test/Numerics/DGMethods/Euler/fvm_isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/fvm_isentropicvortex.jl
@@ -158,14 +158,17 @@ function test_run(
     problem =
         AtmosProblem(boundaryconditions = (), init_state_prognostic = setup)
 
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
-        orientation = NoOrientation(),
         ref_state = NoReferenceState(),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
+        orientation = NoOrientation(),
         source = (),
     )
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -342,14 +342,17 @@ function test_run(
     else
         moisture = DryModel()
     end
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
-        orientation = NoOrientation(),
         ref_state = NoReferenceState(),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = moisture,
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
+        orientation = NoOrientation(),
         source = (),
     )
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -144,14 +144,18 @@ function test_run(
     problem =
         AtmosProblem(boundaryconditions = (), init_state_prognostic = setup)
 
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
-        orientation = NoOrientation(),
         ref_state = IsentropicVortexReferenceState{FT}(setup),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
+        orientation = NoOrientation(),
         source = (),
     )
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_lmars.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_lmars.jl
@@ -132,14 +132,18 @@ function test_run(
         ref_state = NoReferenceState()
     end
 
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
-        orientation = NoOrientation(),
         ref_state = ref_state,
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = moisture,
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
+        orientation = NoOrientation(),
         source = (),
     )
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -137,14 +137,17 @@ function test_run(
     problem =
         AtmosProblem(boundaryconditions = (), init_state_prognostic = setup)
 
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
-        orientation = NoOrientation(),
         ref_state = IsentropicVortexReferenceState{FT}(setup),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
+        orientation = NoOrientation(),
         source = (),
     )
     # The linear model has the fast time scales

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -138,14 +138,17 @@ function test_run(
     problem =
         AtmosProblem(boundaryconditions = (), init_state_prognostic = setup)
 
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
-        orientation = NoOrientation(),
         ref_state = IsentropicVortexReferenceState{FT}(setup),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
+        orientation = NoOrientation(),
         source = (),
     )
     # This is a bad idea; this test is just testing how

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -141,14 +141,18 @@ function test_run(
     problem =
         AtmosProblem(boundaryconditions = (), init_state_prognostic = setup)
 
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        problem = problem,
-        orientation = NoOrientation(),
         ref_state = IsentropicVortexReferenceState{FT}(setup),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        problem = problem,
+        orientation = NoOrientation(),
         source = (),
     )
     # The linear model has the fast time scales

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -125,12 +125,15 @@ function test_run(
     )
     # -------------- Define model ---------------------------------- #
     T_profile = DryAdiabaticProfile{FT}(param_set)
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = Initialise_Density_Current!,
         ref_state = HydrostaticState(T_profile),
         turbulence = AnisoMinDiss{FT}(1),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        init_state_prognostic = Initialise_Density_Current!,
         source = (Gravity(),),
     )
     # -------------- Define DGModel --------------------------- #

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -106,6 +106,12 @@ function test_run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
         meshwarp = warpfun,
     )
 
+    physics = AtmosPhysics{FT}(
+        param_set;
+        ref_state = NoReferenceState(),
+        turbulence = ConstantDynamicViscosity(FT(μ_exact), WithDivergence()),
+        moisture = DryModel(),
+    )
     if dim == 2
         problem = AtmosProblem(
             boundaryconditions = (InitStateBC(),),
@@ -113,15 +119,9 @@ function test_run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
         )
         model = AtmosModel{FT}(
             AtmosLESConfigType,
-            param_set;
+            physics;
             problem = problem,
             orientation = NoOrientation(),
-            ref_state = NoReferenceState(),
-            turbulence = ConstantDynamicViscosity(
-                FT(μ_exact),
-                WithDivergence(),
-            ),
-            moisture = DryModel(),
             source = (MMSSource{2}(),),
         )
     else
@@ -131,15 +131,9 @@ function test_run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
         )
         model = AtmosModel{FT}(
             AtmosLESConfigType,
-            param_set;
+            physics;
             problem = problem,
             orientation = NoOrientation(),
-            ref_state = NoReferenceState(),
-            turbulence = ConstantDynamicViscosity(
-                FT(μ_exact),
-                WithDivergence(),
-            ),
-            moisture = DryModel(),
             source = (MMSSource{3}(),),
         )
     end

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -108,13 +108,17 @@ let
                     init_state_prognostic = initialcondition!,
                 )
 
-                model = AtmosModel{FT}(
-                    AtmosLESConfigType,
+                physics = AtmosPhysics{FT}(
                     param_set;
-                    problem = problem,
                     ref_state = NoReferenceState(),
                     turbulence = ConstantDynamicViscosity(μ, WithDivergence()),
                     moisture = DryModel(),
+                )
+
+                model = AtmosModel{FT}(
+                    AtmosLESConfigType,
+                    physics;
+                    problem = problem,
                     source = (Gravity(),),
                 )
 

--- a/test/Numerics/DGMethods/fv_reconstruction_test.jl
+++ b/test/Numerics/DGMethods/fv_reconstruction_test.jl
@@ -3,6 +3,7 @@ using StaticArrays
 using ClimateMachine.Atmos:
     AtmosProblem,
     NoReferenceState,
+    AtmosPhysics,
     AtmosModel,
     DryModel,
     ConstantDynamicViscosity,
@@ -62,14 +63,17 @@ end
     func = lin_func
 
     for FT in (Float64,)
-        model = AtmosModel{FT}(
-            AtmosLESConfigType,
+        physics = AtmosPhysics{FT}(
             param_set;
-            problem = AtmosProblem(init_state_prognostic = initialcondition!),
-            orientation = FlatOrientation(),
             ref_state = NoReferenceState(),
             turbulence = ConstantDynamicViscosity(FT(0)),
             moisture = DryModel(),
+        )
+        model = AtmosModel{FT}(
+            AtmosLESConfigType,
+            physics;
+            problem = AtmosProblem(init_state_prognostic = initialcondition!),
+            orientation = FlatOrientation(),
         )
 
         vars_prim = Vars{vars_state(model, Primitive(), FT)}

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -83,14 +83,17 @@ function test_run(
 
     # This is the base model which defines all the data (all other DGModels
     # for substepping components will piggy-back off of this models data)
-    fullmodel = AtmosModel{FT}(
-        AtmosLESConfigType,
+    fullphysics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = setup,
-        orientation = SphericalOrientation(),
         ref_state = HydrostaticState(T_profile),
         turbulence = Vreman(FT(0.23)),
         moisture = DryModel(),
+    )
+    fullmodel = AtmosModel{FT}(
+        AtmosLESConfigType,
+        fullphysics;
+        orientation = SphericalOrientation(),
+        init_state_prognostic = setup,
         source = (Gravity(),),
     )
     dg = DGModel(

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -124,12 +124,17 @@ function run_brick_interpolation_test(
         DeviceArray = DA,
         polynomialorder = polynomialorders,
     )
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = Initialize_Brick_Interpolation_Test!,
         ref_state = NoReferenceState(),
         turbulence = ConstantDynamicViscosity(FT(0)),
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        orientation = SphericalOrientation(),
+        init_state_prognostic = Initialize_Brick_Interpolation_Test!,
         source = (Gravity(),),
     )
 
@@ -275,14 +280,17 @@ function run_cubed_sphere_interpolation_test(
         meshwarp = ClimateMachine.Mesh.Topologies.equiangular_cubed_sphere_warp,
     )
 
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = setup,
-        orientation = SphericalOrientation(),
         ref_state = NoReferenceState(),
         turbulence = ConstantDynamicViscosity(FT(0)),
         moisture = DryModel(),
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        init_state_prognostic = setup,
         source = (),
     )
 

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -241,15 +241,18 @@ function config_agnesi_hs_lin(
     nothing # hide
 
     _C_smag = FT(0.21)
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_agnesi_hs_lin!,
         ref_state = ref_state,
         turbulence = Vreman(_C_smag),
         moisture = DryModel(),
-        source = source,
         tracers = NoTracers(),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        init_state_prognostic = init_agnesi_hs_lin!,
+        source = source,
     )
 
     config = ClimateMachine.AtmosLESConfiguration(

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -235,15 +235,18 @@ function config_agnesi_hs_lin(
     nothing # hide
 
     _C_smag = FT(0.0)
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = init_agnesi_hs_lin!,
         ref_state = ref_state,
         turbulence = Vreman(_C_smag),
         moisture = DryModel(),
-        source = source,
         tracers = NoTracers(),
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        physics;
+        init_state_prognostic = init_agnesi_hs_lin!,
+        source = source,
     )
 
     config = ClimateMachine.AtmosLESConfiguration(

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -217,15 +217,18 @@ function config_densitycurrent(
     ##md #     - [`init_state`](@ref init-dc)
 
     _C_smag = FT(0.21)
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,                             # Flow in a box, requires the AtmosLESConfigType
+    physics = AtmosPhysics{FT}(
         param_set;                                      # Parameter set corresponding to earth parameters
-        init_state_prognostic = init_densitycurrent!,   # Apply the initial condition
         ref_state = ref_state,                          # Reference state
         turbulence = Vreman(_C_smag),                   # Turbulence closure model
         moisture = DryModel(),                          # Exclude moisture variables
-        source = (Gravity(),),                          # Gravity is the only source term here
         tracers = NoTracers(),                          # Tracer model with diffusivity coefficients
+    )
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,                             # Flow in a box, requires the AtmosLESConfigType
+        physics;                                        # Atmos physics
+        init_state_prognostic = init_densitycurrent!,   # Apply the initial condition
+        source = (Gravity(),),                          # Gravity is the only source term here
     )
 
     ## Finally, we pass a `Problem Name` string, the mesh information, and the

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -152,13 +152,17 @@ function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
     )
 
     ## Set up the model
+    physics = AtmosPhysics{FT}(
+        param_set;
+        turbulence = Vreman(C_smag),
+        tracers = NTracers{ntracers, FT}(δ_χ),
+    )
+
     model = AtmosModel{FT}(
         AtmosLESConfigType,
-        param_set;
+        physics;
         problem = problem,
-        turbulence = Vreman(C_smag),
         source = (Gravity(),),
-        tracers = NTracers{ntracers, FT}(δ_χ),
         data_config = data_config,
     )
 

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -187,14 +187,18 @@ hyperdiffusion_model = DryBiharmonic(FT(4 * 3600));
 # ## Instantiate the model
 # The Held Suarez setup was designed to produce an equilibrated state that is
 # comparable to the zonal mean of the Earth’s atmosphere.
-model = AtmosModel{FT}(
-    AtmosGCMConfigType,
+physics = AtmosPhysics{FT}(
     param_set;
-    init_state_prognostic = init_heldsuarez!,
     ref_state = ref_state,
     turbulence = turbulence_model,
     hyperdiffusion = hyperdiffusion_model,
     moisture = DryModel(),
+);
+
+model = AtmosModel{FT}(
+    AtmosGCMConfigType,
+    physics;
+    init_state_prognostic = init_heldsuarez!,
     source = (Gravity(), Coriolis(), HeldSuarezForcingTutorial(), sponge),
 );
 

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -226,15 +226,19 @@ function config_risingbubble(
 
     ## Here we assemble the `AtmosModel`.
     _C_smag = FT(C_smag(param_set))
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,                            ## Flow in a box, requires the AtmosLESConfigType
+    physics = AtmosPhysics{FT}(
         param_set;                                     ## Parameter set corresponding to earth parameters
-        init_state_prognostic = init_risingbubble!,    ## Apply the initial condition
         ref_state = ref_state,                         ## Reference state
         turbulence = SmagorinskyLilly(_C_smag),        ## Turbulence closure model
         moisture = DryModel(),                         ## Exclude moisture variables
-        source = (Gravity(),),                         ## Gravity is the only source term here
         tracers = NTracers{ntracers, FT}(δ_χ),         ## Tracer model with diffusivity coefficients
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,                            ## Flow in a box, requires the AtmosLESConfigType
+        physics;                                       ## Atmos physics
+        init_state_prognostic = init_risingbubble!,    ## Apply the initial condition
+        source = (Gravity(),),                         ## Gravity is the only source term here
     )
 
     ## Finally, we pass a `Problem Name` string, the mesh information, and the

--- a/tutorials/Numerics/TimeStepping/tutorial_acousticwave_config.jl
+++ b/tutorials/Numerics/TimeStepping/tutorial_acousticwave_config.jl
@@ -80,13 +80,16 @@ function run_acousticwave(
     T_profile = IsothermalProfile(param_set, setup.T_ref)
     ref_state = HydrostaticState(T_profile)
     turbulence = ConstantDynamicViscosity(FT(0))
-    model = AtmosModel{FT}(
-        AtmosGCMConfigType,
+    physics = AtmosPhysics{FT}(
         param_set;
-        init_state_prognostic = setup,
         ref_state = ref_state,
         turbulence = turbulence,
         moisture = DryModel(),
+    )
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        physics;
+        init_state_prognostic = setup,
         source = (Gravity(),),
     )
 

--- a/tutorials/Numerics/TimeStepping/tutorial_risingbubble_config.jl
+++ b/tutorials/Numerics/TimeStepping/tutorial_risingbubble_config.jl
@@ -226,15 +226,19 @@ function config_risingbubble(
 
     ## Here we assemble the `AtmosModel`.
     _C_smag = FT(C_smag(param_set))
-    model = AtmosModel{FT}(
-        AtmosLESConfigType,                            ## Flow in a box, requires the AtmosLESConfigType
+    physics = AtmosPhysics{FT}(
         param_set;                                     ## Parameter set corresponding to earth parameters
-        init_state_prognostic = init_risingbubble!,    ## Apply the initial condition
         ref_state = ref_state,                         ## Reference state
         turbulence = SmagorinskyLilly(_C_smag),        ## Turbulence closure model
         moisture = DryModel(),                         ## Exclude moisture variables
-        source = (Gravity(),),                         ## Gravity is the only source term here
         tracers = NTracers{ntracers, FT}(δ_χ),         ## Tracer model with diffusivity coefficients
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,                            ## Flow in a box, requires the AtmosLESConfigType
+        physics;                                       ## Atmos physics
+        init_state_prognostic = init_risingbubble!,    ## Apply the initial condition
+        source = (Gravity(),),                         ## Gravity is the only source term here
     )
 
     ## Finally, we pass a `Problem Name` string, the mesh information, and the


### PR DESCRIPTION
### Description

This PR
 - Adds a `AtmosPhysics` outer constructor, which takes over most of the `AtmosModel` constructor
 - Constructs `AtmosPhysics` before `AtmosModel in the drivers
 - Defines `prognostic_vars(::AtmosPhysics)`, so that we can use it for pre-processing BCs.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
