### PR TITLE
Do not create example blocks on executed code

### DIFF
--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -101,14 +101,15 @@ if generate_tutorials
     println("Building literate tutorials...")
 
     @everywhere function generate_tutorial(tutorials_dir, tutorial)
-        gen_dir =
-            joinpath(GENERATED_DIR, relpath(dirname(tutorial), tutorials_dir))
-        input = abspath(tutorial)
-        script = Literate.script(input, gen_dir)
-        code = strip(read(script, String))
-        mdpost(str) = replace(str, "@__CODE__" => code)
-        Literate.markdown(input, gen_dir, postprocess = mdpost)
-        Literate.notebook(input, gen_dir, execute = true)
+        rpath = relpath(dirname(tutorial), tutorials_dir)
+        rpath = rpath == "." ? "" : rpath
+        gen_dir = joinpath(GENERATED_DIR, rpath)
+        mkpath(gen_dir)
+        cd(gen_dir) do
+            input = abspath(tutorial)
+            Literate.markdown(input; execute = true, documenter = false)
+            Literate.notebook(input)
+        end
     end
 
     tutorials_dir = joinpath(@__DIR__, "..", "tutorials")

--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -105,9 +105,26 @@ if generate_tutorials
         rpath = rpath == "." ? "" : rpath
         gen_dir = joinpath(GENERATED_DIR, rpath)
         mkpath(gen_dir)
+
         cd(gen_dir) do
+            # change the Edit on GitHub link
+            # path = relpath(inputfile)
+            path = relpath(clima_dir, pwd())
+            # path = replace(path, "\\" => "/")
+            content = """
+            # ```@meta
+            # EditURL = "https://github.com/CliMA/ClimateMachine.jl/$(path)"
+            # ```
+            """
+            mdpre(str) = content * str
+            # get(config, "repo_root_path", pwd())::String
             input = abspath(tutorial)
-            Literate.markdown(input; execute = true, documenter = false)
+            Literate.markdown(
+                input;
+                execute = true,
+                documenter = false,
+                preprocess = mdpre,
+            )
             Literate.notebook(input)
         end
     end

--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -107,17 +107,14 @@ if generate_tutorials
         mkpath(gen_dir)
 
         cd(gen_dir) do
-            # change the Edit on GitHub link
-            # path = relpath(inputfile)
+            # change the Edit on GitHub link:
             path = relpath(clima_dir, pwd())
-            # path = replace(path, "\\" => "/")
             content = """
             # ```@meta
             # EditURL = "https://github.com/CliMA/ClimateMachine.jl/$(path)"
             # ```
             """
             mdpre(str) = content * str
-            # get(config, "repo_root_path", pwd())::String
             input = abspath(tutorial)
             Literate.markdown(
                 input;

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,8 @@ bib = CitationBibliography(joinpath(@__DIR__, "bibliography.bib"))
 @everywhere using ClimateMachine
 @everywhere using Documenter, Literate
 
+@everywhere const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+
 @everywhere GENERATED_DIR = joinpath(@__DIR__, "src", "generated") # generated files directory
 rm(GENERATED_DIR, force = true, recursive = true)
 mkpath(GENERATED_DIR)

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -78,7 +78,9 @@
 # },
 #
 using ClimateMachine
-ClimateMachine.init(parse_clargs = true)
+ClimateMachine.init(parse_clargs = true);
+nothing
+
 # Setting `parse_clargs=true` allows the use of command-line arguments (see API > Driver docs)
 # to control simulation update and output intervals.
 

--- a/tutorials/Ocean/geostrophic_adjustment.jl
+++ b/tutorials/Ocean/geostrophic_adjustment.jl
@@ -128,7 +128,8 @@ model = Ocean.HydrostaticBoussinesqSuperModel(
     coriolis = (f₀ = f, β = 0),
     boundary_tags = boundary_tags,
     boundary_conditions = boundary_conditions,
-)
+);
+nothing
 
 # !!! info "Horizontallly-periodic boundary conditions"
 #     To set horizontally-periodic boundary conditions with
@@ -220,4 +221,4 @@ animation = @animate for p in movie_plots
     )
 end
 
-gif(animation, "geostrophic_adjustment.gif", fps = 8) # hide
+gif(animation, "geostrophic_adjustment.mp4", fps = 5) # hide

--- a/tutorials/Ocean/internal_wave.jl
+++ b/tutorials/Ocean/internal_wave.jl
@@ -109,7 +109,8 @@ model = HydrostaticBoussinesqSuperModel(
     coriolis = (f₀ = f, β = 0),
     buoyancy = (αᵀ = αᵀ,),
     boundary_tags = ((1, 1), (1, 1), (1, 2)),
-)
+);
+nothing
 
 # # Fetching data for an animation
 #
@@ -232,8 +233,8 @@ animation = @animate for (i, state) in enumerate(fetched_states)
         u_plot,
         layout = Plots.grid(2, 1, heights = (0.3, 0.7)),
         link = :x,
-        size = (1200, 600),
+        size = (600, 300),
     )
 end
 
-gif(animation, "internal_wave.gif", fps = 8) # hide
+gif(animation, "internal_wave.mp4", fps = 5) # hide

--- a/tutorials/Ocean/shear_instability.jl
+++ b/tutorials/Ocean/shear_instability.jl
@@ -55,7 +55,8 @@ model = Ocean.HydrostaticBoussinesqSuperModel(
         OceanBC(Impenetrable(FreeSlip()), Insulating()),
         OceanBC(Penetrable(FreeSlip()), Insulating()),
     ),
-)
+);
+nothing
 
 # We prepare a callback that periodically fetches the horizontal velocity and
 # tracer concentration for later animation,
@@ -132,7 +133,7 @@ animation = @animate for (i, state) in enumerate(fetched_states)
     u_title = @sprintf("u at t = %.2f", state.time)
     θ_title = @sprintf("θ at t = %.2f", state.time)
 
-    plot(u_plot, θ_plot, title = [u_title θ_title], size = (1200, 500))
+    plot(u_plot, θ_plot, title = [u_title θ_title], size = (600, 250))
 end
 
-gif(animation, "shear_instability.gif", fps = 8)
+gif(animation, "shear_instability.mp4", fps = 5)


### PR DESCRIPTION
### Description

We were running tutorials in parallel via `Literate.notebook()`, and running them all again in serial in `makedocs`. This PR removes the `@example` blocks from the tutorial markdown so that they're only executed in parallel in `Literate.notebook()`. One side-effect of this is that suppressing output is more important because truncation seems to work differently when executing markdown in Literate compared to `makedocs`, so some output in the tutorials have also been suppressed (which we probably should have done anyway). In addition, the resolution on some of the animations have been reduced.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
