### PR TITLE
Move energy submodel into atmos.physics

### DIFF
--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -53,6 +53,12 @@ UpwardIntegrals
 DownwardIntegrals
 ```
 
+## Interface
+
+```@docs
+sub_model
+```
+
 ## Variable specification methods
 
 ```@docs

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -205,6 +205,7 @@ struct AtmosModel{FT, PH, PR, O, M, S, DC} <: BalanceLaw
 end
 
 parameter_set(atmos::AtmosModel) = atmos.physics.param_set
+moisture_model(atmos::AtmosModel) = atmos.moisture
 energy_model(atmos::AtmosModel) = atmos.physics.energy
 compressibility_model(atmos::AtmosModel) = atmos.physics.compressibility
 reference_state(atmos::AtmosModel) = atmos.physics.ref_state
@@ -558,7 +559,9 @@ include("get_prognostic_vars.jl")     # get tuple of prognostic variables
 
 
 sub_model(atmos::AtmosModel, ::Type{<:AbstractEnergyModel}) =
-    (energy_model(atmos),)
+    energy_model(atmos)
+sub_model(atmos::AtmosModel, ::Type{<:AbstractMoistureModel}) =
+    moisture_model(atmos)
 
 
 function precompute(atmos::AtmosModel, args, tt::Flux{FirstOrder})

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -64,6 +64,7 @@ using ClimateMachine.Problems
 import ..BalanceLaws:
     vars_state,
     projection,
+    sub_model,
     prognostic_vars,
     get_prog_state,
     flux_first_order!,
@@ -554,6 +555,11 @@ include("linear_atmos_tendencies.jl")
 
 include("atmos_tendencies.jl")        # specify atmos tendencies
 include("get_prognostic_vars.jl")     # get tuple of prognostic variables
+
+
+sub_model(atmos::AtmosModel, ::Type{<:AbstractEnergyModel}) =
+    (energy_model(atmos),)
+
 
 function precompute(atmos::AtmosModel, args, tt::Flux{FirstOrder})
     ts = recover_thermo_state(atmos, args.state, args.aux)

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -38,9 +38,11 @@ eq_tends(::ρθ_liq_ice, m::θModel, tt::Flux{FirstOrder}) = (Advect(),)
 
 # TODO: make radiation aware of which energy formulation is used:
 # eq_tends(pv::PV, m::AtmosModel, tt::Flux{FirstOrder}) where {PV <: AbstractEnergyVariable} =
-#     (eq_tends(pv, m.energy, tt)..., eq_tends(pv, m.energy, radiation_model(m), tt)...)
-eq_tends(pv::AbstractEnergyVariable, m::AtmosModel, tt::Flux{FirstOrder}) =
-    (eq_tends(pv, m.energy, tt)..., eq_tends(pv, radiation_model(m), tt)...)
+#     (eq_tends(pv, energy_model(m), tt)..., eq_tends(pv, energy_model(m), radiation_model(m), tt)...)
+eq_tends(pv::AbstractEnergyVariable, m::AtmosModel, tt::Flux{FirstOrder}) = (
+    eq_tends(pv, energy_model(m), tt)...,
+    eq_tends(pv, radiation_model(m), tt)...,
+)
 
 # AbstractMoistureVariable
 eq_tends(::AbstractMoistureVariable, ::AtmosModel, ::Flux{FirstOrder}) =
@@ -91,7 +93,7 @@ eq_tends(::Energy, m::TotalEnergyModel, tt::Flux{SecondOrder}) =
 eq_tends(::ρθ_liq_ice, m::θModel, tt::Flux{SecondOrder}) = (ViscousFlux(),)
 
 eq_tends(pv::AbstractEnergyVariable, m::AtmosModel, tt::Flux{SecondOrder}) = (
-    eq_tends(pv, m.energy, tt)...,
+    eq_tends(pv, energy_model(m), tt)...,
     eq_tends(pv, turbconv_model(m), tt)...,
     eq_tends(pv, hyperdiffusion_model(m), tt)...,
 )

