### PR TITLE
Update FV reconstruction with anelastic1D capabilities

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -227,8 +227,18 @@ struct Compressible <: Compressibilty end
 
 Dispatch on Anelastic1D model
 
- - Density is constant in time
- - Remove momentum z-component tendencies
+ - The state density is taken constant in time and equal to the reference density. This
+    constant density profile is used in all equations and conversions from conservative to specific
+    variables per unit mass. The density can be accessed using the dispatch function
+    `density(atmos, state, aux)`.
+ - The thermodynamic state is constructed from the reference pressure (constant in time),
+    and the internal energy (which evolves in time).
+ - The state density is not consistent with the thermodynamic state, since we neglect 
+    buoyancy perturbations on all equations except in the vertical buoyancy flux.
+ - The density obtained from the thermodynamic state, `air_density(ts)`, recovers the full density, which
+    should only be used to compute buoyancy and buoyancy fluxes, and in the FV reconstruction.
+ - Removes momentum z-component tendencies, assuming balance between the pressure gradient and buoyancy
+    forces.
 """
 struct Anelastic1D <: Compressibilty end
 
@@ -479,18 +489,27 @@ turbulence_tensors(atmos::AtmosModel, args...) =
 """
     density(atmos::AtmosModel, state::Vars, aux::Vars)
 
