### PR TITLE
Move atmos components to atmos.physics

### DIFF
--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -239,7 +239,7 @@ function init_dycoms!(problem, bl, state, aux, localgeo, t)
         state.moisture.ρq_liq = q_init.liq
         state.moisture.ρq_ice = q_init.ice
     end
-    if bl.precipitation isa RainModel
+    if precipitation_model(bl) isa RainModel
         state.precipitation.ρq_rai = FT(0)
     end
 

--- a/experiments/AtmosLES/squall_line.jl
+++ b/experiments/AtmosLES/squall_line.jl
@@ -107,10 +107,10 @@ function init_squall_line!(problem, bl, state, aux, localgeo, t, args...)
         state.moisture.ρq_ice = FT(0)
     end
 
-    if bl.precipitation isa RainModel
+    if precipitation_model(bl) isa RainModel
         state.precipitation.ρq_rai = FT(0)
     end
-    if bl.precipitation isa RainSnowModel
+    if precipitation_model(bl) isa RainSnowModel
         state.precipitation.ρq_rai = FT(0)
         state.precipitation.ρq_sno = FT(0)
     end

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -81,7 +81,7 @@ eq_tends(pv::Momentum, m::AtmosModel, tt::Flux{SecondOrder}) = (
     ViscousStress(),
     eq_tends(pv, m.moisture, tt)...,
     eq_tends(pv, turbconv_model(m), tt)...,
-    eq_tends(pv, m.hyperdiffusion, tt)...,
+    eq_tends(pv, hyperdiffusion_model(m), tt)...,
 )
 
 # Energy
@@ -93,14 +93,14 @@ eq_tends(::ρθ_liq_ice, m::θModel, tt::Flux{SecondOrder}) = (ViscousFlux(),)
 eq_tends(pv::AbstractEnergyVariable, m::AtmosModel, tt::Flux{SecondOrder}) = (
     eq_tends(pv, m.energy, tt)...,
     eq_tends(pv, turbconv_model(m), tt)...,
-    eq_tends(pv, m.hyperdiffusion, tt)...,
+    eq_tends(pv, hyperdiffusion_model(m), tt)...,
 )
 
 # AbstractMoistureVariable
 eq_tends(pv::AbstractMoistureVariable, m::AtmosModel, tt::Flux{SecondOrder}) = (
     eq_tends(pv, m.moisture, tt)...,
     eq_tends(pv, turbconv_model(m), tt)...,
-    eq_tends(pv, m.hyperdiffusion, tt)...,
+    eq_tends(pv, hyperdiffusion_model(m), tt)...,
 )
 
 # AbstractPrecipitationVariable

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -51,7 +51,7 @@ eq_tends(
     pv::AbstractPrecipitationVariable,
     m::AtmosModel,
     tt::Flux{FirstOrder},
-) = (eq_tends(pv, m.precipitation, tt)...,)
+) = (eq_tends(pv, precipitation_model(m), tt)...,)
 
 # Tracers
 eq_tends(pv::Tracers{N}, ::AtmosModel, ::Flux{FirstOrder}) where {N} =
@@ -108,7 +108,7 @@ eq_tends(
     pv::AbstractPrecipitationVariable,
     m::AtmosModel,
     tt::Flux{SecondOrder},
-) = (eq_tends(pv, m.precipitation, tt)...,)
+) = (eq_tends(pv, precipitation_model(m), tt)...,)
 
 # Tracers
 eq_tends(pv::Tracers{N}, m::AtmosModel, tt::Flux{SecondOrder}) where {N} =

--- a/src/Atmos/Model/get_prognostic_vars.jl
+++ b/src/Atmos/Model/get_prognostic_vars.jl
@@ -20,7 +20,7 @@ prognostic_vars(m::AtmosModel) = (
     Momentum(),
     prognostic_vars(m.energy)...,
     prognostic_vars(m.moisture)...,
-    prognostic_vars(m.precipitation)...,
+    prognostic_vars(precipitation_model(m))...,
     prognostic_vars(m.tracers)...,
     prognostic_vars(turbconv_model(m))...,
 )

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -107,7 +107,7 @@ function vars_state(lm::AtmosLinearModel, st::Prognostic, FT)
         ρu::SVector{3, FT}
         energy::vars_state(lm.atmos.energy, st, FT)
         turbulence::vars_state(turbulence_model(lm.atmos), st, FT)
-        hyperdiffusion::vars_state(lm.atmos.hyperdiffusion, st, FT)
+        hyperdiffusion::vars_state(hyperdiffusion_model(lm.atmos), st, FT)
         moisture::vars_state(lm.atmos.moisture, st, FT)
     end
 end

