### PR TITLE
Fix TurbulenceClosures docs, remove dead code

### DIFF
--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -13,28 +13,6 @@ viscosity terms, diffusivity and stress tensors.
 """
 module TurbulenceClosures
 
-# ## Turbulence Closures
-# In `turbulence.jl` we specify turbulence closures. Currently,
-# pointwise models of the eddy viscosity/eddy diffusivity type are
-# supported for turbulent shear and tracer diffusivity. Methods currently supported
-# are:\
-# [`ConstantViscosity`](@ref constant-viscosity)\
-# [`ViscousSponge`](@ref viscous-sponge)\
-# [`SmagorinskyLilly`](@ref smagorinsky-lilly)\
-# [`Vreman`](@ref vreman)\
-# [`AnisoMinDiss`](@ref aniso-min-diss)\
-
-#md # !!! note
-#md #     Usage: This is a quick-ref guide to using turbulence models as a subcomponent
-#md #     of `BalanceLaw` \
-#md #     $\nu$ is the kinematic viscosity, $C_smag$ is the Smagorinsky Model coefficient,
-#md #     `turbulence=ConstantDynamicViscosity(ρν)`\
-#md #     `turbulence=ConstantKinematicViscosity(ν)`\
-#md #     `turbulence=ViscousSponge(ν, z_max, z_sponge, α, γ)`\
-#md #     `turbulence=SmagorinskyLilly(C_smag)`\
-#md #     `turbulence=Vreman(C_smag)`\
-#md #     `turbulence=AnisoMinDiss(C_poincare)`
-
 using DocStringExtensions
 using LinearAlgebra
 using StaticArrays
@@ -75,16 +53,14 @@ export TurbulenceClosureModel,
     init_aux_hyperdiffusion!,
     sponge_viscosity_modifier,
     HyperdiffEnthalpyFlux,
-    HyperdiffViscousFlux
-
-# ### Abstract Type
-# We define a `TurbulenceClosureModel` abstract type and
-# default functions for the generic turbulence closure
-# which will be overloaded with model specific functions.
-
+    HyperdiffViscousFlux,
+    WithoutDivergence,
+    WithDivergence
 
 """
-    Abstract type with default do-nothing behaviour for
+    TurbulenceClosureModel
+
+Abstract type with default do-nothing behaviour for
 arbitrary turbulence closure models.
 """
 abstract type TurbulenceClosureModel end
@@ -93,17 +69,22 @@ vars_state(::TurbulenceClosureModel, ::AbstractStateType, FT) = @vars()
 
 """
     ConstantViscosity <: TurbulenceClosureModel
+
 Abstract type for constant viscosity models
 """
 abstract type ConstantViscosity <: TurbulenceClosureModel end
 
 """
-    Abstract type for HyperDiffusion models
+    HyperDiffusion
+
+Abstract type for HyperDiffusion models
 """
 abstract type HyperDiffusion end
 
 """
-    Abstract type for viscous sponge layers.
+    ViscousSponge
+
+Abstract type for viscous sponge layers.
 Modifier for viscosity computed from existing turbulence closures.
 """
 abstract type ViscousSponge end
@@ -111,6 +92,7 @@ abstract type ViscousSponge end
 
 """
     init_aux_turbulence!
+
 Initialise auxiliary variables for turbulence models.
 Overload for specific turbulence closure type.
 """
@@ -123,6 +105,7 @@ function init_aux_turbulence!(
 
 """
     compute_gradient_argument!
+
 Assign pre-gradient-transform variables specific to turbulence models.
 """
 function compute_gradient_argument!(
@@ -182,28 +165,33 @@ function compute_gradient_flux!(
 ) end
 
 function turbulence_tensors end
-function hyperviscosity_tensors end
 
 """
     ν, D_t, τ = turbulence_tensors(
-                    ::TurbulenceClosureModel,
-                    orientation::Orientation,
-                    param_set::AbstractParameterSet,
-                    state::Vars,
-                    diffusive::Vars,
-                    aux::Vars,
-                    t::Real
-                )
-Compute the kinematic viscosity (`ν`), the diffusivity (`D_t`) and SGS momentum flux tensor (`τ`)
-for a given turbulence closure. Each closure overloads this method with the appropriate calculations
-for the returned quantities.
+        ::TurbulenceClosureModel,
+        orientation::Orientation,
+        param_set::AbstractParameterSet,
+        state::Vars,
+        diffusive::Vars,
+        aux::Vars,
+        t::Real
+    )
+
+Compute the kinematic viscosity (`ν`), the
+diffusivity (`D_t`) and SGS momentum flux
+tensor (`τ`) for a given turbulence closure.
+Each closure overloads this method with the
+appropriate calculations for the returned
+quantities.
 
 # Arguments
 
