### PR TITLE
Improve some names

### DIFF
--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -13,7 +13,7 @@ BalanceLaw
 ## Tendency types and methods
 
 ```@docs
-PrognosticVariable
+AbstractPrognosticVariable
 AbstractOrder
 FirstOrder
 SecondOrder

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -252,7 +252,7 @@ function AtmosModel{FT}(
     param_set::AbstractParameterSet;
     init_state_prognostic = nothing,
     problem = AtmosProblem(init_state_prognostic = init_state_prognostic),
-    energy = EnergyModel(),
+    energy = TotalEnergyModel(),
     ref_state = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),),
     turbulence = SmagorinskyLilly{FT}(C_smag(param_set)),
     turbconv = NoTurbConv(),

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -31,7 +31,7 @@ eq_tends(pv::Momentum, m::AtmosModel, tt::Flux{FirstOrder}) =
     (Advect(), eq_tends(pv, m.compressibility, tt)...)
 
 # Energy
-eq_tends(::Energy, m::EnergyModel, tt::Flux{FirstOrder}) =
+eq_tends(::Energy, m::TotalEnergyModel, tt::Flux{FirstOrder}) =
     (Advect(), Pressure())
 
 eq_tends(::ρθ_liq_ice, m::θModel, tt::Flux{FirstOrder}) = (Advect(),)
@@ -78,7 +78,7 @@ eq_tends(pv::Momentum, m::AtmosModel, tt::Flux{SecondOrder}) = (
 )
 
 # Energy
-eq_tends(::Energy, m::EnergyModel, tt::Flux{SecondOrder}) =
+eq_tends(::Energy, m::TotalEnergyModel, tt::Flux{SecondOrder}) =
     (ViscousFlux(), DiffEnthalpyFlux())
 
 eq_tends(::ρθ_liq_ice, m::θModel, tt::Flux{SecondOrder}) = (ViscousFlux(),)

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -61,7 +61,7 @@ eq_tends(::Union{Mass, Momentum, Moisture}, ::DryModel, ::Flux{SecondOrder}) =
     ()
 eq_tends(
     ::Union{Mass, Momentum, Moisture},
-    ::MoistureModel,
+    ::AbstractMoistureModel,
     ::Flux{SecondOrder},
 ) = (MoistureDiffusion(),)
 

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -6,7 +6,7 @@
 ##### Sources
 #####
 
-eq_tends(pv::PrognosticVariable, m::AtmosModel, tt::Source) =
+eq_tends(pv::AbstractPrognosticVariable, m::AtmosModel, tt::Source) =
     (m.source[pv]..., eq_tends(pv, m.turbconv, tt)...)
 
 #####

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -42,8 +42,8 @@ eq_tends(::ρθ_liq_ice, m::θModel, tt::Flux{FirstOrder}) = (Advect(),)
 eq_tends(pv::AbstractEnergy, m::AtmosModel, tt::Flux{FirstOrder}) =
     (eq_tends(pv, m.energy, tt)..., eq_tends(pv, m.radiation, tt)...)
 
-# Moisture
-eq_tends(::Moisture, ::AtmosModel, ::Flux{FirstOrder}) = (Advect(),)
+# AbstractMoisture
+eq_tends(::AbstractMoisture, ::AtmosModel, ::Flux{FirstOrder}) = (Advect(),)
 
 # Precipitation
 eq_tends(pv::Precipitation, m::AtmosModel, tt::Flux{FirstOrder}) =
@@ -57,10 +57,13 @@ eq_tends(pv::Tracers{N}, ::AtmosModel, ::Flux{FirstOrder}) where {N} =
 ##### Second order fluxes
 #####
 
-eq_tends(::Union{Mass, Momentum, Moisture}, ::DryModel, ::Flux{SecondOrder}) =
-    ()
 eq_tends(
-    ::Union{Mass, Momentum, Moisture},
+    ::Union{Mass, Momentum, AbstractMoisture},
+    ::DryModel,
+    ::Flux{SecondOrder},
+) = ()
+eq_tends(
+    ::Union{Mass, Momentum, AbstractMoisture},
     ::AbstractMoistureModel,
     ::Flux{SecondOrder},
 ) = (MoistureDiffusion(),)
@@ -89,8 +92,8 @@ eq_tends(pv::AbstractEnergy, m::AtmosModel, tt::Flux{SecondOrder}) = (
     eq_tends(pv, m.hyperdiffusion, tt)...,
 )
 
-# Moisture
-eq_tends(pv::Moisture, m::AtmosModel, tt::Flux{SecondOrder}) = (
+# AbstractMoisture
+eq_tends(pv::AbstractMoisture, m::AtmosModel, tt::Flux{SecondOrder}) = (
     eq_tends(pv, m.moisture, tt)...,
     eq_tends(pv, m.turbconv, tt)...,
     eq_tends(pv, m.hyperdiffusion, tt)...,

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -45,8 +45,8 @@ eq_tends(pv::AbstractEnergy, m::AtmosModel, tt::Flux{FirstOrder}) =
 # AbstractMoisture
 eq_tends(::AbstractMoisture, ::AtmosModel, ::Flux{FirstOrder}) = (Advect(),)
 
-# Precipitation
-eq_tends(pv::Precipitation, m::AtmosModel, tt::Flux{FirstOrder}) =
+# AbstractPrecipitation
+eq_tends(pv::AbstractPrecipitation, m::AtmosModel, tt::Flux{FirstOrder}) =
     (eq_tends(pv, m.precipitation, tt)...,)
 
 # Tracers
@@ -99,8 +99,8 @@ eq_tends(pv::AbstractMoisture, m::AtmosModel, tt::Flux{SecondOrder}) = (
     eq_tends(pv, m.hyperdiffusion, tt)...,
 )
 
-# Precipitation
-eq_tends(pv::Precipitation, m::AtmosModel, tt::Flux{SecondOrder}) =
+# AbstractPrecipitation
+eq_tends(pv::AbstractPrecipitation, m::AtmosModel, tt::Flux{SecondOrder}) =
     (eq_tends(pv, m.precipitation, tt)...,)
 
 # Tracers

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -37,17 +37,21 @@ eq_tends(::Energy, m::TotalEnergyModel, tt::Flux{FirstOrder}) =
 eq_tends(::ρθ_liq_ice, m::θModel, tt::Flux{FirstOrder}) = (Advect(),)
 
 # TODO: make radiation aware of which energy formulation is used:
-# eq_tends(pv::PV, m::AtmosModel, tt::Flux{FirstOrder}) where {PV <: AbstractEnergy} =
+# eq_tends(pv::PV, m::AtmosModel, tt::Flux{FirstOrder}) where {PV <: AbstractEnergyVariable} =
 #     (eq_tends(pv, m.energy, tt)..., eq_tends(pv, m.energy, m.radiation, tt)...)
-eq_tends(pv::AbstractEnergy, m::AtmosModel, tt::Flux{FirstOrder}) =
+eq_tends(pv::AbstractEnergyVariable, m::AtmosModel, tt::Flux{FirstOrder}) =
     (eq_tends(pv, m.energy, tt)..., eq_tends(pv, m.radiation, tt)...)
 
-# AbstractMoisture
-eq_tends(::AbstractMoisture, ::AtmosModel, ::Flux{FirstOrder}) = (Advect(),)
+# AbstractMoistureVariable
+eq_tends(::AbstractMoistureVariable, ::AtmosModel, ::Flux{FirstOrder}) =
+    (Advect(),)
 
-# AbstractPrecipitation
-eq_tends(pv::AbstractPrecipitation, m::AtmosModel, tt::Flux{FirstOrder}) =
-    (eq_tends(pv, m.precipitation, tt)...,)
+# AbstractPrecipitationVariable
+eq_tends(
+    pv::AbstractPrecipitationVariable,
+    m::AtmosModel,
+    tt::Flux{FirstOrder},
+) = (eq_tends(pv, m.precipitation, tt)...,)
 
 # Tracers
 eq_tends(pv::Tracers{N}, ::AtmosModel, ::Flux{FirstOrder}) where {N} =
@@ -58,12 +62,12 @@ eq_tends(pv::Tracers{N}, ::AtmosModel, ::Flux{FirstOrder}) where {N} =
 #####
 
 eq_tends(
-    ::Union{Mass, Momentum, AbstractMoisture},
+    ::Union{Mass, Momentum, AbstractMoistureVariable},
     ::DryModel,
     ::Flux{SecondOrder},
 ) = ()
 eq_tends(
-    ::Union{Mass, Momentum, AbstractMoisture},
+    ::Union{Mass, Momentum, AbstractMoistureVariable},
     ::AbstractMoistureModel,
     ::Flux{SecondOrder},
 ) = (MoistureDiffusion(),)
@@ -86,22 +90,25 @@ eq_tends(::Energy, m::TotalEnergyModel, tt::Flux{SecondOrder}) =
 
 eq_tends(::ρθ_liq_ice, m::θModel, tt::Flux{SecondOrder}) = (ViscousFlux(),)
 
-eq_tends(pv::AbstractEnergy, m::AtmosModel, tt::Flux{SecondOrder}) = (
+eq_tends(pv::AbstractEnergyVariable, m::AtmosModel, tt::Flux{SecondOrder}) = (
     eq_tends(pv, m.energy, tt)...,
     eq_tends(pv, m.turbconv, tt)...,
     eq_tends(pv, m.hyperdiffusion, tt)...,
 )
 
-# AbstractMoisture
-eq_tends(pv::AbstractMoisture, m::AtmosModel, tt::Flux{SecondOrder}) = (
+# AbstractMoistureVariable
+eq_tends(pv::AbstractMoistureVariable, m::AtmosModel, tt::Flux{SecondOrder}) = (
     eq_tends(pv, m.moisture, tt)...,
     eq_tends(pv, m.turbconv, tt)...,
     eq_tends(pv, m.hyperdiffusion, tt)...,
 )
 
-# AbstractPrecipitation
-eq_tends(pv::AbstractPrecipitation, m::AtmosModel, tt::Flux{SecondOrder}) =
-    (eq_tends(pv, m.precipitation, tt)...,)
+# AbstractPrecipitationVariable
+eq_tends(
+    pv::AbstractPrecipitationVariable,
+    m::AtmosModel,
+    tt::Flux{SecondOrder},
+) = (eq_tends(pv, m.precipitation, tt)...,)
 
 # Tracers
 eq_tends(pv::Tracers{N}, m::AtmosModel, tt::Flux{SecondOrder}) where {N} =

--- a/src/Atmos/Model/declare_prognostic_vars.jl
+++ b/src/Atmos/Model/declare_prognostic_vars.jl
@@ -5,7 +5,7 @@ export AbstractMoistureVariable, TotalMoisture, LiquidMoisture, IceMoisture
 export AbstractPrecipitationVariable, Rain, Snow
 export Tracers
 
-struct Mass <: PrognosticVariable end
+struct Mass <: AbstractPrognosticVariable end
 struct Momentum <: AbstractMomentumVariable end
 
 struct Energy <: AbstractEnergyVariable end

--- a/src/Atmos/Model/declare_prognostic_vars.jl
+++ b/src/Atmos/Model/declare_prognostic_vars.jl
@@ -2,7 +2,7 @@
 
 export Mass, Momentum, Energy, ρθ_liq_ice
 export AbstractMoisture, TotalMoisture, LiquidMoisture, IceMoisture
-export Precipitation, Rain, Snow
+export AbstractPrecipitation, Rain, Snow
 export Tracers
 
 struct Mass <: PrognosticVariable end
@@ -15,7 +15,7 @@ struct TotalMoisture <: AbstractMoisture end
 struct LiquidMoisture <: AbstractMoisture end
 struct IceMoisture <: AbstractMoisture end
 
-struct Rain <: Precipitation end
-struct Snow <: Precipitation end
+struct Rain <: AbstractPrecipitation end
+struct Snow <: AbstractPrecipitation end
 
 struct Tracers{N} <: AbstractTracers{N} end

--- a/src/Atmos/Model/declare_prognostic_vars.jl
+++ b/src/Atmos/Model/declare_prognostic_vars.jl
@@ -1,7 +1,7 @@
 ##### Prognostic variable
 
 export Mass, Momentum, Energy, ρθ_liq_ice
-export Moisture, TotalMoisture, LiquidMoisture, IceMoisture
+export AbstractMoisture, TotalMoisture, LiquidMoisture, IceMoisture
 export Precipitation, Rain, Snow
 export Tracers
 
@@ -11,9 +11,9 @@ struct Momentum <: AbstractMomentum end
 struct Energy <: AbstractEnergy end
 struct ρθ_liq_ice <: AbstractEnergy end
 
-struct TotalMoisture <: Moisture end
-struct LiquidMoisture <: Moisture end
-struct IceMoisture <: Moisture end
+struct TotalMoisture <: AbstractMoisture end
+struct LiquidMoisture <: AbstractMoisture end
+struct IceMoisture <: AbstractMoisture end
 
 struct Rain <: Precipitation end
 struct Snow <: Precipitation end

--- a/src/Atmos/Model/declare_prognostic_vars.jl
+++ b/src/Atmos/Model/declare_prognostic_vars.jl
@@ -1,21 +1,21 @@
 ##### Prognostic variable
 
 export Mass, Momentum, Energy, ρθ_liq_ice
-export AbstractMoisture, TotalMoisture, LiquidMoisture, IceMoisture
-export AbstractPrecipitation, Rain, Snow
+export AbstractMoistureVariable, TotalMoisture, LiquidMoisture, IceMoisture
+export AbstractPrecipitationVariable, Rain, Snow
 export Tracers
 
 struct Mass <: PrognosticVariable end
-struct Momentum <: AbstractMomentum end
+struct Momentum <: AbstractMomentumVariable end
 
-struct Energy <: AbstractEnergy end
-struct ρθ_liq_ice <: AbstractEnergy end
+struct Energy <: AbstractEnergyVariable end
+struct ρθ_liq_ice <: AbstractEnergyVariable end
 
-struct TotalMoisture <: AbstractMoisture end
-struct LiquidMoisture <: AbstractMoisture end
-struct IceMoisture <: AbstractMoisture end
+struct TotalMoisture <: AbstractMoistureVariable end
+struct LiquidMoisture <: AbstractMoistureVariable end
+struct IceMoisture <: AbstractMoistureVariable end
 
-struct Rain <: AbstractPrecipitation end
-struct Snow <: AbstractPrecipitation end
+struct Rain <: AbstractPrecipitationVariable end
+struct Snow <: AbstractPrecipitationVariable end
 
-struct Tracers{N} <: AbstractTracers{N} end
+struct Tracers{N} <: AbstractTracersVariable{N} end

--- a/src/Atmos/Model/energy.jl
+++ b/src/Atmos/Model/energy.jl
@@ -1,20 +1,21 @@
-export AbstractEnergyModel, EnergyModel, θModel
+export AbstractEnergyModel, TotalEnergyModel, θModel
 #### Energy component in atmosphere model
 abstract type AbstractEnergyModel end
-struct EnergyModel <: AbstractEnergyModel end
+struct TotalEnergyModel <: AbstractEnergyModel end
 struct θModel <: AbstractEnergyModel end
 
-vars_state(::EnergyModel, ::AbstractStateType, FT) = @vars()
-vars_state(::EnergyModel, ::Prognostic, FT) = @vars(ρe::FT)
-vars_state(::EnergyModel, ::Gradient, FT) = @vars(h_tot::FT)
-vars_state(::EnergyModel, ::GradientFlux, FT) = @vars(∇h_tot::SVector{3, FT})
+vars_state(::TotalEnergyModel, ::AbstractStateType, FT) = @vars()
+vars_state(::TotalEnergyModel, ::Prognostic, FT) = @vars(ρe::FT)
+vars_state(::TotalEnergyModel, ::Gradient, FT) = @vars(h_tot::FT)
+vars_state(::TotalEnergyModel, ::GradientFlux, FT) =
+    @vars(∇h_tot::SVector{3, FT})
 vars_state(::θModel, ::AbstractStateType, FT) = @vars()
 vars_state(::θModel, ::Prognostic, FT) = @vars(ρθ_liq_ice::FT)
 vars_state(::θModel, ::Gradient, FT) = @vars(θ_liq_ice::FT)
 vars_state(::θModel, ::GradientFlux, FT) = @vars(∇θ_liq_ice::SVector{3, FT})
 
 function compute_gradient_argument!(
-    energy::EnergyModel,
+    energy::TotalEnergyModel,
     atmos::AtmosModel,
     transform,
     state,
@@ -37,14 +38,14 @@ function compute_gradient_argument!(
     transform.energy.θ_liq_ice = state.energy.ρθ_liq_ice / state.ρ
 end
 
-compute_gradient_flux!(::EnergyModel, _...) = nothing
+compute_gradient_flux!(::TotalEnergyModel, _...) = nothing
 
 function compute_gradient_flux!(::θModel, diffusive, ∇transform, state, aux, t)
     diffusive.energy.∇θ_liq_ice = ∇transform.energy.θ_liq_ice
 end
 
 function compute_gradient_flux!(
-    ::EnergyModel,
+    ::TotalEnergyModel,
     diffusive,
     ∇transform,
     state,

--- a/src/Atmos/Model/get_prognostic_vars.jl
+++ b/src/Atmos/Model/get_prognostic_vars.jl
@@ -1,6 +1,6 @@
 ##### Get prognostic variable list
 
-prognostic_vars(::EnergyModel) = (Energy(),)
+prognostic_vars(::TotalEnergyModel) = (Energy(),)
 prognostic_vars(::θModel) = (ρθ_liq_ice(),)
 
 prognostic_vars(::DryModel) = ()

--- a/src/Atmos/Model/linear_atmos_tendencies.jl
+++ b/src/Atmos/Model/linear_atmos_tendencies.jl
@@ -14,9 +14,10 @@ eq_tends(::Momentum, ::AtmosLinearModel, ::Flux{FirstOrder}) =
 eq_tends(::Energy, m::AtmosLinearModel, tt::Flux{FirstOrder}) =
     (LinearEnergyFlux(),)
 
-# AbstractMoisture
+# AbstractMoistureVariable
 # TODO: Is this right?
-eq_tends(::AbstractMoisture, ::AtmosLinearModel, ::Flux{FirstOrder}) = ()
+eq_tends(::AbstractMoistureVariable, ::AtmosLinearModel, ::Flux{FirstOrder}) =
+    ()
 
 # Tracers
 eq_tends(::Tracers{N}, ::AtmosLinearModel, ::Flux{FirstOrder}) where {N} = ()

--- a/src/Atmos/Model/linear_atmos_tendencies.jl
+++ b/src/Atmos/Model/linear_atmos_tendencies.jl
@@ -14,9 +14,9 @@ eq_tends(::Momentum, ::AtmosLinearModel, ::Flux{FirstOrder}) =
 eq_tends(::Energy, m::AtmosLinearModel, tt::Flux{FirstOrder}) =
     (LinearEnergyFlux(),)
 
-# Moisture
+# AbstractMoisture
 # TODO: Is this right?
-eq_tends(::Moisture, ::AtmosLinearModel, ::Flux{FirstOrder}) = ()
+eq_tends(::AbstractMoisture, ::AtmosLinearModel, ::Flux{FirstOrder}) = ()
 
 # Tracers
 eq_tends(::Tracers{N}, ::AtmosLinearModel, ::Flux{FirstOrder}) where {N} = ()

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -1,19 +1,19 @@
-export MoistureModel, DryModel, EquilMoist, NonEquilMoist
+export AbstractMoistureModel, DryModel, EquilMoist, NonEquilMoist
 
 #### Moisture component in atmosphere model
-abstract type MoistureModel end
+abstract type AbstractMoistureModel end
 
-vars_state(::MoistureModel, ::AbstractStateType, FT) = @vars()
+vars_state(::AbstractMoistureModel, ::AbstractStateType, FT) = @vars()
 
 function atmos_nodal_update_auxiliary_state!(
-    ::MoistureModel,
+    ::AbstractMoistureModel,
     m::AtmosModel,
     state::Vars,
     aux::Vars,
     t::Real,
 ) end
 function compute_gradient_flux!(
-    ::MoistureModel,
+    ::AbstractMoistureModel,
     diffusive,
     ∇transform,
     state,
@@ -22,7 +22,7 @@ function compute_gradient_flux!(
 ) end
 
 function compute_gradient_argument!(
-    ::MoistureModel,
+    ::AbstractMoistureModel,
     transform::Vars,
     state::Vars,
     aux::Vars,
@@ -51,7 +51,7 @@ end
 
 Assumes the moisture components is in the dry limit.
 """
-struct DryModel <: MoistureModel end
+struct DryModel <: AbstractMoistureModel end
 
 vars_state(::DryModel, ::Auxiliary, FT) = @vars(θ_v::FT, air_T::FT)
 @inline function atmos_nodal_update_auxiliary_state!(
@@ -72,7 +72,7 @@ end
 
 Assumes the moisture components are computed via thermodynamic equilibrium.
 """
-Base.@kwdef struct EquilMoist{FT, IT} <: MoistureModel
+Base.@kwdef struct EquilMoist{FT, IT} <: AbstractMoistureModel
     maxiter::IT = nothing
     tolerance::FT = nothing
 end
@@ -127,7 +127,7 @@ end
 
 Does not assume that the moisture components are in equilibrium.
 """
-struct NonEquilMoist <: MoistureModel end
+struct NonEquilMoist <: AbstractMoistureModel end
 
 vars_state(::NonEquilMoist, ::Prognostic, FT) =
     @vars(ρq_tot::FT, ρq_liq::FT, ρq_ice::FT)

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -140,7 +140,10 @@ end
 eq_tends(::Rain, ::RainModel, ::Flux{FirstOrder}) = (PrecipitationFlux(),)
 eq_tends(::Rain, ::RainModel, ::Flux{SecondOrder}) = (Diffusion(),)
 
-eq_tends(::AbstractPrecipitation, ::RainSnowModel, ::Flux{FirstOrder}) =
+eq_tends(::AbstractPrecipitationVariable, ::RainSnowModel, ::Flux{FirstOrder}) =
     (PrecipitationFlux(),)
-eq_tends(::AbstractPrecipitation, ::RainSnowModel, ::Flux{SecondOrder}) =
-    (Diffusion(),)
+eq_tends(
+    ::AbstractPrecipitationVariable,
+    ::RainSnowModel,
+    ::Flux{SecondOrder},
+) = (Diffusion(),)

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -140,6 +140,7 @@ end
 eq_tends(::Rain, ::RainModel, ::Flux{FirstOrder}) = (PrecipitationFlux(),)
 eq_tends(::Rain, ::RainModel, ::Flux{SecondOrder}) = (Diffusion(),)
 
-eq_tends(::Precipitation, ::RainSnowModel, ::Flux{FirstOrder}) =
+eq_tends(::AbstractPrecipitation, ::RainSnowModel, ::Flux{FirstOrder}) =
     (PrecipitationFlux(),)
-eq_tends(::Precipitation, ::RainSnowModel, ::Flux{SecondOrder}) = (Diffusion(),)
+eq_tends(::AbstractPrecipitation, ::RainSnowModel, ::Flux{SecondOrder}) =
+    (Diffusion(),)

--- a/src/Atmos/Model/prog_prim_conversion.jl
+++ b/src/Atmos/Model/prog_prim_conversion.jl
@@ -22,7 +22,8 @@ function prognostic_to_primitive!(
     prog::Vars,
     aux,
 )
-    atmos.energy isa EnergyModel || error("EnergyModel only supported")
+    atmos.energy isa TotalEnergyModel ||
+        error("TotalEnergyModel only supported")
     prognostic_to_primitive!(atmos, atmos.moisture, prim, prog, aux)
     prognostic_to_primitive!(atmos.turbconv, atmos, atmos.moisture, prim, prog)
 end
@@ -105,7 +106,8 @@ function primitive_to_prognostic!(
     prim::Vars,
     aux::Vars,
 )
-    atmos.energy isa EnergyModel || error("EnergyModel only supported")
+    atmos.energy isa TotalEnergyModel ||
+        error("TotalEnergyModel only supported")
     ts = PhaseDry_ρp(parameter_set(atmos), prim.ρ, prim.p)
     e_kin = prim.u' * prim.u / 2
     ρ = density(atmos, prim, aux)
@@ -123,7 +125,8 @@ function primitive_to_prognostic!(
     prim::Vars,
     aux::Vars,
 )
-    atmos.energy isa EnergyModel || error("EnergyModel only supported")
+    atmos.energy isa TotalEnergyModel ||
+        error("TotalEnergyModel only supported")
     ts = PhaseEquil_ρpq(
         parameter_set(atmos),
         prim.ρ,
@@ -148,7 +151,8 @@ function primitive_to_prognostic!(
     prim::Vars,
     aux::Vars,
 )
-    atmos.energy isa EnergyModel || error("EnergyModel only supported")
+    atmos.energy isa TotalEnergyModel ||
+        error("TotalEnergyModel only supported")
     q_pt = PhasePartition(
         prim.moisture.q_tot,
         prim.moisture.q_liq,

--- a/src/Atmos/Model/thermo_states.jl
+++ b/src/Atmos/Model/thermo_states.jl
@@ -54,7 +54,7 @@ recover_thermo_state(::Anelastic1D, atmos::AtmosModel, state::Vars, aux::Vars) =
 
 function new_thermo_state(
     atmos::AtmosModel,
-    energy::EnergyModel,
+    energy::TotalEnergyModel,
     moist::DryModel,
     state::Vars,
     aux::Vars,
@@ -66,7 +66,7 @@ end
 
 function new_thermo_state(
     atmos::AtmosModel,
-    energy::EnergyModel,
+    energy::TotalEnergyModel,
     moist::EquilMoist,
     state::Vars,
     aux::Vars,
@@ -85,7 +85,7 @@ end
 
 function new_thermo_state(
     atmos::AtmosModel,
-    energy::EnergyModel,
+    energy::TotalEnergyModel,
     moist::NonEquilMoist,
     state::Vars,
     aux::Vars,

--- a/src/Atmos/Model/thermo_states_anelastic.jl
+++ b/src/Atmos/Model/thermo_states_anelastic.jl
@@ -33,7 +33,7 @@ recover_thermo_state_anelastic(atmos::AtmosModel, state::Vars, aux::Vars) =
 
 function new_thermo_state_anelastic(
     atmos::AtmosModel,
-    energy::EnergyModel,
+    energy::TotalEnergyModel,
     moist::DryModel,
     state::Vars,
     aux::Vars,
@@ -46,7 +46,7 @@ end
 
 function new_thermo_state_anelastic(
     atmos::AtmosModel,
-    energy::EnergyModel,
+    energy::TotalEnergyModel,
     moist::EquilMoist,
     state::Vars,
     aux::Vars,
@@ -67,7 +67,7 @@ end
 
 function new_thermo_state_anelastic(
     atmos::AtmosModel,
-    energy::EnergyModel,
+    energy::TotalEnergyModel,
     moist::NonEquilMoist,
     state::Vars,
     aux::Vars,

--- a/src/BalanceLaws/sum_tendencies.jl
+++ b/src/BalanceLaws/sum_tendencies.jl
@@ -63,7 +63,7 @@ function Σfluxes(
     pv::PV,
     fluxes::NTuple{0, TendencyDef{Flux{O}}},
     args...,
-) where {O, PV <: AbstractMomentum}
+) where {O, PV <: AbstractMomentumVariable}
     return SArray{Tuple{3, 3}}(ntuple(i -> 0, 9))
 end
 
@@ -72,7 +72,7 @@ function Σfluxes(
     pv::PV,
     fluxes::NTuple{0, TendencyDef{Flux{O}}},
     args...,
-) where {O, N, PV <: AbstractTracers{N}}
+) where {O, N, PV <: AbstractTracersVariable{N}}
     return SArray{Tuple{3, N}}(ntuple(i -> 0, 3 * N))
 end
 
@@ -114,7 +114,7 @@ end
 
 # Emptry vector case:
 function Σsources(
-    pv::AbstractMomentum,
+    pv::AbstractMomentumVariable,
     sources::NTuple{0, TendencyDef{Source}},
     args...,
 )
@@ -123,7 +123,7 @@ end
 
 # Emptry tracer case:
 function Σsources(
-    pv::AbstractTracers{N},
+    pv::AbstractTracersVariable{N},
     sources::NTuple{0, TendencyDef{Source}},
     args...,
 ) where {N}

--- a/src/BalanceLaws/tendency_types.jl
+++ b/src/BalanceLaws/tendency_types.jl
@@ -17,7 +17,7 @@
 
 using DispatchedTuples
 
-export PrognosticVariable,
+export AbstractPrognosticVariable,
     AbstractMomentumVariable,
     AbstractEnergyVariable,
     AbstractMoistureVariable,
@@ -31,18 +31,18 @@ export prognostic_var_source_map
 export eq_tends, prognostic_vars
 
 """
-    PrognosticVariable
+    AbstractPrognosticVariable
 
 Subtypes are used for specifying
 each prognostic variable.
 """
-abstract type PrognosticVariable end
+abstract type AbstractPrognosticVariable end
 
-abstract type AbstractMomentumVariable <: PrognosticVariable end
-abstract type AbstractEnergyVariable <: PrognosticVariable end
-abstract type AbstractMoistureVariable <: PrognosticVariable end
-abstract type AbstractPrecipitationVariable <: PrognosticVariable end
-abstract type AbstractTracersVariable{N} <: PrognosticVariable end
+abstract type AbstractMomentumVariable <: AbstractPrognosticVariable end
+abstract type AbstractEnergyVariable <: AbstractPrognosticVariable end
+abstract type AbstractMoistureVariable <: AbstractPrognosticVariable end
+abstract type AbstractPrecipitationVariable <: AbstractPrognosticVariable end
+abstract type AbstractTracersVariable{N} <: AbstractPrognosticVariable end
 
 
 """
@@ -100,10 +100,10 @@ each tendency definition.
 abstract type TendencyDef{TT <: AbstractTendencyType} end
 
 """
-    eq_tends(::PrognosticVariable, ::BalanceLaw, ::AbstractTendencyType)
+    eq_tends(::AbstractPrognosticVariable, ::BalanceLaw, ::AbstractTendencyType)
 
 A tuple of `TendencyDef`s given
- - `PrognosticVariable` prognostic variable
+ - `AbstractPrognosticVariable` prognostic variable
  - `AbstractTendencyType` tendency type
  - `BalanceLaw` balance law
 
@@ -118,10 +118,10 @@ function eq_tends end
 """
     prognostic_vars(::BalanceLaw)
 
-A tuple of `PrognosticVariable`s given
+A tuple of `AbstractPrognosticVariable`s given
 the `BalanceLaw`.
 
-i.e., a tuple of `PrognosticVariable`s
+i.e., a tuple of `AbstractPrognosticVariable`s
 corresponding to the column-vector `Yᵢ` in:
 
     `∂_t Yᵢ + (∇•F₁(Y))ᵢ + (∇•F₂(Y,G)))ᵢ = (S(Y,G))ᵢ`
@@ -137,7 +137,7 @@ Return identity by defualt
 projection(pv::PV, bl, ::TendencyDef{TT}, args, x) where {TT, PV} = x
 
 """
-    var, name = get_prog_state(state::Union{Vars, Grad}, pv::PrognosticVariable)
+    var, name = get_prog_state(state::Union{Vars, Grad}, pv::AbstractPrognosticVariable)
 
 Returns a tuple of two elements. `var` is a `Vars` or `Grad`
 object, and `name` is a Symbol. They should be linked such that
@@ -187,7 +187,7 @@ function prognostic_var_source_map(driver_sources::Tuple)
 end
 
 # Flatten "tuple of tuple of tuples" to "tuple of tuples"
-tuple_of_tuples(a::Tuple{PrognosticVariable, T}) where {T} = (a,)
+tuple_of_tuples(a::Tuple{AbstractPrognosticVariable, T}) where {T} = (a,)
 tuple_of_tuples(a, b...) =
     tuple(tuple_of_tuples(a)..., tuple_of_tuples(b...)...)
 tuple_of_tuples(a::Tuple) = tuple_of_tuples(a...)

--- a/src/BalanceLaws/tendency_types.jl
+++ b/src/BalanceLaws/tendency_types.jl
@@ -21,7 +21,7 @@ export PrognosticVariable,
     AbstractMomentum,
     AbstractEnergy,
     AbstractMoisture,
-    Precipitation,
+    AbstractPrecipitation,
     AbstractTracers
 
 export FirstOrder, SecondOrder
@@ -41,7 +41,7 @@ abstract type PrognosticVariable end
 abstract type AbstractMomentum <: PrognosticVariable end
 abstract type AbstractEnergy <: PrognosticVariable end
 abstract type AbstractMoisture <: PrognosticVariable end
-abstract type Precipitation <: PrognosticVariable end
+abstract type AbstractPrecipitation <: PrognosticVariable end
 abstract type AbstractTracers{N} <: PrognosticVariable end
 
 

--- a/src/BalanceLaws/tendency_types.jl
+++ b/src/BalanceLaws/tendency_types.jl
@@ -18,7 +18,11 @@
 using DispatchedTuples
 
 export PrognosticVariable,
-    AbstractMomentum, AbstractEnergy, Moisture, Precipitation, AbstractTracers
+    AbstractMomentum,
+    AbstractEnergy,
+    AbstractMoisture,
+    Precipitation,
+    AbstractTracers
 
 export FirstOrder, SecondOrder
 export AbstractTendencyType, Flux, Source
@@ -36,7 +40,7 @@ abstract type PrognosticVariable end
 
 abstract type AbstractMomentum <: PrognosticVariable end
 abstract type AbstractEnergy <: PrognosticVariable end
-abstract type Moisture <: PrognosticVariable end
+abstract type AbstractMoisture <: PrognosticVariable end
 abstract type Precipitation <: PrognosticVariable end
 abstract type AbstractTracers{N} <: PrognosticVariable end
 
@@ -143,8 +147,8 @@ variable type `pv`.
 # Example
 
 ```julia
