### PR TITLE
Move turbulence and turbconv to atmos.physics

### DIFF
--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -342,7 +342,7 @@ function init_bomex!(problem, bl, state, aux, localgeo, t)
     end
 
     add_perturbations!(state, localgeo)
-    init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
+    init_state_prognostic!(turbconv_model(bl), bl, state, aux, localgeo, t)
 end
 
 function bomex_model(

--- a/experiments/AtmosLES/convective_bl_model.jl
+++ b/experiments/AtmosLES/convective_bl_model.jl
@@ -167,7 +167,7 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     if z <= FT(400) # Add random perturbations to bottom 400m of model
         state.energy.ρe += rand() * ρe_tot / 100
     end
-    init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
+    init_state_prognostic!(turbconv_model(bl), bl, state, aux, localgeo, t)
 end
 
 function surface_temperature_variation(bl, state, t)

--- a/experiments/AtmosLES/ekman_layer_model.jl
+++ b/experiments/AtmosLES/ekman_layer_model.jl
@@ -157,7 +157,7 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
     state.ρu = SVector(ρu, ρv, ρw)
     state.energy.ρe = ρe_tot
     add_perturbations!(state, localgeo)
-    init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
+    init_state_prognostic!(turbconv_model(bl), bl, state, aux, localgeo, t)
 end
 
 function ekman_layer_model(

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -176,7 +176,7 @@ function init_problem!(problem, bl, state, aux, localgeo, t)
         state.moisture.ρq_tot = ρ * q_tot
     end
     add_perturbations!(state, localgeo)
-    init_state_prognostic!(bl.turbconv, bl, state, aux, localgeo, t)
+    init_state_prognostic!(turbconv_model(bl), bl, state, aux, localgeo, t)
 end
 
 function surface_temperature_variation(state, t)

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -11,6 +11,7 @@ export AtmosModel,
     Anelastic1D,
     reference_state,
     compressibility_model,
+    turbulence_model,
     parameter_set
 
 using UnPack
@@ -119,18 +120,21 @@ An `AtmosPhysics` for atmospheric physics
         param_set,
         ref_state,
         compressibility,
+        turbulence,
     )
 
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AtmosPhysics{FT, PS, RS, C}
+struct AtmosPhysics{FT, PS, RS, C, T}
     "Parameter Set (type to dispatch on, e.g., planet parameters. See CLIMAParameters.jl package)"
     param_set::PS
     "Reference State (For initial conditions, or for linearisation when using implicit solvers)"
     ref_state::RS
     "Compressibility switch"
     compressibility::C
+    "Turbulence Closure (Equations for dynamics of under-resolved turbulent flows)"
+    turbulence::T
 end
 
 """
@@ -145,7 +149,6 @@ default values for each field.
         physics,
         problem,
         orientation,
-        turbulence,
         hyperdiffusion,
         spongelayer,
         moisture,
@@ -159,7 +162,7 @@ default values for each field.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct AtmosModel{FT, PH, PR, O, E, T, TC, HD, VS, M, P, R, S, TR, LF, DC} <:
+struct AtmosModel{FT, PH, PR, O, E, TC, HD, VS, M, P, R, S, TR, LF, DC} <:
        BalanceLaw
     "Atmospheric physics"
     physics::PH
@@ -169,8 +172,6 @@ struct AtmosModel{FT, PH, PR, O, E, T, TC, HD, VS, M, P, R, S, TR, LF, DC} <:
     orientation::O
     "Energy sub-model, can be energy-based or θ_liq_ice-based"
     energy::E
-    "Turbulence Closure (Equations for dynamics of under-resolved turbulent flows)"
-    turbulence::T
     "Turbulence Convection Closure (e.g., EDMF)"
     turbconv::TC
     "Hyperdiffusion Model (Equations for dynamics of high-order spatial wave attenuation)"
@@ -196,6 +197,7 @@ end
 parameter_set(atmos::AtmosModel) = atmos.physics.param_set
 compressibility_model(atmos::AtmosModel) = atmos.physics.compressibility
 reference_state(atmos::AtmosModel) = atmos.physics.ref_state
+turbulence_model(atmos::AtmosModel) = atmos.physics.turbulence
 
 abstract type Compressibilty end
 
@@ -259,13 +261,12 @@ function AtmosModel{FT}(
     data_config = nothing,
 ) where {FT <: AbstractFloat}
 
-    phys_args = (param_set, ref_state, compressibility)
+    phys_args = (param_set, ref_state, compressibility, turbulence)
     atmos = (
         AtmosPhysics{FT, typeof.(phys_args)...}(phys_args...),
         problem,
         orientation,
         energy,
-        turbulence,
         turbconv,
         hyperdiffusion,
         viscoussponge,
@@ -327,7 +328,7 @@ function vars_state(m::AtmosModel, st::Prognostic, FT)
         ρ::FT
         ρu::SVector{3, FT}
         energy::vars_state(m.energy, st, FT) # TODO: adjust linearmodel
-        turbulence::vars_state(m.turbulence, st, FT)
+        turbulence::vars_state(turbulence_model(m), st, FT)
         hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
         moisture::vars_state(m.moisture, st, FT)
         # end of inclusion in `AtmosLinearModel`
@@ -358,7 +359,7 @@ function vars_state(m::AtmosModel, st::Gradient, FT)
     @vars begin
         u::SVector{3, FT}
         energy::vars_state(m.energy, st, FT)
-        turbulence::vars_state(m.turbulence, st, FT)
+        turbulence::vars_state(turbulence_model(m), st, FT)
         turbconv::vars_state(m.turbconv, st, FT)
         hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
         moisture::vars_state(m.moisture, st, FT)
@@ -376,7 +377,7 @@ Post-transform gradient variables.
 function vars_state(m::AtmosModel, st::GradientFlux, FT)
     @vars begin
         energy::vars_state(m.energy, st, FT)
-        turbulence::vars_state(m.turbulence, st, FT)
+        turbulence::vars_state(turbulence_model(m), st, FT)
         turbconv::vars_state(m.turbconv, st, FT)
         hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
         moisture::vars_state(m.moisture, st, FT)
@@ -422,7 +423,7 @@ function vars_state(m::AtmosModel, st::Auxiliary, FT)
         coord::SVector{3, FT}
         orientation::vars_state(m.orientation, st, FT)
         ref_state::vars_state(reference_state(m), st, FT)
-        turbulence::vars_state(m.turbulence, st, FT)
+        turbulence::vars_state(turbulence_model(m), st, FT)
         turbconv::vars_state(m.turbconv, st, FT)
         hyperdiffusion::vars_state(m.hyperdiffusion, st, FT)
         moisture::vars_state(m.moisture, st, FT)
@@ -469,7 +470,7 @@ gravitational_potential(bl, aux) = gravitational_potential(bl.orientation, aux)
     ∇gravitational_potential(bl.orientation, aux)
 
 turbulence_tensors(atmos::AtmosModel, args...) =
-    turbulence_tensors(atmos.turbulence, atmos, args...)
+    turbulence_tensors(turbulence_model(atmos), atmos, args...)
 
 """
     density(atmos::AtmosModel, state::Vars, aux::Vars)
@@ -580,7 +581,13 @@ function compute_gradient_argument!(
     compute_gradient_argument!(atmos.energy, atmos, transform, state, aux, t)
     compute_gradient_argument!(atmos.moisture, transform, state, aux, t)
     compute_gradient_argument!(atmos.precipitation, transform, state, aux, t)
-    compute_gradient_argument!(atmos.turbulence, transform, state, aux, t)
+    compute_gradient_argument!(
+        turbulence_model(atmos),
+        transform,
+        state,
+        aux,
+        t,
+    )
     compute_gradient_argument!(
         atmos.hyperdiffusion,
         atmos,
@@ -606,7 +613,7 @@ function compute_gradient_flux!(
 
     # diffusion terms required for SGS turbulence computations
     compute_gradient_flux!(
-        atmos.turbulence,
+        turbulence_model(atmos),
         atmos.orientation,
         diffusive,
         ∇transform,
@@ -812,7 +819,7 @@ function atmos_nodal_init_state_auxiliary!(
     geom::LocalGeometry,
 )
     aux.coord = geom.coord
-    init_aux_turbulence!(m.turbulence, m, aux, geom)
+    init_aux_turbulence!(turbulence_model(m), m, aux, geom)
     init_aux_hyperdiffusion!(m.hyperdiffusion, m, aux, geom)
     atmos_init_aux!(m.tracers, m, aux, geom)
     init_aux_turbconv!(m.turbconv, m, aux, geom)

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -7,7 +7,7 @@
 #####
 
 eq_tends(pv::AbstractPrognosticVariable, m::AtmosModel, tt::Source) =
-    (m.source[pv]..., eq_tends(pv, m.turbconv, tt)...)
+    (m.source[pv]..., eq_tends(pv, turbconv_model(m), tt)...)
 
 #####
 ##### First order fluxes
@@ -80,7 +80,7 @@ eq_tends(pv::Mass, m::AtmosModel, tt::Flux{SecondOrder}) =
 eq_tends(pv::Momentum, m::AtmosModel, tt::Flux{SecondOrder}) = (
     ViscousStress(),
     eq_tends(pv, m.moisture, tt)...,
-    eq_tends(pv, m.turbconv, tt)...,
+    eq_tends(pv, turbconv_model(m), tt)...,
     eq_tends(pv, m.hyperdiffusion, tt)...,
 )
 
@@ -92,14 +92,14 @@ eq_tends(::ρθ_liq_ice, m::θModel, tt::Flux{SecondOrder}) = (ViscousFlux(),)
 
 eq_tends(pv::AbstractEnergyVariable, m::AtmosModel, tt::Flux{SecondOrder}) = (
     eq_tends(pv, m.energy, tt)...,
-    eq_tends(pv, m.turbconv, tt)...,
+    eq_tends(pv, turbconv_model(m), tt)...,
     eq_tends(pv, m.hyperdiffusion, tt)...,
 )
 
 # AbstractMoistureVariable
 eq_tends(pv::AbstractMoistureVariable, m::AtmosModel, tt::Flux{SecondOrder}) = (
     eq_tends(pv, m.moisture, tt)...,
-    eq_tends(pv, m.turbconv, tt)...,
+    eq_tends(pv, turbconv_model(m), tt)...,
     eq_tends(pv, m.hyperdiffusion, tt)...,
 )
 

--- a/src/Atmos/Model/get_prognostic_vars.jl
+++ b/src/Atmos/Model/get_prognostic_vars.jl
@@ -22,7 +22,7 @@ prognostic_vars(m::AtmosModel) = (
     prognostic_vars(m.moisture)...,
     prognostic_vars(m.precipitation)...,
     prognostic_vars(m.tracers)...,
-    prognostic_vars(m.turbconv)...,
+    prognostic_vars(turbconv_model(m))...,
 )
 
 get_prog_state(state, ::Mass) = (state, :ρ)

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -106,7 +106,7 @@ function vars_state(lm::AtmosLinearModel, st::Prognostic, FT)
         ρ::FT
         ρu::SVector{3, FT}
         energy::vars_state(lm.atmos.energy, st, FT)
-        turbulence::vars_state(lm.atmos.turbulence, st, FT)
+        turbulence::vars_state(turbulence_model(lm.atmos), st, FT)
         hyperdiffusion::vars_state(lm.atmos.hyperdiffusion, st, FT)
         moisture::vars_state(lm.atmos.moisture, st, FT)
     end

--- a/src/Atmos/Model/prog_prim_conversion.jl
+++ b/src/Atmos/Model/prog_prim_conversion.jl
@@ -25,7 +25,13 @@ function prognostic_to_primitive!(
     atmos.energy isa TotalEnergyModel ||
         error("TotalEnergyModel only supported")
     prognostic_to_primitive!(atmos, atmos.moisture, prim, prog, aux)
-    prognostic_to_primitive!(atmos.turbconv, atmos, atmos.moisture, prim, prog)
+    prognostic_to_primitive!(
+        turbconv_model(atmos),
+        atmos,
+        atmos.moisture,
+        prim,
+        prog,
+    )
 end
 
 """
@@ -45,7 +51,13 @@ function primitive_to_prognostic!(
     aux,
 )
     primitive_to_prognostic!(atmos, atmos.moisture, prog, prim, aux)
-    primitive_to_prognostic!(atmos.turbconv, atmos, atmos.moisture, prog, prim)
+    primitive_to_prognostic!(
+        turbconv_model(atmos),
+        atmos,
+        atmos.moisture,
+        prog,
+        prim,
+    )
 end
 
 ####

--- a/test/Atmos/EDMF/closures/entr_detr.jl
+++ b/test/Atmos/EDMF/closures/entr_detr.jl
@@ -9,8 +9,9 @@ function entr_detr(
     env,
     buoy,
 ) where {FT}
-    EΔ_up = vuntuple(n_updrafts(bl.turbconv)) do i
-        entr_detr(bl, bl.turbconv.entr_detr, state, aux, ts_up, ts_en, env, buoy, i)
+    turbconv = turbconv_model(bl)
+    EΔ_up = vuntuple(n_updrafts(turbconv)) do i
+        entr_detr(bl, turbconv.entr_detr, state, aux, ts_up, ts_en, env, buoy, i)
     end
     E_dyn, Δ_dyn, E_trb = ntuple(i -> map(x -> x[i], EΔ_up), 3)
     return E_dyn, Δ_dyn, E_trb
@@ -60,8 +61,8 @@ function entr_detr(
     up = state.turbconv.updraft
     en_aux = aux.turbconv.environment
     up_aux = aux.turbconv.updraft
-
-    N_up = n_updrafts(m.turbconv)
+    turbconv = turbconv_model(m)
+    N_up = n_updrafts(turbconv)
     ρ_inv = 1 / gm.ρ
     a_up_i = up[i].ρa * ρ_inv
     lim_E = entr.lim_ϵ
@@ -91,13 +92,13 @@ function entr_detr(
     Λ_tke = entr.c_λ * abs(Δb / (max(en.ρatke * ρ_inv, 0) + w_min))
     λ = lamb_smooth_minimum(
         SVector(Λ_w, Λ_tke),
-        m.turbconv.mix_len.smin_ub,
-        m.turbconv.mix_len.smin_rm,
+        turbconv.mix_len.smin_ub,
+        turbconv.mix_len.smin_rm,
     )
 
     # compute entrainment/detrainment components
     # TO DO: Add updraft height dependency (non-local)
-    E_trb = 2 * up[i].ρa * entr.c_t * sqrt_tke / m.turbconv.pressure.H_up_min
+    E_trb = 2 * up[i].ρa * entr.c_t * sqrt_tke / turbconv.pressure.H_up_min
     E_dyn = up[i].ρa * λ * (D_E + M_E)
     Δ_dyn = up[i].ρa * λ * (D_δ + M_δ)
 

--- a/test/Atmos/EDMF/closures/mixing_length.jl
+++ b/test/Atmos/EDMF/closures/mixing_length.jl
@@ -33,13 +33,13 @@ function mixing_length(
 ) where {FT}
     @unpack state, aux, diffusive, t = args
     # TODO: use functions: obukhov_length, ustar, ϕ_m
-
+    turbconv = turbconv_model(m)
     # Alias convention:
     gm = state
     en = state.turbconv.environment
     up = state.turbconv.updraft
     gm_aux = aux
-    N_up = n_updrafts(m.turbconv)
+    N_up = n_updrafts(turbconv)
 
     z = altitude(m, aux)
     param_set = parameter_set(m)
@@ -51,8 +51,8 @@ function mixing_length(
 
     # buoyancy related functions
     # compute obukhov_length and ustar from SurfaceFlux.jl here
-    ustar = m.turbconv.surface.ustar
-    obukhov_length = m.turbconv.surface.obukhov_length
+    ustar = turbconv.surface.ustar
+    obukhov_length = turbconv.surface.obukhov_length
 
     ∂b∂z, Nˢ_eff = compute_buoyancy_gradients(m, args, ts_gm, ts_en)
     Grad_Ri = ∇Richardson_number(∂b∂z, Shear², 1 / ml.max_length, ml.Ri_c)
@@ -65,9 +65,9 @@ function mixing_length(
 
     # compute L2 - law of the wall
     # TODO: use zLL from altitude
-    surf_vals = subdomain_surface_values(m, gm, gm_aux, m.turbconv.surface.zLL)
+    surf_vals = subdomain_surface_values(m, gm, gm_aux, turbconv.surface.zLL)
 
-    L_W = ml.κ * max(z, 5) / (sqrt(m.turbconv.surface.κ_star²) * ml.c_m)
+    L_W = ml.κ * max(z, 5) / (sqrt(turbconv.surface.κ_star²) * ml.c_m)
     if obukhov_length < -eps(FT)
         L_W *= min((FT(1) - ml.a2 * z / obukhov_length)^ml.a1, 1 / ml.κ)
     end

--- a/test/Atmos/EDMF/closures/pressure.jl
+++ b/test/Atmos/EDMF/closures/pressure.jl
@@ -1,8 +1,8 @@
 #### Pressure model kernels
 
 function perturbation_pressure(bl::AtmosModel{FT}, args, env, buoy) where {FT}
-    dpdz = vuntuple(n_updrafts(bl.turbconv)) do i
-        perturbation_pressure(bl, bl.turbconv.pressure, args, env, buoy, i)
+    dpdz = vuntuple(n_updrafts(turbconv_model(bl))) do i
+        perturbation_pressure(bl, turbconv_model(bl).pressure, args, env, buoy, i)
     end
     return dpdz
 end

--- a/test/Atmos/EDMF/closures/surface_functions.jl
+++ b/test/Atmos/EDMF/closures/surface_functions.jl
@@ -27,14 +27,8 @@ function subdomain_surface_values(
     aux::Vars,
     zLL,
 )
-    subdomain_surface_values(
-        atmos.turbconv.surface,
-        atmos.turbconv,
-        atmos,
-        state,
-        aux,
-        zLL,
-    )
+    turbconv = turbconv_model(atmos)
+    subdomain_surface_values(turbconv.surface, turbconv, atmos, state, aux, zLL)
 end
 
 function subdomain_surface_values(
@@ -46,7 +40,7 @@ function subdomain_surface_values(
     zLL::FT,
 ) where {FT}
 
-    turbconv = atmos.turbconv
+    turbconv = turbconv_model(atmos)
     N_up = n_updrafts(turbconv)
     gm = state
     # TODO: change to new_thermo_state

--- a/test/Atmos/EDMF/closures/turbulence_functions.jl
+++ b/test/Atmos/EDMF/closures/turbulence_functions.jl
@@ -44,7 +44,7 @@ function compute_buoyancy_gradients(
     # Alias convention:
     gm = state
     en_dif = diffusive.turbconv.environment
-    N_up = n_updrafts(m.turbconv)
+    N_up = n_updrafts(turbconv_model(m))
     param_set = parameter_set(m)
 
     _grav::FT = grav(param_set)

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -153,7 +153,7 @@ end
 
 function vars_state(m::EDMF, st::GradientFlux, FT)
     @vars(
-        S²::FT, # should be conditionally grabbed from atmos.turbulence
+        S²::FT, # should be conditionally grabbed from turbulence_model(atmos)
         environment::vars_state(m.environment, st, FT),
         updraft::vars_state(m.updraft, st, FT),
         ∇u::SVector{3, FT},

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -241,7 +241,7 @@ eq_tends(
 
 # Turbconv tendencies
 eq_tends(pv::EDMFPrognosticVariable, m::AtmosModel, tt::Flux{O}) where {O} =
-    eq_tends(pv, m.turbconv, tt)
+    eq_tends(pv, turbconv_model(m), tt)
 
 eq_tends(::EDMFPrognosticVariable, m::EDMF, ::Flux{O}) where {O} = ()
 
@@ -485,9 +485,10 @@ function compute_gradient_flux!(
 
     E_dyn, Δ_dyn, E_trb = entr_detr(m, state, aux, ts.up, ts.en, env, buoy)
 
+    turbconv = turbconv_model(m)
     en_dif.l_mix, ∂b∂z_env, Pr_t = mixing_length(
         m,
-        m.turbconv.mix_len,
+        turbconv.mix_len,
         args,
         Δ_dyn,
         E_trb,
@@ -496,9 +497,9 @@ function compute_gradient_flux!(
         env,
     )
 
-    en_dif.K_m = m.turbconv.mix_len.c_m * en_dif.l_mix * sqrt(tke_en)
+    en_dif.K_m = turbconv.mix_len.c_m * en_dif.l_mix * sqrt(tke_en)
     K_h = en_dif.K_m / Pr_t
-    Diss₀ = m.turbconv.mix_len.c_d * sqrt(tke_en) / en_dif.l_mix
+    Diss₀ = turbconv.mix_len.c_d * sqrt(tke_en) / en_dif.l_mix
 
     en_dif.shear_prod = ρa₀ * en_dif.K_m * gm_dif.S² # tke Shear source
     en_dif.buoy_prod = -ρa₀ * K_h * ∂b∂z_env   # tke Buoyancy source
@@ -547,7 +548,7 @@ function source(::en_ρatke, ::EntrDetr, atmos, args)
     up = state.turbconv.updraft
     en = state.turbconv.environment
     gm = state
-    N_up = n_updrafts(atmos.turbconv)
+    N_up = n_updrafts(turbconv_model(atmos))
     ρ_inv = 1 / gm.ρ
     tke_en = enforce_positivity(en.ρatke) * ρ_inv / env.a
 
@@ -568,7 +569,7 @@ function source(::en_ρaθ_liq_cv, ::EntrDetr, atmos, args)
     ts_gm = args.precomputed.ts
     up = state.turbconv.updraft
     en = state.turbconv.environment
-    N_up = n_updrafts(atmos.turbconv)
+    N_up = n_updrafts(turbconv_model(atmos))
     θ_liq = liquid_ice_pottemp(ts_gm)
     θ_liq_en = liquid_ice_pottemp(ts_en)
 
@@ -597,7 +598,7 @@ function source(::en_ρaq_tot_cv, ::EntrDetr, atmos, args)
     up = state.turbconv.updraft
     en = state.turbconv.environment
     gm = state
-    N_up = n_updrafts(atmos.turbconv)
+    N_up = n_updrafts(turbconv_model(atmos))
     q_tot_en = total_specific_humidity(ts_en)
     ρ_inv = 1 / gm.ρ
     ρq_tot = atmos.moisture isa DryModel ? FT(0) : gm.moisture.ρq_tot
@@ -628,7 +629,7 @@ function source(::en_ρaθ_liq_q_tot_cv, ::EntrDetr, atmos, args)
     up = state.turbconv.updraft
     en = state.turbconv.environment
     gm = state
-    N_up = n_updrafts(atmos.turbconv)
+    N_up = n_updrafts(turbconv_model(atmos))
     q_tot_en = total_specific_humidity(ts_en)
     θ_liq = liquid_ice_pottemp(ts_gm)
     θ_liq_en = liquid_ice_pottemp(ts_en)
@@ -656,7 +657,7 @@ end
 function source(::en_ρatke, ::PressSource, atmos, args)
     @unpack env, ρa_up, dpdz, w_up = args.precomputed.turbconv
     up = args.state.turbconv.updraft
-    N_up = n_updrafts(atmos.turbconv)
+    N_up = n_updrafts(turbconv_model(atmos))
     press_tke = vuntuple(N_up) do i
         fix_void_up(ρa_up[i], ρa_up[i] * (w_up[i] - env.w) * dpdz[i])
     end
@@ -741,7 +742,7 @@ end
 
 function compute_ρa_up(atmos, state, aux)
     # Aliases:
-    turbconv = atmos.turbconv
+    turbconv = turbconv_model(atmos)
     gm = state
     up = state.turbconv.updraft
     N_up = n_updrafts(turbconv)
@@ -818,11 +819,12 @@ end
 function precompute(::EDMF, bl, args, ts, ::Flux{FirstOrder})
     @unpack state, aux = args
     FT = eltype(state)
-    env = environment_vars(state, n_updrafts(bl.turbconv))
+    turbconv = turbconv_model(bl)
+    env = environment_vars(state, n_updrafts(turbconv))
     ρa_up = compute_ρa_up(bl, state, aux)
     up = state.turbconv.updraft
     gm = state
-    N_up = n_updrafts(bl.turbconv)
+    N_up = n_updrafts(turbconv)
     ρ_inv = 1 / gm.ρ
     w_up = vuntuple(N_up) do i
         fix_void_up(ρa_up[i], up[i].ρaw / ρa_up[i])
@@ -849,7 +851,8 @@ function precompute(::EDMF, bl, args, ts, ::Flux{SecondOrder})
     @unpack state, aux, diffusive, t = args
     ts_gm = ts
     up = state.turbconv.updraft
-    N_up = n_updrafts(bl.turbconv)
+    turbconv = turbconv_model(bl)
+    N_up = n_updrafts(turbconv)
     env = environment_vars(state, N_up)
     ts_en = new_thermo_state_en(bl, bl.moisture, state, aux, ts_gm)
     ts_up = new_thermo_state_up(bl, bl.moisture, state, aux, ts_gm)
@@ -860,7 +863,7 @@ function precompute(::EDMF, bl, args, ts, ::Flux{SecondOrder})
 
     l_mix, ∂b∂z_env, Pr_t = mixing_length(
         bl,
-        bl.turbconv.mix_len,
+        turbconv.mix_len,
         args,
         Δ_dyn,
         E_trb,
@@ -872,7 +875,7 @@ function precompute(::EDMF, bl, args, ts, ::Flux{SecondOrder})
 
     en = state.turbconv.environment
     tke_en = enforce_positivity(en.ρatke) / env.a / state.ρ
-    K_m = bl.turbconv.mix_len.c_m * l_mix * sqrt(tke_en)
+    K_m = turbconv.mix_len.c_m * l_mix * sqrt(tke_en)
     K_h = K_m / Pr_t
     ρaw_up = vuntuple(i -> up[i].ρaw, N_up)
 
@@ -915,7 +918,7 @@ function compute_buoyancy(
 )
     FT = eltype(state)
     param_set = parameter_set(bl)
-    N_up = n_updrafts(bl.turbconv)
+    N_up = n_updrafts(turbconv_model(bl))
     _grav::FT = grav(param_set)
     gm = state
     ρ_inv = 1 / gm.ρ
@@ -945,7 +948,8 @@ function precompute(::EDMF, bl, args, ts, ::Source)
     ts_gm = ts
     gm = state
     up = state.turbconv.updraft
-    N_up = n_updrafts(bl.turbconv)
+    turbconv = turbconv_model(bl)
+    N_up = n_updrafts(turbconv)
     # Get environment variables
     env = environment_vars(state, N_up)
     # Recover thermo states
@@ -960,7 +964,7 @@ function precompute(::EDMF, bl, args, ts, ::Source)
 
     l_mix, ∂b∂z_env, Pr_t = mixing_length(
         bl,
-        bl.turbconv.mix_len,
+        turbconv.mix_len,
         args,
         Δ_dyn,
         E_trb,
@@ -975,9 +979,9 @@ function precompute(::EDMF, bl, args, ts, ::Source)
 
     en = state.turbconv.environment
     tke_en = enforce_positivity(en.ρatke) / env.a / state.ρ
-    K_m = bl.turbconv.mix_len.c_m * l_mix * sqrt(tke_en)
+    K_m = turbconv.mix_len.c_m * l_mix * sqrt(tke_en)
     K_h = K_m / Pr_t
-    Diss₀ = bl.turbconv.mix_len.c_d * sqrt(tke_en) / l_mix
+    Diss₀ = turbconv.mix_len.c_d * sqrt(tke_en) / l_mix
 
     return (;
         env,
@@ -1010,7 +1014,7 @@ function flux(::Energy, ::SGSFlux, atmos, args)
     up = state.turbconv.updraft
     gm = state
     ρ_inv = 1 / gm.ρ
-    N_up = n_updrafts(atmos.turbconv)
+    N_up = n_updrafts(turbconv_model(atmos))
     ρu_gm_tup = Tuple(gm.ρu)
 
     # TODO: Consider turbulent contribution:
@@ -1041,7 +1045,7 @@ function flux(::TotalMoisture, ::SGSFlux, atmos, args)
     up = state.turbconv.updraft
     gm = state
     ρ_inv = 1 / gm.ρ
-    N_up = n_updrafts(atmos.turbconv)
+    N_up = n_updrafts(turbconv_model(atmos))
     ρq_tot = atmos.moisture isa DryModel ? FT(0) : gm.moisture.ρq_tot
     ρaq_tot_up = vuntuple(i -> up[i].ρaq_tot, N_up)
 
@@ -1070,7 +1074,7 @@ function flux(::Momentum, ::SGSFlux, atmos, args)
     up = state.turbconv.updraft
     gm = state
     ρ_inv = 1 / gm.ρ
-    N_up = n_updrafts(atmos.turbconv)
+    N_up = n_updrafts(turbconv_model(atmos))
 
     ρu_gm_tup = Tuple(gm.ρu)
 
@@ -1142,7 +1146,7 @@ function turbconv_boundary_state!(
     args,
 ) where {FT}
     @unpack state⁻, aux⁻, aux_int⁻ = args
-    turbconv = atmos.turbconv
+    turbconv = turbconv_model(atmos)
     N_up = n_updrafts(turbconv)
     up⁺ = state⁺.turbconv.updraft
     en⁺ = state⁺.turbconv.environment
@@ -1182,7 +1186,7 @@ function turbconv_boundary_state!(
     state⁺::Vars,
     args,
 ) where {FT}
-    N_up = n_updrafts(atmos.turbconv)
+    N_up = n_updrafts(turbconv_model(atmos))
     up⁺ = state⁺.turbconv.updraft
     @unroll_map(N_up) do i
         up⁺[i].ρaw = FT(0)
@@ -1208,7 +1212,7 @@ function turbconv_normal_boundary_flux_second_order!(
     args,
 ) where {FT}
 
-    turbconv = atmos.turbconv
+    turbconv = turbconv_model(atmos)
     N_up = n_updrafts(turbconv)
     up_flx = fluxᵀn.turbconv.updraft
     en_flx = fluxᵀn.turbconv.environment

--- a/test/Atmos/EDMF/helper_funcs/nondimensional_exchange_functions.jl
+++ b/test/Atmos/EDMF/helper_funcs/nondimensional_exchange_functions.jl
@@ -44,7 +44,7 @@ function nondimensional_exchange_functions(
 
     # precompute vars
     w_min = entr.w_min
-    N_up = n_updrafts(m.turbconv)
+    N_up = n_updrafts(turbconv_model(m))
     ρinv = 1 / gm.ρ
     a_up_i = up[i].ρa * ρinv
     w_up_i = fix_void_up(up[i].ρa, up[i].ρaw / up[i].ρa)

--- a/test/Atmos/EDMF/helper_funcs/save_subdomain_temperature.jl
+++ b/test/Atmos/EDMF/helper_funcs/save_subdomain_temperature.jl
@@ -24,7 +24,7 @@ function save_subdomain_temperature!(
     state::Vars,
     aux::Vars,
 )
-    N_up = n_updrafts(m.turbconv)
+    N_up = n_updrafts(turbconv_model(m))
     ts = recover_thermo_state(m, state, aux)
     ts_up = new_thermo_state_up(m, state, aux, ts)
     ts_en = new_thermo_state_en(m, state, aux, ts)

--- a/test/Atmos/EDMF/helper_funcs/subdomain_statistics.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_statistics.jl
@@ -1,13 +1,15 @@
 #### Subdomain statistics
 
-compute_subdomain_statistics(m::AtmosModel, args, ts_gm, ts_en) =
-    compute_subdomain_statistics(
-        m.turbconv.micro_phys.statistical_model,
+function compute_subdomain_statistics(m::AtmosModel, args, ts_gm, ts_en)
+    turbconv = turbconv_model(m)
+    return compute_subdomain_statistics(
+        turbconv.micro_phys.statistical_model,
         m,
         args,
         ts_gm,
         ts_en,
     )
+end
 
 """
     compute_subdomain_statistics(

--- a/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
@@ -128,7 +128,7 @@ function new_thermo_state_up(
     aux::Vars,
     ts::ThermodynamicState,
 ) where {FT}
-    N_up = n_updrafts(m.turbconv)
+    N_up = n_updrafts(turbconv_model(m))
     up = state.turbconv.updraft
     p = air_pressure(ts)
     param_set = parameter_set(m)
@@ -151,7 +151,7 @@ function new_thermo_state_up(
     ts::ThermodynamicState,
 ) where {FT}
 
-    N_up = n_updrafts(m.turbconv)
+    N_up = n_updrafts(turbconv_model(m))
     up = state.turbconv.updraft
     p = air_pressure(ts)
     param_set = parameter_set(m)
@@ -179,7 +179,8 @@ function new_thermo_state_en(
     aux::Vars,
     ts::ThermodynamicState,
 )
-    N_up = n_updrafts(m.turbconv)
+    turbconv = turbconv_model(m)
+    N_up = n_updrafts(turbconv)
     up = state.turbconv.updraft
 
     # diagnose environment thermo state
@@ -188,8 +189,8 @@ function new_thermo_state_en(
     θ_liq = liquid_ice_pottemp(ts)
     a_en = environment_area(state, N_up)
     θ_liq_en = (θ_liq - sum(vuntuple(j -> up[j].ρaθ_liq * ρ_inv, N_up))) / a_en
-    a_min = m.turbconv.subdomains.a_min
-    a_max = m.turbconv.subdomains.a_max
+    a_min = turbconv.subdomains.a_min
+    a_max = turbconv.subdomains.a_max
     param_set = parameter_set(m)
     if !(0 <= θ_liq_en)
         @print("ρaθ_liq_up = ", up[Val(1)].ρaθ_liq, "\n")
@@ -208,7 +209,8 @@ function new_thermo_state_en(
     aux::Vars,
     ts::ThermodynamicState,
 )
-    N_up = n_updrafts(m.turbconv)
+    turbconv = turbconv_model(m)
+    N_up = n_updrafts(turbconv)
     up = state.turbconv.updraft
 
     # diagnose environment thermo state
@@ -219,8 +221,8 @@ function new_thermo_state_en(
     a_en = environment_area(state, N_up)
     θ_liq_en = (θ_liq - sum(vuntuple(j -> up[j].ρaθ_liq * ρ_inv, N_up))) / a_en
     q_tot_en = (q_tot - sum(vuntuple(j -> up[j].ρaq_tot * ρ_inv, N_up))) / a_en
-    a_min = m.turbconv.subdomains.a_min
-    a_max = m.turbconv.subdomains.a_max
+    a_min = turbconv.subdomains.a_min
+    a_max = turbconv.subdomains.a_max
     param_set = parameter_set(m)
     if !(0 <= θ_liq_en)
         @print("θ_liq_en = ", θ_liq_en, "\n")


### PR DESCRIPTION
### Description

This PR moves `atmos.turbulence` and `atmos.turbconv` to `atmos.physics` and adds a getter methods.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
