### PR TITLE
add mass preserving filter

### DIFF
--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -109,6 +109,45 @@ ClimateMachine.init()
         @test filter.filter_matrices[1] ≈ W1
         @test filter.filter_matrices[2] ≈ W2
     end
+
+    let
+        T = Float64
+        N = (5, 3)
+        Nc = (4, 2)
+
+        topology = ClimateMachine.Mesh.Topologies.BrickTopology(
+            MPI.COMM_SELF,
+            -1.0:2.0:1.0,
+        )
+        grid = ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+            topology;
+            polynomialorder = N,
+            FloatType = T,
+            DeviceArray = Array,
+        )
+
+        ξ = ClimateMachine.Mesh.Grids.referencepoints(grid)
+        ξ1 = ξ[1]
+        ξ2 = ξ[2]
+        a1, b1 = GaussQuadrature.legendre_coefs(T, N[1])
+        a2, b2 = GaussQuadrature.legendre_coefs(T, N[2])
+        V1 = GaussQuadrature.orthonormal_poly(ξ1, a1, b1)
+        V2 = GaussQuadrature.orthonormal_poly(ξ2, a2, b2)
+
+        Σ1 = ones(T, N[1] + 1)
+        Σ2 = ones(T, N[2] + 1)
+        Σ1[(Nc[1]:N[1]) .+ 1] .= 0
+        Σ2[(Nc[2]:N[2]) .+ 1] .= 0
+
+        W1 = V1 * Diagonal(Σ1) / V1
+        W2 = V2 * Diagonal(Σ2) / V2
+
+        filter =
+            ClimateMachine.Mesh.Filters.MassPreservingCutoffFilter(grid, Nc)
+        @test filter.filter_matrices[1] ≈ W1
+        @test filter.filter_matrices[2] ≈ W2
+    end
+
 end
 
 struct FilterTestModel{N} <: ClimateMachine.BalanceLaws.BalanceLaw end
@@ -221,6 +260,75 @@ end
     end
 end
 
