### PR TITLE
Add tendency specification layer to land model

### DIFF
--- a/src/Land/Model/land_tendencies.jl
+++ b/src/Land/Model/land_tendencies.jl
@@ -1,0 +1,50 @@
+#####
+##### Sources
+#####
+
+eq_tends(pv::AbstractPrognosticVariable, m::LandModel, tt::Source) =
+    (m.source_dt[pv]...,)
+
+#####
+##### First order fluxes
+#####
+
+eq_tends(::PV, ::LandModel, ::Flux{FirstOrder}) where {PV} = ()
+
+
+#####
+##### Second order fluxes
+#####
+
+# Empty by default
+eq_tends(pv::PV, ::AbstractSoilComponentModel, ::Flux{SecondOrder}) where {PV} =
+    ()
+
+eq_tends(pv::PV, land::LandModel, tt::Flux{SecondOrder}) where {PV} =
+    (eq_tends(pv, land.soil.heat, tt)..., eq_tends(pv, land.soil.water, tt)...)
+
+eq_tends(
+    pv::PV,
+    land::LandModel,
+    tt::Flux{SecondOrder},
+) where {PV <: VolumetricInternalEnergy} =
+    (eq_tends(pv, land.soil.heat, land.soil.water, tt)...,)
+
+# TODO: move to soi_heat.jl?
+eq_tends(
+    ::VolumetricInternalEnergy,
+    ::SoilHeatModel,
+    ::SoilWaterModel,
+    ::Flux{SecondOrder},
+) = (DiffHeatFlux(), DarcyDrivenHeatFlux())
+
+# TODO: move to soi_water.jl?
+eq_tends(
+    ::VolumetricInternalEnergy,
+    ::SoilHeatModel,
+    ::PrescribedWaterModel,
+    ::Flux{SecondOrder},
+) = (DiffHeatFlux(),)
+
+eq_tends(::VolumetricLiquidFraction, ::SoilWaterModel, ::Flux{SecondOrder}) =
+    (DarcyFlux(),)

--- a/src/Land/Model/prog_types.jl
+++ b/src/Land/Model/prog_types.jl
@@ -1,0 +1,7 @@
+#####
+##### Prognostic Variable types
+#####
+
+struct VolumetricLiquidFraction <: AbstractPrognosticVariable end
+struct VolumetricInternalEnergy <: AbstractPrognosticVariable end
+struct VolumetricIceFraction <: AbstractPrognosticVariable end

--- a/src/Land/Model/prognostic_vars.jl
+++ b/src/Land/Model/prognostic_vars.jl
@@ -1,0 +1,16 @@
+#####
+##### Prognostic Variables
+#####
+
+prognostic_vars(water::PrescribedWaterModel) = ()
+prognostic_vars(water::SoilWaterModel) =
+    (VolumetricLiquidFraction(), VolumetricIceFraction())
+prognostic_vars(heat::PrescribedTemperatureModel) = ()
+prognostic_vars(heat::SoilHeatModel) = (VolumetricInternalEnergy(),)
+
+prognostic_vars(land::LandModel) =
+    (prognostic_vars(land.soil.water)..., prognostic_vars(land.soil.heat)...)
+
+get_prog_state(state, ::VolumetricLiquidFraction) = (state.soil.water, :ϑ_l)
+get_prog_state(state, ::VolumetricIceFraction) = (state.soil.water, :θ_i)
+get_prog_state(state, ::VolumetricInternalEnergy) = (state.soil.heat, :ρe_int)

--- a/src/Land/Model/soil_model.jl
+++ b/src/Land/Model/soil_model.jl
@@ -108,18 +108,6 @@ function vars_state(soil::SoilModel, st::GradientFlux, FT)
     end
 end
 
