### PR TITLE
Land/soil/add residual water

### DIFF
--- a/.dev/clima_formatter_default_image.jl
+++ b/.dev/clima_formatter_default_image.jl
@@ -1,4 +1,5 @@
 #!/usr/bin/env julia
+#! format: off
 #
 # Called with no arguments will replace the default system image with one that
 # includes the JuliaFormatter

--- a/src/Land/Model/Runoff.jl
+++ b/src/Land/Model/Runoff.jl
@@ -94,9 +94,10 @@ function compute_surface_grad_bc(
     incident_water_flux = precip_model(t)
     Δz = runoff_model.Δz
     water = soil.water
+    param_functions = soil.param_functions
     hydraulics = water.hydraulics
-    ν = soil.param_functions.porosity
-    specific_storage = soil.param_functions.S_s
+    ν = param_functions.porosity
+
 
     T = get_temperature(soil.heat, aux⁻, t)
     θ_i = state⁻.soil.water.θ_i
@@ -109,8 +110,8 @@ function compute_surface_grad_bc(
     ∂h∂z =
         FT(1) +
         (
-            pressure_head(hydraulics, ν, specific_storage, ϑ_bc, θ_i) -
-            pressure_head(hydraulics, ν, specific_storage, ϑ_below, θ_i)
+            pressure_head(hydraulics, param_functions, ϑ_bc, θ_i) -
+            pressure_head(hydraulics, param_functions, ϑ_below, θ_i)
         ) / Δz
 
     K =
@@ -120,7 +121,7 @@ function compute_surface_grad_bc(
             water.moisture_factor,
             hydraulics,
             θ_i,
-            soil.param_functions.porosity,
+            param_functions.porosity,
             T,
             ϑ_bc / ν,# when ice is present, K still measured with ν, not νeff.
         )

--- a/src/Land/Model/soil_model.jl
+++ b/src/Land/Model/soil_model.jl
@@ -22,15 +22,17 @@ Base.@kwdef struct SoilParamFunctions{FT} <: AbstractSoilParameterFunctions{FT}
     Ksat::FT = FT(NaN)
     "Specific storage of the soil. Units of m s-1."
     S_s::FT = FT(NaN)
-    "Volume fraction of gravels, relative to soil solids only. Units of m-3 m-3."
+    "Residual Water Fraction - default is zero; unitless."
+    θ_r::FT = FT(0.0)
+    "Volume fraction of gravels, relative to soil solids only; unitless."
     ν_ss_gravel::FT = FT(NaN)
-    "Volume fraction of SOM, relative to soil solids only. Units of m-3 m-3."
+    "Volume fraction of SOM, relative to soil solids only; unitless."
     ν_ss_om::FT = FT(NaN)
-    "Volume fraction of quartz, relative to soil solids only. Units of m-3 m-3."
+    "Volume fraction of quartz, relative to soil solids only; unitless."
     ν_ss_quartz::FT = FT(NaN)
     "Bulk volumetric heat capacity of dry soil. Units of J m-3 K-1."
     ρc_ds::FT = FT(NaN)
-    "Particle density for soil solids. Units of kg/m^3"
+    "Particle density for soil solids. Units of kg m-3"
     ρp::FT = FT(NaN)
     "Thermal conductivity of the soil solids. Units of W m-1 K-1."
     κ_solid::FT = FT(NaN)

--- a/src/Land/Model/soil_water.jl
+++ b/src/Land/Model/soil_water.jl
@@ -203,11 +203,11 @@ function soil_init_aux!(
     S_l = effective_saturation(
         soil.param_functions.porosity,
         water.initialϑ_l(aux),
+        soil.param_functions.θ_r,
     )
     ψ = pressure_head(
         water.hydraulics,
-        soil.param_functions.porosity,
-        soil.param_functions.S_s,
+        soil.param_functions,
         water.initialϑ_l(aux),
         water.initialθ_i(aux),
     )
@@ -238,11 +238,11 @@ function land_nodal_update_auxiliary_state!(
     S_l = effective_saturation(
         soil.param_functions.porosity,
         state.soil.water.ϑ_l,
+        soil.param_functions.θ_r,
     )
     ψ = pressure_head(
         water.hydraulics,
-        soil.param_functions.porosity,
-        soil.param_functions.S_s,
+        soil.param_functions,
         state.soil.water.ϑ_l,
         state.soil.water.θ_i,
     )
@@ -274,11 +274,11 @@ function compute_gradient_argument!(
     S_l = effective_saturation(
         soil.param_functions.porosity,
         state.soil.water.ϑ_l,
+        soil.param_functions.θ_r,
     )
     ψ = pressure_head(
         water.hydraulics,
-        soil.param_functions.porosity,
-        soil.param_functions.S_s,
+        soil.param_functions,
         state.soil.water.ϑ_l,
         state.soil.water.θ_i,
     )

--- a/src/Land/Model/source.jl
+++ b/src/Land/Model/source.jl
@@ -70,8 +70,10 @@ function land_source!(
     # appropriate temperature range (T < _Tfreeze)
     ψ = -abs(_LH_f0 / _g / _Tfreeze * (T - _Tfreeze))
     hydraulics = land.soil.water.hydraulics
+    θ_r = land.soil.param_functions.θ_r
     θstar =
-        land.soil.param_functions.porosity *
+        θ_r +
+        (land.soil.param_functions.porosity - θ_r) *
         inverse_matric_potential(hydraulics, ψ)
 
     τft = max(source_type.Δt, source_type.τLTE)

--- a/test/Land/Model/Artifacts.toml
+++ b/test/Land/Model/Artifacts.toml
@@ -1,2 +1,5 @@
 [richards]
 git-tree-sha1 = "ff73fa6a0b6a807e71a6921f7ef7d0befe776edd"
+
+[richards_sand]
+git-tree-sha1 = "b0dc82dd02159c646e909bfb61170d3b9dc347f3"

--- a/test/Land/Model/haverkamp_test.jl
+++ b/test/Land/Model/haverkamp_test.jl
@@ -41,6 +41,17 @@ haverkamp_dataset = ArtifactWrapper(
 )
 haverkamp_dataset_path = get_data_folder(haverkamp_dataset)
 
+bonan_sand_dataset = ArtifactWrapper(
+    @__DIR__,
+    isempty(get(ENV, "CI", "")),
+    "richards_sand",
+    ArtifactFile[ArtifactFile(
+        url = "https://caltech.box.com/shared/static/2vk7bvyjah8xd5b7wxcqy72yfd2myjss.csv",
+        filename = "sand_bonan_sp801.csv",
+    ),],
+)
+bonan_sand_dataset_path = get_data_folder(bonan_sand_dataset)
+
 @testset "Richard's equation - Haverkamp test" begin
     ClimateMachine.init()
     FT = Float64
@@ -129,6 +140,108 @@ haverkamp_dataset_path = get_data_folder(haverkamp_dataset)
 
     # Compare with Bonan simulation data at 1 day.
     data = joinpath(haverkamp_dataset_path, "bonan_haverkamp_data.csv")
+    ds_bonan = readdlm(data, ',')
+    bonan_moisture = reverse(ds_bonan[:, 1])
+    bonan_z = reverse(ds_bonan[:, 2]) ./ 100.0
+
+
+    # Create an interpolation from the Bonan data
+    bonan_moisture_continuous = Spline1D(bonan_z, bonan_moisture)
+    bonan_at_clima_z = bonan_moisture_continuous.(z)
+    MSE = mean((bonan_at_clima_z .- ϑ_l) .^ 2.0)
+    @test MSE < 1e-5
+end
+
+
+
+@testset "Richard's equation - Sand van Genuchten test" begin
+    ClimateMachine.init()
+    FT = Float64
+
+    function init_soil_water!(land, state, aux, localgeo, time)
+        myfloat = eltype(aux)
+        state.soil.water.ϑ_l = myfloat(land.soil.water.initialϑ_l(aux))
+        state.soil.water.θ_i = myfloat(land.soil.water.initialθ_i(aux))
+    end
+
+    soil_heat_model = PrescribedTemperatureModel()
+
+    soil_param_functions = SoilParamFunctions{FT}(
+        porosity = 0.287,
+        Ksat = 34 / (3600 * 100),
+        θ_r = 0.075,
+    )
+    # Keep in mind that what is passed is aux⁻.
+    # Scalar fluxes are multiplied by ẑ (normal to the surface, -normal to the bottom,
+    # where normal point outs of the domain.)
+    surface_state = (aux, t) -> eltype(aux)(0.267)
+    bottom_flux = (aux, t) -> aux.soil.water.K * eltype(aux)(-1)
+    ϑ_l0 = (aux) -> eltype(aux)(0.1)
+
+    bc = LandDomainBC(
+        bottom_bc = LandComponentBC(soil_water = Neumann(bottom_flux)),
+        surface_bc = LandComponentBC(soil_water = Dirichlet(surface_state)),
+    )
+
+    soil_water_model = SoilWaterModel(
+        FT;
+        moisture_factor = MoistureDependent{FT}(),
+        hydraulics = vanGenuchten{FT}(; n = 3.96, α = 2.7),
+        initialϑ_l = ϑ_l0,
+    )
+
+    m_soil = SoilModel(soil_param_functions, soil_water_model, soil_heat_model)
+    sources = ()
+    m = LandModel(
+        param_set,
+        m_soil;
+        boundary_conditions = bc,
+        source = sources,
+        init_state_prognostic = init_soil_water!,
+    )
+
+
+    N_poly = 1
+    nelem_vert = 150
+
+    # Specify the domain boundaries
+    zmax = FT(0)
+    zmin = FT(-1.5)
+
+    driver_config = ClimateMachine.SingleStackConfiguration(
+        "LandModel",
+        N_poly,
+        nelem_vert,
+        zmax,
+        param_set,
+        m;
+        zmin = zmin,
+        numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
+    )
+
+    t0 = FT(0)
+    timeend = FT(60 * 60 * 0.8)
+
+    dt = FT(0.5)
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        ode_dt = dt,
+    )
+    mygrid = solver_config.dg.grid
+    Q = solver_config.Q
+    aux = solver_config.dg.state_auxiliary
+
+    ClimateMachine.invoke!(solver_config)
+    ϑ_l_ind = varsindex(vars_state(m, Prognostic(), FT), :soil, :water, :ϑ_l)
+    ϑ_l = Array(Q[:, ϑ_l_ind, :][:])
+    z_ind = varsindex(vars_state(m, Auxiliary(), FT), :z)
+    z = Array(aux[:, z_ind, :][:])
+
+    # Compare with Bonan simulation data at 0.8 h
+    data = joinpath(bonan_sand_dataset_path, "sand_bonan_sp801.csv")
     ds_bonan = readdlm(data, ',')
     bonan_moisture = reverse(ds_bonan[:, 1])
     bonan_z = reverse(ds_bonan[:, 2]) ./ 100.0


### PR DESCRIPTION
### Description
This adds in the residual water content parameter. In our planned LSMs, we will set this to zero, but it is useful to have for comparisons to other benchmarks and experiments (which do not set it to zero). Because of this, we added it in as a soil model parameter, but the default is zero.

There was an issue with the formatter and this file: .dev/clima_formatter_default_image.jl. We turned the formatter off for that file.
- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