--- a/src/Atmos/Model/get_prognostic_vars.jl
+++ b/src/Atmos/Model/get_prognostic_vars.jl
@@ -18,7 +18,7 @@ prognostic_vars(::NTracers{N}) where {N} = (Tracers{N}(),)
 prognostic_vars(m::AtmosModel) = (
     Mass(),
     Momentum(),
-    prognostic_vars(m.energy)...,
+    prognostic_vars(energy_model(m))...,
     prognostic_vars(m.moisture)...,
     prognostic_vars(precipitation_model(m))...,
     prognostic_vars(tracer_model(m))...,

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -105,7 +105,7 @@ function vars_state(lm::AtmosLinearModel, st::Prognostic, FT)
     @vars begin
         ρ::FT
         ρu::SVector{3, FT}
-        energy::vars_state(lm.atmos.energy, st, FT)
+        energy::vars_state(energy_model(lm.atmos), st, FT)
         turbulence::vars_state(turbulence_model(lm.atmos), st, FT)
         hyperdiffusion::vars_state(hyperdiffusion_model(lm.atmos), st, FT)
         moisture::vars_state(lm.atmos.moisture, st, FT)

--- a/src/Atmos/Model/prog_prim_conversion.jl
+++ b/src/Atmos/Model/prog_prim_conversion.jl
@@ -22,7 +22,7 @@ function prognostic_to_primitive!(
     prog::Vars,
     aux,
 )
-    atmos.energy isa TotalEnergyModel ||
+    energy_model(atmos) isa TotalEnergyModel ||
         error("TotalEnergyModel only supported")
     prognostic_to_primitive!(atmos, atmos.moisture, prim, prog, aux)
     prognostic_to_primitive!(
@@ -118,7 +118,7 @@ function primitive_to_prognostic!(
     prim::Vars,
     aux::Vars,
 )
-    atmos.energy isa TotalEnergyModel ||
+    energy_model(atmos) isa TotalEnergyModel ||
         error("TotalEnergyModel only supported")
     ts = PhaseDry_ρp(parameter_set(atmos), prim.ρ, prim.p)
     e_kin = prim.u' * prim.u / 2
@@ -137,7 +137,7 @@ function primitive_to_prognostic!(
     prim::Vars,
     aux::Vars,
 )
-    atmos.energy isa TotalEnergyModel ||
+    energy_model(atmos) isa TotalEnergyModel ||
         error("TotalEnergyModel only supported")
     ts = PhaseEquil_ρpq(
         parameter_set(atmos),
@@ -163,7 +163,7 @@ function primitive_to_prognostic!(
     prim::Vars,
     aux::Vars,
 )
-    atmos.energy isa TotalEnergyModel ||
+    energy_model(atmos) isa TotalEnergyModel ||
         error("TotalEnergyModel only supported")
     q_pt = PhasePartition(
         prim.moisture.q_tot,

--- a/src/Atmos/Model/thermo_states.jl
+++ b/src/Atmos/Model/thermo_states.jl
@@ -19,7 +19,7 @@ new_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
     new_thermo_state(compressibility_model(atmos), atmos, state, aux)
 
 new_thermo_state(::Compressible, atmos::AtmosModel, state::Vars, aux::Vars) =
-    new_thermo_state(atmos, atmos.energy, atmos.moisture, state, aux)
+    new_thermo_state(atmos, energy_model(atmos), atmos.moisture, state, aux)
 new_thermo_state(::Anelastic1D, atmos::AtmosModel, state::Vars, aux::Vars) =
     new_thermo_state_anelastic(atmos, state, aux)
 
@@ -47,7 +47,7 @@ recover_thermo_state(
     atmos::AtmosModel,
     state::Vars,
     aux::Vars,
-) = new_thermo_state(atmos, atmos.energy, atmos.moisture, state, aux)
+) = new_thermo_state(atmos, energy_model(atmos), atmos.moisture, state, aux)
 
 recover_thermo_state(::Anelastic1D, atmos::AtmosModel, state::Vars, aux::Vars) =
     new_thermo_state_anelastic(atmos, state, aux)

--- a/src/Atmos/Model/thermo_states_anelastic.jl
+++ b/src/Atmos/Model/thermo_states_anelastic.jl
@@ -13,7 +13,13 @@ the `aux` state.
     procedure for EquilMoist models.
 """
 new_thermo_state_anelastic(atmos::AtmosModel, state::Vars, aux::Vars) =
-    new_thermo_state_anelastic(atmos, atmos.energy, atmos.moisture, state, aux)
+    new_thermo_state_anelastic(
+        atmos,
+        energy_model(atmos),
+        atmos.moisture,
+        state,
+        aux,
+    )
 
 """
     recover_thermo_state_anelastic(atmos::AtmosModel, state::Vars, aux::Vars)
@@ -29,7 +35,13 @@ An atmospheric thermodynamic state.
   (see https://github.com/CliMA/ClimateMachine.jl/issues/1648)
 """
 recover_thermo_state_anelastic(atmos::AtmosModel, state::Vars, aux::Vars) =
-    new_thermo_state_anelastic(atmos, atmos.energy, atmos.moisture, state, aux)
+    new_thermo_state_anelastic(
+        atmos,
+        energy_model(atmos),
+        atmos.moisture,
+        state,
+        aux,
+    )
 
 function new_thermo_state_anelastic(
     atmos::AtmosModel,

--- a/src/BalanceLaws/interface.jl
+++ b/src/BalanceLaws/interface.jl
@@ -384,3 +384,11 @@ function cummulate_fast_solution! end
 function reconcile_from_fast_to_slow! end
 
 parameter_set(balance_law) = balance_law.param_set
+
+"""
+    sub_model(::BalanceLaw, ::Type{AbstractSubModel})
+
+Returns a tuple of balance law properties
+whose supertypes are `AbstractSubModel`.
+"""
+function sub_model end

--- a/src/Diagnostics/DiagnosticsMachine/group_gen.jl
+++ b/src/Diagnostics/DiagnosticsMachine/group_gen.jl
@@ -262,8 +262,8 @@ function generate_collect_calls(
             else
                 AT2 = impl_args[2][2] # the type of the second argument
                 @assert isa_bl(AT2)
-                AN1 = impl_args[1][1] # the name of the first argument
-                impl_extra_params = (:(getproperty(bl, $(QuoteNode(AN1)))),)
+                AT1 = impl_args[1][2] # the type of the first argument
+                impl_extra_params = (:(BalanceLaws.sub_model(bl, $AT1)),)
             end
             cc_ex = DiagnosticsMachine.dv_op(
                 cfg_type,

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -580,7 +580,7 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     nvertelem = topl_info.nvertelem
     nhorzelem = topl_info.nhorzrealelem
 
-    atmos.energy isa TotalEnergyModel ||
+    energy_model(atmos) isa TotalEnergyModel ||
         error("TotalEnergyModel only supported")
 
     # get needed arrays onto the CPU

--- a/src/Diagnostics/atmos_mass_energy_loss.jl
+++ b/src/Diagnostics/atmos_mass_energy_loss.jl
@@ -62,7 +62,8 @@ function atmos_mass_energy_loss_init(dgngrp, currtime)
     Q = Settings.Q
     FT = eltype(Q)
 
-    bl.energy isa TotalEnergyModel || error("Only TotalEnergyModel supported")
+    energy_model(bl) isa TotalEnergyModel ||
+        error("Only TotalEnergyModel supported")
     ρ_idx = varsindices(vars_state(bl, Prognostic(), FT), "ρ")
     ρe_idx = varsindices(vars_state(bl, Prognostic(), FT), :(energy.ρe))
     Σρ₀ = weightedsum(Q, ρ_idx)
@@ -99,7 +100,8 @@ function atmos_mass_energy_loss_collect(dgngrp, currtime)
     Q = Settings.Q
     FT = eltype(Q)
 
-    bl.energy isa TotalEnergyModel || error("Only TotalEnergyModel supported")
+    energy_model(bl) isa TotalEnergyModel ||
+        error("Only TotalEnergyModel supported")
     ρ_idx = varsindices(vars_state(bl, Prognostic(), FT), "ρ")
     ρe_idx = varsindices(vars_state(bl, Prognostic(), FT), :(energy.ρe))
     Σρ = weightedsum(Q, ρ_idx)


### PR DESCRIPTION
### Description

This PR moves the atmos energy submodel into the `atmos.physics` component. I'm open for bikeshedding names here, any thoughts @glwagner? Keep in mind that this is the second PR of many (we need getters for most atmos properties).

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
