### PR TITLE
Move more atmos components to `atmos.physics`

### DIFF
--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -99,7 +99,7 @@ eq_tends(pv::Energy, ::DYCOMSRadiationModel, ::Flux{FirstOrder}) =
 
 function flux(::Energy, ::DYCOMSRadiation, atmos, args)
     @unpack state, aux = args
-    m = atmos.radiation
+    m = radiation_model(atmos)
     FT = eltype(state)
     z = altitude(atmos, aux)
     Δz_i = max(z - m.z_i, -zero(FT))

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -38,9 +38,9 @@ eq_tends(::ρθ_liq_ice, m::θModel, tt::Flux{FirstOrder}) = (Advect(),)
 
 # TODO: make radiation aware of which energy formulation is used:
 # eq_tends(pv::PV, m::AtmosModel, tt::Flux{FirstOrder}) where {PV <: AbstractEnergyVariable} =
-#     (eq_tends(pv, m.energy, tt)..., eq_tends(pv, m.energy, m.radiation, tt)...)
+#     (eq_tends(pv, m.energy, tt)..., eq_tends(pv, m.energy, radiation_model(m), tt)...)
 eq_tends(pv::AbstractEnergyVariable, m::AtmosModel, tt::Flux{FirstOrder}) =
-    (eq_tends(pv, m.energy, tt)..., eq_tends(pv, m.radiation, tt)...)
+    (eq_tends(pv, m.energy, tt)..., eq_tends(pv, radiation_model(m), tt)...)
 
 # AbstractMoistureVariable
 eq_tends(::AbstractMoistureVariable, ::AtmosModel, ::Flux{FirstOrder}) =

--- a/src/Atmos/Model/atmos_tendencies.jl
+++ b/src/Atmos/Model/atmos_tendencies.jl
@@ -112,4 +112,4 @@ eq_tends(
 
 # Tracers
 eq_tends(pv::Tracers{N}, m::AtmosModel, tt::Flux{SecondOrder}) where {N} =
-    (eq_tends(pv, m.tracers, tt)...,)
+    (eq_tends(pv, tracer_model(m), tt)...,)

--- a/src/Atmos/Model/get_prognostic_vars.jl
+++ b/src/Atmos/Model/get_prognostic_vars.jl
@@ -21,7 +21,7 @@ prognostic_vars(m::AtmosModel) = (
     prognostic_vars(m.energy)...,
     prognostic_vars(m.moisture)...,
     prognostic_vars(precipitation_model(m))...,
-    prognostic_vars(m.tracers)...,
+    prognostic_vars(tracer_model(m))...,
     prognostic_vars(turbconv_model(m))...,
 )
 


### PR DESCRIPTION
### Description

This PR moves `radiation`, `tracers`, and `lsforcing` from `atmos` to `atmos.physics`.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
