### PR TITLE
Add boundary condition for hyperdiffusion in AtmosModel

### DIFF
--- a/src/Atmos/Model/bc_initstate.jl
+++ b/src/Atmos/Model/bc_initstate.jl
@@ -8,7 +8,7 @@ mainly useful for cases where the problem has an explicit solution.
 # TODO: This should be fixed later once BCs are figured out (likely want
 # different things here?)
 """
-struct InitStateBC end
+struct InitStateBC <: AbstractAtmosBC end
 function boundary_state!(
     ::Union{NumericalFluxFirstOrder, NumericalFluxGradient},
     bc::InitStateBC,
@@ -43,4 +43,13 @@ function boundary_state!(
 )
     # Put coord in a NamedTuple to mimmic LocalGeometry
     init_state_prognostic!(m, state⁺, aux⁺, (coord = aux⁺.coord,), t)
+end
+
+function boundary_state!(
+    nf::CentralNumericalFluxHigherOrder,
+    bc::InitStateBC,
+    m::AtmosModel,
+    x...,
+)
+    nothing
 end


### PR DESCRIPTION
Adds boundary conditions for hyperdiffusion in the AtmosModel. These should work with `InitStateBC` or impenetrable free-slip wall boundaries.

@akshaysridhar 


<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
