### PR TITLE
Add neutrally stratified Ekman layer experiment and anelastic driver

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1698,6 +1698,16 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "gpu_ekman"
+    key: "gpu_ekman"
+    command:
+      - "mpiexec julia --color=yes --project test/Atmos/EDMF/ekman_layer.jl --fix-rng-seed"
+    agents:
+      config: gpu
+      queue: central
+      slurm_ntasks: 1
+      slurm_gres: "gpu:1"
+
   - label: "gpu_sbl_edmf"
     key: "gpu_sbl_edmf"
     command:

--- a/experiments/AtmosLES/ekman_layer_model.jl
+++ b/experiments/AtmosLES/ekman_layer_model.jl
@@ -1,0 +1,288 @@
+#!/usr/bin/env julia --project
+#=
+# This experiment file establishes the initial conditions, boundary conditions,
+# source terms and simulation parameters (domain size + resolution) for
+# a dry neutrally stratified Ekman layer.
+# 
+# The initial conditions are given by constant horizontal velocity of 1 m/s,
+# and a constant potential temperature profile. The bottom boundary condition
+# results in momentum drag, and there is no exchange of heat from the surface
+# since the fluxes are zero and the temperature is homogeneous.
+#
+=#
+
+using ArgParse
+using Distributions
+using StaticArrays
+using Test
+using DocStringExtensions
+using LinearAlgebra
+using Printf
+using UnPack
+
+using ClimateMachine
+using ClimateMachine.Atmos
+using ClimateMachine.Orientations
+using ClimateMachine.ConfigTypes
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.TemperatureProfiles
+using ClimateMachine.Diagnostics
+using ClimateMachine.GenericCallbacks
+using ClimateMachine.Mesh.Filters
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.ODESolvers
+using ClimateMachine.Thermodynamics
+using ClimateMachine.TurbulenceClosures
+using ClimateMachine.TurbulenceConvection
+using ClimateMachine.VariableTemplates
+using ClimateMachine.BalanceLaws
+import ClimateMachine.BalanceLaws: source, prognostic_vars
+
+using CLIMAParameters
+using CLIMAParameters.Planet: cp_d, cv_d, grav, T_surf_ref
+using CLIMAParameters.Atmos.SubgridScale: C_smag, C_drag
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+import CLIMAParameters
+
+using ClimateMachine.Atmos: altitude, recover_thermo_state, density
+
+"""
+  EkmanLayer Geostrophic Forcing (Source)
+"""
+struct EkmanLayerGeostrophic{FT} <: TendencyDef{Source}
+    "Coriolis parameter [s⁻¹]"
+    f_coriolis::FT
+    "Eastward geostrophic velocity `[m/s]` (Base)"
+    u_geostrophic::FT
+    "Eastward geostrophic velocity `[m/s]` (Slope)"
+    u_slope::FT
+    "Northward geostrophic velocity `[m/s]`"
+    v_geostrophic::FT
+end
+prognostic_vars(::EkmanLayerGeostrophic) = (Momentum(),)
+
+function source(::Momentum, s::EkmanLayerGeostrophic, m, args)
+    @unpack state, aux = args
+    @unpack f_coriolis, u_geostrophic, u_slope, v_geostrophic = s
+
+    z = altitude(m, aux)
+    # Note z dependence of eastward geostrophic velocity
+    u_geo = SVector(u_geostrophic + u_slope * z, v_geostrophic, 0)
+    ẑ = vertical_unit_vector(m, aux)
+    fkvector = f_coriolis * ẑ
+    # Accumulate sources
+    return -fkvector × (state.ρu .- state.ρ * u_geo)
+end
+
+"""
+  EkmanLayer Sponge (Source)
+"""
+struct EkmanLayerSponge{FT} <: TendencyDef{Source}
+    "Maximum domain altitude (m)"
+    z_max::FT
+    "Altitude at with sponge starts (m)"
+    z_sponge::FT
+    "Sponge Strength 0 ⩽ α_max ⩽ 1"
+    α_max::FT
+    "Sponge exponent"
+    γ::FT
+    "Eastward geostrophic velocity `[m/s]` (Base)"
+    u_geostrophic::FT
+    "Eastward geostrophic velocity `[m/s]` (Slope)"
+    u_slope::FT
+    "Northward geostrophic velocity `[m/s]`"
+    v_geostrophic::FT
+end
+prognostic_vars(::EkmanLayerSponge) = (Momentum(),)
+
+function source(::Momentum, s::EkmanLayerSponge, m, args)
+    @unpack state, aux = args
+
+    @unpack z_max, z_sponge, α_max, γ = s
+    @unpack u_geostrophic, u_slope, v_geostrophic = s
+
+    z = altitude(m, aux)
+    u_geo = SVector(u_geostrophic + u_slope * z, v_geostrophic, 0)
+    ẑ = vertical_unit_vector(m, aux)
+    # Accumulate sources
+    if z_sponge <= z
+        r = (z - z_sponge) / (z_max - z_sponge)
+        β_sponge = α_max * sinpi(r / 2)^s.γ
+        return -β_sponge * (state.ρu .- state.ρ * u_geo)
+    else
+        FT = eltype(state)
+        return SVector{3, FT}(0, 0, 0)
+    end
+end
+
+add_perturbations!(state, localgeo) = nothing
+
+"""
+  Initial Condition for EkmanLayer simulation
+"""
+function init_problem!(problem, bl, state, aux, localgeo, t)
+    (x, y, z) = localgeo.coord
+    # Problem floating point precision
+    param_set = parameter_set(bl)
+    FT = eltype(state)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    _grav::FT = grav(param_set)
+    γ::FT = c_p / c_v
+    # Initialise speeds [u = Eastward, v = Northward, w = Vertical]
+    u::FT = 1
+    v::FT = 0
+    w::FT = 0
+    # Assign constant θ profile and equal to surface temperature
+    θ::FT = T_surf_ref(param_set)
+
+    p = aux.ref_state.p
+    TS = PhaseDry_pθ(param_set, p, θ)
+
+    ρ = bl.compressibility isa Compressible ? air_density(TS) : aux.ref_state.ρ
+    # Compute momentum contributions
+    ρu = ρ * u
+    ρv = ρ * v
+    ρw = ρ * w
+
+    # Compute energy contributions
+    e_kin = FT(1 // 2) * (u^2 + v^2 + w^2)
+    e_pot = _grav * z
+    ρe_tot = ρ * total_energy(e_kin, e_pot, TS)
+
+    # Assign initial conditions for prognostic state variables
+    state.ρ = ρ
+    state.ρu = SVector(ρu, ρv, ρw)
+    state.energy.ρe = ρe_tot
+    add_perturbations!(state, localgeo)
+    init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
+end
+
+function ekman_layer_model(
+    ::Type{FT},
+    config_type,
+    zmax,
+    surface_flux;
+    turbulence = ConstantKinematicViscosity(FT(0.1)),
+    turbconv = NoTurbConv(),
+    compressibility = Compressible(),
+    ref_state = HydrostaticState(DryAdiabaticProfile{FT}(param_set),),
+) where {FT}
+
+    ics = init_problem!     # Initial conditions
+
+    C_drag_::FT = C_drag(param_set) # FT(0.001)    # Momentum exchange coefficient
+    u_star = FT(0.30)
+    z_0 = FT(0.1)          # Roughness height
+
+    z_sponge = FT(300)     # Start of sponge layer
+    α_max = FT(0.75)       # Strength of sponge layer (timescale)
+    γ = 2                  # Strength of sponge layer (exponent)
+
+    u_geostrophic = FT(1)        # Eastward relaxation speed
+    u_slope = FT(0)              # Slope of altitude-dependent relaxation speed
+    v_geostrophic = FT(0)        # Northward relaxation speed
+    f_coriolis = FT(1.39e-4) # Coriolis parameter at 73N
+
+    q_sfc = FT(0)
+    θ_sfc = T_surf_ref(param_set)
+    g = compressibility isa Compressible ? (Gravity(),) : ()
+
+    # Assemble source components
+    source_default = (
+        g...,
+        EkmanLayerSponge{FT}(
+            zmax,
+            z_sponge,
+            α_max,
+            γ,
+            u_geostrophic,
+            u_slope,
+            v_geostrophic,
+        ),
+        EkmanLayerGeostrophic(
+            f_coriolis,
+            u_geostrophic,
+            u_slope,
+            v_geostrophic,
+        ),
+        turbconv_sources(turbconv)...,
+    )
+    source = source_default
+
+    # Set up problem initial and boundary conditions
+    if surface_flux == "prescribed"
+        energy_bc = PrescribedEnergyFlux((state, aux, t) -> FT(0))
+    elseif surface_flux == "bulk"
+        energy_bc = BulkFormulaEnergy(
+            (bl, state, aux, t, normPu_int) -> C_drag_,
+            (bl, state, aux, t) -> (θ_sfc, q_sfc),
+        )
+    elseif surface_flux == "custom_sbl"
+        energy_bc = PrescribedTemperature((state, aux, t) -> θ_sfc)
+    elseif surface_flux == "Nishizawa2018"
+        energy_bc = NishizawaEnergyFlux(
+            (bl, state, aux, t, normPu_int) -> z_0,
+            (bl, state, aux, t) -> (θ_sfc, q_sfc),
+        )
+    else
+        @warn @sprintf(
+            """
+%s: unrecognized surface flux; using 'prescribed'""",
+            surface_flux,
+        )
+    end
+
+    moisture_bcs = ()
+    boundary_conditions = (
+        AtmosBC(;
+            momentum = Impenetrable(DragLaw(
+                # normPu_int is the internal horizontal speed
+                # P represents the projection onto the horizontal
+                (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
+            )),
+            energy = energy_bc,
+            moisture_bcs...,
+            turbconv = turbconv_bcs(turbconv)[1],
+        ),
+        AtmosBC(; turbconv = turbconv_bcs(turbconv)[2]),
+    )
+
+    problem = AtmosProblem(
+        init_state_prognostic = ics,
+        boundaryconditions = boundary_conditions,
+    )
+
+    # Assemble model components
+    model = AtmosModel{FT}(
+        config_type,
+        param_set;
+        problem = problem,
+        ref_state = ref_state,
+        turbulence = turbulence,
+        moisture = DryModel(),
+        source = source,
+        turbconv = turbconv,
+        compressibility = compressibility,
+    )
+
+    return model
+end
+
+function config_diagnostics(driver_config)
+    default_dgngrp = setup_atmos_default_diagnostics(
+        AtmosLESConfigType(),
+        "60ssecs",
+        driver_config.name,
+    )
+    core_dgngrp = setup_atmos_core_diagnostics(
+        AtmosLESConfigType(),
+        "60ssecs",
+        driver_config.name,
+    )
+    return ClimateMachine.DiagnosticsConfiguration([
+        default_dgngrp,
+        core_dgngrp,
+    ])
+end

--- a/test/Atmos/EDMF/ekman_layer.jl
+++ b/test/Atmos/EDMF/ekman_layer.jl
@@ -1,0 +1,271 @@
+#!/usr/bin/env julia --project
+#=
+# This driver file simulates the ekman_layer_model.jl in a single column setting.
+# 
+# The user may select in main() the following configurations:
+# - DG or FV vertical discretization by changing the boolean `finite_volume`,
+# - Compressible() or Anelastic1D() changing the compressibility,
+# - Constant kinematic viscosity, Smagorinsky-Lilly or EDMF SGS fluxes.
+#
+# The default is DG, Anelastic1D(), constant kinematic viscosity of 0.1. 
+#
+=#
+
+using JLD2, FileIO
+using ClimateMachine
+using ClimateMachine.SingleStackUtils
+using ClimateMachine.Checkpoint
+using ClimateMachine.BalanceLaws: vars_state
+using ClimateMachine.Atmos
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+import CLIMAParameters
+import ClimateMachine.DGMethods.FVReconstructions: FVLinear
+
+include(joinpath(clima_dir, "experiments", "AtmosLES", "ekman_layer_model.jl"))
+include(joinpath("helper_funcs", "diagnostics_configuration.jl"))
+include("edmf_model.jl")
+include("edmf_kernels.jl")
+
+CLIMAParameters.Planet.T_surf_ref(::EarthParameterSet) = 290.0
+function set_clima_parameters(filename)
+    eval(:(include($filename)))
+end
+
+"""
+    init_state_prognostic!(
+            turbconv::EDMF{FT},
+            m::AtmosModel{FT},
+            state::Vars,
+            aux::Vars,
+            localgeo,
+            t::Real,
+        ) where {FT}
+
+Initialize EDMF state variables if turbconv=EDMF(...) is selected.
+This method is only called at `t=0`.
+"""
+function init_state_prognostic!(
+    turbconv::EDMF{FT},
+    m::AtmosModel{FT},
+    state::Vars,
+    aux::Vars,
+    localgeo,
+    t::Real,
+) where {FT}
+    # Aliases:
+    gm = state
+    en = state.turbconv.environment
+    up = state.turbconv.updraft
+    N_up = n_updrafts(turbconv)
+    z = altitude(m, aux)
+
+    param_set = parameter_set(m)
+    ts = new_thermo_state(m, state, aux)
+    θ_liq = liquid_ice_pottemp(ts)
+
+    a_min = turbconv.subdomains.a_min
+    @unroll_map(N_up) do i
+        up[i].ρa = gm.ρ * a_min
+        up[i].ρaw = gm.ρu[3] * a_min
+        up[i].ρaθ_liq = gm.ρ * a_min * θ_liq
+        up[i].ρaq_tot = FT(0)
+    end
+
+    en.ρatke =
+        z > FT(250) ? FT(0) :
+        gm.ρ *
+        FT(0.4) *
+        FT(1 - z / 250.0) *
+        FT(1 - z / 250.0) *
+        FT(1 - z / 250.0)
+    en.ρaθ_liq_cv = FT(0)
+    en.ρaq_tot_cv = FT(0)
+    en.ρaθ_liq_q_tot_cv = FT(0)
+    return nothing
+end;
+
+function main(::Type{FT}, cl_args) where {FT}
+    # Change boolean to control vertical discretization type
+    finite_volume = false
+
+    # Choice of compressibility and CFL
+    # compressibility = Compressible()
+    compressibility = Anelastic1D()
+    str_comp = compressibility == Compressible() ? "COMPRESS" : "ANELASTIC"
+
+    # Choice of SGS model
+    turbconv = NoTurbConv()
+    # N_updrafts = 1
+    # N_quad = 3
+    # turbconv = EDMF(FT, N_updrafts, N_quad, param_set)
+
+    C_smag_ = C_smag(param_set)
+    turbulence = ConstantKinematicViscosity(FT(0.1))
+    # turbulence = SmagorinskyLilly{FT}(C_smag_)
+
+    # Prescribe domain parameters
+    zmax = FT(400)
+    # Simulation time
+    t0 = FT(0)
+    timeend = FT(3600 * 2) # Change to 7h for low-level jet
+    CFLmax = compressibility == Compressible() ? FT(1) : FT(100)
+
+    config_type = SingleStackConfigType
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
+    if finite_volume
+        N = (1, 0)
+        nelem_vert = 80
+        ref_state = HydrostaticState(
+            DryAdiabaticProfile{FT}(param_set),
+            ;
+            subtract_off = false,
+        )
+        output_prefix = string("EL_", str_comp, "_FVM")
+        fv_reconstruction = FVLinear()
+    else
+        N = 4
+        nelem_vert = 20
+        ref_state = HydrostaticState(DryAdiabaticProfile{FT}(param_set),)
+        output_prefix = string("EL_", str_comp, "_DG")
+        fv_reconstruction = nothing
+    end
+
+    surface_flux = cl_args["surface_flux"]
+    model = ekman_layer_model(
+        FT,
+        config_type,
+        zmax,
+        surface_flux;
+        turbulence = turbulence,
+        turbconv = turbconv,
+        ref_state = ref_state,
+        compressibility = compressibility,
+    )
+    # Assemble configuration
+    driver_config = ClimateMachine.SingleStackConfiguration(
+        output_prefix,
+        N,
+        nelem_vert,
+        zmax,
+        param_set,
+        model;
+        hmax = FT(40),
+        solver_type = ode_solver_type,
+        fv_reconstruction = fv_reconstruction,
+    )
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+    )
+
+    # --- Zero-out horizontal variations:
+    vsp = vars_state(model, Prognostic(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :turbconv),
+    )
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :energy, :ρe),
+    )
+    vsa = vars_state(model, Auxiliary(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.dg.state_auxiliary,
+        varsindex(vsa, :turbconv),
+    )
+    # ---
+
+    dgn_config = config_diagnostics(driver_config)
+
+    # boyd vandeven filter
+    cb_boyd = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            ("energy.ρe",),
+            solver_config.dg.grid,
+            BoydVandevenFilter(solver_config.dg.grid, 1, 4),
+        )
+        nothing
+    end
+
+    diag_arr = [single_stack_diagnostics(solver_config)]
+    time_data = FT[0]
+
+    # Define the number of outputs from `t0` to `timeend`
+    n_outputs = 5
+    # This equates to exports every ceil(Int, timeend/n_outputs) time-step:
+    every_x_simulation_time = ceil(Int, timeend / n_outputs)
+
+    cb_data_vs_time =
+        GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
+            diag_vs_z = single_stack_diagnostics(solver_config)
+
+            nstep = getsteps(solver_config.solver)
+
+            push!(diag_arr, diag_vs_z)
+            push!(time_data, gettime(solver_config.solver))
+            nothing
+        end
+
+    # Mass tendencies = 0 for Anelastic1D model,
+    # so mass should be completely conserved:
+    Δρ_lim = compressibility == Compressible() ? FT(0.001) : FT(0.00000001)
+    check_cons = (ClimateMachine.ConservationCheck("ρ", "3000steps", Δρ_lim),)
+
+    cb_print_step = GenericCallbacks.EveryXSimulationSteps(100) do
+        @show getsteps(solver_config.solver)
+        nothing
+    end
+
+    if !isnothing(cl_args["cparam_file"])
+        ClimateMachine.Settings.output_dir = cl_args["cparam_file"] * ".output"
+    end
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        check_cons = check_cons,
+        user_callbacks = (cb_data_vs_time, cb_print_step),
+        check_euclidean_distance = true,
+    )
+
+    diag_vs_z = single_stack_diagnostics(solver_config)
+    push!(diag_arr, diag_vs_z)
+    push!(time_data, gettime(solver_config.solver))
+
+    return solver_config, diag_arr, time_data
+end
+
+# ArgParse in global scope to modify Clima Parameters
+sl_args = ArgParseSettings(autofix_names = true)
+add_arg_group!(sl_args, "EkmanLayer")
+@add_arg_table! sl_args begin
+    "--cparam-file"
+    help = "specify CLIMAParameters file"
+    arg_type = Union{String, Nothing}
+    default = nothing
+
+    "--surface-flux"
+    help = "specify surface flux for energy and moisture"
+    metavar = "prescribed|bulk|custom_sl"
+    arg_type = String
+    default = "prescribed"
+end
+
+cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sl_args)
+if !isnothing(cl_args["cparam_file"])
+    filename = cl_args["cparam_file"]
+    set_clima_parameters(filename)
+end
+
+solver_config, diag_arr, time_data = main(Float64, cl_args)
+
+nothing


### PR DESCRIPTION
### Description

This PR adds a new neutrally stratified Ekman layer experiment to the LES/SCM library, and an anelastic driver to run it. The anelastic driver can be switched from DG to FV with a single boolean.

This configuration removes the effect of density stratification from the dynamics (in theory...), helping debug the source code in the DG and FV configurations.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
