### PR TITLE
Simplify Ekman BCs, set a_min=0

### DIFF
--- a/test/Atmos/EDMF/edmf_model.jl
+++ b/test/Atmos/EDMF/edmf_model.jl
@@ -88,7 +88,7 @@ end
 function SubdomainModel(
     ::Type{FT},
     N_up;
-    a_min::FT = 0.001,
+    a_min::FT = FT(0),
     a_max::FT = 1 - N_up * a_min,
 ) where {FT}
     return SubdomainModel(; a_min = a_min, a_max = a_max)
@@ -113,8 +113,6 @@ Base.@kwdef struct SurfaceModel{FT <: AbstractFloat, SV}
     "Updraft normalized standard deviation at the surface"
     upd_surface_std::SV
     # The following will be deleted after SurfaceFlux coupling
-    "Temperature ‵[k]‵"
-    T::FT = 300.4
     "Liquid water potential temperature ‵[k]‵"
     θ_liq::FT = 299.1
     "Specific humidity ‵[kg/kg]‵"
@@ -165,6 +163,42 @@ function SurfaceModel{FT}(N_up, param_set::AbstractEarthParameterSet) where {FT}
     )
 end
 
+"""
+    NeutralDrySurfaceModel
+
+A surface model for EDMF simulations in a
+dry, neutral environment, containing all boundary
+values and parameters needed by the model.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct NeutralDrySurfaceModel{FT <: AbstractFloat}
+    "Area"
+    a::FT
+    "Square ratio of rms turbulent velocity to friction velocity"
+    κ_star²::FT
+    "Friction velocity"
+    ustar::FT = 0.3
+    "Height of the lowest level"
+    zLL::FT = 60
+    "Monin - Obukhov length"
+    obukhov_length::FT = 0
+end
+
+"""
+    NeutralDrySurfaceModel{FT}(N_up, param_set) where {FT}
+
+Constructor for `NeutralDrySurfaceModel` for EDMF, given:
+ - `param_set`, an AbstractEarthParameterSet
+"""
+function NeutralDrySurfaceModel{FT}(
+    param_set::AbstractEarthParameterSet,
+) where {FT}
+    a_surf_ = a_surf(param_set)
+    κ_star²_ = κ_star²(param_set)
+    return NeutralDrySurfaceModel{FT}(; a = a_surf_, κ_star² = κ_star²_)
+end
 
 """
     PressureModel

--- a/test/Atmos/EDMF/ekman_layer.jl
+++ b/test/Atmos/EDMF/ekman_layer.jl
@@ -75,7 +75,7 @@ function init_state_prognostic!(
     en.ρatke =
         z > FT(250) ? FT(0) :
         gm.ρ *
-        FT(0.4) *
+        FT(0.3375) *
         FT(1 - z / 250.0) *
         FT(1 - z / 250.0) *
         FT(1 - z / 250.0)
@@ -96,9 +96,15 @@ function main(::Type{FT}, cl_args) where {FT}
 
     # Choice of SGS model
     turbconv = NoTurbConv()
-    # N_updrafts = 1
-    # N_quad = 3
-    # turbconv = EDMF(FT, N_updrafts, N_quad, param_set)
+    N_updrafts = 1
+    N_quad = 3
+    turbconv = EDMF(
+        FT,
+        N_updrafts,
+        N_quad,
+        param_set,
+        surface = NeutralDrySurfaceModel{FT}(param_set),
+    )
 
     C_smag_ = C_smag(param_set)
     turbulence = ConstantKinematicViscosity(FT(0.1))
@@ -191,7 +197,7 @@ function main(::Type{FT}, cl_args) where {FT}
     cb_boyd = GenericCallbacks.EveryXSimulationSteps(1) do
         Filters.apply!(
             solver_config.Q,
-            ("energy.ρe",),
+            (turbconv_filters(turbconv)...,),
             solver_config.dg.grid,
             BoydVandevenFilter(solver_config.dg.grid, 1, 4),
         )
@@ -234,7 +240,7 @@ function main(::Type{FT}, cl_args) where {FT}
         solver_config;
         diagnostics_config = dgn_config,
         check_cons = check_cons,
-        user_callbacks = (cb_data_vs_time, cb_print_step),
+        user_callbacks = (cb_boyd, cb_data_vs_time, cb_print_step),
         check_euclidean_distance = true,
     )
 
