### PR TITLE
Shear from precomputed args becomes negative

### DIFF
--- a/test/Atmos/EDMF/closures/mixing_length.jl
+++ b/test/Atmos/EDMF/closures/mixing_length.jl
@@ -112,5 +112,6 @@ function mixing_length(
 
     l_mix =
         lamb_smooth_minimum(SVector(L_Nˢ, L_W, L_tke), ml.smin_ub, ml.smin_rm)
+    l_mix = FT(5)
     return l_mix, ∂b∂z, Pr_t
 end;

--- a/test/Atmos/EDMF/closures/surface_functions.jl
+++ b/test/Atmos/EDMF/closures/surface_functions.jl
@@ -52,8 +52,8 @@ function subdomain_surface_values(
     ρ_inv = 1 / gm.ρ
     upd_surface_std = turbconv.surface.upd_surface_std
 
-    θ_liq_surface_flux = surf.shf / Π / _cp_m
-    q_tot_surface_flux = surf.lhf / lv
+    θ_liq_surface_flux = FT(0)
+    q_tot_surface_flux = FT(0)
     # these value should be given from the SurfaceFluxes.jl once it is merged
     oblength = turbconv.surface.obukhov_length
     ustar = turbconv.surface.ustar
@@ -62,11 +62,10 @@ function subdomain_surface_values(
     fact = unstable ? (1 - surf.ψϕ_stab * zLL / oblength)^(-FT(2 // 3)) : 1
     tke_fact = unstable ? cbrt(zLL / oblength * zLL / oblength) : 0
     ustar² = ustar^2
-    θ_liq_cv = 4 * (θ_liq_surface_flux * θ_liq_surface_flux) / (ustar²) * fact
-    q_tot_cv = 4 * (q_tot_surface_flux * q_tot_surface_flux) / (ustar²) * fact
-    θ_liq_q_tot_cv =
-        4 * (θ_liq_surface_flux * q_tot_surface_flux) / (ustar²) * fact
-    tke = ustar² * (surf.κ_star² + tke_fact)
+    θ_liq_cv = FT(0)
+    q_tot_cv = FT(0)
+    θ_liq_q_tot_cv = FT(0)
+    tke = FT(0.4)
 
     a_up_surf = ntuple(i -> FT(surf.a / N_up), N_up)
     e_int = internal_energy(atmos, state, aux)

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -255,7 +255,7 @@ eq_tends(pv::PV, m::EDMF, ::Source) where {PV} = ()
 eq_tends(::EDMFPrognosticVariable, m::EDMF, ::Source) = (EntrDetr(m),)
 
 eq_tends(pv::en_ρatke, m::EDMF, ::Source) = (ShearSource(),)
-    #(EntrDetr(m), PressSource(m), BuoySource(m), ShearSource(), DissSource())
+#(EntrDetr(m), PressSource(m), BuoySource(m), ShearSource(), DissSource())
 
 eq_tends(
     ::Union{en_ρaθ_liq_cv, en_ρaq_tot_cv, en_ρaθ_liq_q_tot_cv},

--- a/test/Atmos/EDMF/edmf_model.jl
+++ b/test/Atmos/EDMF/edmf_model.jl
@@ -88,7 +88,7 @@ end
 function SubdomainModel(
     ::Type{FT},
     N_up;
-    a_min::FT = 0.001,
+    a_min::FT = 0.0,
     a_max::FT = 1 - N_up * a_min,
 ) where {FT}
     return SubdomainModel(; a_min = a_min, a_max = a_max)

--- a/test/Atmos/EDMF/ekman_layer.jl
+++ b/test/Atmos/EDMF/ekman_layer.jl
@@ -96,9 +96,9 @@ function main(::Type{FT}, cl_args) where {FT}
 
     # Choice of SGS model
     turbconv = NoTurbConv()
-    # N_updrafts = 1
-    # N_quad = 3
-    # turbconv = EDMF(FT, N_updrafts, N_quad, param_set)
+    N_updrafts = 1
+    N_quad = 3
+    turbconv = EDMF(FT, N_updrafts, N_quad, param_set)
 
     C_smag_ = C_smag(param_set)
     turbulence = ConstantKinematicViscosity(FT(0.1))
@@ -108,7 +108,7 @@ function main(::Type{FT}, cl_args) where {FT}
     zmax = FT(400)
     # Simulation time
     t0 = FT(0)
-    timeend = FT(3600 * 2) # Change to 7h for low-level jet
+    timeend = FT(60) # Change to 7h for low-level jet
     CFLmax = compressibility == Compressible() ? FT(1) : FT(100)
 
     config_type = SingleStackConfigType
@@ -191,7 +191,7 @@ function main(::Type{FT}, cl_args) where {FT}
     cb_boyd = GenericCallbacks.EveryXSimulationSteps(1) do
         Filters.apply!(
             solver_config.Q,
-            ("energy.ρe",),
+            (turbconv_filters(turbconv)...,),
             solver_config.dg.grid,
             BoydVandevenFilter(solver_config.dg.grid, 1, 4),
         )
@@ -234,7 +234,7 @@ function main(::Type{FT}, cl_args) where {FT}
         solver_config;
         diagnostics_config = dgn_config,
         check_cons = check_cons,
-        user_callbacks = (cb_data_vs_time, cb_print_step),
+        user_callbacks = (cb_boyd, cb_data_vs_time, cb_print_step),
         check_euclidean_distance = true,
     )
 

--- a/test/Atmos/EDMF/ekman_layer.jl
+++ b/test/Atmos/EDMF/ekman_layer.jl
@@ -269,4 +269,26 @@ end
 
 solver_config, diag_arr, time_data = main(Float64, cl_args)
 
+# Uncomment lines to save output using JLD2
+output_dir = @__DIR__;
+mkpath(output_dir);
+function dons(diag_vs_z)
+    return Dict(map(keys(first(diag_vs_z))) do k
+        string(k) => [getproperty(ca, k) for ca in diag_vs_z]
+    end)
+end
+get_dons_arr(diag_arr) = [dons(diag_vs_z) for diag_vs_z in diag_arr]
+dons_arr = get_dons_arr(diag_arr)
+println(dons_arr[1].keys)
+z = get_z(solver_config.dg.grid; rm_dupes = true);
+save(
+    string(output_dir, "/ekman.jld2"),
+    "dons_arr",
+    dons_arr,
+    "time_data",
+    time_data,
+    "z",
+    z,
+)
+
 nothing


### PR DESCRIPTION
### Description

This draft PR (**not to be merged**) simulates an erroneous behavior encountered when drawing the squared shear from the precomputed arguments in the computation of sources. To reproduce the behavior, do:

`julia --project test/Atmos/EDMF/ekman_layer.jl `

The simulation will print occurrences of shear being negative, both at the computation and at the unpacking level. It is observed that the shear is negative when unpacked, but not when computed. 

The ekman_layer.jl simulation in this case has the following characteristics:

- Make BCs consistent with ICs to ensure there are no oscillations coming from the ground. This was tested offline without other contributions to the TKE equation.
- EDMF is tested in **decoupled mode**, with the grid-mean being evolved by a constant kinematic viscosity closure. For the results in the grid mean variables, refer to #2116 .
- Make mixing length constant and equal to 5 m.
- Strip the TKE equations of all sources except for the shear production. It is observed that the TKE goes negative, which is inconsistent with the fact that the shear production is always positive.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