-- `::TurbulenceClosureModel` = Struct identifier for turbulence closure model
+- `::TurbulenceClosureModel` = Struct identifier
+   for turbulence closure model
 - `orientation` = `BalanceLaw.orientation`
 - `param_set` parameter set
-- `state` = Array of prognostic (state) variables. See `vars_state` in `BalanceLaw`
+- `state` = Array of prognostic (state) variables.
+   See `vars_state` in `BalanceLaw`
 - `diffusive` = Array of diffusive variables
 - `aux` = Array of auxiliary variables
 - `t` = time
@@ -230,16 +218,6 @@ function turbulence_tensors(
     return (ν, D_t, τ)
 end
 
-# We also provide generic math functions for use within the turbulence closures,
-# commonly used quantities such as the [principal tensor invariants](@ref tensor-invariants), handling of
-# [symmetric tensors](@ref symmetric-tensors) and [tensor norms](@ref tensor-norms)are addressed.
-
-# ### [Pricipal Invariants](@id tensor-invariants)
-# ```math
-# \textit{I}_{1} = \mathrm{tr(X)} \\
-# \textit{I}_{2} = (\mathrm{tr(X)}^2 - \mathrm{tr(X^2)}) / 2 \\
-# \textit{I}_{3} = \mathrm{det(X)} \\
-# ```
 """
     principal_invariants(X)
 
@@ -252,10 +230,6 @@ function principal_invariants(X)
     return (first, second, third)
 end
 
-# ### [Symmetrize](@id symmetric-tensors)
-# ```math
-# \frac{\mathrm{X} + \mathrm{X}^{T}}{2} \\
-# ```
 """
     symmetrize(X)
 
@@ -273,13 +247,9 @@ function symmetrize(X::StaticArray{Tuple{3, 3}})
     ))
 end
 
-# ### [2-Norm](@id tensor-norms)
-# Given a tensor X, return the tensor dot product
-# ```math
-# \sum_{i,j} S_{ij}^2
-# ```
 """
     norm2(X)
+
 Given a tensor `X`, computes X:X.
 """
 function norm2(X::SMatrix{3, 3, FT}) where {FT}
@@ -302,20 +272,9 @@ function norm2(X::SHermitianCompact{3, FT, 6}) where {FT}
     abs2(X[3, 3])
 end
 
-# ### [Strain-rate Magnitude](@id strain-rate-magnitude)
-# By definition, the strain-rate magnitude, as defined in
-# standard turbulence modelling is computed such that
-# ```math
-# |\mathrm{S}| = \sqrt{2 \sum_{i,j} \mathrm{S}_{ij}^2}
-# ```
-# where
-# ```math
-# \vec{S}(\vec{u}) = \frac{1}{2}  \left(\nabla\vec{u} +  \left( \nabla\vec{u} \right)^T \right)
-# ```
-# \mathrm{S} is the rate-of-strain tensor. (Symmetric component of the velocity gradient). Note that the
-# skew symmetric component (rate-of-rotation) is not currently computed.
 """
     strain_rate_magnitude(S)
+
 Given the rate-of-strain tensor `S`, computes its magnitude.
 """
 function strain_rate_magnitude(S::SHermitianCompact{3, FT, 6}) where {FT}
@@ -324,35 +283,26 @@ end
 
 """
     WithDivergence
-A divergence type which includes the divergence term in the momentum flux tensor
+
+A divergence type which includes the
+divergence term in the momentum flux tensor
 """
 struct WithDivergence end
-export WithDivergence
+
 """
     WithoutDivergence
-A divergence type which does not include the divergence term in the momentum flux tensor
+
+A divergence type which does not include the
+divergence term in the momentum flux tensor
 """
 struct WithoutDivergence end
