### PR TITLE
Add parameter_set method, and remove .param_set calls

### DIFF
--- a/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
+++ b/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
@@ -66,9 +66,11 @@ include("heldsuarez_problem.jl")     # runs to equilibration
 # Initial conditions (common to all GCM experiments)
 function init_gcm_experiment!(problem, bl, state, aux, coords, t)
     FT = eltype(state)
-
+    param_set = parameter_set(bl)
     # General parameters
-    M_v::FT = molmass_ratio(bl.param_set) - 1 # constant for virtual temperature conversion - FIX: this assumes no initial liq/ice
+    # constant for virtual temperature conversion
+    # - FIX: this assumes no initial liq/ice
+    M_v::FT = molmass_ratio(param_set) - 1
 
     # Select initial perturbation
     u′, v′, w′, rand_pert =
@@ -97,12 +99,12 @@ function init_gcm_experiment!(problem, bl, state, aux, coords, t)
     phase_partition = PhasePartition(q_tot)
     T::FT = T_v / (1 + M_v * q_tot) # this needs to be adapted for ice and liq
 
-    ρ::FT = air_density(bl.param_set, T, p, phase_partition)
+    ρ::FT = air_density(param_set, T, p, phase_partition)
 
     ## potential & kinetic energy
     e_pot::FT = gravitational_potential(bl.orientation, aux)
     e_kin::FT = 0.5 * u_cart' * u_cart
-    e_tot::FT = total_energy(bl.param_set, e_kin, e_pot, T, phase_partition)
+    e_tot::FT = total_energy(param_set, e_kin, e_pot, T, phase_partition)
 
     ## Assign state variables
     state.ρ = ρ

--- a/experiments/AtmosGCM/GCMDriver/gcm_base_states.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_base_states.jl
@@ -26,10 +26,11 @@ end
 # Initial base state from rest, independent of the model reference state
 function init_base_state(::ZeroBaseState, bl, state, aux, coords, t)
     FT = eltype(state)
-    _R_d = R_d(bl.param_set)::FT
-    _grav = grav(bl.param_set)::FT
-    _a = planet_radius(bl.param_set)::FT
-    _p_0::FT = MSLP(bl.param_set)
+    param_set = parameter_set(bl)
+    _R_d::FT = R_d(param_set)
+    _grav::FT = grav(param_set)
+    _a::FT = planet_radius(param_set)
+    _p_0::FT = MSLP(param_set)
     T_initial = FT(255)
     r = norm(coords, 2)
     h = r - _a
@@ -58,11 +59,12 @@ function init_base_state(::BCWaveBaseState, bl, state, aux, coords, t)
     FT = eltype(state)
 
     # general parameters
-    _grav = grav(bl.param_set)::FT
-    _R_d = R_d(bl.param_set)::FT
-    _Ω = Omega(bl.param_set)::FT
-    _a = planet_radius(bl.param_set)::FT
-    _p_0 = MSLP(bl.param_set)::FT
+    param_set = parameter_set(bl)
+    _grav::FT = grav(param_set)
+    _R_d::FT = R_d(param_set)
+    _Ω::FT = Omega(param_set)
+    _a::FT = planet_radius(param_set)
+    _p_0::FT = MSLP(param_set)
 
     # grid
     φ = latitude(bl, aux)

--- a/experiments/AtmosGCM/GCMDriver/gcm_bcs.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_bcs.jl
@@ -72,15 +72,15 @@ function (st::Varying_SST_TJ16)(state, aux, t)
 
     q_tot = state.moisture.ρq_tot / ρ
     q = PhasePartition(q_tot)
-
+    param_set = st.param_set
     e_int = internal_energy(st.orientation, state, aux)
-    T = air_temperature(st.param_set, e_int, q)
-    p = air_pressure(st.param_set, T, ρ, q)
+    T = air_temperature(param_set, e_int, q)
+    p = air_pressure(param_set, T, ρ, q)
 
-    _T_triple = T_triple(st.param_set)::FT          # triple point of water
-    _press_triple = press_triple(st.param_set)::FT  # sat water pressure at T_triple
-    _LH_v0 = LH_v0(st.param_set)::FT                # latent heat of vaporization at T_triple
-    _R_v = R_v(st.param_set)::FT                    # gas constant for water vapor
+    _T_triple::FT = T_triple(param_set)          # triple point of water
+    _press_triple::FT = press_triple(param_set)  # sat water pressure at T_triple
+    _LH_v0::FT = LH_v0(param_set)                # latent heat of vaporization at T_triple
+    _R_v::FT = R_v(param_set)                    # gas constant for water vapor
 
     q_sfc =
         eps / p *

--- a/experiments/AtmosGCM/GCMDriver/gcm_moisture_profiles.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_moisture_profiles.jl
@@ -64,7 +64,8 @@ function init_moisture_profile(
 )
     FT = eltype(state)
 
-    _p_0 = MSLP(bl.param_set)::FT
+    param_set = parameter_set(bl)
+    _p_0::FT = MSLP(param_set)
 
     φ = latitude(bl, aux)
 