-get_prog_state(state, ::Moisture) = (state.moisture, :ρq_tot)
-var, name = get_prog_state(state, Moisture())
+get_prog_state(state, ::TotalMoisture) = (state.moisture, :ρq_tot)
+var, name = get_prog_state(state, TotalMoisture())
 @test getproperty(var, name) == state.moisture.ρq_tot
 ```
 """

--- a/src/BalanceLaws/tendency_types.jl
+++ b/src/BalanceLaws/tendency_types.jl
@@ -18,11 +18,11 @@
 using DispatchedTuples
 
 export PrognosticVariable,
-    AbstractMomentum,
-    AbstractEnergy,
-    AbstractMoisture,
-    AbstractPrecipitation,
-    AbstractTracers
+    AbstractMomentumVariable,
+    AbstractEnergyVariable,
+    AbstractMoistureVariable,
+    AbstractPrecipitationVariable,
+    AbstractTracersVariable
 
 export FirstOrder, SecondOrder
 export AbstractTendencyType, Flux, Source
@@ -38,11 +38,11 @@ each prognostic variable.
 """
 abstract type PrognosticVariable end
 
-abstract type AbstractMomentum <: PrognosticVariable end
-abstract type AbstractEnergy <: PrognosticVariable end
-abstract type AbstractMoisture <: PrognosticVariable end
-abstract type AbstractPrecipitation <: PrognosticVariable end
-abstract type AbstractTracers{N} <: PrognosticVariable end
+abstract type AbstractMomentumVariable <: PrognosticVariable end
+abstract type AbstractEnergyVariable <: PrognosticVariable end
+abstract type AbstractMoistureVariable <: PrognosticVariable end
+abstract type AbstractPrecipitationVariable <: PrognosticVariable end
+abstract type AbstractTracersVariable{N} <: PrognosticVariable end
 
 
 """

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -918,11 +918,11 @@ struct HyperdiffViscousFlux <: TendencyDef{Flux{SecondOrder}} end
 eq_tends(pv::PV, ::HyperDiffusion, ::AbstractTendencyType) where {PV} = ()
 
 # Enthalpy and viscous for Biharmonic model
-eq_tends(::AbstractEnergy, ::Biharmonic, ::Flux{SecondOrder}) =
+eq_tends(::AbstractEnergyVariable, ::Biharmonic, ::Flux{SecondOrder}) =
     (HyperdiffEnthalpyFlux(), HyperdiffViscousFlux())
 
 # Viscous for Biharmonic model
-eq_tends(::AbstractMomentum, ::Biharmonic, ::Flux{SecondOrder}) =
+eq_tends(::AbstractMomentumVariable, ::Biharmonic, ::Flux{SecondOrder}) =
     (HyperdiffViscousFlux(),)
 
 end #module TurbulenceClosures.jl

--- a/src/Diagnostics/DiagnosticsMachine/atmos_diagnostic_funs.jl
+++ b/src/Diagnostics/DiagnosticsMachine/atmos_diagnostic_funs.jl
@@ -6,7 +6,7 @@ using ..TurbulenceConvection
 # of `AtmosModel`.
 
 const AtmosComponentTypes = Union{
-    MoistureModel,
+    AbstractMoistureModel,
     PrecipitationModel,
     RadiationModel,
     TracerModel,

--- a/src/Diagnostics/StdDiagnostics/atmos_gcm_diagnostic_vars.jl
+++ b/src/Diagnostics/StdDiagnostics/atmos_gcm_diagnostic_vars.jl
@@ -47,7 +47,13 @@ end
     "J kg^-1",
     "total specific energy",
     "specific_dry_energy_of_air",
-) do (energy::EnergyModel, atmos::AtmosModel, states::States, curr_time, cache)
+) do (
+    energy::TotalEnergyModel,
+    atmos::AtmosModel,
+    states::States,
+    curr_time,
+    cache,
+)
     states.prognostic.energy.ρe / states.prognostic.ρ
 end
 
@@ -109,7 +115,13 @@ end
     "J kg^-1",
     "specific enthalpy based on total energy",
     "",
-) do (energy::EnergyModel, atmos::AtmosModel, states::States, curr_time, cache)
+) do (
+    energy::TotalEnergyModel,
+    atmos::AtmosModel,
+    states::States,
+    curr_time,
+    cache,
+)
     ts = get!(cache, :ts) do
         recover_thermo_state(atmos, states.prognostic, states.auxiliary)
     end

--- a/src/Diagnostics/StdDiagnostics/atmos_les_diagnostic_vars.jl
+++ b/src/Diagnostics/StdDiagnostics/atmos_les_diagnostic_vars.jl
@@ -146,7 +146,13 @@ end
     "total specific energy",
     "specific_dry_energy_of_air",
     rho,
-) do (energy::EnergyModel, atmos::AtmosModel, states::States, curr_time, cache)
+) do (
+    energy::TotalEnergyModel,
+    atmos::AtmosModel,
+    states::States,
+    curr_time,
+    cache,
+)
     states.prognostic.energy.ρe
 end
 
@@ -171,7 +177,13 @@ end
     "specific enthalpy based on total energy",
     "",
     rho,
-) do (energy::EnergyModel, atmos::AtmosModel, states::States, curr_time, cache)
+) do (
+    energy::TotalEnergyModel,
+    atmos::AtmosModel,
+    states::States,
+    curr_time,
+    cache,
+)
     ts = get!(cache, :ts) do
         recover_thermo_state(atmos, states.prognostic, states.auxiliary)
     end
@@ -200,7 +212,13 @@ end
     "vertical sgs flux of total specific enthalpy",
     "",
     rho,
-) do (energy::EnergyModel, atmos::AtmosModel, states::States, curr_time, cache)
+) do (
+    energy::TotalEnergyModel,
+    atmos::AtmosModel,
+    states::States,
+    curr_time,
+    cache,
+)
     D_t = get!(cache, :D_t) do
         _, D_t, _ = turbulence_tensors(
             atmos,

--- a/src/Diagnostics/atmos_gcm_default.jl
+++ b/src/Diagnostics/atmos_gcm_default.jl
@@ -121,7 +121,7 @@ function vars_atmos_gcm_default_simple_3d(atmos::AtmosModel, FT)
         moisture::vars_atmos_gcm_default_simple_3d(atmos.moisture, FT)
     end
 end
-vars_atmos_gcm_default_simple_3d(::MoistureModel, FT) = @vars()
+vars_atmos_gcm_default_simple_3d(::AbstractMoistureModel, FT) = @vars()
 function vars_atmos_gcm_default_simple_3d(m::EquilMoist, FT)
     @vars begin
         qt::FT                  # q_tot
@@ -174,7 +174,7 @@ function atmos_gcm_default_simple_3d_vars!(
     return nothing
 end
 function atmos_gcm_default_simple_3d_vars!(
-    ::MoistureModel,
+    ::AbstractMoistureModel,
     state_prognostic,
     thermo,
     vars,

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -1,5 +1,5 @@
 using ..Atmos
-using ..Atmos: MoistureModel, PrecipitationModel, recover_thermo_state
+using ..Atmos: AbstractMoistureModel, PrecipitationModel, recover_thermo_state
 using ..Mesh.Topologies
 using ..Mesh.Grids
 using ..Thermodynamics
@@ -113,7 +113,7 @@ function vars_atmos_les_default_simple(m::AtmosModel, FT)
         precipitation::vars_atmos_les_default_simple(m.precipitation, FT)
     end
 end
-vars_atmos_les_default_simple(::MoistureModel, FT) = @vars()
+vars_atmos_les_default_simple(::AbstractMoistureModel, FT) = @vars()
 function vars_atmos_les_default_simple(m::Union{EquilMoist, NonEquilMoist}, FT)
     @vars begin
         qt::FT                  # q_tot
@@ -190,7 +190,7 @@ function atmos_les_default_simple_sums!(
     return nothing
 end
 function atmos_les_default_simple_sums!(
-    ::MoistureModel,
+    ::AbstractMoistureModel,
     state,
     gradflux,
     thermo,
@@ -260,7 +260,7 @@ function atmos_les_default_simple_sums!(
 end
 
 function atmos_les_default_clouds(
-    ::MoistureModel,
+    ::AbstractMoistureModel,
     thermo,
     idx,
     qc_gt_0_z,
@@ -312,7 +312,7 @@ function vars_atmos_les_default_ho(m::AtmosModel, FT)
         precipitation::vars_atmos_les_default_ho(m.precipitation, FT)
     end
 end
-vars_atmos_les_default_ho(::MoistureModel, FT) = @vars()
+vars_atmos_les_default_ho(::AbstractMoistureModel, FT) = @vars()
 function vars_atmos_les_default_ho(m::Union{EquilMoist, NonEquilMoist}, FT)
     @vars begin
         var_qt::FT              # q_tot′q_tot′
@@ -401,7 +401,7 @@ function atmos_les_default_ho_sums!(
     return nothing
 end
 function atmos_les_default_ho_sums!(
-    ::MoistureModel,
+    ::AbstractMoistureModel,
     state,
     thermo,
     MH,

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -580,7 +580,8 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
     nvertelem = topl_info.nvertelem
     nhorzelem = topl_info.nhorzrealelem
 
-    atmos.energy isa EnergyModel || error("EnergyModel only supported")
+    atmos.energy isa TotalEnergyModel ||
+        error("TotalEnergyModel only supported")
 
     # get needed arrays onto the CPU
     if array_device(Q) isa CPU

--- a/src/Diagnostics/atmos_les_default_perturbations.jl
+++ b/src/Diagnostics/atmos_les_default_perturbations.jl
@@ -97,7 +97,7 @@ function atmos_les_default_perturbations_sums!(
     return nothing
 end
 function atmos_les_default_perturbations_sums!(
-    ::MoistureModel,
+    ::AbstractMoistureModel,
     state,
     thermo,
     sums,
@@ -137,7 +137,7 @@ function vars_atmos_les_default_perturbations(m::AtmosModel, FT)
         moisture::vars_atmos_les_default_perturbations(m.moisture, FT)
     end
 end
-vars_atmos_les_default_perturbations(::MoistureModel, FT) = @vars()
+vars_atmos_les_default_perturbations(::AbstractMoistureModel, FT) = @vars()
 function vars_atmos_les_default_perturbations(m::EquilMoist, FT)
     @vars begin
         qt_prime::FT                  # q_tot
@@ -188,7 +188,7 @@ function atmos_les_default_perturbations!(
     return nothing
 end
 function atmos_les_default_perturbations!(
-    ::MoistureModel,
+    ::AbstractMoistureModel,
     ::AtmosModel,
     state,
     thermo,

--- a/src/Diagnostics/atmos_mass_energy_loss.jl
+++ b/src/Diagnostics/atmos_mass_energy_loss.jl
@@ -62,7 +62,7 @@ function atmos_mass_energy_loss_init(dgngrp, currtime)
     Q = Settings.Q
     FT = eltype(Q)
 
-    bl.energy isa EnergyModel || error("Only EnergyModel supported")
+    bl.energy isa TotalEnergyModel || error("Only TotalEnergyModel supported")
     ρ_idx = varsindices(vars_state(bl, Prognostic(), FT), "ρ")
     ρe_idx = varsindices(vars_state(bl, Prognostic(), FT), :(energy.ρe))
     Σρ₀ = weightedsum(Q, ρ_idx)
@@ -99,7 +99,7 @@ function atmos_mass_energy_loss_collect(dgngrp, currtime)
     Q = Settings.Q
     FT = eltype(Q)
 
-    bl.energy isa EnergyModel || error("Only EnergyModel supported")
+    bl.energy isa TotalEnergyModel || error("Only TotalEnergyModel supported")
     ρ_idx = varsindices(vars_state(bl, Prognostic(), FT), "ρ")
     ρe_idx = varsindices(vars_state(bl, Prognostic(), FT), :(energy.ρe))
     Σρ = weightedsum(Q, ρ_idx)

--- a/src/Diagnostics/thermo.jl
+++ b/src/Diagnostics/thermo.jl
@@ -1,5 +1,5 @@
 using ..Atmos
-using ..Atmos: MoistureModel
+using ..Atmos: AbstractMoistureModel
 
 # Helpers to gather the thermodynamic variables across the DG grid
 
@@ -15,7 +15,7 @@ function vars_thermo(atmos::AtmosModel, FT)
         moisture::vars_thermo(atmos.moisture, FT)
     end
 end
-vars_thermo(::MoistureModel, FT) = @vars()
+vars_thermo(::AbstractMoistureModel, FT) = @vars()
 function vars_thermo(m::Union{EquilMoist, NonEquilMoist}, FT)
     @vars begin
         q_liq::FT
@@ -47,7 +47,7 @@ function compute_thermo!(atmos::AtmosModel, state, aux, thermo)
 
     return nothing
 end
-function compute_thermo!(::MoistureModel, state, aux, ts, thermo)
+function compute_thermo!(::AbstractMoistureModel, state, aux, ts, thermo)
     return nothing
 end
 function compute_thermo!(

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -161,7 +161,7 @@ function vars_state(m::EDMF, st::GradientFlux, FT)
     )
 end
 
-abstract type EDMFPrognosticVariable <: PrognosticVariable end
+abstract type EDMFPrognosticVariable <: AbstractPrognosticVariable end
 
 abstract type EnvironmentPrognosticVariable <: EDMFPrognosticVariable end
 struct en_ρatke <: EnvironmentPrognosticVariable end

--- a/test/BalanceLaws/runtests.jl
+++ b/test/BalanceLaws/runtests.jl
@@ -9,8 +9,8 @@ const BL = BalanceLaws
 import ClimateMachine.BalanceLaws: vars_state, eq_tends, prognostic_vars
 
 struct TestBL <: BalanceLaw end
-struct X <: PrognosticVariable end
-struct Y <: PrognosticVariable end
+struct X <: AbstractPrognosticVariable end
+struct Y <: AbstractPrognosticVariable end
 struct F1 <: TendencyDef{Flux{FirstOrder}} end
 struct F2 <: TendencyDef{Flux{SecondOrder}} end
 struct S <: TendencyDef{Source} end

--- a/tutorials/BalanceLaws/tendency_specification_layer.jl
+++ b/tutorials/BalanceLaws/tendency_specification_layer.jl
@@ -41,10 +41,10 @@ struct MyBalanceLaw <: BalanceLaw end
 # ## Define prognostic variable types
 
 # Here, we'll define some prognostic variable types,
-# by sub-typing [`PrognosticVariable`](@ref ClimateMachine.BalanceLaws.PrognosticVariable),
+# by sub-typing [`AbstractPrognosticVariable`](@ref ClimateMachine.BalanceLaws.AbstractPrognosticVariable),
 # for mass and energy:
-struct Mass <: PrognosticVariable end
-struct Energy <: PrognosticVariable end
+struct Mass <: AbstractPrognosticVariable end
+struct Energy <: AbstractPrognosticVariable end
 
 # Define [`prognostic_vars`](@ref ClimateMachine.BalanceLaws.prognostic_vars),
 # which returns _all_ prognostic variables


### PR DESCRIPTION
### Description

 - Renames EnergyModel to TotalEnergyModel (as it's more concrete)
 - Renames MoistureModel to AbstractMoistureModel (since it's abstract, and we defined `Moisture <: PrognosticVariable`)
 - Renames Moisture to AbstractMoisture (since it's abstract)
 - Renames Precipitation to AbstractPrecipitation (since it's abstract)

A note about bikeshedding names: we cannot generally change, for example, `EnergyModel` to `AbstractEnergy`, because we're already using `AbstractEnergy <: PrognosticVariable`.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
