### PR TITLE
Add `--start-datetime` and `ClimateMachine.datetime()`

### DIFF
--- a/docs/src/APIs/Driver/index.md
+++ b/docs/src/APIs/Driver/index.md
@@ -35,6 +35,7 @@ ConservationCheck
 
 ```@docs
 array_type
+datetime
 init
 invoke!
 ```

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -75,6 +75,15 @@ function ArgParse.parse_item(::Type{NTuple{3, Float64}}, s::AbstractString)
 end
 
 """
+    ArgParse.parse_item
+
+Parses custom command line option for `DateTime`s.
+"""
+function ArgParse.parse_item(::Type{DateTime}, s::AbstractString)
+    DateTime(s, "yyyy-mm-ddTHH:MM:SS")
+end
+
+"""
     get_polyorders
 
 Utility function that gets the polynomial orders for the given configuration

--- a/src/Numerics/ODESolvers/ODESolvers.jl
+++ b/src/Numerics/ODESolvers/ODESolvers.jl
@@ -13,7 +13,7 @@ using ..SystemSolvers
 using ..MPIStateArrays: array_device, realview
 using ..GenericCallbacks
 
-export solve!, updatedt!, gettime, getsteps
+export AbstractODESolver, solve!, updatedt!, gettime, getsteps
 
 abstract type AbstractODESolver end
 


### PR DESCRIPTION
### Description

<!-- Provide a clear description of the content -->
Needed for radiation (when Insolation.jl is added). Defaults to [`J2000`](https://en.wikipedia.org/wiki/Epoch_(astronomy)#Julian_dates_and_J2000).

<!-- Check all the boxes below before taking the PR out of draft -->

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