--- a/experiments/AtmosGCM/GCMDriver/gcm_perturbations.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_perturbations.jl
@@ -50,7 +50,8 @@ function init_perturbation(
     FT = eltype(state)
 
     # get parameters
-    _a = planet_radius(bl.param_set)::FT
+    param_set = parameter_set(bl)
+    _a::FT = planet_radius(param_set)
 
     φ = latitude(bl, aux)
     λ = longitude(bl, aux)

--- a/experiments/AtmosGCM/GCMDriver/gcm_sources.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_sources.jl
@@ -25,11 +25,12 @@ function held_suarez_forcing_coefficients(bl, args)
     # Parameters
     T_ref = FT(255)
 
-    _R_d = FT(R_d(bl.param_set))
-    _day = FT(day(bl.param_set))
-    _grav = FT(grav(bl.param_set))
-    _cp_d = FT(cp_d(bl.param_set))
-    _p0 = FT(MSLP(bl.param_set))
+    param_set = parameter_set(bl)
+    _R_d = FT(R_d(param_set))
+    _day = FT(day(param_set))
+    _grav = FT(grav(param_set))
+    _cp_d = FT(cp_d(param_set))
+    _p0 = FT(MSLP(param_set))
 
     # Held-Suarez parameters
     k_a = FT(1 / (40 * _day))
@@ -63,7 +64,8 @@ function source(s::HeldSuarezForcing{Energy}, m, args)
     @unpack ts = args.precomputed
     nt = held_suarez_forcing_coefficients(m, args)
     FT = eltype(state)
-    _cv_d = FT(cv_d(m.param_set))
+    param_set = parameter_set(bl)
+    _cv_d = FT(cv_d(param_set))
     @unpack k_T, T_equil = nt
     T = air_temperature(ts)
     return -k_T * state.ρ * _cv_d * (T - T_equil)

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -46,8 +46,9 @@ const param_set = EarthParameterSet()
 function init_heldsuarez!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
+    param_set = parameter_set(bl)
     # parameters
-    _a::FT = planet_radius(bl.param_set)
+    _a::FT = planet_radius(param_set)
 
     z_t::FT = 15e3
     λ_c::FT = π / 9
@@ -58,7 +59,7 @@ function init_heldsuarez!(problem, bl, state, aux, localgeo, t)
     # grid
     φ = latitude(bl.orientation, aux)
     λ = longitude(bl.orientation, aux)
-    z = altitude(bl.orientation, bl.param_set, aux)
+    z = altitude(bl.orientation, param_set, aux)
 
     # deterministic velocity perturbation
     F_z::FT = 1 - 3 * (z / z_t)^2 + 2 * (z / z_t)^3
@@ -120,12 +121,12 @@ function held_suarez_forcing_coefficients(bl, args)
 
     # Parameters
     T_ref = FT(255)
-
-    _R_d = FT(R_d(bl.param_set))
-    _day = FT(day(bl.param_set))
-    _grav = FT(grav(bl.param_set))
-    _cp_d = FT(cp_d(bl.param_set))
-    _p0 = FT(MSLP(bl.param_set))
+    param_set = parameter_set(bl)
+    _R_d = FT(R_d(param_set))
+    _day = FT(day(param_set))
+    _grav = FT(grav(param_set))
+    _cp_d = FT(cp_d(param_set))
+    _p0 = FT(MSLP(param_set))
 
     # Held-Suarez parameters
     k_a = FT(1 / (40 * _day))
@@ -159,7 +160,8 @@ function source(s::HeldSuarezForcing{Energy}, m, args)
     @unpack ts = args.precomputed
     nt = held_suarez_forcing_coefficients(m, args)
     FT = eltype(state)
-    _cv_d = FT(cv_d(m.param_set))
+    param_set = parameter_set(m)
+    _cv_d = FT(cv_d(param_set))
     @unpack k_T, T_equil = nt
     T = air_temperature(ts)
     return -k_T * state.ρ * _cv_d * (T - T_equil)

--- a/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
+++ b/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
@@ -44,11 +44,12 @@ function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     # parameters
-    _grav::FT = grav(bl.param_set)
-    _R_d::FT = R_d(bl.param_set)
-    _Ω::FT = Omega(bl.param_set)
-    _a::FT = planet_radius(bl.param_set)
-    _p_0::FT = MSLP(bl.param_set)
+    param_set = parameter_set(bl)
+    _grav::FT = grav(param_set)
+    _R_d::FT = R_d(param_set)
+    _Ω::FT = Omega(param_set)
+    _a::FT = planet_radius(param_set)
+    _p_0::FT = MSLP(param_set)
 
     k::FT = 3
     T_E::FT = 310
@@ -75,7 +76,7 @@ function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
     # grid
     φ = latitude(bl.orientation, aux)
     λ = longitude(bl.orientation, aux)
-    z = altitude(bl.orientation, bl.param_set, aux)
+    z = altitude(bl.orientation, param_set, aux)
     r::FT = z + _a
     γ::FT = 1 # set to 0 for shallow-atmosphere case and to 1 for deep atmosphere case
 
@@ -150,12 +151,12 @@ function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
 
     ## temperature & density
     T::FT = T_v / (1 + M_v * q_tot)
-    ρ::FT = air_density(bl.param_set, T, p, phase_partition)
+    ρ::FT = air_density(param_set, T, p, phase_partition)
 
     ## potential & kinetic energy
     e_pot::FT = gravitational_potential(bl.orientation, aux)
     e_kin::FT = 0.5 * u_cart' * u_cart
-    e_tot::FT = total_energy(bl.param_set, e_kin, e_pot, T, phase_partition)
+    e_tot::FT = total_energy(param_set, e_kin, e_pot, T, phase_partition)
 
     ## Assign state variables
     state.ρ = ρ
@@ -184,7 +185,8 @@ function (st::Varying_SST_TJ16)(state, aux, t)
     FT = eltype(state)
     φ = latitude(st.orientation, aux)
 
-    _T_sfc_pole = T_sfc_pole(st.param_set)::FT
+    param_set = st.param_set
+    _T_sfc_pole = T_sfc_pole(param_set)::FT
 
     Δφ = FT(26) * FT(π) / FT(180)       # latitudinal width of Gaussian function
     ΔSST = FT(29)                       # Eq-pole SST difference in K
@@ -197,13 +199,13 @@ function (st::Varying_SST_TJ16)(state, aux, t)
     q = PhasePartition(q_tot)
 
     e_int = internal_energy(st.orientation, state, aux)
-    T = air_temperature(st.param_set, e_int, q)
-    p = air_pressure(st.param_set, T, ρ, q)
+    T = air_temperature(param_set, e_int, q)
+    p = air_pressure(param_set, T, ρ, q)
 
-    _T_triple = T_triple(st.param_set)::FT          # triple point of water
-    _press_triple = press_triple(st.param_set)::FT  # sat water pressure at T_triple
-    _LH_v0 = LH_v0(st.param_set)::FT                # latent heat of vaporization at T_triple
-    _R_v = R_v(st.param_set)::FT                    # gas constant for water vapor
+    _T_triple = T_triple(param_set)::FT          # triple point of water
+    _press_triple = press_triple(param_set)::FT  # sat water pressure at T_triple
+    _LH_v0 = LH_v0(param_set)::FT                # latent heat of vaporization at T_triple
+    _R_v = R_v(param_set)::FT                    # gas constant for water vapor
 
     q_sfc =
         eps / p *

--- a/experiments/AtmosGCM/nonhydrostatic_gravity_wave.jl
+++ b/experiments/AtmosGCM/nonhydrostatic_gravity_wave.jl
@@ -42,13 +42,14 @@ function init_nonhydrostatic_gravity_wave!(problem, bl, state, aux, localgeo, t)
     z = altitude(bl, aux)
 
     # parameters
-    _grav::FT = grav(bl.param_set)
-    _cp::FT = cp_d(bl.param_set)
-    _Ω::FT = Omega(bl.param_set)
-    _a::FT = planet_radius(bl.param_set)
-    _R_d::FT = R_d(bl.param_set)
-    _kappa::FT = kappa_d(bl.param_set)
-    _p_eq::FT = MSLP(bl.param_set)
+    param_set = parameter_set(bl)
+    _grav::FT = grav(param_set)
+    _cp::FT = cp_d(param_set)
+    _Ω::FT = Omega(param_set)
+    _a::FT = planet_radius(param_set)
+    _R_d::FT = R_d(param_set)
+    _kappa::FT = kappa_d(param_set)
+    _p_eq::FT = MSLP(param_set)
 
     N::FT = 0.01
     u_0::FT = 0.0
@@ -94,7 +95,7 @@ function init_nonhydrostatic_gravity_wave!(problem, bl, state, aux, localgeo, t)
     T::FT = T_b + T′
 
     # density
-    ρ = air_density(bl.param_set, T_b, p)
+    ρ = air_density(param_set, T_b, p)
 
     # potential & kinetic energy
     e_pot = gravitational_potential(bl.orientation, aux)
@@ -102,7 +103,7 @@ function init_nonhydrostatic_gravity_wave!(problem, bl, state, aux, localgeo, t)
 
     state.ρ = ρ
     state.ρu = ρ * u_init
-    state.energy.ρe = ρ * total_energy(bl.param_set, e_kin, e_pot, T)
+    state.energy.ρe = ρ * total_energy(param_set, e_kin, e_pot, T)
 
     nothing
 end

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -237,7 +237,8 @@ function source(s::BomexTendencies{Energy}, m, args)
     FT = eltype(state)
     @unpack ρ∂qt∂t, ρ∂θ∂t, w_s, k̂ = params
     cvm = cv_m(ts)
-    _e_int_v0 = FT(e_int_v0(m.param_set))
+    param_set = parameter_set(m)
+    _e_int_v0 = FT(e_int_v0(param_set))
     term1 = cvm * ρ∂θ∂t * exner(ts) + _e_int_v0 * ρ∂qt∂t
     term2 = state.ρ * w_s * dot(k̂, diffusive.energy.∇h_tot)
     return term1 - term2
@@ -262,14 +263,15 @@ function init_bomex!(problem, bl, state, aux, localgeo, t)
 
     # Problem floating point precision
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     P_sfc::FT = 1.015e5 # Surface air pressure
     qg::FT = 22.45e-3 # Total moisture at surface
     q_pt_sfc = PhasePartition(qg) # Surface moisture partitioning
-    Rm_sfc = gas_constant_air(bl.param_set, q_pt_sfc) # Moist gas constant
+    Rm_sfc = gas_constant_air(param_set, q_pt_sfc) # Moist gas constant
     θ_liq_sfc = FT(299.1) # Prescribed θ_liq at surface
     T_sfc = FT(300.4) # Surface temperature
-    _grav = FT(grav(bl.param_set))
+    _grav = FT(grav(param_set))
 
     # Initialise speeds [u = Eastward, v = Northward, w = Vertical]
     u::FT = 0
@@ -320,7 +322,7 @@ function init_bomex!(problem, bl, state, aux, localgeo, t)
     P = P_sfc * exp(-z / H)
 
     # Establish thermodynamic state and moist phase partitioning
-    ts = PhaseEquil_pθq(bl.param_set, P, θ_liq, q_tot)
+    ts = PhaseEquil_pθq(param_set, P, θ_liq, q_tot)
     T = air_temperature(ts)
     ρ = air_density(ts)
 

--- a/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
+++ b/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
@@ -107,7 +107,8 @@ function source(s::LargeScaleProcess{Energy}, m, args)
     FT = eltype(state)
     # Establish vertical orientation
     k̂ = vertical_unit_vector(m, aux)
-    _e_int_v0 = e_int_v0(m.param_set)
+    param_set = parameter_set(m)
+    _e_int_v0 = e_int_v0(param_set)
     # Unpack vertical gradients
     ∂qt∂z = diffusive.lsforcing.∇ᵥhus
     ∂T∂z = diffusive.lsforcing.∇ᵥta
@@ -349,8 +350,9 @@ end
 const seed = MersenneTwister(0)
 function init_cfsites!(problem, bl, state, aux, localgeo, t, spl)
     FT = eltype(state)
+    param_set = parameter_set(bl)
     (x, y, z) = localgeo.coord
-    _grav = grav(bl.param_set)
+    _grav = FT(grav(param_set))
 
     # Unpack splines, interpolate to z coordinate at
     # present grid index. (Functions are all pointwise)
@@ -367,9 +369,10 @@ function init_cfsites!(problem, bl, state, aux, localgeo, t, spl)
     wap = FT(spl.spl_wap(z))
     ρ_gcm = FT(1 / spl.spl_alpha(z))
 
+    param_set = parameter_set(bl)
     # Compute field properties based on interpolated data
-    ρ = air_density(bl.param_set, ta, pfull, PhasePartition(hus))
-    e_int = internal_energy(bl.param_set, ta, PhasePartition(hus))
+    ρ = air_density(param_set, ta, pfull, PhasePartition(hus))
+    e_int = internal_energy(param_set, ta, PhasePartition(hus))
     e_kin = (ua^2 + va^2) / 2
     e_pot = _grav * z
     # Assignment of state variables

--- a/experiments/AtmosLES/convective_bl_model.jl
+++ b/experiments/AtmosLES/convective_bl_model.jl
@@ -124,12 +124,13 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     (x, y, z) = localgeo.coord
 
     # Problem floating point precision
+    param_set = parameter_set(bl)
     FT = eltype(state)
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
     # Initialise speeds [u = Eastward, v = Northward, w = Vertical]
     u::FT = 4
@@ -145,7 +146,7 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     π_exner = FT(1) - _grav / (c_p * θ) * z # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
     # Establish thermodynamic state and moist phase partitioning
-    TS = PhaseEquil_ρθq(bl.param_set, ρ, θ_liq, q_tot)
+    TS = PhaseEquil_ρθq(param_set, ρ, θ_liq, q_tot)
 
     # Compute momentum contributions
     ρu = ρ * u
@@ -175,11 +176,12 @@ function surface_temperature_variation(bl, state, t)
     FT = eltype(state)
     ρ = state.ρ
     θ_liq_sfc = FT(291.15) + FT(20) * sinpi(FT(t / 12 / 3600))
+    param_set = parameter_set(bl)
     if bl.moisture isa DryModel
-        TS = PhaseDry_ρθ(bl.param_set, ρ, θ_liq_sfc)
+        TS = PhaseDry_ρθ(param_set, ρ, θ_liq_sfc)
     else
         q_tot = state.moisture.ρq_tot / ρ
-        TS = PhaseEquil_ρθq(bl.param_set, ρ, θ_liq_sfc, q_tot)
+        TS = PhaseEquil_ρθq(param_set, ρ, θ_liq_sfc, q_tot)
     end
     return air_temperature(TS)
 end

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -108,9 +108,10 @@ function flux(::DYCOMSRadiation{Energy}, atmos, args)
     # Constants
     upward_flux_from_cloud = m.F_0 * exp(-aux.∫dnz.radiation.attenuation_coeff)
     upward_flux_from_sfc = m.F_1 * exp(-aux.∫dz.radiation.attenuation_coeff)
+    param_set = parameter_set(atmos)
     free_troposphere_flux =
         m.ρ_i *
-        FT(cp_d(atmos.param_set)) *
+        FT(cp_d(param_set)) *
         m.D_subsidence *
         m.α_z *
         cbrt(Δz_i) *
@@ -180,16 +181,17 @@ function init_dycoms!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     (x, y, z) = localgeo.coord
+    param_set = parameter_set(bl)
 
     z = altitude(bl, aux)
 
     # These constants are those used by Stevens et al. (2005)
     qref = FT(9.0e-3)
     q_pt_sfc = PhasePartition(qref)
-    Rm_sfc = gas_constant_air(bl.param_set, q_pt_sfc)
+    Rm_sfc = gas_constant_air(param_set, q_pt_sfc)
     T_sfc = FT(290.4)
-    _MSLP = FT(MSLP(bl.param_set))
-    _grav = FT(grav(bl.param_set))
+    _MSLP = FT(MSLP(param_set))
+    _grav = FT(grav(param_set))
 
     # Specify moisture profiles
     q_liq = FT(0)
@@ -221,7 +223,7 @@ function init_dycoms!(problem, bl, state, aux, localgeo, t)
 
     # Density, Temperature
 
-    ts = PhaseEquil_pθq(bl.param_set, p, θ_liq, q_tot)
+    ts = PhaseEquil_pθq(param_set, p, θ_liq, q_tot)
     ρ = air_density(ts)
 
     e_kin = FT(1 / 2) * FT((u^2 + v^2 + w^2))

--- a/experiments/AtmosLES/rising_bubble_bryan.jl
+++ b/experiments/AtmosLES/rising_bubble_bryan.jl
@@ -45,12 +45,13 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     (x, y, z) = localgeo.coord
 
     FT = eltype(state)
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
+    param_set = parameter_set(bl)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
     γ::FT = c_p / c_v
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
 
     xc::FT = 10000
     zc::FT = 2000
@@ -68,7 +69,7 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     π_exner = FT(1) - _grav / (c_p * θ) * z # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
     q_tot = FT(0)
-    ts = PhaseEquil_ρθq(bl.param_set, ρ, θ, q_tot)
+    ts = PhaseEquil_ρθq(param_set, ρ, θ, q_tot)
     q_pt = PhasePartition(ts)
 
     ρu = SVector(FT(0), FT(0), FT(0))

--- a/experiments/AtmosLES/rising_bubble_theta_formulation.jl
+++ b/experiments/AtmosLES/rising_bubble_theta_formulation.jl
@@ -116,11 +116,12 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     ## Unpack constant parameters
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    param_set = parameter_set(bl)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     ## Define bubble center and background potential temperature
@@ -145,8 +146,8 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     π_exner = FT(1) - _grav / (c_p * θ) * z             ## exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas)      ## density
     T = θ * π_exner
-    e_int = internal_energy(bl.param_set, T)
-    ts = PhaseDry(bl.param_set, e_int, ρ)
+    e_int = internal_energy(param_set, T)
+    ts = PhaseDry(param_set, e_int, ρ)
     ρu = SVector(FT(0), FT(0), FT(0))                   ## momentum
     ## State (prognostic) variable assignment
     e_kin = FT(0)                                       ## kinetic energy

--- a/experiments/AtmosLES/schar_scalar_advection.jl
+++ b/experiments/AtmosLES/schar_scalar_advection.jl
@@ -34,11 +34,12 @@ function init_schar!(problem, bl, state, aux, localgeo, t)
     (x, y, z) = localgeo.coord
 
     ## Unpack constant parameters
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    param_set = parameter_set(bl)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     c::FT = c_v / R_gas
@@ -59,8 +60,8 @@ function init_schar!(problem, bl, state, aux, localgeo, t)
 
     ## Compute perturbed thermodynamic state:
     T = θ * π_exner
-    e_int = internal_energy(bl.param_set, T)
-    ts = PhaseDry(bl.param_set, e_int, ρ)
+    e_int = internal_energy(param_set, T)
+    ts = PhaseDry(param_set, e_int, ρ)
 
     ## Initial velocity
     z₁::FT = 4000

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -127,12 +127,13 @@ add_perturbations!(state, localgeo) = nothing
 function init_problem!(problem, bl, state, aux, localgeo, t)
     (x, y, z) = localgeo.coord
     # Problem floating point precision
+    param_set = parameter_set(bl)
     FT = eltype(state)
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
     # Initialise speeds [u = Eastward, v = Northward, w = Vertical]
     u::FT = 8
@@ -152,9 +153,9 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     p = aux.ref_state.p
     # Establish thermodynamic state and moist phase partitioning
     if bl.moisture isa DryModel
-        TS = PhaseDry_pθ(bl.param_set, p, θ)
+        TS = PhaseDry_pθ(param_set, p, θ)
     else
-        TS = PhaseEquil_pθq(bl.param_set, p, θ_liq, q_tot)
+        TS = PhaseEquil_pθq(param_set, p, θ_liq, q_tot)
     end
 
     ρ = bl.compressibility isa Compressible ? air_density(TS) : aux.ref_state.ρ

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -41,12 +41,13 @@ const param_set = EarthParameterSet()
 """
 function init_surfacebubble!(problem, bl, state, aux, localgeo, t)
     (x, y, z) = localgeo.coord
+    param_set = parameter_set(bl)
     FT = eltype(state)
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     xc::FT = 1250
@@ -61,7 +62,7 @@ function init_surfacebubble!(problem, bl, state, aux, localgeo, t)
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
 
     q_tot = FT(0)
-    ts = PhaseEquil_ρθq(bl.param_set, ρ, θ, q_tot)
+    ts = PhaseEquil_ρθq(param_set, ρ, θ, q_tot)
     q_pt = PhasePartition(ts)
 
     ρu = SVector(FT(0), FT(0), FT(0))

--- a/experiments/AtmosLES/taylor_green.jl
+++ b/experiments/AtmosLES/taylor_green.jl
@@ -52,13 +52,14 @@ function init_greenvortex!(problem, bl, state, aux, localgeo, t)
 
     # Problem float-type
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     # Unpack constant parameters
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     # Compute perturbed thermodynamic state:
@@ -73,7 +74,7 @@ function init_greenvortex!(problem, bl, state, aux, localgeo, t)
     v = -Uzero * cos(x) * sin(y) * cos(z)
     e_kin = 0.5 * (u^2 + v^2)
     T = p / (ρ * R_gas)
-    e_int = internal_energy(bl.param_set, T, PhasePartition(FT(0)))
+    e_int = internal_energy(param_set, T, PhasePartition(FT(0)))
     ρe_tot = ρ * (e_kin + e_pot + e_int)
     # Assign State Variables
     state.ρ = ρ

--- a/experiments/TestCase/baroclinic_wave.jl
+++ b/experiments/TestCase/baroclinic_wave.jl
@@ -32,11 +32,12 @@ function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     # parameters
-    _grav::FT = grav(bl.param_set)
-    _R_d::FT = R_d(bl.param_set)
-    _Ω::FT = Omega(bl.param_set)
-    _a::FT = planet_radius(bl.param_set)
-    _p_0::FT = MSLP(bl.param_set)
+    param_set = parameter_set(bl)
+    _grav::FT = grav(param_set)
+    _R_d::FT = R_d(param_set)
+    _Ω::FT = Omega(param_set)
+    _a::FT = planet_radius(param_set)
+    _p_0::FT = MSLP(param_set)
 
     k::FT = 3
     T_E::FT = 310
@@ -63,7 +64,7 @@ function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
     # grid
     φ = latitude(bl.orientation, aux)
     λ = longitude(bl.orientation, aux)
-    z = altitude(bl.orientation, bl.param_set, aux)
+    z = altitude(bl.orientation, param_set, aux)
     r::FT = z + _a
     γ::FT = 1 # set to 0 for shallow-atmosphere case and to 1 for deep atmosphere case
 
@@ -142,12 +143,12 @@ function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
 
     ## temperature & density
     T::FT = T_v / (1 + M_v * q_tot)
-    ρ::FT = air_density(bl.param_set, T, p, phase_partition)
+    ρ::FT = air_density(param_set, T, p, phase_partition)
 
     ## potential & kinetic energy
     e_pot::FT = gravitational_potential(bl.orientation, aux)
     e_kin::FT = 0.5 * u_cart' * u_cart
-    e_tot::FT = total_energy(bl.param_set, e_kin, e_pot, T, phase_partition)
+    e_tot::FT = total_energy(param_set, e_kin, e_pot, T, phase_partition)
 
     ## Assign state variables
     state.ρ = ρ

--- a/experiments/TestCase/baroclinic_wave_fvm.jl
+++ b/experiments/TestCase/baroclinic_wave_fvm.jl
@@ -32,11 +32,12 @@ function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     # parameters
-    _grav::FT = grav(bl.param_set)
-    _R_d::FT = R_d(bl.param_set)
-    _Ω::FT = Omega(bl.param_set)
-    _a::FT = planet_radius(bl.param_set)
-    _p_0::FT = MSLP(bl.param_set)
+    param_set = parameter_set(bl)
+    _grav::FT = grav(param_set)
+    _R_d::FT = R_d(param_set)
+    _Ω::FT = Omega(param_set)
+    _a::FT = planet_radius(param_set)
+    _p_0::FT = MSLP(param_set)
 
     k::FT = 3
     T_E::FT = 310
@@ -63,7 +64,7 @@ function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
     # grid
     φ = latitude(bl.orientation, aux)
     λ = longitude(bl.orientation, aux)
-    z = altitude(bl.orientation, bl.param_set, aux)
+    z = altitude(bl.orientation, param_set, aux)
     r::FT = z + _a
     γ::FT = 1 # set to 0 for shallow-atmosphere case and to 1 for deep atmosphere case
 
@@ -142,12 +143,12 @@ function init_baroclinic_wave!(problem, bl, state, aux, localgeo, t)
 
     ## temperature & density
     T::FT = T_v / (1 + M_v * q_tot)
-    ρ::FT = air_density(bl.param_set, T, p, phase_partition)
+    ρ::FT = air_density(param_set, T, p, phase_partition)
 
     ## potential & kinetic energy
     e_pot::FT = gravitational_potential(bl.orientation, aux)
     e_kin::FT = 0.5 * u_cart' * u_cart
-    e_tot::FT = total_energy(bl.param_set, e_kin, e_pot, T, phase_partition)
+    e_tot::FT = total_energy(param_set, e_kin, e_pot, T, phase_partition)
 
     ## Assign state variables
     state.ρ = ρ

--- a/experiments/TestCase/isothermal_zonal_flow.jl
+++ b/experiments/TestCase/isothermal_zonal_flow.jl
@@ -36,14 +36,14 @@ CLIMAParameters.Planet.MSLP(::EarthParameterSet) = 1e5
 
 function init_isothermal_zonal_flow!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
-
+    param_set = parameter_set(bl)
     φ = latitude(bl.orientation, aux)
     z = altitude(bl.orientation, param_set, aux)
 
-    _grav::FT = grav(bl.param_set)
-    _a::FT = planet_radius(bl.param_set)
-    _R_d::FT = R_d(bl.param_set)
-    _MSLP::FT = MSLP(bl.param_set)
+    _grav::FT = grav(param_set)
+    _a::FT = planet_radius(param_set)
+    _R_d::FT = R_d(param_set)
+    _MSLP::FT = MSLP(param_set)
 
     u₀ = FT(20)
     T₀ = FT(300)
@@ -69,14 +69,14 @@ function init_isothermal_zonal_flow!(problem, bl, state, aux, localgeo, t)
     exparg = fac1 - fac2 - fac3
     p = _MSLP * exp(exparg)
 
-    ρ = air_density(bl.param_set, T₀, p)
+    ρ = air_density(param_set, T₀, p)
 
     e_pot = gravitational_potential(bl.orientation, aux)
     e_kin = u_init' * u_init / 2
 
     state.ρ = ρ
     state.ρu = ρ * u_init
-    state.energy.ρe = ρ * total_energy(bl.param_set, e_kin, e_pot, T₀)
+    state.energy.ρe = ρ * total_energy(param_set, e_kin, e_pot, T₀)
 end
 
 function config_isothermal_zonal_flow(

--- a/experiments/TestCase/risingbubble.jl
+++ b/experiments/TestCase/risingbubble.jl
@@ -25,13 +25,14 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     (x, y, z) = localgeo.coord
+    param_set = parameter_set(bl)
 
     ## Unpack constant parameters
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     ## Define bubble center and background potential temperature
@@ -58,19 +59,19 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     ## Compute perturbed thermodynamic state:
     θ = θ_ref + Δθ                                      # potential temperature
     q_pt = PhasePartition(Δq_tot)
-    R_m = gas_constant_air(bl.param_set, q_pt)
-    _cp_m = cp_m(bl.param_set, q_pt)
-    _cv_m = cv_m(bl.param_set, q_pt)
+    R_m = gas_constant_air(param_set, q_pt)
+    _cp_m = cp_m(param_set, q_pt)
+    _cv_m = cv_m(param_set, q_pt)
     π_exner = FT(1) - _grav / (_cp_m * θ) * z           # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(_cv_m / R_m)      # density
     T = θ * π_exner
 
     if bl.moisture isa EquilMoist
-        e_int = internal_energy(bl.param_set, T, q_pt)
-        ts = PhaseEquil(bl.param_set, e_int, ρ, Δq_tot)
+        e_int = internal_energy(param_set, T, q_pt)
+        ts = PhaseEquil(param_set, e_int, ρ, Δq_tot)
     else
-        e_int = internal_energy(bl.param_set, T)
-        ts = PhaseDry(bl.param_set, e_int, ρ)
+        e_int = internal_energy(param_set, T)
+        ts = PhaseDry(param_set, e_int, ρ)
     end
     ρu = SVector(FT(0), FT(0), FT(0))                   # momentum
     ## State (prognostic) variable assignment

--- a/experiments/TestCase/risingbubble_fvm.jl
+++ b/experiments/TestCase/risingbubble_fvm.jl
@@ -27,13 +27,14 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
 
     (x, y, z) = localgeo.coord
+    param_set = parameter_set(bl)
 
     ## Unpack constant parameters
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     ## Define bubble center and background potential temperature
@@ -60,19 +61,19 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     ## Compute perturbed thermodynamic state:
     θ = θ_ref + Δθ                                      # potential temperature
     q_pt = PhasePartition(Δq_tot)
-    R_m = gas_constant_air(bl.param_set, q_pt)
-    _cp_m = cp_m(bl.param_set, q_pt)
-    _cv_m = cv_m(bl.param_set, q_pt)
+    R_m = gas_constant_air(param_set, q_pt)
+    _cp_m = cp_m(param_set, q_pt)
+    _cv_m = cv_m(param_set, q_pt)
     π_exner = FT(1) - _grav / (_cp_m * θ) * z           # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(_cv_m / R_m)      # density
     T = θ * π_exner
 
     if bl.moisture isa EquilMoist
-        e_int = internal_energy(bl.param_set, T, q_pt)
-        ts = PhaseEquil(bl.param_set, e_int, ρ, Δq_tot)
+        e_int = internal_energy(param_set, T, q_pt)
+        ts = PhaseEquil(param_set, e_int, ρ, Δq_tot)
     else
-        e_int = internal_energy(bl.param_set, T)
-        ts = PhaseDry(bl.param_set, e_int, ρ)
+        e_int = internal_energy(param_set, T)
+        ts = PhaseDry(param_set, e_int, ρ)
     end
     ρu = SVector(FT(0), FT(0), FT(0))                   # momentum
     ## State (prognostic) variable assignment

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -38,7 +38,7 @@ end
 @inline linearized_pressure(atmos, state::Vars, aux::Vars) =
     linearized_pressure(
         atmos.moisture,
-        atmos.param_set,
+        parameter_set(atmos),
         atmos.orientation,
         state,
         aux,
@@ -164,7 +164,7 @@ function wavespeed(
     direction,
 )
     ref = aux.ref_state
-    return soundspeed_air(lm.atmos.param_set, ref.T)
+    return soundspeed_air(parameter_set(lm.atmos), ref.T)
 end
 
 boundary_conditions(atmoslm::AtmosLinearModel) = (AtmosBC(), AtmosBC())
@@ -306,7 +306,7 @@ function numerical_flux_first_order!(
     )
 
     atmos = balance_law.atmos
-    param_set = atmos.param_set
+    param_set = parameter_set(atmos)
 
     ρu⁻ = state_prognostic⁻.ρu
 
@@ -397,7 +397,7 @@ function numerical_flux_first_order!(
     )
 
     atmos = balance_law.atmos
-    param_set = atmos.param_set
+    param_set = parameter_set(atmos)
     FT = eltype(aux)
     ρu⁻ = state_prognostic⁻.ρu
 

--- a/src/Atmos/Model/prog_prim_conversion.jl
+++ b/src/Atmos/Model/prog_prim_conversion.jl
@@ -75,7 +75,7 @@ function prognostic_to_primitive!(
     prog::Vars,
     e_int::AbstractFloat,
 )
-    ts = PhaseDry(atmos.param_set, e_int, prog.ρ)
+    ts = PhaseDry(parameter_set(atmos), e_int, prog.ρ)
     prim.ρ = prog.ρ
     prim.u = prog.ρu ./ prog.ρ
     prim.p = air_pressure(ts)
@@ -90,7 +90,7 @@ function prognostic_to_primitive!(
 )
     FT = eltype(prim)
     ts = PhaseEquil(
-        atmos.param_set,
+        parameter_set(atmos),
         e_int,
         prog.ρ,
         prog.moisture.ρq_tot / prog.ρ,
@@ -115,7 +115,7 @@ function prognostic_to_primitive!(
         prog.moisture.ρq_liq / prog.ρ,
         prog.moisture.ρq_ice / prog.ρ,
     )
-    ts = PhaseNonEquil(atmos.param_set, e_int, prog.ρ, q_pt)
+    ts = PhaseNonEquil(parameter_set(atmos), e_int, prog.ρ, q_pt)
     prim.ρ = prog.ρ
     prim.u = prog.ρu ./ prog.ρ
     prim.p = air_pressure(ts)
@@ -136,7 +136,7 @@ function primitive_to_prognostic!(
     e_pot::AbstractFloat,
 )
     atmos.energy isa EnergyModel || error("EnergyModel only supported")
-    ts = PhaseDry_ρp(atmos.param_set, prim.ρ, prim.p)
+    ts = PhaseDry_ρp(parameter_set(atmos), prim.ρ, prim.p)
     e_kin = prim.u' * prim.u / 2
 
     prog.ρ = prim.ρ
@@ -153,7 +153,7 @@ function primitive_to_prognostic!(
 )
     atmos.energy isa EnergyModel || error("EnergyModel only supported")
     ts = PhaseEquil_ρpq(
-        atmos.param_set,
+        parameter_set(atmos),
         prim.ρ,
         prim.p,
         prim.moisture.q_tot,
@@ -180,7 +180,7 @@ function primitive_to_prognostic!(
         prim.moisture.q_liq,
         prim.moisture.q_ice,
     )
-    ts = PhaseNonEquil_ρpq(atmos.param_set, prim.ρ, prim.p, q_pt)
+    ts = PhaseNonEquil_ρpq(parameter_set(atmos), prim.ρ, prim.p, q_pt)
     e_kin = prim.u' * prim.u / 2
 
     prog.ρ = prim.ρ
@@ -198,7 +198,8 @@ function construct_face_auxiliary_state!(
     aux_cell::AbstractArray,
     Δz::FT,
 ) where {FT <: Real}
-    _grav = FT(grav(bl.param_set))
+    param_set = parameter_set(bl)
+    _grav = FT(grav(param_set))
     var_aux = Vars{vars_state(bl, Auxiliary(), FT)}
     aux_face .= aux_cell
 

--- a/src/Atmos/Model/reconstructions.jl
+++ b/src/Atmos/Model/reconstructions.jl
@@ -20,7 +20,8 @@ function (hb_recon::HBFVReconstruction)(
 ) where {D}
     FT = eltype(state_bot)
     vars_prim = Vars{vars_state(hb_recon._atmo, Primitive(), FT)}
-    _grav = FT(grav(hb_recon._atmo.param_set))
+    param_set = parameter_set(hb_recon._atmo)
+    _grav = FT(grav(param_set))
 
     # stencil info
     stencil_diameter = D
@@ -37,7 +38,7 @@ function (hb_recon::HBFVReconstruction)(
                 vars_prim(cell_states[i]).ρ * _grav * cell_weights[i] / 2
         end
 
-        # construct reference pressure steates and update pressure states
+        # construct reference pressure states and update pressure states
         p_ref = ps[stencil_center]
         p_bot_ref = p_ref + ρgΔz_half[stencil_center]
         p_top_ref = p_ref - ρgΔz_half[stencil_center]

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -73,10 +73,11 @@ function ref_state_init_pρ!(
     tmp::Vars,
     geom::LocalGeometry,
 )
+    param_set = parameter_set(atmos)
     z = altitude(atmos, aux)
-    T_virt, p = atmos.ref_state.virtual_temperature_profile(atmos.param_set, z)
+    T_virt, p = atmos.ref_state.virtual_temperature_profile(param_set, z)
     aux.ref_state.p = p
-    aux.ref_state.ρ = p / (T_virt * R_d(atmos.param_set))
+    aux.ref_state.ρ = p / (T_virt * R_d(param_set))
 end
 
 function ref_state_init_density_from_pressure!(
@@ -99,15 +100,15 @@ function ref_state_finalize_init!(
     geom::LocalGeometry,
 )
     FT = eltype(aux)
-
+    param_set = parameter_set(atmos)
     ρ = aux.ref_state.ρ
     p = aux.ref_state.p
-    T_virt = p / (ρ * FT(R_d(atmos.param_set)))
+    T_virt = p / (ρ * FT(R_d(param_set)))
 
     RH = atmos.ref_state.relative_humidity
     phase_type = PhaseEquil
     (T, q_pt) = TD.temperature_and_humidity_given_TᵥρRH(
-        atmos.param_set,
+        param_set,
         T_virt,
         ρ,
         RH,
@@ -117,9 +118,9 @@ function ref_state_finalize_init!(
     # Update temperature to be exactly consistent with
     # p, ρ, and q_pt
     if atmos.moisture isa DryModel
-        ts = PhaseDry_ρp(atmos.param_set, ρ, p)
+        ts = PhaseDry_ρp(param_set, ρ, p)
     else
-        ts = PhaseEquil_ρpq(atmos.param_set, ρ, p, q_pt.tot)
+        ts = PhaseEquil_ρpq(param_set, ρ, p, q_pt.tot)
     end
     T = air_temperature(ts)
     q_pt = PhasePartition(ts)
@@ -259,13 +260,14 @@ function ∇reference_pressure(::ReferenceState, state_auxiliary, grid)
 end
 
 function fvm_balance_init!(
-    m::AtmosModel,
+    atmos::AtmosModel,
     aux_top::Vars,
     aux::Vars,
     Δz::MArray{Tuple{2}, FT},
 ) where {FT}
-    _grav::FT = grav(m.param_set)
-    _R_d::FT = R_d(m.param_set)
+    param_set = parameter_set(atmos)
+    _grav::FT = grav(param_set)
+    _R_d::FT = R_d(param_set)
 
     ref = aux.ref_state
     topref = aux_top.ref_state

--- a/src/Atmos/Model/tendencies_moisture.jl
+++ b/src/Atmos/Model/tendencies_moisture.jl
@@ -84,14 +84,15 @@ function source(s::CreateClouds{LiquidMoisture}, m, args)
     FT = eltype(state)
     q = PhasePartition(ts)
     T = air_temperature(ts)
+    param_set = parameter_set(m)
 
     # phase partition corresponding to the current T and q.tot
     # (this is not the same as phase partition from saturation adjustment)
-    ts_eq = PhaseEquil_ρTq(m.param_set, state.ρ, T, q.tot)
+    ts_eq = PhaseEquil_ρTq(param_set, state.ρ, T, q.tot)
     q_eq = PhasePartition(ts_eq)
 
     # cloud condensate as relaxation source terms
-    S_q_liq = conv_q_vap_to_q_liq_ice(m.param_set.microphys.liq, q_eq, q)
+    S_q_liq = conv_q_vap_to_q_liq_ice(param_set.microphys.liq, q_eq, q)
 
     return state.ρ * S_q_liq
 end
@@ -103,14 +104,15 @@ function source(s::CreateClouds{IceMoisture}, m, args)
     FT = eltype(state)
     q = PhasePartition(ts)
     T = air_temperature(ts)
+    param_set = parameter_set(m)
 
     # phase partition corresponding to the current T and q.tot
     # (this is not the same as phase partition from saturation adjustment)
-    ts_eq = PhaseEquil_ρTq(m.param_set, state.ρ, T, q.tot)
+    ts_eq = PhaseEquil_ρTq(param_set, state.ρ, T, q.tot)
     q_eq = PhasePartition(ts_eq)
 
     # cloud condensate as relaxation source terms
-    S_q_ice = conv_q_vap_to_q_liq_ice(m.param_set.microphys.ice, q_eq, q)
+    S_q_ice = conv_q_vap_to_q_liq_ice(param_set.microphys.ice, q_eq, q)
 
     return state.ρ * S_q_ice
 end

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -69,7 +69,8 @@ Coriolis() = Coriolis{Momentum}()
 function source(s::Coriolis{Momentum}, m, args)
     @unpack state = args
     FT = eltype(state)
-    _Omega::FT = Omega(m.param_set)
+    param_set = parameter_set(m)
+    _Omega::FT = Omega(param_set)
     # note: this assumes a SphericalOrientation
     return -SVector(0, 0, 2 * _Omega) × state.ρu
 end

--- a/src/Atmos/Model/tendencies_precipitation.jl
+++ b/src/Atmos/Model/tendencies_precipitation.jl
@@ -11,10 +11,11 @@ function flux(::PrecipitationFlux{Rain}, atmos, args)
     q_rai = state.precipitation.ρq_rai / state.ρ
 
     v_term_rai::FT = FT(0)
+    param_set = parameter_set(atmos)
     if q_rai > FT(0)
         v_term_rai = terminal_velocity(
-            atmos.param_set,
-            atmos.param_set.microphys.rai,
+            param_set,
+            param_set.microphys.rai,
             state.ρ,
             q_rai,
         )
@@ -29,12 +30,12 @@ function flux(::PrecipitationFlux{Snow}, atmos, args)
     FT = eltype(state)
     u = state.ρu / state.ρ
     q_sno = state.precipitation.ρq_sno / state.ρ
-
+    param_set = parameter_set(atmos)
     v_term_sno::FT = FT(0)
     if q_sno > FT(0)
         v_term_sno = terminal_velocity(
-            atmos.param_set,
-            atmos.param_set.microphys.sno,
+            param_set,
+            param_set.microphys.sno,
             state.ρ,
             q_sno,
         )

--- a/src/Atmos/Model/thermo_states.jl
+++ b/src/Atmos/Model/thermo_states.jl
@@ -59,8 +59,9 @@ function new_thermo_state(
     state::Vars,
     aux::Vars,
 )
+    param_set = parameter_set(atmos)
     e_int = internal_energy(atmos, state, aux)
-    return PhaseDry(atmos.param_set, e_int, state.ρ)
+    return PhaseDry(param_set, e_int, state.ρ)
 end
 
 function new_thermo_state(
@@ -71,8 +72,9 @@ function new_thermo_state(
     aux::Vars,
 )
     e_int = internal_energy(atmos, state, aux)
+    param_set = parameter_set(atmos)
     return PhaseEquil(
-        atmos.param_set,
+        param_set,
         e_int,
         state.ρ,
         state.moisture.ρq_tot / state.ρ,
@@ -88,6 +90,7 @@ function new_thermo_state(
     state::Vars,
     aux::Vars,
 )
+    param_set = parameter_set(atmos)
     e_int = internal_energy(atmos, state, aux)
     q = PhasePartition(
         state.moisture.ρq_tot / state.ρ,
@@ -95,8 +98,8 @@ function new_thermo_state(
         state.moisture.ρq_ice / state.ρ,
     )
 
-    return PhaseNonEquil{eltype(state), typeof(atmos.param_set)}(
-        atmos.param_set,
+    return PhaseNonEquil{eltype(state), typeof(param_set)}(
+        param_set,
         e_int,
         state.ρ,
         q,
@@ -110,8 +113,9 @@ function new_thermo_state(
     state::Vars,
     aux::Vars,
 )
+    param_set = parameter_set(atmos)
     θ_liq_ice = state.energy.ρθ_liq_ice / state.ρ
-    return PhaseDry_ρθ(atmos.param_set, state.ρ, θ_liq_ice)
+    return PhaseDry_ρθ(param_set, state.ρ, θ_liq_ice)
 end
 
 function new_thermo_state(
@@ -121,9 +125,10 @@ function new_thermo_state(
     state::Vars,
     aux::Vars,
 )
+    param_set = parameter_set(atmos)
     θ_liq_ice = state.energy.ρθ_liq_ice / state.ρ
     return PhaseEquil_ρθq(
-        atmos.param_set,
+        param_set,
         state.ρ,
         θ_liq_ice,
         state.moisture.ρq_tot / state.ρ,
@@ -139,6 +144,7 @@ function new_thermo_state(
     state::Vars,
     aux::Vars,
 )
+    param_set = parameter_set(atmos)
     θ_liq_ice = state.energy.ρθ_liq_ice / state.ρ
     q = PhasePartition(
         state.moisture.ρq_tot / state.ρ,
@@ -146,8 +152,8 @@ function new_thermo_state(
         state.moisture.ρq_ice / state.ρ,
     )
 
-    return PhaseNonEquil{eltype(state), typeof(atmos.param_set)}(
-        atmos.param_set,
+    return PhaseNonEquil{eltype(state), typeof(param_set)}(
+        param_set,
         state.ρ,
         θ_liq_ice,
         q,

--- a/src/Atmos/Model/thermo_states_anelastic.jl
+++ b/src/Atmos/Model/thermo_states_anelastic.jl
@@ -38,9 +38,10 @@ function new_thermo_state_anelastic(
     state::Vars,
     aux::Vars,
 )
+    param_set = parameter_set(atmos)
     e_int = internal_energy(atmos, state, aux)
     p = aux.ref_state.p
-    return PhaseDry_pe(atmos.param_set, p, e_int)
+    return PhaseDry_pe(param_set, p, e_int)
 end
 
 function new_thermo_state_anelastic(
@@ -50,11 +51,12 @@ function new_thermo_state_anelastic(
     state::Vars,
     aux::Vars,
 )
+    param_set = parameter_set(atmos)
     e_int = internal_energy(atmos, state, aux)
     p = aux.ref_state.p
     ρ = density(atmos, state, aux)
     return PhaseEquil_peq(
-        atmos.param_set,
+        param_set,
         p,
         e_int,
         state.moisture.ρq_tot / ρ,
@@ -70,6 +72,7 @@ function new_thermo_state_anelastic(
     state::Vars,
     aux::Vars,
 )
+    param_set = parameter_set(atmos)
     e_int = internal_energy(atmos, state, aux)
     p = aux.ref_state.p
     ρ = density(atmos, state, aux)
@@ -79,5 +82,5 @@ function new_thermo_state_anelastic(
         state.moisture.ρq_ice / ρ,
     )
 
-    return PhaseNonEquil_peq(atmos.param_set, p, e_int, q)
+    return PhaseNonEquil_peq(param_set, p, e_int, q)
 end

--- a/src/BalanceLaws/BalanceLaws.jl
+++ b/src/BalanceLaws/BalanceLaws.jl
@@ -26,7 +26,8 @@ export BalanceLaw,
     indefinite_stack_integral!,
     reverse_indefinite_stack_integral!,
     reverse_integral_load_auxiliary_state!,
-    reverse_integral_set_auxiliary_state!
+    reverse_integral_set_auxiliary_state!,
+    parameter_set
 
 include("state_types.jl")
 include("interface.jl")

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -382,3 +382,5 @@ function initialize_states! end
 function tendency_from_slow_to_fast! end
 function cummulate_fast_solution! end
 function reconcile_from_fast_to_slow! end
+
+parameter_set(balance_law) = balance_law.param_set

--- a/src/Common/Orientations/Orientations.jl
+++ b/src/Common/Orientations/Orientations.jl
@@ -105,10 +105,11 @@ function init_aux!(
     grid,
     direction,
 )
+    param_set = parameter_set(m)
     init_state_auxiliary!(
         m,
         (m, aux, tmp, geom) ->
-            orientation_nodal_init_aux!(m.orientation, m.param_set, aux, geom),
+            orientation_nodal_init_aux!(m.orientation, param_set, aux, geom),
         state_auxiliary,
         grid,
         direction,

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -216,10 +216,11 @@ function turbulence_tensors(
     aux,
     t,
 )
+    param_set = parameter_set(bl)
     ν, D_t, τ = turbulence_tensors(
         m,
         bl.orientation,
-        bl.param_set,
+        param_set,
         state,
         diffusive,
         aux,
@@ -799,7 +800,7 @@ Defines a default hyperdiffusion model with zero hyperdiffusive fluxes.
 struct NoHyperDiffusion <: HyperDiffusion end
 
 hyperviscosity_tensors(m::HyperDiffusion, bl::BalanceLaw, args...) =
-    hyperviscosity_tensors(m, bl.orientation, bl.param_set, args...)
+    hyperviscosity_tensors(m, bl.orientation, parameter_set(bl), args...)
 
 """
   EquilMoistBiharmonic{FT} <: HyperDiffusion
@@ -866,7 +867,8 @@ function transform_post_gradient_laplacian!(
     aux::Vars,
     t::Real,
 )
-    _inv_Pr_turb = eltype(state)(inv_Pr_turb(bl.param_set))
+    param_set = parameter_set(bl)
+    _inv_Pr_turb = eltype(state)(inv_Pr_turb(param_set))
     ∇Δu_h = hypertransform.hyperdiffusion.u_h
     ∇Δh_tot = hypertransform.hyperdiffusion.h_tot
     ∇Δq_tot = hypertransform.hyperdiffusion.q_tot
@@ -937,7 +939,8 @@ function transform_post_gradient_laplacian!(
     aux::Vars,
     t::Real,
 )
-    _inv_Pr_turb = eltype(state)(inv_Pr_turb(bl.param_set))
+    param_set = parameter_set(bl)
+    _inv_Pr_turb = eltype(state)(inv_Pr_turb(param_set))
     ∇Δu_h = hypertransform.hyperdiffusion.u_h
     ∇Δh_tot = hypertransform.hyperdiffusion.h_tot
     # Unpack
@@ -1004,7 +1007,8 @@ function sponge_viscosity_modifier(
     τ,
     aux::Vars,
 )
-    z = altitude(bl.orientation, bl.param_set, aux)
+    param_set = parameter_set(bl)
+    z = altitude(bl.orientation, param_set, aux)
     if z >= m.sponge
         r = (z - m.z_sponge) / (m.z_max - m.z_sponge)
         β_sponge = m.α_max * sinpi(r / 2)^m.γ

--- a/src/Driver/Callbacks/Callbacks.jl
+++ b/src/Driver/Callbacks/Callbacks.jl
@@ -495,7 +495,8 @@ function CB_constructor(interval::String, solver_config, default = nothing)
     solver = solver_config.solver
     dg = solver_config.dg
     bl = dg.balance_law
-    secs_per_day = day(bl.param_set)
+    param_set = parameter_set(bl)
+    secs_per_day = day(param_set)
 
     if (
         m = match(r"^([0-9\.]+)(smonths|sdays|shours|smins|ssecs)$", interval)

--- a/src/Land/Model/LandModel.jl
+++ b/src/Land/Model/LandModel.jl
@@ -17,6 +17,7 @@ import ..BalanceLaws:
     flux_second_order!,
     source!,
     boundary_conditions,
+    parameter_set,
     boundary_state!,
     compute_gradient_argument!,
     compute_gradient_flux!,
@@ -58,6 +59,8 @@ struct LandModel{PS, S, LBC, SRC, IS} <: BalanceLaw
     "Initial Condition (Function to assign initial values of state variables)"
     init_state_prognostic::IS
 end
+
+parameter_set(m::LandModel) = m.param_set
 
 """
     LandModel(

--- a/src/Land/Model/soil_bc.jl
+++ b/src/Land/Model/soil_bc.jl
@@ -103,22 +103,18 @@ function soil_boundary_state!(
     _...,
 )
     bc_function = bc.state_bc
-
+    param_set = parameter_set(land)
     ϑ_l, θ_i = get_water_content(land.soil.water, aux⁻, state⁻, t)
     θ_l = volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
     ρc_s = volumetric_heat_capacity(
         θ_l,
         θ_i,
         land.soil.param_functions.ρc_ds,
-        land.param_set,
+        param_set,
     )
 
-    ρe_int_bc = volumetric_internal_energy(
-        θ_i,
-        ρc_s,
-        bc_function(aux⁻, t),
-        land.param_set,
-    )
+    ρe_int_bc =
+        volumetric_internal_energy(θ_i, ρc_s, bc_function(aux⁻, t), param_set)
 
     state⁺.soil.heat.ρe_int = ρe_int_bc
 end

--- a/src/Land/Model/soil_heat.jl
+++ b/src/Land/Model/soil_heat.jl
@@ -137,17 +137,14 @@ function land_nodal_update_auxiliary_state!(
     t::Real,
 )
 
+    param_set = parameter_set(land)
     ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, t)
     eff_porosity = soil.param_functions.porosity - θ_i
     θ_l = volumetric_liquid_fraction(ϑ_l, eff_porosity)
     ρc_ds = soil.param_functions.ρc_ds
-    ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, land.param_set)
-    aux.soil.heat.T = temperature_from_ρe_int(
-        state.soil.heat.ρe_int,
-        θ_i,
-        ρc_s,
-        land.param_set,
-    )
+    ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, param_set)
+    aux.soil.heat.T =
+        temperature_from_ρe_int(state.soil.heat.ρe_int, θ_i, ρc_s, param_set)
 end
 
 function compute_gradient_argument!(
@@ -160,17 +157,14 @@ function compute_gradient_argument!(
     t::Real,
 )
 
+    param_set = parameter_set(land)
     ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, t)
     eff_porosity = soil.param_functions.porosity - θ_i
     θ_l = volumetric_liquid_fraction(ϑ_l, eff_porosity)
     ρc_ds = soil.param_functions.ρc_ds
-    ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, land.param_set)
-    transform.soil.heat.T = temperature_from_ρe_int(
-        state.soil.heat.ρe_int,
-        θ_i,
-        ρc_s,
-        land.param_set,
-    )
+    ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, param_set)
+    transform.soil.heat.T =
+        temperature_from_ρe_int(state.soil.heat.ρe_int, θ_i, ρc_s, param_set)
 end
 
 function compute_gradient_flux!(
@@ -183,10 +177,11 @@ function compute_gradient_flux!(
     aux::Vars,
     t::Real,
 )
+    param_set = parameter_set(land)
     ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, t)
     eff_porosity = soil.param_functions.porosity - θ_i
     θ_l = volumetric_liquid_fraction(ϑ_l, eff_porosity)
-    κ_dry = k_dry(land.param_set, soil.param_functions)
+    κ_dry = k_dry(param_set, soil.param_functions)
     S_r = relative_saturation(θ_l, θ_i, soil.param_functions.porosity)
     kersten = kersten_number(θ_i, S_r, soil.param_functions)
     κ_sat = saturated_thermal_conductivity(
@@ -210,7 +205,8 @@ function flux_second_order!(
     aux::Vars,
     t::Real,
 )
-    ρe_int_l = volumetric_internal_energy_liq(aux.soil.heat.T, land.param_set)
+    param_set = parameter_set(land)
+    ρe_int_l = volumetric_internal_energy_liq(aux.soil.heat.T, param_set)
     diffusive_water_flux =
         -ρe_int_l .* get_diffusive_water_term(soil.water, diffusive)
     diffusive_heat_flux = -diffusive.soil.heat.κ∇T

--- a/src/Land/Model/source.jl
+++ b/src/Land/Model/source.jl
@@ -51,11 +51,12 @@ function land_source!(
 )
     FT = eltype(state)
 
-    _ρliq = FT(ρ_cloud_liq(land.param_set))
-    _ρice = FT(ρ_cloud_ice(land.param_set))
-    _Tfreeze = FT(T_freeze(land.param_set))
-    _LH_f0 = FT(LH_f0(land.param_set))
-    _g = FT(grav(land.param_set))
+    param_set = parameter_set(land)
+    _ρliq = FT(ρ_cloud_liq(param_set))
+    _ρice = FT(ρ_cloud_ice(param_set))
+    _Tfreeze = FT(T_freeze(param_set))
+    _LH_f0 = FT(LH_f0(param_set))
+    _g = FT(grav(param_set))
 
     ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, t)
     eff_porosity = land.soil.param_functions.porosity - θ_i

--- a/src/Ocean/HydrostaticBoussinesq/hydrostatic_boussinesq_model.jl
+++ b/src/Ocean/HydrostaticBoussinesq/hydrostatic_boussinesq_model.jl
@@ -455,7 +455,7 @@ end
         -0 -0
     ]
 
-    F.u += grav(m.param_set) * η * Iʰ
+    F.u += grav(parameter_set(m)) * η * Iʰ
 
     return nothing
 end
@@ -467,7 +467,7 @@ end
         -0 1
         -0 -0
     ]
-    F.u += grav(m.param_set) * pkin * Iʰ
+    F.u += grav(parameter_set(m)) * pkin * Iʰ
 
     return nothing
 end

--- a/src/Ocean/OceanProblems/OceanProblems.jl
+++ b/src/Ocean/OceanProblems/OceanProblems.jl
@@ -8,6 +8,7 @@ using CLIMAParameters.Planet: grav
 using ...Problems
 
 using ..Ocean
+using ..BalanceLaws: parameter_set
 using ..HydrostaticBoussinesq
 using ..ShallowWater
 using ..SplitExplicit01

--- a/src/Ocean/OceanProblems/shallow_water_initial_states.jl
+++ b/src/Ocean/OceanProblems/shallow_water_initial_states.jl
@@ -117,7 +117,7 @@ function gyre_init_state!(
     βᵖ = β * Lʸ / fₒ
     ϵ = γ / (Lˣ * β)
 
-    _grav::FT = grav(m.param_set)
+    _grav::FT = grav(parameter_set(m))
 
     uˢ(ϵ) = (τₒ * D(ϵ)) / (H * γ * π)
     hˢ(ϵ) = (fₒ * Lˣ * uˢ(ϵ)) / _grav
@@ -153,7 +153,7 @@ function gyre_init_state!(
     coords = local_geometry.coord
 
     FT = eltype(state.U)
-    _grav::FT = grav(m.param_set)
+    _grav::FT = grav(parameter_set(m))
 
     τₒ = p.τₒ
     fₒ = m.fₒ

--- a/src/Ocean/OceanProblems/simple_box_problem.jl
+++ b/src/Ocean/OceanProblems/simple_box_problem.jl
@@ -171,9 +171,9 @@ end
 viscosity(m::SWModel) = (m.turbulence.ν, m.turbulence.ν, -0)
 viscosity(m::BarotropicModel) = (m.baroclinic.νʰ, m.baroclinic.νʰ, -0)
 
-gravity_speed(m::SWModel) = grav(m.param_set) * m.problem.H
+gravity_speed(m::SWModel) = grav(parameter_set(m)) * m.problem.H
 gravity_speed(m::BarotropicModel) =
-    grav(m.baroclinic.param_set) * m.baroclinic.problem.H
+    grav(parameter_set(m)) * m.baroclinic.problem.H
 
 function ocean_init_state!(
     m::Union{HBModel, OceanModel},
@@ -189,7 +189,7 @@ function ocean_init_state!(
     k = (2π / p.Lˣ, 2π / p.Lʸ, 2π / p.H)
     ν = (m.νʰ, m.νʰ, m.νᶻ)
 
-    gH = grav(m.param_set) * p.H
+    gH = grav(parameter_set(m)) * p.H
     @inbounds f = coriolis_parameter(m, p, coords[2])
 
     U, V, η = barotropic_state!(p.rotation, (coords..., t), ν, k, (gH, f))

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -211,7 +211,7 @@ end
     ]
 
     F.η += U
-    F.U += grav(m.param_set) * H * η * Iʰ
+    F.U += grav(parameter_set(m)) * H * η * Iʰ
 
     advective_flux!(m, m.advection, F, q, α, t)
 

--- a/src/Ocean/SplitExplicit01/BarotropicModel.jl
+++ b/src/Ocean/SplitExplicit01/BarotropicModel.jl
@@ -5,6 +5,8 @@ struct BarotropicModel{M} <: AbstractOceanModel
     end
 end
 
+parameter_set(m::BarotropicModel) = parameter_set(m.baroclinic)
+
 function vars_state(m::BarotropicModel, ::Prognostic, T)
     @vars begin
         U::SVector{2, T}

--- a/src/Ocean/SplitExplicit01/SplitExplicitModel.jl
+++ b/src/Ocean/SplitExplicit01/SplitExplicitModel.jl
@@ -48,6 +48,7 @@ import ...BalanceLaws:
     flux_second_order!,
     source!,
     wavespeed,
+    parameter_set,
     boundary_conditions,
     boundary_state!,
     update_auxiliary_state!,

--- a/src/Ocean/SuperModels.jl
+++ b/src/Ocean/SuperModels.jl
@@ -5,6 +5,7 @@ using MPI
 using ClimateMachine
 
 using ClimateMachine: Settings
+using ...BalanceLaws: parameter_set
 
 using ...DGMethods.NumericalFluxes
 
@@ -167,7 +168,7 @@ function HydrostaticBoussinesqSuperModel(;
         eltype(domain),
         array_type,
         timestepper,
-        equations.param_set,
+        parameter_set(equations),
         equations,
         MPI.COMM_WORLD,
         grid,

--- a/test/Atmos/EDMF/bomex_edmf.jl
+++ b/test/Atmos/EDMF/bomex_edmf.jl
@@ -46,13 +46,13 @@ function init_state_prognostic!(
     # SCM setting - need to have separate cases coded and called from a folder - see what LES does
     # a moist_thermo state is used here to convert the input θ,q_tot to e_int, q_tot profile
     e_int = internal_energy(m, state, aux)
-
+    param_set = parameter_set(m)
     if m.moisture isa DryModel
         ρq_tot = FT(0)
-        ts = PhaseDry(m.param_set, e_int, state.ρ)
+        ts = PhaseDry(param_set, e_int, state.ρ)
     else
         ρq_tot = gm.moisture.ρq_tot
-        ts = PhaseEquil(m.param_set, e_int, state.ρ, ρq_tot / state.ρ)
+        ts = PhaseEquil(param_set, e_int, state.ρ, ρq_tot / state.ρ)
     end
     T = air_temperature(ts)
     p = air_pressure(ts)

--- a/test/Atmos/EDMF/closures/mixing_length.jl
+++ b/test/Atmos/EDMF/closures/mixing_length.jl
@@ -42,7 +42,8 @@ function mixing_length(
     N_up = n_updrafts(m.turbconv)
 
     z = altitude(m, aux)
-    _grav::FT = grav(m.param_set)
+    param_set = parameter_set(m)
+    _grav::FT = grav(param_set)
     ρinv = 1 / gm.ρ
 
     Shear² = diffusive.turbconv.S²

--- a/test/Atmos/EDMF/closures/turbulence_functions.jl
+++ b/test/Atmos/EDMF/closures/turbulence_functions.jl
@@ -45,11 +45,12 @@ function compute_buoyancy_gradients(
     gm = state
     en_dif = diffusive.turbconv.environment
     N_up = n_updrafts(m.turbconv)
+    param_set = parameter_set(m)
 
-    _grav::FT = grav(m.param_set)
-    _R_d::FT = R_d(m.param_set)
-    _R_v::FT = R_v(m.param_set)
-    ε_v::FT = 1 / molmass_ratio(m.param_set)
+    _grav::FT = grav(param_set)
+    _R_d::FT = R_d(param_set)
+    _R_v::FT = R_v(param_set)
+    ε_v::FT = 1 / molmass_ratio(param_set)
     p = air_pressure(ts_gm)
 
     q_tot_en = total_specific_humidity(ts_en)

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -406,11 +406,11 @@ function compute_gradient_argument!(
 
     # Get environment variables
     env = environment_vars(state, N_up)
-
+    param_set = parameter_set(m)
     @unroll_map(N_up) do i
         up_tf[i].w = fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)
     end
-    _grav::FT = grav(m.param_set)
+    _grav::FT = grav(param_set)
 
     ρ_inv = 1 / gm.ρ
     θ_liq_en = liquid_ice_pottemp(ts.en)
@@ -939,8 +939,9 @@ function compute_buoyancy(
     ref_state::Vars,
 )
     FT = eltype(state)
+    param_set = parameter_set(bl)
     N_up = n_updrafts(bl.turbconv)
-    _grav::FT = grav(bl.param_set)
+    _grav::FT = grav(param_set)
     gm = state
     ρ_inv = 1 / gm.ρ
     buoyancy_en = -_grav * (air_density(ts_en) - ref_state.ρ) * ρ_inv
@@ -1027,7 +1028,8 @@ function flux(::SGSFlux{Energy}, atmos, args)
     @unpack state, aux, diffusive = args
     @unpack env, K_h, ρa_up, ρaw_up, ts_up = args.precomputed.turbconv
     FT = eltype(state)
-    _grav::FT = grav(atmos.param_set)
+    param_set = parameter_set(atmos)
+    _grav::FT = grav(param_set)
     z = altitude(atmos, aux)
     en_dif = diffusive.turbconv.environment
     up = state.turbconv.updraft

--- a/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
@@ -131,14 +131,14 @@ function new_thermo_state_up(
     N_up = n_updrafts(m.turbconv)
     up = state.turbconv.updraft
     p = air_pressure(ts)
-
+    param_set = parameter_set(m)
     # compute thermo state for updrafts
     ts_up = vuntuple(N_up) do i
         ρa_up = up[i].ρa
         ρaθ_liq_up = up[i].ρaθ_liq
         θ_liq_up =
             fix_void_up(ρa_up, ρaθ_liq_up / ρa_up, liquid_ice_pottemp(ts))
-        PhaseDry_pθ(m.param_set, p, θ_liq_up)
+        PhaseDry_pθ(param_set, p, θ_liq_up)
     end
     return ts_up
 end
@@ -154,7 +154,7 @@ function new_thermo_state_up(
     N_up = n_updrafts(m.turbconv)
     up = state.turbconv.updraft
     p = air_pressure(ts)
-
+    param_set = parameter_set(m)
     # compute thermo state for updrafts
     ts_up = vuntuple(N_up) do i
         ρa_up = up[i].ρa
@@ -167,7 +167,7 @@ function new_thermo_state_up(
             ρaq_tot_up / ρa_up,
             total_specific_humidity(ts),
         )
-        PhaseEquil_pθq(m.param_set, p, θ_liq_up, q_tot_up)
+        PhaseEquil_pθq(param_set, p, θ_liq_up, q_tot_up)
     end
     return ts_up
 end
@@ -190,13 +190,14 @@ function new_thermo_state_en(
     θ_liq_en = (θ_liq - sum(vuntuple(j -> up[j].ρaθ_liq * ρ_inv, N_up))) / a_en
     a_min = m.turbconv.subdomains.a_min
     a_max = m.turbconv.subdomains.a_max
+    param_set = parameter_set(m)
     if !(0 <= θ_liq_en)
         @print("ρaθ_liq_up = ", up[Val(1)].ρaθ_liq, "\n")
         @print("θ_liq = ", θ_liq, "\n")
         @print("θ_liq_en = ", θ_liq_en, "\n")
         error("Environment θ_liq_en out-of-bounds in new_thermo_state_en")
     end
-    ts_en = PhaseDry_pθ(m.param_set, p, θ_liq_en)
+    ts_en = PhaseDry_pθ(param_set, p, θ_liq_en)
     return ts_en
 end
 
@@ -220,6 +221,7 @@ function new_thermo_state_en(
     q_tot_en = (q_tot - sum(vuntuple(j -> up[j].ρaq_tot * ρ_inv, N_up))) / a_en
     a_min = m.turbconv.subdomains.a_min
     a_max = m.turbconv.subdomains.a_max
+    param_set = parameter_set(m)
     if !(0 <= θ_liq_en)
         @print("θ_liq_en = ", θ_liq_en, "\n")
         error("Environment θ_liq_en out-of-bounds in new_thermo_state_en")
@@ -228,6 +230,6 @@ function new_thermo_state_en(
         @print("q_tot_en = ", q_tot_en, "\n")
         error("Environment q_tot_en out-of-bounds in new_thermo_state_en")
     end
-    ts_en = PhaseEquil_pθq(m.param_set, p, θ_liq_en, q_tot_en)
+    ts_en = PhaseEquil_pθq(param_set, p, θ_liq_en, q_tot_en)
     return ts_en
 end

--- a/test/Atmos/EDMF/stable_bl_anelastic1d.jl
+++ b/test/Atmos/EDMF/stable_bl_anelastic1d.jl
@@ -52,8 +52,8 @@ function init_state_prognostic!(
     # SCM setting - need to have separate cases coded and called from a folder - see what LES does
     # a thermo state is used here to convert the input θ to e_int profile
     e_int = internal_energy(m, state, aux)
-
-    ts = PhaseDry(m.param_set, e_int, state.ρ)
+    param_set = parameter_set(m)
+    ts = PhaseDry(param_set, e_int, state.ρ)
     T = air_temperature(ts)
     p = air_pressure(ts)
     q = PhasePartition(ts)

--- a/test/Atmos/EDMF/stable_bl_edmf.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf.jl
@@ -42,8 +42,8 @@ function init_state_prognostic!(
     # SCM setting - need to have separate cases coded and called from a folder - see what LES does
     # a thermo state is used here to convert the input θ to e_int profile
     e_int = internal_energy(m, state, aux)
-
-    ts = PhaseDry(m.param_set, e_int, state.ρ)
+    param_set = parameter_set(m)
+    ts = PhaseDry(param_set, e_int, state.ρ)
     T = air_temperature(ts)
     p = air_pressure(ts)
     q = PhasePartition(ts)

--- a/test/Atmos/EDMF/stable_bl_edmf_fvm.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf_fvm.jl
@@ -42,8 +42,8 @@ function init_state_prognostic!(
     # SCM setting - need to have separate cases coded and called from a folder - see what LES does
     # a thermo state is used here to convert the input θ to e_int profile
     e_int = internal_energy(m, state, aux)
-
-    ts = PhaseDry(m.param_set, e_int, state.ρ)
+    param_set = parameter_set(m)
+    ts = PhaseDry(param_set, e_int, state.ρ)
     T = air_temperature(ts)
     p = air_pressure(ts)
     q = PhasePartition(ts)

--- a/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
@@ -91,6 +91,7 @@ import ClimateMachine.BalanceLaws:
     flux_first_order!,
     flux_second_order!,
     wavespeed,
+    parameter_set,
     boundary_conditions,
     boundary_state!,
     source!
@@ -129,6 +130,8 @@ struct KinematicModel{FT, PS, O, M, P, S, BC, IS, DC} <: BalanceLaw
     init_state_prognostic::IS
     data_config::DC
 end
+
+parameter_set(m::KinematicModel) = m.param_set
 
 function KinematicModel{FT}(
     ::Type{AtmosLESConfigType},
@@ -172,13 +175,14 @@ function nodal_init_state_auxiliary!(
     FT = eltype(aux)
     x, y, z = geom.coord
     dc = m.data_config
+    param_set = parameter_set(m)
 
-    _R_d::FT = R_d(m.param_set)
-    _cp_d::FT = cp_d(m.param_set)
-    _grav::FT = grav(m.param_set)
+    _R_d::FT = R_d(param_set)
+    _cp_d::FT = cp_d(param_set)
+    _grav::FT = grav(param_set)
 
     # TODO - should R_d and cp_d here be R_m and cp_m?
-    R_m, cp_m, cv_m, γ = gas_constants(m.param_set, PhasePartition(dc.qt_0))
+    R_m, cp_m, cv_m, γ = gas_constants(param_set, PhasePartition(dc.qt_0))
 
     # Pressure profile assuming hydrostatic and constant θ and qt profiles.
     # It is done this way to be consistent with Arabas paper.

--- a/test/Atmos/prog_prim_conversion/runtests.jl
+++ b/test/Atmos/prog_prim_conversion/runtests.jl
@@ -56,8 +56,8 @@ function assign!(state, bl, nt, st::Prognostic)
     @unpack u, v, w, ρ, e_kin, e_pot, T, q_pt = nt
     state.ρ = ρ
     state.ρu = SVector(ρ * u, ρ * v, ρ * w)
-    state.energy.ρe =
-        state.ρ * total_energy(bl.param_set, e_kin, e_pot, T, q_pt)
+    param_set = parameter_set(bl)
+    state.energy.ρe = state.ρ * total_energy(param_set, e_kin, e_pot, T, q_pt)
     assign!(state, bl, bl.moisture, nt, st)
 end
 assign!(state, bl, moisture::DryModel, nt, ::Prognostic) = nothing

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -45,12 +45,13 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     (x, y, z) = localgeo.coord
 
     FT = eltype(state)
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
+    param_set = parameter_set(bl)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
     γ::FT = c_p / c_v
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
 
     xc::FT = 1250
     yc::FT = 1250
@@ -69,7 +70,7 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     π_exner = FT(1) - _grav / (c_p * θ) * z # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
     q_tot = FT(0)
-    ts = PhaseEquil_ρθq(bl.param_set, ρ, θ, q_tot)
+    ts = PhaseEquil_ρθq(param_set, ρ, θ, q_tot)
     q_pt = PhasePartition(ts)
 
     ρu = SVector(FT(0), FT(0), FT(0))

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -31,10 +31,11 @@ function init_sin_test!(problem, bl, state, aux, localgeo, t)
     (x, y, z) = localgeo.coord
 
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     z = FT(z)
-    _grav::FT = grav(bl.param_set)
-    _MSLP::FT = MSLP(bl.param_set)
+    _grav::FT = grav(param_set)
+    _MSLP::FT = MSLP(param_set)
 
     # These constants are those used by Stevens et al. (2005)
     qref = FT(9.0e-3)
@@ -72,7 +73,7 @@ function init_sin_test!(problem, bl, state, aux, localgeo, t)
     p = P_sfc * exp(-z / H)
 
     # Density, Temperature
-    ts = PhaseEquil_pθq(bl.param_set, p, θ_liq, q_tot)
+    ts = PhaseEquil_pθq(param_set, p, θ_liq, q_tot)
     #ρ = air_density(ts)
     ρ = one(FT)
 

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -43,8 +43,9 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     g = sin(setup.nv * FT(π) * z / setup.domain_height)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
+    param_set = parameter_set(bl)
 
-    ts = PhaseDry_pT(bl.param_set, p, setup.T_ref)
+    ts = PhaseDry_pT(param_set, p, setup.T_ref)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -39,8 +39,9 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     g = sin(setup.nv * FT(π) * z / setup.domain_height)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
+    param_set = parameter_set(bl)
 
-    ts = PhaseDry_pT(bl.param_set, p, setup.T_ref)
+    ts = PhaseDry_pT(param_set, p, setup.T_ref)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/test/Driver/les_driver_test.jl
+++ b/test/Driver/les_driver_test.jl
@@ -17,10 +17,11 @@ function init_test!(problem, bl, state, aux, localgeo, t)
     (x, y, z) = localgeo.coord
 
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     z = FT(z)
-    _grav::FT = grav(bl.param_set)
-    _MSLP::FT = MSLP(bl.param_set)
+    _grav::FT = grav(param_set)
+    _MSLP::FT = MSLP(param_set)
 
     # These constants are those used by Stevens et al. (2005)
     qref = FT(9.0e-3)
@@ -45,7 +46,7 @@ function init_test!(problem, bl, state, aux, localgeo, t)
     p = P_sfc * exp(-z / H)
 
     # Density, Temperature
-    ts = PhaseEquil_pθq(bl.param_set, p, θ_liq, q_tot)
+    ts = PhaseEquil_pθq(param_set, p, θ_liq, q_tot)
     ρ = air_density(ts)
 
     e_kin = FT(1 / 2) * FT((u^2 + v^2 + w^2))

--- a/test/Land/Model/heat_analytic_unit_test.jl
+++ b/test/Land/Model/heat_analytic_unit_test.jl
@@ -24,25 +24,25 @@ using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
 using ClimateMachine.VariableTemplates
 using ClimateMachine.SingleStackUtils
-using ClimateMachine.BalanceLaws:
-    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, vars_state
+using ClimateMachine.BalanceLaws
 
 function init_soil!(land, state, aux, localgeo, time)
     FT = eltype(state)
     ϑ_l, θ_i = get_water_content(land.soil.water, aux, state, time)
     θ_l = volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
+    param_set = parameter_set(land)
     ρc_s = volumetric_heat_capacity(
         θ_l,
         θ_i,
         land.soil.param_functions.ρc_ds,
-        land.param_set,
+        param_set,
     )
 
     state.soil.heat.ρe_int = FT(volumetric_internal_energy(
         θ_i,
         ρc_s,
         land.soil.heat.initialT(aux),
-        land.param_set,
+        param_set,
     ))
 end
 

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -27,7 +27,8 @@ using ClimateMachine.Atmos:
     vars_state,
     Gravity,
     HydrostaticState,
-    AtmosAcousticGravityLinearModel
+    AtmosAcousticGravityLinearModel,
+    parameter_set
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations:
     SphericalOrientation, gravitational_potential, altitude, latitude, longitude
@@ -145,7 +146,7 @@ function test_run(
 
     # determine the time step
     element_size = (setup.domain_height / numelem_vert)
-    acoustic_speed = soundspeed_air(model.param_set, FT(setup.T_ref))
+    acoustic_speed = soundspeed_air(param_set, FT(setup.T_ref))
     dt_factor = 445
     dt = dt_factor * element_size / acoustic_speed / polynomialorder^2
     # Adjust the time step so we exactly hit 1 hour for VTK output
@@ -279,6 +280,7 @@ end
 function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     # callable to set initial conditions
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     λ = longitude(bl, aux)
     φ = latitude(bl, aux)
@@ -290,7 +292,7 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
 
-    ts = PhaseDry_pT(bl.param_set, p, setup.T_ref)
+    ts = PhaseDry_pT(param_set, p, setup.T_ref)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -33,7 +33,8 @@ using ClimateMachine.Atmos:
     Gravity,
     HydrostaticState,
     AtmosAcousticGravityLinearModel,
-    AtmosAcousticLinearModel
+    AtmosAcousticLinearModel,
+    parameter_set
 using ClimateMachine.Orientations:
     SphericalOrientation, gravitational_potential, altitude, latitude, longitude
 using ClimateMachine.VariableTemplates: flattenednames
@@ -162,7 +163,7 @@ function test_run(
     rem_dg = remainder_DGModel(dg, (vacoustic_dg,))
 
     # determine the time step for the model components
-    acoustic_speed = soundspeed_air(fullmodel.param_set, FT(setup.T_ref))
+    acoustic_speed = soundspeed_air(param_set, FT(setup.T_ref))
     advection_speed = 1 # What's a reasonable number here?
 
     vacoustic_dt = vmnd / acoustic_speed
@@ -306,6 +307,7 @@ end
 function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     # callable to set initial conditions
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     λ = longitude(bl, aux)
     φ = latitude(bl, aux)
@@ -317,7 +319,7 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
 
-    ts = PhaseDry_pT(bl.param_set, p, setup.T_ref)
+    ts = PhaseDry_pT(param_set, p, setup.T_ref)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
@@ -27,7 +27,8 @@ using ClimateMachine.Atmos:
     vars_state,
     Gravity,
     HydrostaticState,
-    AtmosAcousticGravityLinearModel
+    AtmosAcousticGravityLinearModel,
+    parameter_set
 using ClimateMachine.TurbulenceClosures
 using ClimateMachine.Orientations:
     SphericalOrientation, gravitational_potential, altitude, latitude, longitude
@@ -145,7 +146,7 @@ function test_run(
 
     # determine the time step
     element_size = (setup.domain_height / numelem_vert)
-    acoustic_speed = soundspeed_air(model.param_set, FT(setup.T_ref))
+    acoustic_speed = soundspeed_air(param_set, FT(setup.T_ref))
     dt_factor = 445
     Nmax = maximum(polynomialorder)
     dt = dt_factor * element_size / acoustic_speed / Nmax^2
@@ -247,6 +248,7 @@ end
 function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     # callable to set initial conditions
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     λ = longitude(bl, aux)
     φ = latitude(bl, aux)
@@ -258,7 +260,7 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
 
-    ts = PhaseDry_pT(bl.param_set, p, setup.T_ref)
+    ts = PhaseDry_pT(param_set, p, setup.T_ref)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/test/Numerics/DGMethods/Euler/fvm_isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/fvm_isentropicvortex.jl
@@ -182,9 +182,7 @@ function test_run(
 
     # Determine the time step
     elementsize = minimum(step.(brickrange))
-    dt =
-        elementsize / soundspeed_air(model.param_set, setup.T∞) /
-        polynomialorder^2
+    dt = elementsize / soundspeed_air(param_set, setup.T∞) / polynomialorder^2
     nsteps = ceil(Int, timeend / dt)
     dt = timeend / nsteps
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -365,9 +365,7 @@ function test_run(
 
     # determine the time step
     elementsize = minimum(step.(brickrange))
-    dt =
-        elementsize / soundspeed_air(model.param_set, setup.T∞) /
-        polynomialorder^2
+    dt = elementsize / soundspeed_air(param_set, setup.T∞) / polynomialorder^2
     nsteps = ceil(Int, timeend / dt)
     dt = timeend / nsteps
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -182,9 +182,7 @@ function test_run(
 
     # determine the time step
     elementsize = minimum(step.(brickrange))
-    dt =
-        elementsize / soundspeed_air(model.param_set, setup.T∞) /
-        polynomialorder^2
+    dt = elementsize / soundspeed_air(param_set, setup.T∞) / polynomialorder^2
     nsteps = ceil(Int, timeend / dt)
     dt = timeend / nsteps
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_lmars.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_lmars.jl
@@ -155,9 +155,7 @@ function test_run(
 
     # determine the time step
     elementsize = minimum(step.(brickrange))
-    dt =
-        elementsize / soundspeed_air(model.param_set, setup.T∞) /
-        polynomialorder^2
+    dt = elementsize / soundspeed_air(param_set, setup.T∞) / polynomialorder^2
     nsteps = ceil(Int, timeend / dt)
     dt = timeend / nsteps
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -171,7 +171,7 @@ function test_run(
     # determine the slow time step
     elementsize = minimum(step.(brickrange))
     slow_dt =
-        2 * elementsize / soundspeed_air(model.param_set, setup.T∞) /
+        2 * elementsize / soundspeed_air(param_set, setup.T∞) /
         polynomialorder^2
     nsteps = ceil(Int, timeend / slow_dt)
     slow_dt = timeend / nsteps

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -176,8 +176,8 @@ function test_run(
     # determine the time step
     elementsize = minimum(step.(brickrange))
     dt =
-        elementsize / soundspeed_air(model.param_set, setup.T∞) /
-        polynomialorder^2 / 5
+        elementsize / soundspeed_air(param_set, setup.T∞) / polynomialorder^2 /
+        5
     nsteps = ceil(Int, timeend / dt)
     dt = timeend / nsteps
 

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -176,7 +176,7 @@ function test_run(
     # determine the slow time step
     elementsize = minimum(step.(brickrange))
     slow_dt =
-        8 * elementsize / soundspeed_air(model.param_set, setup.T∞) /
+        8 * elementsize / soundspeed_air(param_set, setup.T∞) /
         polynomialorder^2
     nsteps = ceil(Int, timeend / slow_dt)
     slow_dt = timeend / nsteps

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_setup.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_setup.jl
@@ -22,6 +22,7 @@ function (setup::IsentropicVortexSetup)(
 )
     FT = eltype(state)
     x = MVector(localgeo.coord)
+    param_set = parameter_set(bl)
 
     ρ∞ = setup.ρ∞
     p∞ = setup.p∞
@@ -49,12 +50,12 @@ function (setup::IsentropicVortexSetup)(
     T = T∞ * (1 - _kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
     # adiabatic/isentropic relation
     p = p∞ * (T / T∞)^(FT(1) / _kappa_d)
-    ρ = air_density(bl.param_set, T, p)
+    ρ = air_density(param_set, T, p)
 
     state.ρ = ρ
     state.ρu = ρ * u
     e_kin = u' * u / 2
-    state.energy.ρe = ρ * total_energy(bl.param_set, e_kin, FT(0), T)
+    state.energy.ρe = ρ * total_energy(param_set, e_kin, FT(0), T)
     if !(bl.moisture isa DryModel)
         state.moisture.ρq_tot = FT(0)
     end
@@ -91,9 +92,9 @@ function init_vortex_ref_state!(
     ρ∞ = setup.ρ∞
     p∞ = setup.p∞
     T∞ = setup.T∞
-
+    param_set = parameter_set(atmos)
     aux.ref_state.ρ = ρ∞
     aux.ref_state.p = p∞
     aux.ref_state.T = T∞
-    aux.ref_state.ρe = ρ∞ * internal_energy(atmos.param_set, T∞)
+    aux.ref_state.ρe = ρ∞ * internal_energy(param_set, T∞)
 end

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -62,6 +62,7 @@ function Initialise_Density_Current!(
     t,
 )
     (x1, x2, x3) = localgeo.coord
+    param_set = parameter_set(bl)
     FT = eltype(state)
     _R_d::FT = R_d(param_set)
     _grav::FT = grav(param_set)
@@ -89,7 +90,7 @@ function Initialise_Density_Current!(
     π_exner = FT(1) - _grav / (_cp_d * θ) * x3 # exner pressure
     ρ = _MSLP / (_R_d * θ) * (π_exner)^(_cv_d / _R_d) # density
 
-    ts = PhaseEquil_ρθq(bl.param_set, ρ, θ, q_tot)
+    ts = PhaseEquil_ρθq(param_set, ρ, θ, q_tot)
     q_pt = PhasePartition(ts)
 
     U, V, W = FT(0), FT(0), FT(0)  # momentum components

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -30,6 +30,7 @@ const T∞ = 300.0
 
 function initialcondition!(problem, bl, state, aux, localgeo, t)
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     coord = localgeo.coord
 
@@ -47,12 +48,12 @@ function initialcondition!(problem, bl, state, aux, localgeo, t)
     T = FT(T∞)
     # adiabatic/isentropic relation
     p = FT(p∞) * (T / FT(T∞))^(FT(1) / _kappa_d)
-    ρ = air_density(bl.param_set, T, p)
+    ρ = air_density(param_set, T, p)
 
     state.ρ = ρ
     state.ρu = ρ * u
     e_kin = u' * u / 2
-    state.energy.ρe = ρ * total_energy(bl.param_set, e_kin, FT(0), T)
+    state.energy.ρe = ρ * total_energy(param_set, e_kin, FT(0), T)
 
     nothing
 end
@@ -134,16 +135,14 @@ let
                 Δx_h = min_node_distance(grid, HorizontalDirection())
 
                 translation_speed = FT(norm([150.0, 150.0, 0.0]))
-                diff_speed_h =
-                    FT(μ / air_density(model.param_set, FT(T∞), FT(p∞)))
-                diff_speed_v =
-                    FT(μ / air_density(model.param_set, FT(T∞), FT(p∞)))
+
+                diff_speed_h = FT(μ / air_density(param_set, FT(T∞), FT(p∞)))
+                diff_speed_v = FT(μ / air_density(param_set, FT(T∞), FT(p∞)))
                 c_h =
-                    Δt * (
-                        translation_speed +
-                        soundspeed_air(model.param_set, FT(T∞))
-                    ) / Δx_h
-                c_v = Δt * (soundspeed_air(model.param_set, FT(T∞))) / Δx_v
+                    Δt *
+                    (translation_speed + soundspeed_air(param_set, FT(T∞))) /
+                    Δx_h
+                c_v = Δt * (soundspeed_air(param_set, FT(T∞))) / Δx_v
                 d_h = Δt * diff_speed_h / Δx_h^2
                 d_v = Δt * diff_speed_v / Δx_v^2
                 simtime = FT(0)

--- a/test/Numerics/DGMethods/fv_reconstruction_test.jl
+++ b/test/Numerics/DGMethods/fv_reconstruction_test.jl
@@ -75,7 +75,7 @@ end
         vars_prim = Vars{vars_state(model, Primitive(), FT)}
 
         hb_recon! = HBFVReconstruction(model, fv_recon!)
-        _grav = FT(grav(hb_recon!._atmo.param_set))
+        _grav = FT(grav(param_set))
 
         @test width(hb_recon!) == 1
 

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -69,6 +69,7 @@ end
 function (setup::TestSphereSetup)(problem, bl, state, aux, coords, t)
     # callable to set initial conditions
     FT = eltype(state)
+    param_set = parameter_set(bl)
     _grav::FT = grav(param_set)
     _R_d::FT = R_d(param_set)
 
@@ -76,11 +77,11 @@ function (setup::TestSphereSetup)(problem, bl, state, aux, coords, t)
 
     scale_height::FT = _R_d * setup.T_initial / _grav
     p::FT = setup.p_ground * exp(-z / scale_height)
-    e_int = internal_energy(bl.param_set, setup.T_initial)
+    e_int = internal_energy(param_set, setup.T_initial)
     e_pot = gravitational_potential(bl.orientation, aux)
 
     # TODO: Fix type instability: typeof(setup.T_initial) == typeof(p) fails
-    state.ρ = air_density(bl.param_set, FT(setup.T_initial), p)
+    state.ρ = air_density(param_set, FT(setup.T_initial), p)
     state.ρu = SVector{3, FT}(0, 0, 0)
     state.energy.ρe = state.ρ * (e_int + e_pot)
     return nothing

--- a/test/Ocean/HydrostaticBoussinesq/test_3D_spindown.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_3D_spindown.jl
@@ -5,6 +5,7 @@ ClimateMachine.init(parse_clargs = true)
 using ClimateMachine.MPIStateArrays: euclidean_distance, norm
 using ClimateMachine.GenericCallbacks
 using ClimateMachine.ODESolvers
+using ClimateMachine.BalanceLaws: parameter_set
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Mesh.Grids: polynomialorders

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -116,13 +116,14 @@ function init_agnesi_hs_lin!(problem, bl, state, aux, localgeo, t)
 
     ## Problem float-type
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     ## Unpack constant parameters
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     c::FT = c_v / R_gas
@@ -142,8 +143,8 @@ function init_agnesi_hs_lin!(problem, bl, state, aux, localgeo, t)
 
     ## Compute perturbed thermodynamic state:
     T = θ * π_exner
-    e_int = internal_energy(bl.param_set, T)
-    ts = PhaseDry(bl.param_set, e_int, ρ)
+    e_int = internal_energy(param_set, T)
+    ts = PhaseDry(param_set, e_int, ρ)
 
     ## initial velocity
     u = FT(20.0)

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -112,13 +112,14 @@ function init_agnesi_hs_lin!(problem, bl, state, aux, localgeo, t)
 
     ## Problem float-type
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     ## Unpack constant parameters
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     c::FT = c_v / R_gas
@@ -139,8 +140,8 @@ function init_agnesi_hs_lin!(problem, bl, state, aux, localgeo, t)
 
     ## Compute perturbed thermodynamic state:
     T = θ * π_exner
-    e_int = internal_energy(bl.param_set, T)
-    ts = PhaseDry(bl.param_set, e_int, ρ)
+    e_int = internal_energy(param_set, T)
+    ts = PhaseDry(param_set, e_int, ρ)
 
     ## initial velocity
     u = FT(10.0)

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -83,7 +83,7 @@ using ClimateMachine.Writers
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.BalanceLaws:
-    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, parameter_set
 
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.MPIStateArrays
@@ -295,8 +295,9 @@ function compute_gradient_flux!(
     aux::Vars,
     t::Real,
 ) where {FT}
+    param_set = parameter_set(m)
     ∇ρu = ∇transform.ρu
-    ẑ = vertical_unit_vector(m.orientation, m.param_set, aux)
+    ẑ = vertical_unit_vector(m.orientation, param_set, aux)
     divergence = tr(∇ρu) - ẑ' * ∇ρu * ẑ
     diffusive.α∇ρcT = Diagonal(SVector(m.αh, m.αh, m.αv)) * ∇transform.ρcT
     diffusive.μ∇u = Diagonal(SVector(m.μh, m.μh, m.μv)) * ∇transform.u
@@ -316,7 +317,8 @@ function source!(
     aux::Vars,
     args...,
 ) where {FT}
-    ẑ = vertical_unit_vector(m.orientation, m.param_set, aux)
+    param_set = parameter_set(m)
+    ẑ = vertical_unit_vector(m.orientation, param_set, aux)
     z = aux.coord[3]
     ρ̄ū =
         state.ρ * SVector{3, FT}(
@@ -326,7 +328,7 @@ function source!(
         )
     ρu_p = state.ρu - ρ̄ū
     source.ρu -=
-        m.γ * projection_tangential(m.orientation, m.param_set, aux, ρu_p)
+        m.γ * projection_tangential(m.orientation, param_set, aux, ρu_p)
 end;
 
 # Compute advective flux.

--- a/tutorials/Atmos/burgers_single_stack_bjfnk.jl
+++ b/tutorials/Atmos/burgers_single_stack_bjfnk.jl
@@ -84,7 +84,7 @@ using ClimateMachine.Writers
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.BalanceLaws:
-    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, parameter_set
 
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.MPIStateArrays
@@ -297,8 +297,9 @@ function compute_gradient_flux!(
     aux::Vars,
     t::Real,
 ) where {FT}
+    param_set = parameter_set(m)
     ∇ρu = ∇transform.ρu
-    ẑ = vertical_unit_vector(m.orientation, m.param_set, aux)
+    ẑ = vertical_unit_vector(m.orientation, param_set, aux)
     divergence = tr(∇ρu) - ẑ' * ∇ρu * ẑ
     diffusive.α∇ρcT = Diagonal(SVector(m.αh, m.αh, m.αv)) * ∇transform.ρcT
     diffusive.μ∇u = Diagonal(SVector(m.μh, m.μh, m.μv)) * ∇transform.u
@@ -318,7 +319,8 @@ function source!(
     aux::Vars,
     args...,
 ) where {FT}
-    ẑ = vertical_unit_vector(m.orientation, m.param_set, aux)
+    param_set = parameter_set(m)
+    ẑ = vertical_unit_vector(m.orientation, param_set, aux)
     z = aux.coord[3]
     ρ̄ū =
         state.ρ * SVector{3, FT}(
@@ -328,7 +330,7 @@ function source!(
         )
     ρu_p = state.ρu - ρ̄ū
     source.ρu -=
-        m.γ * projection_tangential(m.orientation, m.param_set, aux, ρu_p)
+        m.γ * projection_tangential(m.orientation, param_set, aux, ρu_p)
 end;
 
 # Compute advective flux.

--- a/tutorials/Atmos/burgers_single_stack_fvm.jl
+++ b/tutorials/Atmos/burgers_single_stack_fvm.jl
@@ -84,7 +84,7 @@ using ClimateMachine.Writers
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.BalanceLaws:
-    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux
+    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, parameter_set
 
 using ClimateMachine.Mesh.Geometry: LocalGeometry
 using ClimateMachine.MPIStateArrays
@@ -272,7 +272,8 @@ function construct_face_auxiliary_state!(
     aux_cell::AbstractArray,
     Δz::FT,
 ) where {FT <: Real}
-    _grav = FT(grav(bl.param_set))
+    param_set = parameter_set(bl)
+    _grav = FT(grav(param_set))
     var_aux = Vars{vars_state(bl, Auxiliary(), FT)}
     aux_face .= aux_cell
 
@@ -316,8 +317,9 @@ function compute_gradient_flux!(
     aux::Vars,
     t::Real,
 ) where {FT}
+    param_set = parameter_set(m)
     ∇ρu = ∇transform.ρu
-    ẑ = vertical_unit_vector(m.orientation, m.param_set, aux)
+    ẑ = vertical_unit_vector(m.orientation, param_set, aux)
     divergence = tr(∇ρu) - ẑ' * ∇ρu * ẑ
     diffusive.α∇ρcT = Diagonal(SVector(m.αh, m.αh, m.αv)) * ∇transform.ρcT
     diffusive.μ∇u = Diagonal(SVector(m.μh, m.μh, m.μv)) * ∇transform.u
@@ -337,7 +339,8 @@ function source!(
     aux::Vars,
     args...,
 ) where {FT}
-    ẑ = vertical_unit_vector(m.orientation, m.param_set, aux)
+    param_set = parameter_set(m)
+    ẑ = vertical_unit_vector(m.orientation, param_set, aux)
     z = aux.coord[3]
     ρ̄ū =
         state.ρ * SVector{3, FT}(
@@ -347,7 +350,7 @@ function source!(
         )
     ρu_p = state.ρu - ρ̄ū
     source.ρu -=
-        m.γ * projection_tangential(m.orientation, m.param_set, aux, ρu_p)
+        m.γ * projection_tangential(m.orientation, param_set, aux, ρu_p)
 end;
 
 # Compute advective flux.

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -132,13 +132,14 @@ function init_densitycurrent!(problem, bl, state, aux, localgeo, t)
 
     ## Problem float-type
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     ## Unpack constant parameters
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     ## Define bubble center and background potential temperature
@@ -165,8 +166,8 @@ function init_densitycurrent!(problem, bl, state, aux, localgeo, t)
     π_exner = FT(1) - _grav / (c_p * θ) * z             ## exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas)      ## density
     T = θ * π_exner
-    e_int = internal_energy(bl.param_set, T)
-    ts = PhaseDry(bl.param_set, e_int, ρ)
+    e_int = internal_energy(param_set, T)
+    ts = PhaseDry(param_set, e_int, ρ)
     ρu = SVector(FT(0), FT(0), FT(0))                   ## momentum
     ## State (prognostic) variable assignment
     e_kin = FT(0)                                       ## kinetic energy

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -66,12 +66,13 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
 
     dc = bl.data_config
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
-    _R_d::FT = R_d(bl.param_set)
-    _cp_d::FT = cp_d(bl.param_set)
-    _grav::FT = grav(bl.param_set)
-    _cv_d::FT = cv_d(bl.param_set)
-    _MSLP::FT = MSLP(bl.param_set)
+    _R_d::FT = R_d(param_set)
+    _cp_d::FT = cp_d(param_set)
+    _grav::FT = grav(param_set)
+    _cv_d::FT = cv_d(param_set)
+    _MSLP::FT = MSLP(param_set)
 
     γ::FT = _cp_d / _cv_d
     δT =
@@ -87,7 +88,7 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
 
     q_tot = FT(0)
     e_pot = gravitational_potential(bl.orientation, aux)
-    ts = PhaseEquil_pTq(bl.param_set, P, T, q_tot)
+    ts = PhaseEquil_pTq(param_set, P, T, q_tot)
 
     ρu, ρv, ρw = FT(0), FT(0), ρ * δw
 

--- a/tutorials/Atmos/heldsuarez.jl
+++ b/tutorials/Atmos/heldsuarez.jl
@@ -64,12 +64,13 @@ function held_suarez_forcing_coefficients(bl, args)
 
     ## Parameters
     T_ref = FT(255)
+    param_set = parameter_set(bl)
 
-    _R_d = FT(R_d(bl.param_set))
-    _day = FT(day(bl.param_set))
-    _grav = FT(grav(bl.param_set))
-    _cp_d = FT(cp_d(bl.param_set))
-    _p0 = FT(MSLP(bl.param_set))
+    _R_d = FT(R_d(param_set))
+    _day = FT(day(param_set))
+    _grav = FT(grav(param_set))
+    _cp_d = FT(cp_d(param_set))
+    _p0 = FT(MSLP(param_set))
 
     ## Held-Suarez parameters
     k_a = FT(1 / (40 * _day))
@@ -98,21 +99,22 @@ function held_suarez_forcing_coefficients(bl, args)
     return (k_v = k_v, k_T = k_T, T_equil = T_equil)
 end
 
-function source(s::HeldSuarezForcingTutorial{Energy}, m, args)
+function source(s::HeldSuarezForcingTutorial{Energy}, atmos, args)
     @unpack state = args
     FT = eltype(state)
     @unpack ts = args.precomputed
-    nt = held_suarez_forcing_coefficients(m, args)
-    _cv_d = FT(cv_d(m.param_set))
+    nt = held_suarez_forcing_coefficients(atmos, args)
+    param_set = parameter_set(atmos)
+    _cv_d = FT(cv_d(param_set))
     @unpack k_T, T_equil = nt
     T = air_temperature(ts)
     return -k_T * state.ρ * _cv_d * (T - T_equil)
 end
 
-function source(s::HeldSuarezForcingTutorial{Momentum}, m, args)
+function source(s::HeldSuarezForcingTutorial{Momentum}, atmos, args)
     @unpack state, aux = args
-    nt = held_suarez_forcing_coefficients(m, args)
-    return -nt.k_v * projection_tangential(m, aux, state.ρu)
+    nt = held_suarez_forcing_coefficients(atmos, args)
+    return -nt.k_v * projection_tangential(atmos, aux, state.ρu)
 end
 
 

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -113,13 +113,14 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
 
     ## Problem float-type
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     ## Unpack constant parameters
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     ## Define bubble center and background potential temperature
@@ -144,8 +145,8 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     π_exner = FT(1) - _grav / (c_p * θ) * z             ## exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas)      ## density
     T = θ * π_exner
-    e_int = internal_energy(bl.param_set, T)
-    ts = PhaseDry(bl.param_set, e_int, ρ)
+    e_int = internal_energy(param_set, T)
+    ts = PhaseDry(param_set, e_int, ρ)
     ρu = SVector(FT(0), FT(0), FT(0))                   ## momentum
     ## State (prognostic) variable assignment
     e_kin = FT(0)                                       ## kinetic energy

--- a/tutorials/Land/Soil/Coupled/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Coupled/equilibrium_test.jl
@@ -112,7 +112,13 @@ using ClimateMachine.ODESolvers
 using ClimateMachine.VariableTemplates
 using ClimateMachine.SingleStackUtils
 using ClimateMachine.BalanceLaws:
-    BalanceLaw, Prognostic, Auxiliary, Gradient, GradientFlux, vars_state
+    BalanceLaw,
+    Prognostic,
+    Auxiliary,
+    Gradient,
+    GradientFlux,
+    vars_state,
+    parameter_set
 
 # # Preliminary set-up
 
@@ -261,16 +267,17 @@ function init_soil!(land, state, aux, localgeo, time)
     θ_i = myFT(land.soil.water.initialθ_i(aux))
     state.soil.water.ϑ_l = ϑ_l
     state.soil.water.θ_i = θ_i
+    param_set = parameter_set(land)
 
     θ_l = volumetric_liquid_fraction(ϑ_l, land.soil.param_functions.porosity)
     ρc_ds = land.soil.param_functions.ρc_ds
-    ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, land.param_set)
+    ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, param_set)
 
     state.soil.heat.ρe_int = volumetric_internal_energy(
         θ_i,
         ρc_s,
         land.soil.heat.initialT(aux),
-        land.param_set,
+        param_set,
     )
 end;
 

--- a/tutorials/Numerics/TimeStepping/tutorial_acousticwave_config.jl
+++ b/tutorials/Numerics/TimeStepping/tutorial_acousticwave_config.jl
@@ -36,6 +36,7 @@ end
 function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     ## callable to set initial conditions
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     λ = longitude(bl, aux)
     φ = latitude(bl, aux)
@@ -47,7 +48,7 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
 
-    ts = PhaseDry_pT(bl.param_set, p, setup.T_ref)
+    ts = PhaseDry_pT(param_set, p, setup.T_ref)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/tutorials/Numerics/TimeStepping/tutorial_risingbubble_config.jl
+++ b/tutorials/Numerics/TimeStepping/tutorial_risingbubble_config.jl
@@ -113,13 +113,14 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
 
     ## Problem float-type
     FT = eltype(state)
+    param_set = parameter_set(bl)
 
     ## Unpack constant parameters
-    R_gas::FT = R_d(bl.param_set)
-    c_p::FT = cp_d(bl.param_set)
-    c_v::FT = cv_d(bl.param_set)
-    p0::FT = MSLP(bl.param_set)
-    _grav::FT = grav(bl.param_set)
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     γ::FT = c_p / c_v
 
     ## Define bubble center and background potential temperature
@@ -144,8 +145,8 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     π_exner = FT(1) - _grav / (c_p * θ) * z             ## exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas)      ## density
     T = θ * π_exner
-    e_int = internal_energy(bl.param_set, T)
-    ts = PhaseDry(bl.param_set, e_int, ρ)
+    e_int = internal_energy(param_set, T)
+    ts = PhaseDry(param_set, e_int, ρ)
     ρu = SVector(FT(0), FT(0), FT(0))                   ## momentum
     ## State (prognostic) variable assignment
     e_kin = FT(0)                                       ## kinetic energy


### PR DESCRIPTION
### Description

This PR adds `parameter_set` to `BalanceLaws` and uses this in favor of `.param_set`. If we create/use enough getter wrappers, then we won't need to duplicate code in #2100.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