-
-function flux_first_order!(
-    land::LandModel,
-    soil::SoilModel,
-    flux::Grad,
-    state::Vars,
-    aux::Vars,
-    t::Real,
-    directions,
-) end
-
-
 function compute_gradient_argument!(
     land::LandModel,
     soil::SoilModel,
@@ -165,43 +153,6 @@ function compute_gradient_flux!(
     )
 
 end
-
-
-function flux_second_order!(
-    land::LandModel,
-    soil::SoilModel,
-    flux::Grad,
-    state::Vars,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
-    aux::Vars,
-    t::Real,
-)
-    flux_second_order!(
-        land,
-        soil,
-        soil.water,
-        flux,
-        state,
-        diffusive,
-        hyperdiffusive,
-        aux,
-        t,
-    )
-    flux_second_order!(
-        land,
-        soil,
-        soil.heat,
-        flux,
-        state,
-        diffusive,
-        hyperdiffusive,
-        aux,
-        t,
-    )
-
-end
-
 
 function land_nodal_update_auxiliary_state!(
     land::LandModel,
@@ -280,21 +231,6 @@ function compute_gradient_flux!(
     diffusive::Vars,
     ∇transform::Grad,
     state::Vars,
-    aux::Vars,
-    t::Real,
-)
-
-end
-
-
-function flux_second_order!(
-    land::LandModel,
-    soil::SoilModel,
-    m::AbstractSoilComponentModel,
-    flux::Grad,
-    state::Vars,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
     aux::Vars,
     t::Real,
 )

--- a/src/Land/Model/soil_water.jl
+++ b/src/Land/Model/soil_water.jl
@@ -8,8 +8,8 @@ abstract type AbstractWaterModel <: AbstractSoilComponentModel end
 Model structure for a prescribed water content model.
 
 The user supplies functions of space and time for both `ϑ_l` and
-`θ_i`. No auxiliary or state variables are added, no PDE is solved. 
-The defaults are no moisture anywhere, for all time. 
+`θ_i`. No auxiliary or state variables are added, no PDE is solved.
+The defaults are no moisture anywhere, for all time.
 
 # Fields
 $(DocStringExtensions.FIELDS)
@@ -22,18 +22,16 @@ struct PrescribedWaterModel{FN1, FN2} <: AbstractWaterModel
 end
 
 """
-    function PrescribedWaterModel(
+    PrescribedWaterModel(
         ϑ_l::Function = (aux, t) -> eltype(aux)(0.0),
         θ_i::Function = (aux, t) -> eltype(aux)(0.0),
     )
-        args = (ϑ_l, θ_i)
-        return PrescribedWaterModel{typeof.(args)...}(args...)
-    end
+
 Outer constructor for the PrescribedWaterModel defining default values.
 
-The functions supplied by the user are point-wise evaluated and are 
+The functions supplied by the user are point-wise evaluated and are
 evaluated in the Balance Law functions compute_gradient_argument,
-nodal_update, etc. whenever the prescribed water content variables are 
+nodal_update, etc. whenever the prescribed water content variables are
 needed by the heat model.
 """
 function PrescribedWaterModel(
@@ -47,16 +45,16 @@ end
 """
     SoilWaterModel{FT, IF, VF, MF, HM, Fiϑl, Fiθi} <: AbstractWaterModel
 
-The necessary components for solving the equations for water (liquid or ice) in soil. 
+The necessary components for solving the equations for water (liquid or ice) in soil.
 
 Without freeze/thaw source terms added (separately), this model reduces to
-Richard's equation for liquid water. Note that the default for `θ_i` is zero. 
-Without freeze/thaw source terms added to both the liquid and ice equations, 
-the default should never be changed, because we do not enforce that the total 
+Richard's equation for liquid water. Note that the default for `θ_i` is zero.
+Without freeze/thaw source terms added to both the liquid and ice equations,
+the default should never be changed, because we do not enforce that the total
 volumetric water fraction is less than or equal to porosity otherwise.
 
 When freeze/thaw source terms are included, this model encompasses water in both
-liquid and ice form, and water content is conserved upon phase change. 
+liquid and ice form, and water content is conserved upon phase change.
 
 # Fields
 $(DocStringExtensions.FIELDS)
@@ -153,33 +151,6 @@ function get_water_content(
     θ_i = water.θ_i(aux, t)
     return FT(ϑ_l), FT(θ_i)
 end
-
-
-"""
-    function get_diffusive_water_term(
-        water::SoilWaterModel,
-        diffusive::Vars
-    )
-
-Returns the diffusive water term from the `diffusive` vector.
-"""
-function get_diffusive_water_term(water::SoilWaterModel, diffusive::Vars)
-    return diffusive.soil.water.K∇h
-end
-
-"""
-    function get_diffusive_water_term(
-        water::PrescribedWaterModel,
-        diffusive::Vars
-    )
-
-Returns zero for the diffusive water term, under the PrescribedWaterModel.
-"""
-function get_diffusive_water_term(water::PrescribedWaterModel, diffusive::Vars)
-    FT = eltype(diffusive)
-    return SVector{3, FT}(0, 0, 0)
-end
-
 
 vars_state(water::SoilWaterModel, st::Prognostic, FT) = @vars(ϑ_l::FT, θ_i::FT)
 
@@ -300,16 +271,9 @@ function compute_gradient_flux!(
     diffusive.soil.water.K∇h = aux.soil.water.K * ∇transform.soil.water.h
 end
 
-function flux_second_order!(
-    land::LandModel,
-    soil::SoilModel,
-    water::SoilWaterModel,
-    flux::Grad,
-    state::Vars,
-    diffusive::Vars,
-    hyperdiffusive::Vars,
-    aux::Vars,
-    t::Real,
-)
-    flux.soil.water.ϑ_l -= diffusive.soil.water.K∇h
+struct DarcyFlux <: TendencyDef{Flux{SecondOrder}} end
+
+function flux(::VolumetricLiquidFraction, ::DarcyFlux, ::LandModel, args)
+    @unpack diffusive = args
+    return -diffusive.soil.water.K∇h
 end


### PR DESCRIPTION
### Description

This PR adds the tendency specification layer to the land model. This is basically how the atmosphere does it.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
