### PR TITLE
Move compressibility to atmos.physics

### DIFF
--- a/experiments/AtmosLES/ekman_layer_model.jl
+++ b/experiments/AtmosLES/ekman_layer_model.jl
@@ -140,7 +140,8 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     p = aux.ref_state.p
     TS = PhaseDry_pθ(param_set, p, θ)
 
-    ρ = bl.compressibility isa Compressible ? air_density(TS) : aux.ref_state.ρ
+    compress = compressibility_model(bl) isa Compressible
+    ρ = compress ? air_density(TS) : aux.ref_state.ρ
     # Compute momentum contributions
     ρu = ρ * u
     ρv = ρ * v

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -156,7 +156,8 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
         TS = PhaseEquil_pθq(param_set, p, θ_liq, q_tot)
     end
 
-    ρ = bl.compressibility isa Compressible ? air_density(TS) : aux.ref_state.ρ
+    compress = compressibility_model(bl) isa Compressible
+    ρ = compress ? air_density(TS) : aux.ref_state.ρ
     # Compute momentum contributions
     ρu = ρ * u
     ρv = ρ * v

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -19,7 +19,7 @@ eq_tends(::Mass, ::Compressible, ::Flux{FirstOrder}) = (Advect(),)
 
 # Mass
 eq_tends(pv::Mass, atmos::AtmosModel, tt::Flux{FirstOrder}) =
-    (eq_tends(pv, atmos.compressibility, tt))
+    (eq_tends(pv, compressibility_model(atmos), tt))
 
 # Momentum
 eq_tends(pv::Momentum, ::Compressible, ::Flux{FirstOrder}) =
@@ -28,7 +28,7 @@ eq_tends(pv::Momentum, ::Compressible, ::Flux{FirstOrder}) =
 eq_tends(pv::Momentum, ::Anelastic1D, ::Flux{FirstOrder}) = ()
 
 eq_tends(pv::Momentum, m::AtmosModel, tt::Flux{FirstOrder}) =
-    (Advect(), eq_tends(pv, m.compressibility, tt)...)
+    (Advect(), eq_tends(pv, compressibility_model(m), tt)...)
 
 # Energy
 eq_tends(::Energy, m::TotalEnergyModel, tt::Flux{FirstOrder}) =

--- a/src/Atmos/Model/projections.jl
+++ b/src/Atmos/Model/projections.jl
@@ -2,7 +2,7 @@ import ..BalanceLaws: projection
 
 # Zero-out vertical momentum tendencies based on compressibility
 function projection(pv::Momentum, atmos::AtmosModel, td::TendencyDef, args, x)
-    return projection(pv, atmos.compressibility, td, args, x)
+    return projection(pv, compressibility_model(atmos), td, args, x)
 end
 
 # Zero-out vertical momentum fluxes for Anelastic1D:

--- a/src/Atmos/Model/thermo_states.jl
+++ b/src/Atmos/Model/thermo_states.jl
@@ -16,7 +16,7 @@ function new_thermo_state end
 
 # First dispatch on compressibility
 new_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
-    new_thermo_state(atmos.compressibility, atmos, state, aux)
+    new_thermo_state(compressibility_model(atmos), atmos, state, aux)
 
 new_thermo_state(::Compressible, atmos::AtmosModel, state::Vars, aux::Vars) =
     new_thermo_state(atmos, atmos.energy, atmos.moisture, state, aux)
@@ -40,7 +40,7 @@ function recover_thermo_state end
 
 # First dispatch on compressibility
 recover_thermo_state(atmos::AtmosModel, state::Vars, aux::Vars) =
-    new_thermo_state(atmos.compressibility, atmos, state, aux)
+    new_thermo_state(compressibility_model(atmos), atmos, state, aux)
 
 recover_thermo_state(
     ::Compressible,

--- a/test/Atmos/prog_prim_conversion/runtests.jl
+++ b/test/Atmos/prog_prim_conversion/runtests.jl
@@ -42,7 +42,7 @@ end
 function assign!(state, bl, nt, st::Prognostic, aux)
     @unpack u, v, w, ρ, e_kin, e_pot, T, q_pt = nt
     state.ρ = ρ
-    assign!(state, bl, bl.compressibility, nt, st, aux)
+    assign!(state, bl, compressibility_model(bl), nt, st, aux)
     state.ρu = SVector(state.ρ * u, state.ρ * v, state.ρ * w)
     param_set = parameter_set(bl)
     state.energy.ρe = state.ρ * total_energy(param_set, e_kin, e_pot, T, q_pt)
@@ -67,7 +67,7 @@ function assign!(state, bl, nt, st::Primitive, aux)
     state.ρ = ρ
     state.u = SVector(u, v, w)
     state.p = p
-    assign!(state, bl, bl.compressibility, nt, st, aux)
+    assign!(state, bl, compressibility_model(bl), nt, st, aux)
     assign!(state, bl, bl.moisture, nt, st)
 end
 assign!(state, bl, moisture::DryModel, nt, ::Primitive) = nothing


### PR DESCRIPTION
### Description

This PR moves compressibility to the `atmos.physics` struct.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