-export WithoutDivergence
-
-# ### [Constant Viscosity Model](@id constant-viscosity)
-# `ConstantViscosity` requires a user to specify the constant viscosity (dynamic or kinematic)
-# and appropriately computes the turbulent stress tensor based on this term. Diffusivity can be
-# computed using the turbulent Prandtl number for the appropriate problem regime.
-# ```math
-# \tau =
-#     \begin{cases}
-#     - 2 \nu \mathrm{S} & \mathrm{WithoutDivergence},\\
-#     - 2 \nu \mathrm{S} + \frac{2}{3} \nu \mathrm{tr(S)} I_3 & \mathrm{WithDivergence}.
-#     \end{cases}
-# ```
-
 
 """
     ConstantDynamicViscosity <: ConstantViscosity
 
 Turbulence with constant dynamic viscosity (`ρν`).
-Divergence terms are included in the momentum flux tensor if divergence_type is WithDivergence.
+Divergence terms are included in the momentum flux
+tensor if divergence_type is WithDivergence.
 
 # Fields
 
@@ -374,7 +324,8 @@ end
     ConstantKinematicViscosity <: ConstantViscosity
 
 Turbulence with constant kinematic viscosity (`ν`).
-Divergence terms are included in the momentum flux tensor if divergence_type is WithDivergence.
+Divergence terms are included in the momentum flux
+tensor if divergence_type is WithDivergence.
 
 # Fields
 
@@ -450,37 +401,6 @@ function turbulence_tensors(
     τ = compute_stress(m.divergence_type, ν, S)
     return ν, D_t, τ
 end
-
-# ### [Smagorinsky-Lilly](@id smagorinsky-lilly)
-# The Smagorinsky turbulence model, with Lilly's correction to
-# stratified atmospheric flows, is included in ClimateMachine.
-# The input parameter to this model is the Smagorinsky coefficient.
-# For atmospheric flows, the coefficient `C_smag` typically takes values between
-# 0.15 and 0.23. Flow dependent `C_smag` are currently not supported (e.g. Germano's
-# extension). The Smagorinsky-Lilly model does not contain explicit filtered terms.
-# #### Equations
-# ```math
-# \nu = (C_{s} \mathrm{f}_{b} \Delta)^2 \sqrt{|\mathrm{S}|}
-# ```
-# with the stratification correction term
-# ```math
-# f_{b} =
-#    \begin{cases}
-#    1 & \mathrm{Ri} \leq 0 ,\\
-#    \max(0, 1 - \mathrm{Ri} / \mathrm{Pr}_{t})^{1/4} & \mathrm{Ri} > 0 .
-#    \end{cases}
-# ```
-# ```math
-# \mathrm{Ri} =  \frac{N^2}{{|S|}^2}
-# ```
-# ```math
-# N = \left( \frac{g}{\theta_v} \frac{\partial \theta_v}{\partial z}\right)^{1/2}
-# ```
-# Here, $\mathrm{Ri}$ and $\mathrm{Pr}_{t}$ are the Richardson and
-# turbulent Prandtl numbers respectively.  $\Delta$ is the mixing length in the
-# relevant coordinate direction. We use the DG metric terms to determine the
-# local effective resolution (see `src/Mesh/Geometry.jl`), and modify the vertical lengthscale by the
-# stratification correction factor $\mathrm{f}_{b}$ so that $\Delta_{vert} = \Delta z f_b$.
 
 """
     SmagorinskyLilly <: TurbulenceClosureModel