+@testset "Mass Preserving Cutoff filter application" begin
+    N = 3
+    Ne = (1, 1, 1)
+
+    @testset for FT in (Float64, Float32)
+        @testset for dim in 2:3
+            @testset for direction in (
+                EveryDirection,
+                HorizontalDirection,
+                VerticalDirection,
+            )
+                brickrange = ntuple(
+                    j -> range(FT(-1); length = Ne[j] + 1, stop = 1),
+                    dim,
+                )
+                topl = ClimateMachine.Mesh.Topologies.BrickTopology(
+                    MPI.COMM_WORLD,
+                    brickrange,
+                    periodicity = ntuple(j -> true, dim),
+                )
+
+                grid =
+                    ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+                        topl,
+                        FloatType = FT,
+                        DeviceArray = ClimateMachine.array_type(),
+                        polynomialorder = N,
+                    )
+
+                filter = ClimateMachine.Mesh.Filters.MassPreservingCutoffFilter(
+                    grid,
+                    2,
+                )
+
+                model = FilterTestModel{4}()
+                dg = ClimateMachine.DGMethods.DGModel(
+                    model,
+                    grid,
+                    nothing,
+                    nothing,
+                    nothing;
+                    state_gradient_flux = nothing,
+                )
+
+                @testset for target in ((1, 3), (:q1, :q3))
+                    Q = ClimateMachine.DGMethods.init_ode_state(
+                        dg,
+                        nothing,
+                        dim,
+                    )
+                    ClimateMachine.Mesh.Filters.apply!(
+                        Q,
+                        target,
+                        grid,
+                        filter,
+                        direction = direction(),
+                    )
+                    P = ClimateMachine.DGMethods.init_ode_state(
+                        dg,
+                        direction(),
+                        dim,
+                    )
+                    @test Array(Q.data) ≈ Array(P.data)
+                end
+            end
+        end
+    end
+end
+
 ClimateMachine.BalanceLaws.vars_state(
     ::FilterTestModel{1},
     ::Prognostic,
@@ -287,5 +395,115 @@ end
                 @test isapprox(initialsumQ, sumQ; rtol = 10 * eps(FT))
             end
         end
+    end
+end
+
+function cubedshellwarp(a, b, c, R = max(abs(a), abs(b), abs(c)))
+
+    function f(sR, ξ, η)
+        X, Y = tan(π * ξ / 4), tan(π * η / 4)
+        x1 = sR / sqrt(X^2 + Y^2 + 1)
+        x2, x3 = X * x1, Y * x1
+        x1, x2, x3
+    end
+
+    fdim = argmax(abs.((a, b, c)))
+    if fdim == 1 && a < 0
+        # (-R, *, *) : Face I from Ronchi, Iacono, Paolucci (1996)
+        x1, x2, x3 = f(-R, b / a, c / a)
+    elseif fdim == 2 && b < 0
+        # ( *,-R, *) : Face II from Ronchi, Iacono, Paolucci (1996)
+        x2, x1, x3 = f(-R, a / b, c / b)
+    elseif fdim == 1 && a > 0
+        # ( R, *, *) : Face III from Ronchi, Iacono, Paolucci (1996)
+        x1, x2, x3 = f(R, b / a, c / a)
+    elseif fdim == 2 && b > 0
+        # ( *, R, *) : Face IV from Ronchi, Iacono, Paolucci (1996)
+        x2, x1, x3 = f(R, a / b, c / b)
+    elseif fdim == 3 && c > 0
+        # ( *, *, R) : Face V from Ronchi, Iacono, Paolucci (1996)
+        x3, x2, x1 = f(R, b / c, a / c)
+    elseif fdim == 3 && c < 0
+        # ( *, *,-R) : Face VI from Ronchi, Iacono, Paolucci (1996)
+        x3, x2, x1 = f(-R, b / c, a / c)
+    else
+        error("invalid case for cubedshellwarp: $a, $b, $c")
+    end
+
+    return x1, x2, x3
+end
+
+@testset "Mass Preserving Cutoff Filter Conservation Test" begin
+    N = 3
+    Ne = (1, 1, 1)
+    dim = 3
+    # dim, direction
+    @testset for FT in (Float64,)
+        Rrange = [FT(1.0), FT(1.2)]
+
+        topl = ClimateMachine.Mesh.Grids.StackedCubedSphereTopology(
+            MPI.COMM_WORLD,
+            1,
+            Rrange,
+            boundary = (5, 6),
+        )
+
+        grid = ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+            topl,
+            FloatType = FT,
+            DeviceArray = ClimateMachine.array_type(),
+            polynomialorder = (N, N),
+            meshwarp = cubedshellwarp,
+        )
+
+
+        mp_filter =
+            ClimateMachine.Mesh.Filters.MassPreservingCutoffFilter(grid, 2)
+
+        reg_filter = ClimateMachine.Mesh.Filters.CutoffFilter(grid, 2)
+
+        model = FilterTestModel{4}()
+        dg = ClimateMachine.DGMethods.DGModel(
+            model,
+            grid,
+            nothing,
+            nothing,
+            nothing;
+            state_gradient_flux = nothing,
+        )
+
+        # test mp filter
+        filter = mp_filter
+        Q = ClimateMachine.DGMethods.init_ode_state(dg, nothing, dim)
+        sum_before_1 = weightedsum(Q, 1)
+        sum_before_2 = weightedsum(Q, 2)
+        sum_before_3 = weightedsum(Q, 3)
+        target = 1:3
+        ClimateMachine.Mesh.Filters.apply!(Q, target, grid, filter)
+        sum_after_1 = weightedsum(Q, 1)
+        sum_after_2 = weightedsum(Q, 2)
+        sum_after_3 = weightedsum(Q, 3)
+
+        @test sum_before_1 ≈ sum_after_1
+        @test sum_before_2 ≈ sum_after_2
+        @test sum_before_3 ≈ sum_after_3
+
+
+        # test regular filter
+        filter = reg_filter
+        Q = ClimateMachine.DGMethods.init_ode_state(dg, nothing, dim)
+        sum_before_1 = weightedsum(Q, 1)
+        sum_before_2 = weightedsum(Q, 2)
+        sum_before_3 = weightedsum(Q, 3)
+        target = 1:3
+        ClimateMachine.Mesh.Filters.apply!(Q, target, grid, filter)
+        sum_after_1 = weightedsum(Q, 1)
+        sum_after_2 = weightedsum(Q, 2)
+        sum_after_3 = weightedsum(Q, 3)
+
+        @test !(sum_before_1 ≈ sum_after_1)
+        @test !(sum_before_2 ≈ sum_after_2)
+        @test !(sum_before_3 ≈ sum_after_3)
+
     end
 end


### PR DESCRIPTION
This PR adds a cutoff filter that preserves the cell average for curved elements. The current filters in CLIMA do not have this property

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