--- a/src/Common/TurbulenceClosures/TurbulenceClosures.jl
+++ b/src/Common/TurbulenceClosures/TurbulenceClosures.jl
@@ -198,6 +198,7 @@ quantities.
 """
 function turbulence_tensors(
     m::TurbulenceClosureModel,
+    viscoussponge,
     bl::BalanceLaw,
     state,
     diffusive,
@@ -214,7 +215,7 @@ function turbulence_tensors(
         aux,
         t,
     )
-    ν, D_t, τ = sponge_viscosity_modifier(bl, bl.viscoussponge, ν, D_t, τ, aux)
+    ν, D_t, τ = sponge_viscosity_modifier(bl, viscoussponge, ν, D_t, τ, aux)
     return (ν, D_t, τ)
 end
 

--- a/src/Diagnostics/atmos_les_default.jl
+++ b/src/Diagnostics/atmos_les_default.jl
@@ -110,7 +110,7 @@ function vars_atmos_les_default_simple(m::AtmosModel, FT)
         w_ht_sgs::FT
 
         moisture::vars_atmos_les_default_simple(m.moisture, FT)
-        precipitation::vars_atmos_les_default_simple(m.precipitation, FT)
+        precipitation::vars_atmos_les_default_simple(precipitation_model(m), FT)
     end
 end
 vars_atmos_les_default_simple(::AbstractMoistureModel, FT) = @vars()
@@ -179,7 +179,7 @@ function atmos_les_default_simple_sums!(
         sums,
     )
     atmos_les_default_simple_sums!(
-        atmos.precipitation,
+        precipitation_model(atmos),
         state,
         gradflux,
         thermo,
@@ -309,7 +309,7 @@ function vars_atmos_les_default_ho(m::AtmosModel, FT)
         cov_w_ei::FT            # w′e_int′
 
         moisture::vars_atmos_les_default_ho(m.moisture, FT)
-        precipitation::vars_atmos_les_default_ho(m.precipitation, FT)
+        precipitation::vars_atmos_les_default_ho(precipitation_model(m), FT)
     end
 end
 vars_atmos_les_default_ho(::AbstractMoistureModel, FT) = @vars()
@@ -389,7 +389,7 @@ function atmos_les_default_ho_sums!(
         sums,
     )
     atmos_les_default_ho_sums!(
-        atmos.precipitation,
+        precipitation_model(atmos),
         state,
         thermo,
         MH,
@@ -665,11 +665,11 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
             ρq_liq_z[evk] += MH * thermo.moisture.q_liq * state.ρ * state.ρ
             ρq_ice_z[evk] += MH * thermo.moisture.q_ice * state.ρ * state.ρ
         end
-        if isa(atmos.precipitation, RainModel)
+        if isa(precipitation_model(atmos), RainModel)
             # for RWP
             ρq_rai_z[evk] += MH * state.precipitation.ρq_rai * state.ρ
         end
-        if isa(atmos.precipitation, RainSnowModel)
+        if isa(precipitation_model(atmos), RainSnowModel)
             # for RWP
             ρq_rai_z[evk] += MH * state.precipitation.ρq_rai * state.ρ
             # for SWP
@@ -703,14 +703,14 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
                 ρq_ice_z[evk] = tot_ρq_ice_z / MH_z[evk]
             end
         end
-        if isa(atmos.precipitation, RainModel)
+        if isa(precipitation_model(atmos), RainModel)
             # for RWP
             tot_ρq_rai_z = MPI.Reduce(ρq_rai_z[evk], +, 0, mpicomm)
             if mpirank == 0
                 ρq_rai_z[evk] = tot_ρq_rai_z / MH_z[evk]
             end
         end
-        if isa(atmos.precipitation, RainSnowModel)
+        if isa(precipitation_model(atmos), RainSnowModel)
             # for RWP and SWP
             tot_ρq_rai_z = MPI.Reduce(ρq_rai_z[evk], +, 0, mpicomm)
             tot_ρq_sno_z = MPI.Reduce(ρq_sno_z[evk], +, 0, mpicomm)
@@ -759,10 +759,10 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
             ρq_liq_z[evk] /= avg_rho
             ρq_ice_z[evk] /= avg_rho
         end
-        if isa(atmos.precipitation, RainModel)
+        if isa(precipitation_model(atmos), RainModel)
             ρq_rai_z[evk] /= avg_rho
         end
-        if isa(atmos.precipitation, RainSnowModel)
+        if isa(precipitation_model(atmos), RainSnowModel)
             ρq_rai_z[evk] /= avg_rho
             ρq_sno_z[evk] /= avg_rho
         end
@@ -849,10 +849,10 @@ function atmos_les_default_collect(dgngrp::DiagnosticsGroup, currtime)
             varvals["lwp"] = lwp
             varvals["iwp"] = iwp
         end
-        if isa(atmos.precipitation, RainModel)
+        if isa(precipitation_model(atmos), RainModel)
             varvals["rwp"] = rwp
         end
-        if isa(atmos.precipitation, RainSnowModel)
+        if isa(precipitation_model(atmos), RainSnowModel)
             varvals["rwp"] = rwp
             varvals["swp"] = swp
         end


### PR DESCRIPTION
### Description

This PR moves `hyperdiffusion`, `viscoussponge`, and `precipitation` from `atmos` to `atmos.physics`


<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