@@ -577,27 +497,6 @@ function turbulence_tensors(
     return ν, D_t, τ
 end
 
-# ### [Vreman Model](@id vreman)
-# Vreman's turbulence model for anisotropic flows, which provides a
-# less dissipative solution (specifically in the near-wall and transitional regions)
-# than the Smagorinsky-Lilly method. This model
-# relies of first derivatives of the velocity vector (i.e., the gradient tensor).
-# By design, the Vreman model handles transitional as well as fully turbulent flows adequately.
-# The input parameter to this model is the Smagorinsky coefficient - the coefficient is modified
-# within the model functions to account for differences in model construction.
-# #### Equations
-# ```math
-# \nu_{t} = 2.5 C_{s}^2 \sqrt{\frac{B_{\beta}}{u_{i,j}u_{i,j}}},
-# ```
-# where ($i,j, m = (1,2,3)$)
-# ```math
-# \begin{align}
-# B_{\beta} &= \beta_{11}\beta_{22} + \beta_{11}\beta_{33} + \beta_{22}\beta_{33} - (\beta_{13}^2 + \beta_{12}^2 + \beta_{23}^2) \\
-# \beta_{ij} &= \Delta_{m}^2 u_{i, m} u_{j, m} \\
-# u_{i,j} &= \frac{\partial u_{i}}{\partial x_{j}}.
-# \end{align}
-# ```
-
 """
     Vreman{FT} <: TurbulenceClosureModel
 
@@ -693,19 +592,14 @@ function turbulence_tensors(
     return ν, D_t, τ
 end
 
-# ### [Anisotropic Minimum Dissipation](@id aniso-min-diss)
-# This method is based Vreugdenhil and Taylor's minimum-dissipation eddy-viscosity model.
-# The principles of the Rayleigh quotient minimizer are applied to the energy dissipation terms in the
-# conservation equations, resulting in a maximum dissipation bound, and a model for
-# eddy viscosity and eddy diffusivity.
-# ```math
-# \nu_e = (\mathrm{C}\delta)^2  \mathrm{max}\left[0, - \frac{\hat{\partial}_k \hat{u}_{i} \hat{\partial}_k \hat{u}_{j} \mathrm{\hat{S}}_{ij}}{\hat{\partial}_p \hat{u}_{q}} \right]
-# ```
 """
     AnisoMinDiss{FT} <: TurbulenceClosureModel
 
-Filter width Δ is the local grid resolution calculated from the mesh metric tensor. A Poincare coefficient
-is specified and used to compute the equivalent AnisoMinDiss coefficient (computed as the solution to the
+Filter width Δ is the local grid resolution
+calculated from the mesh metric tensor. A
+Poincare coefficient is specified and used
+to compute the equivalent AnisoMinDiss
+coefficient (computed as the solution to the
 eigenvalue problem for the Laplacian operator).
 
 # Fields
@@ -794,21 +688,21 @@ function turbulence_tensors(
 end
 
 """
-  NoHyperDiffusion <: HyperDiffusion
-Defines a default hyperdiffusion model with zero hyperdiffusive fluxes.
+    NoHyperDiffusion <: HyperDiffusion
+
+Defines a default hyperdiffusion model with
+zero hyperdiffusive fluxes.
 """
 struct NoHyperDiffusion <: HyperDiffusion end
 
-hyperviscosity_tensors(m::HyperDiffusion, bl::BalanceLaw, args...) =
-    hyperviscosity_tensors(m, bl.orientation, parameter_set(bl), args...)
-
 """
-  EquilMoistBiharmonic{FT} <: HyperDiffusion
+    EquilMoistBiharmonic{FT} <: HyperDiffusion
 
-Assumes equilibrium thermodynamics in compressible flow.
-Horizontal hyperdiffusion methods for application in GCM and LES settings
-Timescales are prescribed by the user while the diffusion coefficient is
-computed as a function of the grid lengthscale.
+Assumes equilibrium thermodynamics in compressible
+flow. Horizontal hyperdiffusion methods for
+application in GCM and LES settings Timescales are
+prescribed by the user while the diffusion coefficient
+is computed as a function of the grid lengthscale.
 
 # Fields
 $(DocStringExtensions.FIELDS)
@@ -884,11 +778,12 @@ function transform_post_gradient_laplacian!(
 end
 
 """
-  DryBiharmonic{FT} <: HyperDiffusion
+    DryBiharmonic{FT} <: HyperDiffusion
 
 Assumes dry compressible flow.
-Horizontal hyperdiffusion methods for application in GCM and LES settings
-Timescales are prescribed by the user while the diffusion coefficient is
+Horizontal hyperdiffusion methods for application
+in GCM and LES settings Timescales are prescribed
+by the user while the diffusion coefficient is
 computed as a function of the grid lengthscale.
 
 # Fields
@@ -951,21 +846,13 @@ function transform_post_gradient_laplacian!(
     hyperdiffusive.hyperdiffusion.ν∇³h_tot = ν₄ * ∇Δh_tot
 end
 
-# ### [Viscous Sponge](@id viscous-sponge)
-# `ViscousSponge` requires a user to specify a constant viscosity (kinematic),
-# a sponge start height, the domain height, a sponge strength, and a sponge
-# exponent.
-# Given viscosity, diffusivity and stresses from arbitrary turbulence models,
-# the viscous sponge enhances diffusive terms within a user-specified layer,
-# typically used at the top of the domain to absorb waves. A smooth onset is
-# ensured through a weight function that increases weight height from the sponge
-# onset height.
-# ```
 """
     NoViscousSponge
+
 No modifiers applied to viscosity/diffusivity in sponge layer
+
 # Fields
-#
+
 $(DocStringExtensions.FIELDS)
 """
 struct NoViscousSponge <: ViscousSponge end
@@ -981,11 +868,14 @@ function sponge_viscosity_modifier(
 end
 
 """
-    Upper domain viscous relaxation
+    UpperAtmosSponge{FT} <: ViscousSponge
+
+Upper domain viscous relaxation.
+
 Applies modifier to viscosity and diffusivity terms
 in a user-specified upper domain sponge region
+
 # Fields
-#
 $(DocStringExtensions.FIELDS)
 """
 struct UpperAtmosSponge{FT} <: ViscousSponge


### PR DESCRIPTION
### Description

This PR makes some changes in TurbulenceClosures.jl:
 - Fixes several doc strings
 - Removes `hyperviscosity_tensors`, which is not used anywhere
 - Removes comments that I believe are already in `TurbulenceClosures.md`

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