@@ -268,5 +274,27 @@ if !isnothing(cl_args["cparam_file"])
 end
 
 solver_config, diag_arr, time_data = main(Float64, cl_args)
+
+# Uncomment lines to save output using JLD2
+# output_dir = @__DIR__;
+# mkpath(output_dir);
+# function dons(diag_vs_z)
+#     return Dict(map(keys(first(diag_vs_z))) do k
+#         string(k) => [getproperty(ca, k) for ca in diag_vs_z]
+#     end)
+# end
+# get_dons_arr(diag_arr) = [dons(diag_vs_z) for diag_vs_z in diag_arr]
+# dons_arr = get_dons_arr(diag_arr)
+# println(dons_arr[1].keys)
+# z = get_z(solver_config.dg.grid; rm_dupes = true);
+# save(
+#     string(output_dir, "/ekman.jld2"),
+#     "dons_arr",
+#     dons_arr,
+#     "time_data",
+#     time_data,
+#     "z",
+#     z,
+# )
 
 nothing

--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -17,13 +17,13 @@ best_mse["prog_ρ"] = 3.4917662870525452e-02
 best_mse["prog_ρu_1"] = 3.0715053983126868e+03
 best_mse["prog_ρu_2"] = 1.2895738234435595e-03
 best_mse["prog_moisture_ρq_tot"] = 4.1331426262587470e-02
-best_mse["prog_turbconv_environment_ρatke"] = 6.7533239891240294e+02
-best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.5667222943126376e+01
-best_mse["prog_turbconv_environment_ρaq_tot_cv"] = 1.6435513364925598e+02
-best_mse["prog_turbconv_updraft_1_ρa"] = 7.9508842202205457e+01
-best_mse["prog_turbconv_updraft_1_ρaw"] = 8.4146135253643992e-02
-best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 9.0081242205607168e+00
-best_mse["prog_turbconv_updraft_1_ρaq_tot"] = 1.0766808806387345e+01
+best_mse["prog_turbconv_environment_ρatke"] = 6.7642719033845833e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.5667226792770009e+01
+best_mse["prog_turbconv_environment_ρaq_tot_cv"] = 1.6435640302009438e+02
+best_mse["prog_turbconv_updraft_1_ρa"] = 8.0846149716812874e+01
+best_mse["prog_turbconv_updraft_1_ρaw"] = 8.5071202823418249e-02
+best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 9.0386633006301569e+00
+best_mse["prog_turbconv_updraft_1_ρaq_tot"] = 1.0803376910477068e+01
 #! format: on
 
 computed_mse = compute_mse(

--- a/test/Atmos/EDMF/report_mse_sbl_fv.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_fv.jl
@@ -16,11 +16,11 @@ best_mse = OrderedDict()
 best_mse["prog_ρ"] = 6.8766006877255519e-03
 best_mse["prog_ρu_1"] = 6.2597055026242824e+03
 best_mse["prog_ρu_2"] = 1.3231034873190784e-04
-best_mse["prog_turbconv_environment_ρatke"] = 2.3567381097766608e+02
+best_mse["prog_turbconv_environment_ρatke"] = 2.3576732937749242e+02
 best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.7727378309967946e+01
-best_mse["prog_turbconv_updraft_1_ρa"] = 1.7945530391906004e+01
-best_mse["prog_turbconv_updraft_1_ρaw"] = 1.7798447663638761e-01
-best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 1.3315160127630856e+01
+best_mse["prog_turbconv_updraft_1_ρa"] = 1.8213581913998944e+01
+best_mse["prog_turbconv_updraft_1_ρaw"] = 1.7800899665237452e-01
+best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 1.3358308964295857e+01
 #! format: on
 
 computed_mse = compute_mse(


### PR DESCRIPTION
### Description

This PR simplifies the Ekman BCs, so that the BC of TKE equates the initial TKE, preventing sharp initial gradients. The new EDMF BCs are given by a new SurfaceModel type, as suggested by @charleskawczynski .

I also set `a_min=0` for all EDMF simulations since this has already been tested to work, and this is the physical limit. We might want to remove `a_min` soon when we transition to convective cases.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