-In the Anelastic1D state, `state.ρ` that is used to
-extract intrinsic values (i.e. `e=state.energy.ρe/state.ρ`)
-is time invariant (by eliminating the tendencies) while
-`ref_state.ρ` is used to construct a thermodynamic state.
-`density` will get the `ref_state.ρ` for thermodynamic state
-when the model is Anelastic1D.
+Density used in the conservative form of the prognostic equations.
+In the Compressible case, it is equal to the prognostic density,
+whereas in the Anelastic1D case it is the reference density,
+which is constant in time.
 """
 density(atmos::AtmosModel, state::Vars, aux::Vars) =
     density(atmos.compressibility, state, aux)
 density(::Compressible, state, aux) = state.ρ
 density(::Anelastic1D, state, aux) = aux.ref_state.ρ
 
+"""
+    pressure(atmos::AtmosModel, ts, aux::Vars)
+
+Diagnostic pressure consistent with the given thermodynamic state ts.
+In the Anelastic1D case it is the reference pressure,
+which is constant in time.
+"""
+pressure(atmos::AtmosModel, ts, aux::Vars) =
+    pressure(atmos.compressibility, ts, aux)
+pressure(::Compressible, ts, aux) = air_pressure(ts)
+pressure(::Anelastic1D, ts, aux) = aux.ref_state.p
 
 include("declare_prognostic_vars.jl") # declare prognostic variables
 include("multiphysics_types.jl")      # types for multi-physics tendencies

--- a/src/Atmos/Model/prog_prim_conversion.jl
+++ b/src/Atmos/Model/prog_prim_conversion.jl
@@ -23,18 +23,7 @@ function prognostic_to_primitive!(
     aux,
 )
     atmos.energy isa EnergyModel || error("EnergyModel only supported")
-    prognostic_to_primitive!(
-        atmos,
-        atmos.moisture,
-        prim,
-        prog,
-        Thermodynamics.internal_energy(
-            prog.ρ,
-            prog.energy.ρe,
-            prog.ρu,
-            gravitational_potential(atmos.orientation, aux),
-        ),
-    )
+    prognostic_to_primitive!(atmos, atmos.moisture, prim, prog, aux)
     prognostic_to_primitive!(atmos.turbconv, atmos, atmos.moisture, prim, prog)
 end
 
@@ -54,13 +43,7 @@ function primitive_to_prognostic!(
     prim::Vars,
     aux,
 )
-    primitive_to_prognostic!(
-        atmos,
-        atmos.moisture,
-        prog,
-        prim,
-        gravitational_potential(atmos.orientation, aux),
-    )
+    primitive_to_prognostic!(atmos, atmos.moisture, prog, prim, aux)
     primitive_to_prognostic!(atmos.turbconv, atmos, atmos.moisture, prog, prim)
 end
 
@@ -73,12 +56,12 @@ function prognostic_to_primitive!(
     moist::DryModel,
     prim::Vars,
     prog::Vars,
-    e_int::AbstractFloat,
+    aux::Vars,
 )
-    ts = PhaseDry(parameter_set(atmos), e_int, prog.ρ)
-    prim.ρ = prog.ρ
-    prim.u = prog.ρu ./ prog.ρ
-    prim.p = air_pressure(ts)
+    ts = new_thermo_state(atmos, prog, aux)
+    prim.ρ = air_density(ts) # Needed for recovery of energy, not prog.ρ in anelastic1d
+    prim.u = prog.ρu ./ density(atmos, prog, aux)
+    prim.p = pressure(atmos, ts, aux)
 end
 
 function prognostic_to_primitive!(
@@ -86,20 +69,12 @@ function prognostic_to_primitive!(
     moist::EquilMoist,
     prim::Vars,
     prog::Vars,
-    e_int::AbstractFloat,
+    aux::Vars,
 )
-    FT = eltype(prim)
-    ts = PhaseEquil(
-        parameter_set(atmos),
-        e_int,
-        prog.ρ,
-        prog.moisture.ρq_tot / prog.ρ,
-        # 20,       # can improve test error with better convergence
-        # FT(1e-3), # can improve test error with better convergence
-    )
-    prim.ρ = prog.ρ
-    prim.u = prog.ρu ./ prog.ρ
-    prim.p = air_pressure(ts)
+    ts = new_thermo_state(atmos, prog, aux)
+    prim.ρ = air_density(ts) # Needed for recovery of energy, not prog.ρ in anelastic1d
+    prim.u = prog.ρu ./ density(atmos, prog, aux)
+    prim.p = pressure(atmos, ts, aux)
     prim.moisture.q_tot = PhasePartition(ts).tot
 end
 
@@ -108,17 +83,12 @@ function prognostic_to_primitive!(
     moist::NonEquilMoist,
     prim::Vars,
     prog::Vars,
-    e_int::AbstractFloat,
+    aux::Vars,
 )
-    q_pt = PhasePartition(
-        prog.moisture.ρq_tot / prog.ρ,
-        prog.moisture.ρq_liq / prog.ρ,
-        prog.moisture.ρq_ice / prog.ρ,
-    )
-    ts = PhaseNonEquil(parameter_set(atmos), e_int, prog.ρ, q_pt)
-    prim.ρ = prog.ρ
-    prim.u = prog.ρu ./ prog.ρ
-    prim.p = air_pressure(ts)
+    ts = new_thermo_state(atmos, prog, aux)
+    prim.ρ = air_density(ts) # Needed for recovery of energy, not prog.ρ in anelastic1d
+    prim.u = prog.ρu ./ density(atmos, prog, aux)
+    prim.p = pressure(atmos, ts, aux)
     prim.moisture.q_tot = PhasePartition(ts).tot
     prim.moisture.q_liq = PhasePartition(ts).liq
     prim.moisture.q_ice = PhasePartition(ts).ice
@@ -133,15 +103,17 @@ function primitive_to_prognostic!(
     moist::DryModel,
     prog::Vars,
     prim::Vars,
-    e_pot::AbstractFloat,
+    aux::Vars,
 )
     atmos.energy isa EnergyModel || error("EnergyModel only supported")
     ts = PhaseDry_ρp(parameter_set(atmos), prim.ρ, prim.p)
     e_kin = prim.u' * prim.u / 2
+    ρ = density(atmos, prim, aux)
+    e_pot = gravitational_potential(atmos.orientation, aux)
 
-    prog.ρ = prim.ρ
-    prog.ρu = prim.ρ .* prim.u
-    prog.energy.ρe = prim.ρ * total_energy(e_kin, e_pot, ts)
+    prog.ρ = ρ
+    prog.ρu = ρ .* prim.u
+    prog.energy.ρe = ρ * total_energy(e_kin, e_pot, ts)
 end
 
 function primitive_to_prognostic!(
@@ -149,7 +121,7 @@ function primitive_to_prognostic!(
     moist::EquilMoist,
     prog::Vars,
     prim::Vars,
-    e_pot::AbstractFloat,
+    aux::Vars,
 )
     atmos.energy isa EnergyModel || error("EnergyModel only supported")
     ts = PhaseEquil_ρpq(
@@ -160,11 +132,13 @@ function primitive_to_prognostic!(
         true,
     )
     e_kin = prim.u' * prim.u / 2
+    ρ = density(atmos, prim, aux)
+    e_pot = gravitational_potential(atmos.orientation, aux)
 
-    prog.ρ = prim.ρ
-    prog.ρu = prim.ρ .* prim.u
-    prog.energy.ρe = prim.ρ * total_energy(e_kin, e_pot, ts)
-    prog.moisture.ρq_tot = prim.ρ * PhasePartition(ts).tot
+    prog.ρ = ρ
+    prog.ρu = ρ .* prim.u
+    prog.energy.ρe = ρ * total_energy(e_kin, e_pot, ts)
+    prog.moisture.ρq_tot = ρ * PhasePartition(ts).tot
 end
 
 function primitive_to_prognostic!(
@@ -172,7 +146,7 @@ function primitive_to_prognostic!(
     moist::NonEquilMoist,
     prog::Vars,
     prim::Vars,
-    e_pot::AbstractFloat,
+    aux::Vars,
 )
     atmos.energy isa EnergyModel || error("EnergyModel only supported")
     q_pt = PhasePartition(
@@ -182,13 +156,15 @@ function primitive_to_prognostic!(
     )
     ts = PhaseNonEquil_ρpq(parameter_set(atmos), prim.ρ, prim.p, q_pt)
     e_kin = prim.u' * prim.u / 2
+    ρ = density(atmos, prim, aux)
+    e_pot = gravitational_potential(atmos.orientation, aux)
 
-    prog.ρ = prim.ρ
-    prog.ρu = prim.ρ .* prim.u
-    prog.energy.ρe = prim.ρ * total_energy(e_kin, e_pot, ts)
-    prog.moisture.ρq_tot = prim.ρ * PhasePartition(ts).tot
-    prog.moisture.ρq_liq = prim.ρ * PhasePartition(ts).liq
-    prog.moisture.ρq_ice = prim.ρ * PhasePartition(ts).ice
+    prog.ρ = ρ
+    prog.ρu = ρ .* prim.u
+    prog.energy.ρe = ρ * total_energy(e_kin, e_pot, ts)
+    prog.moisture.ρq_tot = ρ * PhasePartition(ts).tot
+    prog.moisture.ρq_liq = ρ * PhasePartition(ts).liq
+    prog.moisture.ρq_ice = ρ * PhasePartition(ts).ice
 end
 
 

--- a/test/Atmos/prog_prim_conversion/runtests.jl
+++ b/test/Atmos/prog_prim_conversion/runtests.jl
@@ -18,8 +18,7 @@ using ClimateMachine.ConfigTypes
 using ClimateMachine.VariableTemplates
 using ClimateMachine.Thermodynamics
 using ClimateMachine.TemperatureProfiles
-using ClimateMachine.Atmos:
-    AtmosModel, DryModel, EquilMoist, NonEquilMoist, EnergyModel
+using ClimateMachine.Atmos
 using ClimateMachine.BalanceLaws:
     prognostic_to_primitive!, primitive_to_prognostic!
 const BL = BalanceLaws
@@ -32,48 +31,43 @@ atol_energy = cv_d(param_set) * atol_temperature
 
 import ClimateMachine.BalanceLaws: vars_state
 
-struct TestBL{PS, M, E} <: BalanceLaw
-    param_set::PS
-    moisture::M
-    energy::E
+# Assign aux.ref_state different than state for general testing
+function assign!(aux, bl, nt, st::Auxiliary)
+    @unpack p, ρ, e_pot, = nt
+    aux.ref_state.ρ = ρ / 2
+    aux.ref_state.p = p / 2
+    aux.orientation.Φ = e_pot
 end
 
-vars_state(bl::TestBL, st::Prognostic, FT) = @vars begin
-    ρ::FT
-    ρu::SVector{3, FT}
-    energy::vars_state(bl.energy, st, FT)
-    moisture::vars_state(bl.moisture, st, FT)
-end
-
-vars_state(bl::TestBL, st::Primitive, FT) = @vars begin
-    ρ::FT
-    u::SVector{3, FT}
-    p::FT
-    moisture::vars_state(bl.moisture, st, FT)
-end
-
-function assign!(state, bl, nt, st::Prognostic)
+function assign!(state, bl, nt, st::Prognostic, aux)
     @unpack u, v, w, ρ, e_kin, e_pot, T, q_pt = nt
     state.ρ = ρ
-    state.ρu = SVector(ρ * u, ρ * v, ρ * w)
+    assign!(state, bl, bl.compressibility, nt, st, aux)
+    state.ρu = SVector(state.ρ * u, state.ρ * v, state.ρ * w)
     param_set = parameter_set(bl)
     state.energy.ρe = state.ρ * total_energy(param_set, e_kin, e_pot, T, q_pt)
     assign!(state, bl, bl.moisture, nt, st)
 end
 assign!(state, bl, moisture::DryModel, nt, ::Prognostic) = nothing
 assign!(state, bl, moisture::EquilMoist, nt, ::Prognostic) =
-    (state.moisture.ρq_tot = nt.ρ * nt.q_pt.tot)
+    (state.moisture.ρq_tot = state.ρ * nt.q_pt.tot)
 function assign!(state, bl, moisture::NonEquilMoist, nt, ::Prognostic)
-    state.moisture.ρq_tot = nt.ρ * nt.q_pt.tot
-    state.moisture.ρq_liq = nt.ρ * nt.q_pt.liq
-    state.moisture.ρq_ice = nt.ρ * nt.q_pt.ice
+    state.moisture.ρq_tot = state.ρ * nt.q_pt.tot
+    state.moisture.ρq_liq = state.ρ * nt.q_pt.liq
+    state.moisture.ρq_ice = state.ρ * nt.q_pt.ice
+end
+# Assign prog.ρ = aux.ref_state.ρ in anelastic1D
+assign!(state, bl, ::Compressible, nt, ::Prognostic, aux) = nothing
+function assign!(state, bl, ::Anelastic1D, nt, ::Prognostic, aux)
+    state.ρ = aux.ref_state.ρ
 end
 
-function assign!(state, bl, nt, st::Primitive)
+function assign!(state, bl, nt, st::Primitive, aux)
     @unpack u, v, w, ρ, p = nt
     state.ρ = ρ
     state.u = SVector(u, v, w)
     state.p = p
+    assign!(state, bl, bl.compressibility, nt, st, aux)
     assign!(state, bl, bl.moisture, nt, st)
 end
 assign!(state, bl, moisture::DryModel, nt, ::Primitive) = nothing
@@ -84,79 +78,107 @@ function assign!(state, bl, moisture::NonEquilMoist, nt, ::Primitive)
     state.moisture.q_liq = nt.q_pt.liq
     state.moisture.q_ice = nt.q_pt.ice
 end
-
+# Assign prim.p = aux.ref_state.p in anelastic1D
+assign!(state, bl, ::Compressible, nt, ::Primitive, aux) = nothing
+function assign!(state, bl, ::Anelastic1D, nt, ::Primitive, aux)
+    state.p = aux.ref_state.p
+end
 
 @testset "Prognostic-Primitive conversion (dry)" begin
     FT = Float64
-    bl = TestBL(param_set, DryModel(), EnergyModel())
-    vs_prog = vars_state(bl, Prognostic(), FT)
-    vs_prim = vars_state(bl, Primitive(), FT)
-    prog_arr = zeros(varsize(vs_prog))
-    prim_arr = zeros(varsize(vs_prim))
-    prog = Vars{vs_prog}(prog_arr)
-    prim = Vars{vs_prim}(prim_arr)
-    for nt in PhaseDryProfiles(param_set, ArrayType)
-        @unpack e_int, e_pot = nt
+    compressibility = (Anelastic1D(), Compressible())
+    for comp in compressibility
+        bl = AtmosModel{FT}(
+            AtmosLESConfigType,
+            param_set;
+            moisture = DryModel(),
+            compressibility = comp,
+            init_state_prognostic = x -> x,
+        )
+        vs_prog = vars_state(bl, Prognostic(), FT)
+        vs_prim = vars_state(bl, Primitive(), FT)
+        vs_aux = vars_state(bl, Auxiliary(), FT)
+        prog_arr = zeros(varsize(vs_prog))
+        prim_arr = zeros(varsize(vs_prim))
+        aux_arr = zeros(varsize(vs_aux))
+        prog = Vars{vs_prog}(prog_arr)
+        prim = Vars{vs_prim}(prim_arr)
+        aux = Vars{vs_aux}(aux_arr)
+        for nt in PhaseDryProfiles(param_set, ArrayType)
+            assign!(aux, bl, nt, Auxiliary())
 
-        # Test prognostic_to_primitive! identity
-        assign!(prog, bl, nt, Prognostic())
-        prog_0 = deepcopy(parent(prog))
-        prim_arr .= 0
-        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
-        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
-        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
-        @test all(parent(prog) .≈ prog_0)
+            # Test prognostic_to_primitive! identity
+            assign!(prog, bl, nt, Prognostic(), aux)
+            prog_0 = deepcopy(parent(prog))
+            prim_arr .= 0
+            prognostic_to_primitive!(bl, prim, prog, aux)
+            @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
+            primitive_to_prognostic!(bl, prog, prim, aux)
+            @test all(parent(prog) .≈ prog_0)
 
-        # Test primitive_to_prognostic! identity
-        assign!(prim, bl, nt, Primitive())
-        prim_0 = deepcopy(parent(prim))
-        prog_arr .= 0
-        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
-        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
-        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
-        @test all(parent(prim) .≈ prim_0)
+            # Test primitive_to_prognostic! identity
+            assign!(prim, bl, nt, Primitive(), aux)
+            prim_0 = deepcopy(parent(prim))
+            prog_arr .= 0
+            primitive_to_prognostic!(bl, prog, prim, aux)
+            @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
+            prognostic_to_primitive!(bl, prim, prog, aux)
+            @test all(parent(prim) .≈ prim_0)
+        end
     end
 end
 
 @testset "Prognostic-Primitive conversion (EquilMoist)" begin
     FT = Float64
-    bl = TestBL(param_set, EquilMoist(), EnergyModel())
-    vs_prog = vars_state(bl, Prognostic(), FT)
-    vs_prim = vars_state(bl, Primitive(), FT)
-    prog_arr = zeros(varsize(vs_prog))
-    prim_arr = zeros(varsize(vs_prim))
-    prog = Vars{vs_prog}(prog_arr)
-    prim = Vars{vs_prim}(prim_arr)
-    err_max_fwd = 0
-    err_max_bwd = 0
-    for nt in PhaseEquilProfiles(param_set, ArrayType)
-        @unpack e_int, e_pot, q_tot = nt
+    compressibility = (Compressible(),) # Anelastic1D() does not converge
+    for comp in compressibility
+        bl = AtmosModel{FT}(
+            AtmosLESConfigType,
+            param_set;
+            moisture = EquilMoist(; maxiter = 5), # maxiter=3 does not converge
+            compressibility = comp,
+            init_state_prognostic = x -> x,
+        )
+        vs_prog = vars_state(bl, Prognostic(), FT)
+        vs_prim = vars_state(bl, Primitive(), FT)
+        vs_aux = vars_state(bl, Auxiliary(), FT)
+        prog_arr = zeros(varsize(vs_prog))
+        prim_arr = zeros(varsize(vs_prim))
+        aux_arr = zeros(varsize(vs_aux))
+        prog = Vars{vs_prog}(prog_arr)
+        prim = Vars{vs_prim}(prim_arr)
+        aux = Vars{vs_aux}(aux_arr)
+        err_max_fwd = 0
+        err_max_bwd = 0
+        for nt in PhaseEquilProfiles(param_set, ArrayType)
+            assign!(aux, bl, nt, Auxiliary())
 
-        # Test prognostic_to_primitive! identity
-        assign!(prog, bl, nt, Prognostic())
-        prog_0 = deepcopy(parent(prog))
-        prim_arr .= 0
-        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
-        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
-        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
-        @test all(parent(prog)[1:4] .≈ prog_0[1:4])
-        @test isapprox(parent(prog)[5], prog_0[5]; atol = atol_energy)
-        # @test all(parent(prog)[5] .≈ prog_0[5]) # fails
-        @test all(parent(prog)[6] .≈ prog_0[6])
-        err_max_fwd = max(abs(parent(prog)[5] .- prog_0[5]), err_max_fwd)
+            # Test prognostic_to_primitive! identity
+            assign!(prog, bl, nt, Prognostic(), aux)
+            prog_0 = deepcopy(parent(prog))
+            prim_arr .= 0
+            prognostic_to_primitive!(bl, prim, prog, aux)
+            @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
+            primitive_to_prognostic!(bl, prog, prim, aux)
+            @test all(parent(prog)[1:4] .≈ prog_0[1:4])
+            @test isapprox(parent(prog)[5], prog_0[5]; atol = atol_energy)
+            # @test all(parent(prog)[5] .≈ prog_0[5]) # fails
+            @test all(parent(prog)[6] .≈ prog_0[6])
+            err_max_fwd = max(abs(parent(prog)[5] .- prog_0[5]), err_max_fwd)
 
-        # Test primitive_to_prognostic! identity
-        assign!(prim, bl, nt, Primitive())
-        prim_0 = deepcopy(parent(prim))
-        prog_arr .= 0
-        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
-        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
-        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
-        @test all(parent(prim)[1:4] .≈ prim_0[1:4])
-        # @test all(parent(prim)[5] .≈ prim_0[5]) # fails
-        @test isapprox(parent(prim)[5], prim_0[5]; atol = atol_energy)
-        @test all(parent(prim)[6] .≈ prim_0[6])
-        err_max_bwd = max(abs(parent(prim)[5] .- prim_0[5]), err_max_bwd)
+            # Test primitive_to_prognostic! identity
+            assign!(prim, bl, nt, Primitive(), aux)
+            prim_0 = deepcopy(parent(prim))
+            prog_arr .= 0
+            primitive_to_prognostic!(bl, prog, prim, aux)
+            @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
+            prognostic_to_primitive!(bl, prim, prog, aux)
+            @test all(parent(prim)[1:4] .≈ prim_0[1:4])
+            # @test all(parent(prim)[5] .≈ prim_0[5]) # fails
+            @test isapprox(parent(prim)[5], prim_0[5]; atol = atol_energy)
+            @test all(parent(prim)[6] .≈ prim_0[6])
+            err_max_bwd = max(abs(parent(prim)[5] .- prim_0[5]), err_max_bwd)
+        end
     end
     # We may want/need to improve this later, so leaving debug info:
     # @show err_max_fwd
@@ -165,32 +187,44 @@ end
 
 @testset "Prognostic-Primitive conversion (NonEquilMoist)" begin
     FT = Float64
-    bl = TestBL(param_set, NonEquilMoist(), EnergyModel())
-    vs_prog = vars_state(bl, Prognostic(), FT)
-    vs_prim = vars_state(bl, Primitive(), FT)
-    prog_arr = zeros(varsize(vs_prog))
-    prim_arr = zeros(varsize(vs_prim))
-    prog = Vars{vs_prog}(prog_arr)
-    prim = Vars{vs_prim}(prim_arr)
-    for nt in PhaseEquilProfiles(param_set, ArrayType)
-        @unpack e_int, e_pot = nt
-        # Test prognostic_to_primitive! identity
-        assign!(prog, bl, nt, Prognostic())
-        prog_0 = deepcopy(parent(prog))
-        prim_arr .= 0
-        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
-        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
-        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
-        @test all(parent(prog) .≈ prog_0)
+    compressibility = (Anelastic1D(), Compressible())
+    for comp in compressibility
+        bl = AtmosModel{FT}(
+            AtmosLESConfigType,
+            param_set;
+            moisture = NonEquilMoist(),
+            init_state_prognostic = x -> x,
+        )
+        vs_prog = vars_state(bl, Prognostic(), FT)
+        vs_prim = vars_state(bl, Primitive(), FT)
+        vs_aux = vars_state(bl, Auxiliary(), FT)
+        prog_arr = zeros(varsize(vs_prog))
+        prim_arr = zeros(varsize(vs_prim))
+        aux_arr = zeros(varsize(vs_aux))
+        prog = Vars{vs_prog}(prog_arr)
+        prim = Vars{vs_prim}(prim_arr)
+        aux = Vars{vs_aux}(aux_arr)
+        for nt in PhaseEquilProfiles(param_set, ArrayType)
+            assign!(aux, bl, nt, Auxiliary())
 
-        # Test primitive_to_prognostic! identity
-        assign!(prim, bl, nt, Primitive())
-        prim_0 = deepcopy(parent(prim))
-        prog_arr .= 0
-        primitive_to_prognostic!(bl, bl.moisture, prog, prim, e_pot)
-        @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
-        prognostic_to_primitive!(bl, bl.moisture, prim, prog, e_int)
-        @test all(parent(prim) .≈ prim_0)
+            # Test prognostic_to_primitive! identity
+            assign!(prog, bl, nt, Prognostic(), aux)
+            prog_0 = deepcopy(parent(prog))
+            prim_arr .= 0
+            prognostic_to_primitive!(bl, prim, prog, aux)
+            @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
+            primitive_to_prognostic!(bl, prog, prim, aux)
+            @test all(parent(prog) .≈ prog_0)
+
+            # Test primitive_to_prognostic! identity
+            assign!(prim, bl, nt, Primitive(), aux)
+            prim_0 = deepcopy(parent(prim))
+            prog_arr .= 0
+            primitive_to_prognostic!(bl, prog, prim, aux)
+            @test !all(parent(prim) .≈ parent(prog)) # ensure not calling fallback
+            prognostic_to_primitive!(bl, prim, prog, aux)
+            @test all(parent(prim) .≈ prim_0)
+        end
     end
 end
 
@@ -212,11 +246,10 @@ end
     prim = Vars{vs_prim}(prim_arr)
     aux = Vars{vs_aux}(aux_arr)
     for nt in PhaseDryProfiles(param_set, ArrayType)
-        @unpack e_pot = nt
+        assign!(aux, bl, nt, Auxiliary())
 
         # Test prognostic_to_primitive! identity
-        assign!(prog, bl, nt, Prognostic())
-        aux.orientation.Φ = e_pot
+        assign!(prog, bl, nt, Prognostic(), aux)
         prog_0 = deepcopy(parent(prog))
         prim_arr .= 0
         BL.prognostic_to_primitive!(bl, prim_arr, prog_arr, aux_arr)
@@ -225,7 +258,7 @@ end
         @test all(parent(prog) .≈ prog_0)
 
         # Test primitive_to_prognostic! identity
-        assign!(prim, bl, nt, Primitive())
+        assign!(prim, bl, nt, Primitive(), aux)
         prim_0 = deepcopy(parent(prim))
         prog_arr .= 0
         BL.primitive_to_prognostic!(bl, prog_arr, prim_arr, aux_arr)


### PR DESCRIPTION
### Description

This PR updates `prognostic_to_primitive!` and `primitive_to_prognostic!` to be consistent with the Anelastic1D and Compressible formulations. Inner thermo state constructors are now handled through dispatchers when possible. Recovery tests are added for the Anelastic1D() `prognostic_to_primitive!` and `primitive_to_prognostic!` constructors.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
