### PR TITLE
Move `atmos.ref_state` to `atmos.physics.ref_state`

### DIFF
--- a/experiments/TestCase/risingbubble.jl
+++ b/experiments/TestCase/risingbubble.jl
@@ -46,7 +46,8 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
 
     ## TODO: clean this up, or add convenience function:
     ## This is configured in the reference hydrostatic state
-    θ_ref::FT = bl.ref_state.virtual_temperature_profile.T_surface
+    ref_state = reference_state(bl)
+    θ_ref::FT = ref_state.virtual_temperature_profile.T_surface
 
     ## Add the thermal perturbation:
     Δθ::FT = 0

--- a/experiments/TestCase/risingbubble_fvm.jl
+++ b/experiments/TestCase/risingbubble_fvm.jl
@@ -48,7 +48,8 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
 
     ## TODO: clean this up, or add convenience function:
     ## This is configured in the reference hydrostatic state
-    θ_ref::FT = bl.ref_state.virtual_temperature_profile.T_surface
+    ref_state = reference_state(bl)
+    θ_ref::FT = ref_state.virtual_temperature_profile.T_surface
 
     ## Add the thermal perturbation:
     Δθ::FT = 0

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -213,7 +213,7 @@ init_state_prognostic!(
 struct AtmosAcousticLinearModel{M} <: AtmosLinearModel
     atmos::M
     function AtmosAcousticLinearModel(atmos::M) where {M}
-        if atmos.ref_state === NoReferenceState()
+        if reference_state(atmos) === NoReferenceState()
             error("AtmosAcousticLinearModel needs a model with a reference state")
         end
         new{M}(atmos)
@@ -246,7 +246,7 @@ end
 struct AtmosAcousticGravityLinearModel{M} <: AtmosLinearModel
     atmos::M
     function AtmosAcousticGravityLinearModel(atmos::M) where {M}
-        if atmos.ref_state === NoReferenceState()
+        if reference_state(atmos) === NoReferenceState()
             error("AtmosAcousticGravityLinearModel needs a model with a reference state")
         end
         new{M}(atmos)

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -75,7 +75,8 @@ function ref_state_init_pρ!(
 )
     param_set = parameter_set(atmos)
     z = altitude(atmos, aux)
-    T_virt, p = atmos.ref_state.virtual_temperature_profile(param_set, z)
+    ref_state = reference_state(atmos)
+    T_virt, p = ref_state.virtual_temperature_profile(param_set, z)
     aux.ref_state.p = p
     aux.ref_state.ρ = p / (T_virt * R_d(param_set))
 end
@@ -105,7 +106,8 @@ function ref_state_finalize_init!(
     p = aux.ref_state.p
     T_virt = p / (ρ * FT(R_d(param_set)))
 
-    RH = atmos.ref_state.relative_humidity
+    ref_state = reference_state(atmos)
+    RH = ref_state.relative_humidity
     phase_type = PhaseEquil
     (T, q_pt) = TD.temperature_and_humidity_given_TᵥρRH(
         param_set,
@@ -162,7 +164,8 @@ function atmos_init_aux!(
         # pᵢ - pᵢ₊₁ =  g ρᵢ₊₁ Δzᵢ₊₁/2 + g ρᵢ Δzᵢ/2
         fvm_balance!(fvm_balance_init!, atmos, state_auxiliary, grid)
     else
-        ∇p = ∇reference_pressure(atmos.ref_state, state_auxiliary, grid)
+        ref_state = reference_state(atmos)
+        ∇p = ∇reference_pressure(ref_state, state_auxiliary, grid)
         init_state_auxiliary!(
             atmos,
             ref_state_init_density_from_pressure!,

--- a/src/Atmos/Model/tendencies_momentum.jl
+++ b/src/Atmos/Model/tendencies_momentum.jl
@@ -20,7 +20,8 @@ function flux(::Momentum, ::PressureGradient, atmos, args)
     @unpack ts = args.precomputed
     s = state.ρu * state.ρu'
     pad = SArray{Tuple{size(s)...}}(ntuple(i -> 0, length(s)))
-    if atmos.ref_state isa HydrostaticState && atmos.ref_state.subtract_off
+    ref_state = reference_state(atmos)
+    if ref_state isa HydrostaticState && ref_state.subtract_off
         return pad + (air_pressure(ts) - aux.ref_state.p) * I
     else
         return pad + air_pressure(ts) * I
@@ -62,7 +63,8 @@ prognostic_vars(::Gravity) = (Momentum(),)
 
 function source(::Momentum, ::Gravity, m, args)
     @unpack state, aux = args
-    if m.ref_state isa HydrostaticState && m.ref_state.subtract_off
+    ref_state = reference_state(m)
+    if ref_state isa HydrostaticState && ref_state.subtract_off
         return -(state.ρ - aux.ref_state.ρ) * aux.orientation.∇Φ
     else
         return -state.ρ * aux.orientation.∇Φ

--- a/src/Diagnostics/atmos_refstate_perturbations.jl
+++ b/src/Diagnostics/atmos_refstate_perturbations.jl
@@ -56,7 +56,7 @@ end
 
 function vars_atmos_refstate_perturbations(m::AtmosModel, FT)
     @vars begin
-        ref_state::vars_atmos_refstate_perturbations(m.ref_state, FT)
+        ref_state::vars_atmos_refstate_perturbations(reference_state(m), FT)
     end
 end
 vars_atmos_refstate_perturbations(::ReferenceState, FT) = @vars()
@@ -82,7 +82,7 @@ function atmos_refstate_perturbations!(
     vars,
 )
     atmos_refstate_perturbations!(
-        atmos.ref_state,
+        reference_state(atmos),
         atmos,
         state,
         aux,
@@ -180,7 +180,7 @@ function atmos_refstate_perturbations_collect(
     Q = Settings.Q
     mpirank = MPI.Comm_rank(mpicomm)
     atmos = dg.balance_law
-    if !isa(atmos.ref_state, HydrostaticState)
+    if !isa(reference_state(atmos), HydrostaticState)
         @warn """
             Diagnostics $(dgngrp.name): has useful output only for `HydrostaticState`
             """

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -152,7 +152,8 @@ function init_densitycurrent!(problem, bl, state, aux, localgeo, t)
 
     ## TODO: clean this up, or add convenience function:
     ## This is configured in the reference hydrostatic state
-    θ_ref::FT = bl.ref_state.virtual_temperature_profile.T_surface
+    ref_state = reference_state(bl)
+    θ_ref::FT = ref_state.virtual_temperature_profile.T_surface
     Δθ::FT = 0
     θamplitude::FT = -15.0
 

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -132,7 +132,8 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     θamplitude::FT = 2
 
     ## This is configured in the reference hydrostatic state
-    θ_ref::FT = bl.ref_state.virtual_temperature_profile.T_surface
+    ref_state = reference_state(bl)
+    θ_ref::FT = ref_state.virtual_temperature_profile.T_surface
 
     ## Add the thermal perturbation:
     Δθ::FT = 0

--- a/tutorials/Numerics/TimeStepping/tutorial_risingbubble_config.jl
+++ b/tutorials/Numerics/TimeStepping/tutorial_risingbubble_config.jl
@@ -132,7 +132,8 @@ function init_risingbubble!(problem, bl, state, aux, localgeo, t)
     θamplitude::FT = 2
 
     ## This is configured in the reference hydrostatic state
-    θ_ref::FT = bl.ref_state.virtual_temperature_profile.T_surface
+    ref_state = reference_state(bl)
+    θ_ref::FT = ref_state.virtual_temperature_profile.T_surface
 
     ## Add the thermal perturbation:
     Δθ::FT = 0


### PR DESCRIPTION
### Description

This PR moves the atmos ref state submodel into the `atmos.physics` component.

This will probably need rebase after #2128.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
