### PR TITLE
Allow zero surface area fraction in EDMF 

### DIFF
--- a/test/Atmos/EDMF/closures/surface_functions.jl
+++ b/test/Atmos/EDMF/closures/surface_functions.jl
@@ -50,7 +50,7 @@ function subdomain_surface_values(
     lv = latent_heat_vapor(ts)
     Π = exner(ts)
     ρ_inv = 1 / gm.ρ
-    surface_scalar_coeff = turbconv.surface.scalar_coeff
+    upd_surface_std = turbconv.surface.upd_surface_std
 
     θ_liq_surface_flux = surf.shf / Π / _cp_m
     q_tot_surface_flux = surf.lhf / lv
@@ -74,12 +74,12 @@ function subdomain_surface_values(
     θ_liq = liquid_ice_pottemp(ts_new)
 
     θ_liq_up_surf = ntuple(N_up) do i
-        θ_liq + surface_scalar_coeff[i] * sqrt(max(θ_liq_cv, 0))
+        θ_liq + upd_surface_std[i] * sqrt(max(θ_liq_cv, 0))
     end
 
     ρq_tot = atmos.moisture isa DryModel ? FT(0) : gm.moisture.ρq_tot
     q_tot_up_surf = ntuple(N_up) do i
-        ρq_tot * ρ_inv + surface_scalar_coeff[i] * sqrt(max(q_tot_cv, 0))
+        ρq_tot * ρ_inv + upd_surface_std[i] * sqrt(max(q_tot_cv, 0))
     end
 
     return (;

--- a/test/Atmos/EDMF/ekman_layer.jl
+++ b/test/Atmos/EDMF/ekman_layer.jl
@@ -27,6 +27,7 @@ include("edmf_model.jl")
 include("edmf_kernels.jl")
 
 CLIMAParameters.Planet.T_surf_ref(::EarthParameterSet) = 290.0
+CLIMAParameters.Atmos.EDMF.a_surf(::EarthParameterSet) = 0.0
 function set_clima_parameters(filename)
     eval(:(include($filename)))
 end

--- a/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
+++ b/test/Atmos/EDMF/helper_funcs/subdomain_thermo_states.jl
@@ -188,12 +188,15 @@ function new_thermo_state_en(
     p = air_pressure(ts)
     θ_liq = liquid_ice_pottemp(ts)
     a_en = environment_area(state, N_up)
-    θ_liq_en = (θ_liq - sum(vuntuple(j -> up[j].ρaθ_liq * ρ_inv, N_up))) / a_en
+    ρaθ_liq_up = vuntuple(N_up) do i
+        fix_void_up(up[i].ρa, up[i].ρaθ_liq)
+    end
+    θ_liq_en = (θ_liq - sum(vuntuple(j -> ρaθ_liq_up[j] * ρ_inv, N_up))) / a_en
     a_min = turbconv.subdomains.a_min
     a_max = turbconv.subdomains.a_max
     param_set = parameter_set(m)
     if !(0 <= θ_liq_en)
-        @print("ρaθ_liq_up = ", up[Val(1)].ρaθ_liq, "\n")
+        @print("ρaθ_liq_up = ", ρaθ_liq_up[Val(1)], "\n")
         @print("θ_liq = ", θ_liq, "\n")
         @print("θ_liq_en = ", θ_liq_en, "\n")
         error("Environment θ_liq_en out-of-bounds in new_thermo_state_en")


### PR DESCRIPTION
### Description
This PR handles several issues needed for the EDMF to work as an ED only with zero updraft area everywhere. 
1) Allows zero area fraction at the surface to use the EMDF as ED only model 
It also renames the 'surface_scalar_coeff' to a clear name 'upd_surface_std' that reflects better on what it is used for.
2) adds fix_void_upd where the thermodynamic is using 
3) Sets the area fraction to zero in the ekman_layer EDMF driver 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.