### PR TITLE
Geometric factors data structures

### DIFF
--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -91,12 +91,12 @@ Metrics.compute_reference_to_physical_coord_jacobian
 Metrics.computemetric
 ```
 
-## GeomData
-GeomData groups data structures that collect geometric terms data needed at each quadrature point, in each element.
+## GeometricFactors
+GeometricFactors groups data structures that collect geometric terms data needed at each quadrature point, in each element.
 ### Types
 ```@docs
-GeomData.VolumeGeometry
-GeomData.SurfaceGeometry
+GeometricFactors.VolumeGeometry
+GeometricFactors.SurfaceGeometry
 ```
 
 ## Filters

--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -71,11 +71,32 @@ BrickMesh.centroidtocode
 
 Grids specify the approximation within each element, and any necessary warping.
 
+### Functions
 ```@docs
 Grids.get_z
 Grids.referencepoints
 Grids.min_node_distance
 Grids.DiscontinuousSpectralElementGrid
+Grids.computegeometry
+```
+
+## Metrics
+
+Metrics encode the computation of metric terms defined at each quadrature point, in each element.
+
+### Functions
+```@docs
+Metrics.creategrid
+Metrics.compute_reference_to_physical_coord_jacobian
+Metrics.computemetric
+```
+
+## GeomData
+GeomData groups data structures that collect geometric terms data needed at each quadrature point, in each element.
+### Types
+```@docs
+GeomData.VolumeGeometry
+GeomData.SurfaceGeometry
 ```
 
 ## Filters

--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -67,6 +67,25 @@ BrickMesh.connectmeshfull
 BrickMesh.centroidtocode
 ```
 
+## GeometricFactors
+GeometricFactors groups data structures that collect geometric terms data needed at each quadrature point, in each element.
+### Types
+```@docs
+GeometricFactors.VolumeGeometry
+GeometricFactors.SurfaceGeometry
+```
+
+## Metrics
+
+Metrics encode the computation of metric terms defined at each quadrature point, in each element.
+
+### Functions
+```@docs
+Metrics.creategrid!
+Metrics.compute_reference_to_physical_coord_jacobian!
+Metrics.computemetric!
+```
+
 ## Grids
 
 Grids specify the approximation within each element, and any necessary warping.
@@ -78,25 +97,6 @@ Grids.referencepoints
 Grids.min_node_distance
 Grids.DiscontinuousSpectralElementGrid
 Grids.computegeometry
-```
-
-## Metrics
-
-Metrics encode the computation of metric terms defined at each quadrature point, in each element.
-
-### Functions
-```@docs
-Metrics.creategrid
-Metrics.compute_reference_to_physical_coord_jacobian
-Metrics.computemetric
-```
-
-## GeometricFactors
-GeometricFactors groups data structures that collect geometric terms data needed at each quadrature point, in each element.
-### Types
-```@docs
-GeometricFactors.VolumeGeometry
-GeometricFactors.SurfaceGeometry
 ```
 
 ## Filters

--- a/src/Numerics/Mesh/GeomData.jl
+++ b/src/Numerics/Mesh/GeomData.jl
@@ -1,0 +1,74 @@
+module GeomData
+
+export VolumeGeometry, SurfaceGeometry
+
+struct VolumeGeometry{Nq, A<:AbstractArray}
+    ξ1x1::A
+    ξ2x1::A
+    ξ3x1::A
+    ξ1x2::A
+    ξ2x2::A
+    ξ3x2::A
+    ξ1x3::A
+    ξ2x3::A
+    ξ3x3::A
+    x1ξ1::A
+    x2ξ1::A
+    x3ξ1::A
+    x1ξ2::A
+    x2ξ2::A
+    x3ξ2::A
+    x1ξ3::A
+    x2ξ3::A
+    x3ξ3::A
+    ωJ::A
+    ωJI::A
+    ωJH::A
+    x1::A
+    x2::A
+    x3::A
+    JcV::A
+    function VolumeGeometry{Nq}(args::A...) where {Nq, A<:AbstractArray}
+        new{Nq,A}(args...)
+    end
+end
+
+"""
+    VolumeGeometry(FT, Nq::Tuple, nelems::Integer)
+
+Construct an empty `VolumeGeometry` object, in `FT` precision.
+- `Nq` is a tuple containing the number of quadrature points in each direction.
+- `nelem` is the number of elements.
+"""
+function VolumeGeometry(FT, Nq::NTuple{N,Int}, nelem::Int) where {N}
+    array = zeros(FT, prod(Nq), fieldcount(VolumeGeometry), nelem)
+    VolumeGeometry{Nq}(ntuple(j -> @view(array[:, j, :]), fieldcount(VolumeGeometry))...)
+end
+
+struct SurfaceGeometry{Nq, A<:AbstractArray}
+    n1::A
+    n2::A
+    n3::A
+    sωJ::A
+    vωJI::A
+    function SurfaceGeometry{Nq}(args::A...) where {Nq, A<:AbstractArray}
+        new{Nq,A}(args...)
+    end
+end
+
+"""
+SurfaceGeometry(FT, Nq::Tuple, nface::Integer, nelem::Integer)
+
+Construct an empty `SurfaceGeometry` object, in `FT` precision.
+- `Nq` is a tuple containing the number of quadrature points in each direction.
+- `nface` is the number of faces.
+- `nelem` is the number of elements.
+"""
+function SurfaceGeometry(FT, Nq::NTuple{N,Int}, nface::Int, nelem::Int) where {N}
+    Np = prod(Nq)
+    Nfp = div.(Np, Nq)
+    array = zeros(FT, maximum(Nfp), fieldcount(SurfaceGeometry), nface, nelem)
+    SurfaceGeometry{Nfp}(ntuple(j -> @view(array[:, j, :, :]), fieldcount(SurfaceGeometry))...)
+end
+
+end # module

--- a/src/Numerics/Mesh/GeomData.jl
+++ b/src/Numerics/Mesh/GeomData.jl
@@ -2,7 +2,8 @@ module GeomData
 
 export VolumeGeometry, SurfaceGeometry
 
-struct VolumeGeometry{Nq, A <: AbstractArray}
+struct VolumeGeometry{Nq, AA <: AbstractArray, A <: AbstractArray}
+    array::AA
     ξ1x1::A
     ξ2x1::A
     ξ3x1::A
@@ -28,8 +29,11 @@ struct VolumeGeometry{Nq, A <: AbstractArray}
     x2::A
     x3::A
     JcV::A
-    function VolumeGeometry{Nq}(args::A...) where {Nq, A <: AbstractArray}
-        new{Nq, A}(args...)
+    function VolumeGeometry{Nq}(
+        array::AA,
+        args::A...,
+    ) where {Nq, AA, A <: AbstractArray}
+        new{Nq, AA, A}(array, args...)
     end
 end
 
@@ -42,10 +46,10 @@ Construct an empty `VolumeGeometry` object, in `FT` precision.
 """
 function VolumeGeometry(FT, Nq::NTuple{N, Int}, nelem::Int) where {N}
     array = zeros(FT, prod(Nq), fieldcount(VolumeGeometry), nelem)
-    VolumeGeometry{Nq}(ntuple(
-        j -> @view(array[:, j, :]),
-        fieldcount(VolumeGeometry),
-    )...)
+    VolumeGeometry{Nq}(
+        array,
+        ntuple(j -> @view(array[:, j, :]), fieldcount(VolumeGeometry) - 1)...,
+    )
 end
 
 struct SurfaceGeometry{Nq, A <: AbstractArray}

--- a/src/Numerics/Mesh/GeomData.jl
+++ b/src/Numerics/Mesh/GeomData.jl
@@ -34,7 +34,7 @@ struct VolumeGeometry{Nq, A <: AbstractArray}
 end
 
 """
-    VolumeGeometry(FT, Nq::Tuple, nelems::Integer)
+   VolumeGeometry(FT, Nq::Tuple, nelems::Integer)
 
 Construct an empty `VolumeGeometry` object, in `FT` precision.
 - `Nq` is a tuple containing the number of quadrature points in each direction.
@@ -60,7 +60,7 @@ struct SurfaceGeometry{Nq, A <: AbstractArray}
 end
 
 """
-SurfaceGeometry(FT, Nq::Tuple, nface::Integer, nelem::Integer)
+   SurfaceGeometry(FT, Nq::Tuple, nface::Integer, nelem::Integer)
 
 Construct an empty `SurfaceGeometry` object, in `FT` precision.
 - `Nq` is a tuple containing the number of quadrature points in each direction.

--- a/src/Numerics/Mesh/GeomData.jl
+++ b/src/Numerics/Mesh/GeomData.jl
@@ -2,7 +2,7 @@ module GeomData
 
 export VolumeGeometry, SurfaceGeometry
 
-struct VolumeGeometry{Nq, A<:AbstractArray}
+struct VolumeGeometry{Nq, A <: AbstractArray}
     ξ1x1::A
     ξ2x1::A
     ξ3x1::A
@@ -28,8 +28,8 @@ struct VolumeGeometry{Nq, A<:AbstractArray}
     x2::A
     x3::A
     JcV::A
-    function VolumeGeometry{Nq}(args::A...) where {Nq, A<:AbstractArray}
-        new{Nq,A}(args...)
+    function VolumeGeometry{Nq}(args::A...) where {Nq, A <: AbstractArray}
+        new{Nq, A}(args...)
     end
 end
 
@@ -40,19 +40,22 @@ Construct an empty `VolumeGeometry` object, in `FT` precision.
 - `Nq` is a tuple containing the number of quadrature points in each direction.
 - `nelem` is the number of elements.
 """
-function VolumeGeometry(FT, Nq::NTuple{N,Int}, nelem::Int) where {N}
+function VolumeGeometry(FT, Nq::NTuple{N, Int}, nelem::Int) where {N}
     array = zeros(FT, prod(Nq), fieldcount(VolumeGeometry), nelem)
-    VolumeGeometry{Nq}(ntuple(j -> @view(array[:, j, :]), fieldcount(VolumeGeometry))...)
+    VolumeGeometry{Nq}(ntuple(
+        j -> @view(array[:, j, :]),
+        fieldcount(VolumeGeometry),
+    )...)
 end
 
-struct SurfaceGeometry{Nq, A<:AbstractArray}
+struct SurfaceGeometry{Nq, A <: AbstractArray}
     n1::A
     n2::A
     n3::A
     sωJ::A
     vωJI::A
-    function SurfaceGeometry{Nq}(args::A...) where {Nq, A<:AbstractArray}
-        new{Nq,A}(args...)
+    function SurfaceGeometry{Nq}(args::A...) where {Nq, A <: AbstractArray}
+        new{Nq, A}(args...)
     end
 end
 
@@ -64,11 +67,19 @@ Construct an empty `SurfaceGeometry` object, in `FT` precision.
 - `nface` is the number of faces.
 - `nelem` is the number of elements.
 """
-function SurfaceGeometry(FT, Nq::NTuple{N,Int}, nface::Int, nelem::Int) where {N}
+function SurfaceGeometry(
+    FT,
+    Nq::NTuple{N, Int},
+    nface::Int,
+    nelem::Int,
+) where {N}
     Np = prod(Nq)
     Nfp = div.(Np, Nq)
     array = zeros(FT, maximum(Nfp), fieldcount(SurfaceGeometry), nface, nelem)
-    SurfaceGeometry{Nfp}(ntuple(j -> @view(array[:, j, :, :]), fieldcount(SurfaceGeometry))...)
+    SurfaceGeometry{Nfp}(ntuple(
+        j -> @view(array[:, j, :, :]),
+        fieldcount(SurfaceGeometry),
+    )...)
 end
 
 end # module

--- a/src/Numerics/Mesh/GeometricFactors.jl
+++ b/src/Numerics/Mesh/GeometricFactors.jl
@@ -2,6 +2,19 @@ module GeometricFactors
 
 export VolumeGeometry, SurfaceGeometry
 
+"""
+    VolumeGeometry{Nq, AA <: AbstractArray, A <: AbstractArray}
+
+A struct that collects `VolumeGeometry` fields:
+- array: Array contatining the data stored in a VolumeGeometry struct (the following fields are views into this array)
+- ∂ξk/∂xi: Derivative of the Cartesian reference element coordinate `ξ_k` with respect to the Cartesian physical coordinate `x_i`
+- ωJ: Mass matrix. This is the physical mass matrix, and thus contains the Jacobian determinant, J .* (ωᵢ ⊗ ωⱼ ⊗ ωₖ), where ωᵢ are the quadrature weights and J is the Jacobian determinant, det(∂x/∂ξ)
+- ωJI: Inverse mass matrix: 1 ./ ωJ
+- ωJH: Horizontal mass matrix (used in diagnostics),  J .* norm(∂ξ3/∂x) * (ωᵢ ⊗ ωⱼ); for integrating over a plane (in 2-D ξ2 is used, not ξ3)
+- xi: Nodal degrees of freedom locations in Cartesian physical space
+- JcV: Metric terms for vertical line integrals norm(∂x/∂ξ3) (in 2-D ξ2 is used, not ξ3)
+- ∂xk/∂ξi: Inverse of matrix `∂ξk/∂xi` that represents the derivative of Cartesian physical coordinate `x_i` with respect to Cartesian reference element coordinate `ξ_k`
+"""
 struct VolumeGeometry{Nq, AA <: AbstractArray, A <: AbstractArray}
     array::AA
     ξ1x1::A
@@ -38,33 +51,47 @@ struct VolumeGeometry{Nq, AA <: AbstractArray, A <: AbstractArray}
 end
 
 """
-   VolumeGeometry(FT, Nq::NTuple{N, Int}, nelems::Int)
+    VolumeGeometry(FT, Nq::NTuple{N, Int}, nelems::Int)
 
 Construct an empty `VolumeGeometry` object, in `FT` precision.
 - `Nq` is a tuple containing the number of quadrature points in each direction.
 - `nelem` is the number of elements.
 """
 function VolumeGeometry(FT, Nq::NTuple{N, Int}, nelem::Int) where {N}
-    array = zeros(FT, prod(Nq), fieldcount(VolumeGeometry), nelem)
+    # - 1 after fieldcount is to remove the `array` field from the array allocation
+    array = zeros(FT, prod(Nq), fieldcount(VolumeGeometry) - 1, nelem)
     VolumeGeometry{Nq}(
         array,
         ntuple(j -> @view(array[:, j, :]), fieldcount(VolumeGeometry) - 1)...,
     )
 end
 
-struct SurfaceGeometry{Nq, A <: AbstractArray}
+"""
+    SurfaceGeometry{Nq, AA, A <: AbstractArray}
+
+A struct that collects `VolumeGeometry` fields:
+- array: Array contatining the data stored in a SurfaceGeometry struct (the following fields are views into this array)
+- ni: Outward pointing unit normal in physical space
+- sωJ: Surface mass matrix. This is the physical mass matrix, and thus contains the surface Jacobian determinant, sJ .* (ωⱼ ⊗ ωₖ), where ωᵢ are the quadrature weights and sJ is the surface Jacobian determinant
+- vωJI: Volume mass matrix at the surface nodes (needed in the lift operation, i.e., the projection of a face field back to the volume). Since DGSEM is used only collocated, volume mass matrices are required.
+"""
+struct SurfaceGeometry{Nq, AA, A <: AbstractArray}
+    array::AA
     n1::A
     n2::A
     n3::A
     sωJ::A
     vωJI::A
-    function SurfaceGeometry{Nq}(args::A...) where {Nq, A <: AbstractArray}
-        new{Nq, A}(args...)
+    function SurfaceGeometry{Nq}(
+        array::AA,
+        args::A...,
+    ) where {Nq, AA, A <: AbstractArray}
+        new{Nq, AA, A}(array, args...)
     end
 end
 
 """
-   SurfaceGeometry(FT, Nq::NTuple{N, Int}, nface::Int, nelem::Int)
+    SurfaceGeometry(FT, Nq::NTuple{N, Int}, nface::Int, nelem::Int)
 
 Construct an empty `SurfaceGeometry` object, in `FT` precision.
 - `Nq` is a tuple containing the number of quadrature points in each direction.
@@ -79,11 +106,16 @@ function SurfaceGeometry(
 ) where {N}
     Np = prod(Nq)
     Nfp = div.(Np, Nq)
-    array = zeros(FT, maximum(Nfp), fieldcount(SurfaceGeometry), nface, nelem)
-    SurfaceGeometry{Nfp}(ntuple(
-        j -> @view(array[:, j, :, :]),
-        fieldcount(SurfaceGeometry),
-    )...)
+    # - 1 after fieldcount is to remove the `array` field from the array allocation
+    array =
+        zeros(FT, fieldcount(SurfaceGeometry) - 1, maximum(Nfp), nface, nelem)
+    SurfaceGeometry{Nfp}(
+        array,
+        ntuple(
+            j -> @view(array[j, :, :, :]),
+            fieldcount(SurfaceGeometry) - 1,
+        )...,
+    )
 end
 
 end # module

--- a/src/Numerics/Mesh/GeometricFactors.jl
+++ b/src/Numerics/Mesh/GeometricFactors.jl
@@ -1,4 +1,4 @@
-module GeomData
+module GeometricFactors
 
 export VolumeGeometry, SurfaceGeometry
 
@@ -13,6 +13,13 @@ struct VolumeGeometry{Nq, AA <: AbstractArray, A <: AbstractArray}
     ξ1x3::A
     ξ2x3::A
     ξ3x3::A
+    ωJ::A
+    ωJI::A
+    ωJH::A
+    x1::A
+    x2::A
+    x3::A
+    JcV::A
     x1ξ1::A
     x2ξ1::A
     x3ξ1::A
@@ -22,13 +29,6 @@ struct VolumeGeometry{Nq, AA <: AbstractArray, A <: AbstractArray}
     x1ξ3::A
     x2ξ3::A
     x3ξ3::A
-    ωJ::A
-    ωJI::A
-    ωJH::A
-    x1::A
-    x2::A
-    x3::A
-    JcV::A
     function VolumeGeometry{Nq}(
         array::AA,
         args::A...,
@@ -38,7 +38,7 @@ struct VolumeGeometry{Nq, AA <: AbstractArray, A <: AbstractArray}
 end
 
 """
-   VolumeGeometry(FT, Nq::Tuple, nelems::Integer)
+   VolumeGeometry(FT, Nq::NTuple{N, Int}, nelems::Int)
 
 Construct an empty `VolumeGeometry` object, in `FT` precision.
 - `Nq` is a tuple containing the number of quadrature points in each direction.
@@ -64,7 +64,7 @@ struct SurfaceGeometry{Nq, A <: AbstractArray}
 end
 
 """
-   SurfaceGeometry(FT, Nq::Tuple, nface::Integer, nelem::Integer)
+   SurfaceGeometry(FT, Nq::NTuple{N, Int}, nface::Int, nelem::Int)
 
 Construct an empty `SurfaceGeometry` object, in `FT` precision.
 - `Nq` is a tuple containing the number of quadrature points in each direction.

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -829,7 +829,21 @@ function computegeometry_fvm(elemtocoord, D, ξ, ω, meshwarp)
     (vgeo, sgeo, x_vtk)
 end
 
+"""
+    computegeometry(elemtocoord, D, ξ, ω, meshwarp)
+
+Compute the geometric factors data needed to define metric terms at
+each quadrature point. First, compute so called "topology coordinates" from
+reference coordinates ξ. Then map these topology coordinate
+to physical coordinates. Then setup the geometric factors data necessary at
+each quadrature point by calling [`setup_geom_factors_data!`](@ref). Then
+compute the Jacobian of the mapping from reference coordinates to physical
+coordinates, i.e., ∂x/∂ξ. Finally, compute the metric terms by calling the
+function [`computemetric!`](@ref).
+"""
+
 function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
+    FT = eltype(D[1])
     dim = length(D)
     nface = 2dim
     nelem = size(elemtocoord, 3)
@@ -843,8 +857,6 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
 
     Np = prod(Nq)
     Nfp = div.(Np, Nq)
-
-    FT = eltype(D[1])
 
     vgeo = VolumeGeometry(FT, Nq, nelem)
 
@@ -866,9 +878,8 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
 
     setup_geom_factors_data!(vgeo, D...)
 
-    # c) computes partial derivatives ∂x/∂ξ
+    # c) computes Jacobian matrix, ∂x/∂ξ
     compute_dxdxi_jacobian!(vgeo, D...)
-    # Compute Jacobian matrix, ∂x/∂ξ
 
     # d) computes the metric terms
     Metrics.computemetric!(vgeo, sgeo, D...)

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -1,5 +1,5 @@
 module Grids
-using ..Topologies
+using ..Topologies, ..GeomData
 import ..Metrics, ..Elements
 import ..BrickMesh
 
@@ -829,75 +829,6 @@ function computegeometry_fvm(elemtocoord, D, ξ, ω, meshwarp)
     (vgeo, sgeo, x_vtk)
 end
 
-struct VolumeGeometry{Nq, A<:AbstractArray}
-    ξ1x1::A
-    ξ2x1::A
-    ξ3x1::A
-    ξ1x2::A
-    ξ2x2::A
-    ξ3x2::A
-    ξ1x3::A
-    ξ2x3::A
-    ξ3x3::A
-    x1ξ1::A
-    x2ξ1::A
-    x3ξ1::A
-    x1ξ2::A
-    x2ξ2::A
-    x3ξ2::A
-    x1ξ3::A
-    x2ξ3::A
-    x3ξ3::A
-    ωJ::A
-    ωJI::A
-    ωJH::A
-    x1::A
-    x2::A
-    x3::A
-    JcV::A
-    function VolumeGeometry{Nq}(args::A...) where {Nq, A<:AbstractArray}
-        new{Nq,A}(args...)
-    end
-end
-
-"""
-    VolumeGeometry(FT, Nq::Tuple, nelems::Integer)
-
-Construct an empty `VolumeGeometry` object, in `FT` precision.
-- `Nq` is a tuple containing the number of quadrature points in each direction.
-- `nelem` is the number of elements.
-"""
-function VolumeGeometry(FT, Nq::NTuple{N,Int}, nelem::Int) where {N}
-    array = zeros(FT, prod(Nq), fieldcount(VolumeGeometry), nelem)
-    VolumeGeometry{Nq}(ntuple(j -> @view(array[:, j, :]), fieldcount(VolumeGeometry))...)
-end
-
-struct SurfaceGeometry{Nq, A<:AbstractArray}
-    n1::A
-    n2::A
-    n3::A
-    sωJ::A
-    vωJI::A
-    function SurfaceGeometry{Nq}(args::A...) where {Nq, A<:AbstractArray}
-        new{Nq,A}(args...)
-    end
-end
-
-"""
-SurfaceGeometry(FT, Nq::Tuple, nface::Integer, nelem::Integer)
-
-Construct an empty `SurfaceGeometry` object, in `FT` precision.
-- `Nq` is a tuple containing the number of quadrature points in each direction.
-- `nface` is the number of faces.
-- `nelem` is the number of elements.
-"""
-function SurfaceGeometry(FT, Nq::NTuple{N,Int}, nface::Int, nelem::Int) where {N}
-    Np = prod(Nq)
-    Nfp = div.(Np, Nq)
-    array = zeros(FT, maximum(Nfp), fieldcount(SurfaceGeometry), nface, nelem)
-    SurfaceGeometry{Nfp}(ntuple(j -> @view(array[:, j, :, :]), fieldcount(SurfaceGeometry))...)
-end
-
 function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
     dim = length(D)
     nface = 2dim
@@ -994,7 +925,7 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
 end
 
 """
-    horizontal_metrics!(vgeo::VerticalGeometry, Nq, ω)
+    horizontal_metrics!(vgeo::VolumeGeometry, Nq, ω)
 
 Compute the horizontal mass matrix `ωJH` field of `vgeo`
 ```
@@ -1002,7 +933,7 @@ J .* norm(∂ξ3/∂x) * (ωᵢ ⊗ ωⱼ); for integrating over a plane
 ```
 (in 2-D ξ2 not ξ3 is used).
 """
-function horizontal_metrics!(vgeo::VerticalGeometry, Nq, ω)
+function horizontal_metrics!(vgeo::VolumeGeometry, Nq, ω)
     dim = length(Nq)
 
     MH = dim == 1 ? 1 : kron(ones(1, Nq[dim]), reverse(ω[1:(dim - 1)])...)[:]

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -869,20 +869,19 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
     #
 
     # a) computes "topology coordinates" from reference coordinates ξ
-    Metrics.creategrid!(vgeo, elemtocoord, ξ...)
+    Metrics.creategrid!(vgeo, elemtocoord, ξ)
 
     # b) topology coordinates -> physical coordinates
     @inbounds for j in 1:length(x1)
-        (vgeo.x1[j], vgeo.x2[j], vgeo.x3[j]) = meshwarp(vgeo.x1[j], vgeo.x2[j], vgeo.x3[j])
+        (vgeo.x1[j], vgeo.x2[j], vgeo.x3[j]) =
+            meshwarp(vgeo.x1[j], vgeo.x2[j], vgeo.x3[j])
     end
 
-    setup_geom_factors_data!(vgeo, D...)
-
     # c) computes Jacobian matrix, ∂x/∂ξ
-    compute_dxdxi_jacobian!(vgeo, D...)
+    compute_reference_to_physical_coord_jacobian!(vgeo, D)
 
     # d) computes the metric terms
-    Metrics.computemetric!(vgeo, sgeo, D...)
+    Metrics.computemetric!(vgeo, sgeo, D)
 
     # Compute the metric terms
     p = reshape(1:Np, Nq)
@@ -904,7 +903,7 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
     # since `ξ1` is the fastest dimension and `ξdim` the slowest the tensor
     # product order is reversed
     M = kron(1, reverse(ω)...)
-    vgeo.ωMJ .= M .*vgeo.ωJ
+    vgeo.ωMJ .= M .* vgeo.ωJ
     vgeo.ωJI .= 1 ./ vgeo.ωJ
     for d in 1:dim
         for f in (2d - 1):(2d)

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -1,5 +1,5 @@
 module Grids
-using ..Topologies, ..GeomData
+using ..Topologies, ..GeometricFactors
 import ..Metrics, ..Elements
 import ..BrickMesh
 
@@ -697,7 +697,8 @@ function computegeometry_fvm(elemtocoord, D, ξ, ω, meshwarp)
 
     @views begin
         # ωJ should be a sum
-        vgeo.ωJ[:] .= sum(vgeo_N1.ωJ, dims = findall(Nq .== 1))[:]
+        ωJ_N1 = reshape(vgeo_N1.ωJ, (Nq_N1..., nelem))
+        vgeo.ωJ[:] .= sum(ωJ_N1, dims = findall(Nq .== 1))[:]
         num_vgeo_handled += 1
 
         # need to recompute ωJI
@@ -706,32 +707,44 @@ function computegeometry_fvm(elemtocoord, D, ξ, ω, meshwarp)
 
         # coordinates should just be averages
         avg_den = 2^sum(Nq .== 1)
-        vgeo.JcV .= sum(vgeo_N1.JcV, dims = findall(Nq .== 1))[:] ./ avg_den
+        JcV_N1 = reshape(vgeo_N1.JcV, (Nq_N1..., nelem))
+        vgeo.JcV[:] .= sum(JcV_N1, dims = findall(Nq .== 1))[:] ./ avg_den
         num_vgeo_handled += 1
 
         # For the metrics it is J * ξixk we approximate so multiply and divide the
         # mass matrix (which has the Jacobian determinant and the proper averaging
         # due to the quadrature weights)
-        ωJ_N1 = vgeo_N1.ωJ
+        ωJ_N1 = reshape(vgeo_N1.ωJ, (Nq_N1..., nelem))
         ωJI = vgeo.ωJI
-        vgeo.ξ1x1 .=
-            sum(ωJ_N1 .* vgeo_N1.ξ1x1, dims = findall(Nq .== 1))[:] .* ωJI[:]
-        vgeo.ξ2x1 .=
-            sum(ωJ_N1 .* vgeo_N1.ξ2x1, dims = findall(Nq .== 1))[:] .* ωJI[:]
-        vgeo.ξ3x1 .=
-            sum(ωJ_N1 .* vgeo_N1.ξ3x1, dims = findall(Nq .== 1))[:] .* ωJI[:]
-        vgeo.ξ1x2 .=
-            sum(ωJ_N1 .* vgeo_N1.ξ1x2, dims = findall(Nq .== 1))[:] .* ωJI[:]
-        vgeo.ξ2x2 .=
-            sum(ωJ_N1 .* vgeo_N1.ξ2x2, dims = findall(Nq .== 1))[:] .* ωJI[:]
-        vgeo.ξ3x2 .=
-            sum(ωJ_N1 .* vgeo_N1.ξ3x2, dims = findall(Nq .== 1))[:] .* ωJI[:]
-        vgeo.ξ1x3 .=
-            sum(ωJ_N1 .* vgeo_N1.ξ1x3, dims = findall(Nq .== 1))[:] .* ωJI[:]
-        vgeo.ξ2x3 .=
-            sum(ωJ_N1 .* vgeo_N1.ξ2x3, dims = findall(Nq .== 1))[:] .* ωJI[:]
-        vgeo.ξ3x3 .=
-            sum(ωJ_N1 .* vgeo_N1.ξ3x3, dims = findall(Nq .== 1))[:] .* ωJI[:]
+
+        ξ1x1_N1 = reshape(vgeo_N1.ξ1x1, (Nq_N1..., nelem))
+        ξ2x1_N1 = reshape(vgeo_N1.ξ2x1, (Nq_N1..., nelem))
+        ξ3x1_N1 = reshape(vgeo_N1.ξ3x1, (Nq_N1..., nelem))
+        ξ1x2_N1 = reshape(vgeo_N1.ξ1x2, (Nq_N1..., nelem))
+        ξ2x2_N1 = reshape(vgeo_N1.ξ2x2, (Nq_N1..., nelem))
+        ξ3x2_N1 = reshape(vgeo_N1.ξ3x2, (Nq_N1..., nelem))
+        ξ1x3_N1 = reshape(vgeo_N1.ξ1x3, (Nq_N1..., nelem))
+        ξ2x3_N1 = reshape(vgeo_N1.ξ2x3, (Nq_N1..., nelem))
+        ξ3x3_N1 = reshape(vgeo_N1.ξ3x3, (Nq_N1..., nelem))
+
+        vgeo.ξ1x1[:] .=
+            sum(ωJ_N1 .* ξ1x1_N1, dims = findall(Nq .== 1))[:] .* ωJI[:]
+        vgeo.ξ2x1[:] .=
+            sum(ωJ_N1 .* ξ2x1_N1, dims = findall(Nq .== 1))[:] .* ωJI[:]
+        vgeo.ξ3x1[:] .=
+            sum(ωJ_N1 .* ξ3x1_N1, dims = findall(Nq .== 1))[:] .* ωJI[:]
+        vgeo.ξ1x2[:] .=
+            sum(ωJ_N1 .* ξ1x2_N1, dims = findall(Nq .== 1))[:] .* ωJI[:]
+        vgeo.ξ2x2[:] .=
+            sum(ωJ_N1 .* ξ2x2_N1, dims = findall(Nq .== 1))[:] .* ωJI[:]
+        vgeo.ξ3x2[:] .=
+            sum(ωJ_N1 .* ξ3x2_N1, dims = findall(Nq .== 1))[:] .* ωJI[:]
+        vgeo.ξ1x3[:] .=
+            sum(ωJ_N1 .* ξ1x3_N1, dims = findall(Nq .== 1))[:] .* ωJI[:]
+        vgeo.ξ2x3[:] .=
+            sum(ωJ_N1 .* ξ2x3_N1, dims = findall(Nq .== 1))[:] .* ωJI[:]
+        vgeo.ξ3x3[:] .=
+            sum(ωJ_N1 .* ξ3x3_N1, dims = findall(Nq .== 1))[:] .* ωJI[:]
         num_vgeo_handled += 9
 
         # compute ωJH and JvC
@@ -744,10 +757,9 @@ function computegeometry_fvm(elemtocoord, D, ξ, ω, meshwarp)
 
     # Sort out the sgeo terms
     @views begin
-        sgeo = zeros(FT, _nsgeo, maximum(Nfp), nface, nelem)
+        sgeo = SurfaceGeometry(FT, Nq, nface, nelem)
 
         # for the volume inverse mass matrix
-        MI = vgeo[:, _MI, :]
         p = reshape(1:Np, Nq)
         if dim == 1
             fmask = (p[1:1], p[Nq[1]:Nq[1]])
@@ -768,10 +780,13 @@ function computegeometry_fvm(elemtocoord, D, ξ, ω, meshwarp)
                 # number of points matches means that we keep all the data
                 # (N = 0 is not on the face)
                 if Nfp[d] == Nfp_N1[d]
-                    sgeo[:, 1:Nfp[d], f, :] .= sgeo_N1[:, 1:Nfp[d], f, :]
+                    sgeo.n1[:, f, :] .= sgeo_N1.n1[:, f, :]
+                    sgeo.n2[:, f, :] .= sgeo_N1.n2[:, f, :]
+                    sgeo.n3[:, f, :] .= sgeo_N1.n3[:, f, :]
+                    sgeo.sωJ[:, f, :] .= sgeo_N1.sωJ[:, f, :]
 
                     # Volume inverse mass will be wrong so reset it
-                    sgeo[_vMI, 1:Nfp[d], f, :] .= MI[fmask[f], :]
+                    sgeo.vωJI[:, f, :] .= vgeo.ωJI[fmask[f], :]
                 else
                     # Counter to make sure we got all the sgeo terms
                     num_sgeo_handled = 0
@@ -780,32 +795,62 @@ function computegeometry_fvm(elemtocoord, D, ξ, ω, meshwarp)
                     Nq_f = (Nq[1:(d - 1)]..., Nq[(d + 1):dim]...)
                     Nq_f_N1 = (Nq_N1[1:(d - 1)]..., Nq_N1[(d + 1):dim]...)
                     sM_N1 = reshape(
-                        sgeo_N1[_sM, 1:Nfp_N1[d], f, :],
+                        sgeo_N1.sωJ[1:Nfp_N1[d], f, :],
                         Nq_f_N1...,
                         nelem,
                     )
-                    sgeo[_sM, 1:Nfp[d], f, :][:] .=
+                    sgeo.sωJ[1:Nfp[d], f, :][:] .=
                         sum(sM_N1, dims = findall(Nq_f .== 1))[:]
                     num_sgeo_handled += 1
 
                     # Normals (like metrics in the volume) need to be computed
                     # scaled by surface Jacobian which we can do with the
                     # surface mass matrices
-                    sM = sgeo[_sM, 1:Nfp[d], f, :]
-                    for fld in (_n1, _n2, _n3)
-                        fld_N1 = reshape(
-                            sgeo_N1[fld, 1:Nfp_N1[d], f, :],
-                            Nq_f_N1...,
-                            nelem,
-                        )
-                        sgeo[fld, 1:Nfp[d], f, :][:] .=
-                            sum(sM_N1 .* fld_N1, dims = findall(Nq_f .== 1))[:] ./
-                            sM[:]
-                        num_sgeo_handled += 1
-                    end
+                    sM = sgeo.sωJ[1:Nfp[d], f, :]
+
+                    fld_N1_n1 = reshape(
+                        sgeo_N1.n1[1:Nfp_N1[d], f, :],
+                        Nq_f_N1...,
+                        nelem,
+                    )
+                    fld_N1_n2 = reshape(
+                        sgeo_N1.n2[1:Nfp_N1[d], f, :],
+                        Nq_f_N1...,
+                        nelem,
+                    )
+                    fld_N1_n3 = reshape(
+                        sgeo_N1.n3[1:Nfp_N1[d], f, :],
+                        Nq_f_N1...,
+                        nelem,
+                    )
+
+                    sgeo.n1[1:Nfp[d], f, :][:] .=
+                        sum(sM_N1 .* fld_N1_n1, dims = findall(Nq_f .== 1))[:] ./
+                        sM[:]
+
+                    sgeo.n2[1:Nfp[d], f, :][:] .=
+                        sum(sM_N1 .* fld_N1_n2, dims = findall(Nq_f .== 1))[:] ./
+                        sM[:]
+
+                    sgeo.n3[1:Nfp[d], f, :][:] .=
+                        sum(sM_N1 .* fld_N1_n3, dims = findall(Nq_f .== 1))[:] ./
+                        sM[:]
+
+                    num_sgeo_handled += 3
+                    # for fld in (_n1, _n2, _n3)
+                    # fld_N1 = reshape(
+                    #     sgeo_N1[fld, 1:Nfp_N1[d], f, :],
+                    #     Nq_f_N1...,
+                    #     nelem,
+                    # )
+                    # sgeo[fld, 1:Nfp[d], f, :][:] .=
+                    #     sum(sM_N1 .* fld_N1, dims = findall(Nq_f .== 1))[:] ./
+                    #     sM[:]
+                    # num_sgeo_handled += 1
+                    # end
 
                     # set the volume inverse mass matrix
-                    sgeo[_vMI, 1:Nfp[d], f, :] .= MI[fmask[f], :]
+                    sgeo.vωJI[1:Nfp[d], f, :] .= vgeo.ωJI[fmask[f], :]
                     num_sgeo_handled += 1
 
                     # Make sure we handled all the vgeo terms
@@ -847,37 +892,36 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
     Np = prod(Nq)
     Nfp = div.(Np, Nq)
 
+    # Initialize volume and surface geometric term data structures
     vgeo = VolumeGeometry(FT, Nq, nelem)
-
     sgeo = SurfaceGeometry(FT, Nq, nface, nelem)
 
-    # TODO:
-    # - split out (c),(d)
-    # - to get analytic derivatives, we need to be able differentiate through (a,b)
-    #   - combines (a,b,c)
-    #
-
-    # a) computes "topology coordinates" from reference coordinates ξ
+    # a) Compute "topology coordinates" from reference coordinates ξ
     Metrics.creategrid!(vgeo, elemtocoord, ξ)
 
-    # b) topology coordinates -> physical coordinates
+    # Create local variables
     x1 = vgeo.x1
     x2 = vgeo.x2
     x3 = vgeo.x3
+
+    # b) Map "topology coordinates" -> physical coordinates
     @inbounds for j in 1:length(vgeo.x1)
         (x1[j], x2[j], x3[j]) = meshwarp(vgeo.x1[j], vgeo.x2[j], vgeo.x3[j])
     end
 
-    # Update data in vgeo
+    # Update global data in vgeo
     vgeo.x1 .= x1
     vgeo.x2 .= x2
     vgeo.x3 .= x3
 
-    # c) computes Jacobian matrix, ∂x/∂ξ
-    Metrics.compute_reference_to_physical_coord_jacobian!(vgeo, D)
+    # c) Compute Jacobian matrix, ∂x/∂ξ
+    Metrics.compute_reference_to_physical_coord_jacobian!(vgeo, nelem, D)
 
-    # d) computes the metric terms
+    # d) Compute the metric terms
     Metrics.computemetric!(vgeo, sgeo, D)
+
+    # Note:
+    # To get analytic derivatives, we need to be able differentiate through (a,b) and combine (a,b,c)
 
     # Compute the metric terms
     p = reshape(1:Np, Nq)
@@ -899,7 +943,7 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
     # since `ξ1` is the fastest dimension and `ξdim` the slowest the tensor
     # product order is reversed
     M = kron(1, reverse(ω)...)
-    vgeo.ωMJ .= M .* vgeo.ωJ
+    vgeo.ωJ .*= M
     vgeo.ωJI .= 1 ./ vgeo.ωJ
     for d in 1:dim
         for f in (2d - 1):(2d)
@@ -918,7 +962,7 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
             sM[1:Nfp[d], f] .= dim > 1 ? kron(1, ωf...) : one(FT)
         end
     end
-    sgeo.sωMJ .= sM .* sgeo.sωJ
+    sgeo.sωJ .*= sM
 
     # compute MH and JvC
     horizontal_metrics!(vgeo, Nq, ω)
@@ -944,6 +988,7 @@ function horizontal_metrics!(vgeo::VolumeGeometry, Nq, ω)
 
     MH = dim == 1 ? 1 : kron(ones(1, Nq[dim]), reverse(ω[1:(dim - 1)])...)[:]
     M = vec(kron(1, reverse(ω)...))
+
     J = vgeo.ωJ ./ M
 
     # Compute |r'(ξ3)| for vertical line integrals

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -9,7 +9,7 @@ using KernelAbstractions
 
 export DiscontinuousSpectralElementGrid, AbstractGrid
 export dofs_per_element, arraytype, dimensionality, polynomialorders
-export referencepoints, min_node_distance, get_z
+export referencepoints, min_node_distance, get_z, computegeometry
 export EveryDirection, HorizontalDirection, VerticalDirection, Direction
 
 abstract type Direction end
@@ -602,7 +602,7 @@ end
 # }}}
 
 """
-   commmapping(N, commelems, commfaces, nabrtocomm)
+    commmapping(N, commelems, commfaces, nabrtocomm)
 
 This function takes in a tuple of polynomial orders `N` and parts of a mesh (as
 returned from `connectmesh` such as `sendelems`, `sendfaces`, and `nabrtosend`)

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -682,11 +682,17 @@ function computegeometry_fvm(elemtocoord, D, ξ, ω, meshwarp)
 
     Metrics.creategrid!(vgeo, elemtocoord, ξ)
 
+    x1 = vgeo.x1
+    x2 = vgeo.x2
+    x3 = vgeo.x3
     @inbounds for j in 1:length(vgeo.x1)
-        (vgeo.x1[j], vgeo.x2[j], vgeo.x3[j]) .=
-            meshwarp(vgeo.x1[j], vgeo.x2[j], vgeo.x3[j])
+        (x1[j], x2[j], x3[j]) = meshwarp(vgeo.x1[j], vgeo.x2[j], vgeo.x3[j])
     end
 
+    # Update data in vgeo
+    vgeo.x1 .= x1
+    vgeo.x2 .= x2
+    vgeo.x3 .= x3
     num_vgeo_handled += 3
 
     @views begin
@@ -855,13 +861,20 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
     Metrics.creategrid!(vgeo, elemtocoord, ξ)
 
     # b) topology coordinates -> physical coordinates
+    x1 = vgeo.x1
+    x2 = vgeo.x2
+    x3 = vgeo.x3
     @inbounds for j in 1:length(vgeo.x1)
-        (vgeo.x1[j], vgeo.x2[j], vgeo.x3[j]) .=
-            meshwarp(vgeo.x1[j], vgeo.x2[j], vgeo.x3[j])
+        (x1[j], x2[j], x3[j]) = meshwarp(vgeo.x1[j], vgeo.x2[j], vgeo.x3[j])
     end
 
+    # Update data in vgeo
+    vgeo.x1 .= x1
+    vgeo.x2 .= x2
+    vgeo.x3 .= x3
+
     # c) computes Jacobian matrix, ∂x/∂ξ
-    compute_reference_to_physical_coord_jacobian!(vgeo, D)
+    Metrics.compute_reference_to_physical_coord_jacobian!(vgeo, D)
 
     # d) computes the metric terms
     Metrics.computemetric!(vgeo, sgeo, D)

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -839,6 +839,15 @@ struct VolumeGeometry{Nq, A<:AbstractArray}
     ξ1x3::A
     ξ2x3::A
     ξ3x3::A
+    x1ξ1::A
+    x2ξ1::A
+    x3ξ1::A
+    x1ξ2::A
+    x2ξ2::A
+    x3ξ2::A
+    x1ξ3::A
+    x2ξ3::A
+    x3ξ3::A
     ωJ::A
     ωJI::A
     ωJH::A
@@ -910,22 +919,13 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
 
     sgeo = SurfaceGeometry(FT, Nq, nface, nelem)
 
-    # (n1, n2, n3, sMJ, vMJI) = ntuple(j -> (@view sgeo[j, :, :, :]), _nsgeo)
-    # sωJ = similar(sωJ)
-
-    # reference element -> topology coordinates
-    # X = ntuple(j -> (@view vgeo[:, _x1 + j - 1, :]), dim)
-
-    # 1) a function which
-
-
     # TODO:
     # - split out (c),(d)
     # - to get analytic derivatives, we need to be able differentiate through (a,b)
     #   - combines (a,b,c)
     #
 
-    # a) computes "topology coordinates"
+    # a) computes "topology coordinates" from reference coordinates ξ
     Metrics.creategrid!(vgeo, elemtocoord, ξ...)
 
     # b) topology coordinates -> physical coordinates
@@ -933,8 +933,12 @@ function computegeometry(elemtocoord, D, ξ, ω, meshwarp)
         (vgeo.x1[j], vgeo.x2[j], vgeo.x3[j]) = meshwarp(vgeo.x1[j], vgeo.x2[j], vgeo.x3[j])
     end
 
+    setup_geom_factors_data!(vgeo, D...)
 
     # c) computes partial derivatives ∂x/∂ξ
+    compute_dxdxi_jacobian!(vgeo, D...)
+    # Compute Jacobian matrix, ∂x/∂ξ
+
     # d) computes the metric terms
     Metrics.computemetric!(vgeo, sgeo, D...)
 

--- a/src/Numerics/Mesh/Mesh.jl
+++ b/src/Numerics/Mesh/Mesh.jl
@@ -1,6 +1,7 @@
 module Mesh
 include("BrickMesh.jl")
 include("Topologies.jl")
+include("GeomData.jl")
 include("Metrics.jl")
 include("Elements.jl")
 include("Grids.jl")

--- a/src/Numerics/Mesh/Mesh.jl
+++ b/src/Numerics/Mesh/Mesh.jl
@@ -1,7 +1,7 @@
 module Mesh
 include("BrickMesh.jl")
 include("Topologies.jl")
-include("GeomData.jl")
+include("GeometricFactors.jl")
 include("Metrics.jl")
 include("Elements.jl")
 include("Grids.jl")

--- a/src/Numerics/Mesh/Metrics.jl
+++ b/src/Numerics/Mesh/Metrics.jl
@@ -1,7 +1,9 @@
 module Metrics
 
+using ..GeomData
+
 """
-    creategrid!(x1, elemtocoord, ξ1)
+    creategrid!(vgeo, elemtocoord, ξ1)
 
 Create a 1-D grid using `elemtocoord` (see [`brickmesh`](@ref)) using the 1-D
 `(-1, 1)` reference coordinates `ξ1`. The element grids are filled using linear

--- a/src/Numerics/Mesh/Metrics.jl
+++ b/src/Numerics/Mesh/Metrics.jl
@@ -8,18 +8,18 @@ Create a 1-D grid using `elemtocoord` (see [`brickmesh`](@ref)) using the 1-D
 interpolation of the element coordinates.
 
 If `Nq = length(ξ1)` and `nelem = size(elemtocoord, 3)` then the preallocated
-array `x1` should be `Nq * nelem == length(x1)`.
+array `vgeo.x1` should be `Nq * nelem == length(x1)`.
 """
-function creategrid!(x1, e2c, ξ1)
+function creategrid!(vgeo::VolumeGeometry{NTuple{1,Int}, <:AbstractArray}, e2c, ξ1)
     (d, nvert, nelem) = size(e2c)
     @assert d == 1
     Nq = length(ξ1)
-    x1 = reshape(x1, (Nq, nelem))
+    vgeo.x1 = reshape(vgeo.x1, (Nq, nelem))
 
     # linear blend
     @inbounds for e in 1:nelem
         for i in 1:Nq
-            x1[i, e] =
+            vgeo.x1[i, e] =
                 ((1 - ξ1[i]) * e2c[1, 1, e] + (1 + ξ1[i]) * e2c[1, 2, e]) / 2
         end
     end
@@ -27,25 +27,25 @@ function creategrid!(x1, e2c, ξ1)
 end
 
 """
-    creategrid!(x1, x2, elemtocoord, ξ1, ξ2)
+    creategrid!(vgeo, elemtocoord, ξ1, ξ2)
 
 Create a 2-D tensor product grid using `elemtocoord` (see [`brickmesh`](@ref))
 using the 1-D `(-1, 1)` reference coordinates `ξ1` and `ξ2`. The element grids
 are filled using bilinear interpolation of the element coordinates.
 
 If `Nq = (length(ξ1), length(ξ2))` and `nelem = size(elemtocoord, 3)` then the
-preallocated arrays `x1` and `x2` should be
-`prod(Nq) * nelem == size(x1) == size(x2)`.
+preallocated arrays `vgeo.x1` and `vgeo.x2` should be
+`prod(Nq) * nelem == size(vgeo.x1) == size(vgeo.x2)`.
 """
-function creategrid!(x1, x2, e2c, ξ1, ξ2)
+function creategrid!(vgeo::VolumeGeometry{NTuple{2,Int}, <:AbstractArray}, e2c, ξ1, ξ2)
     (d, nvert, nelem) = size(e2c)
     @assert d == 2
     Nq = (length(ξ1), length(ξ2))
-    x1 = reshape(x1, (Nq..., nelem))
-    x2 = reshape(x2, (Nq..., nelem))
+    vgeo.x1 = reshape(vgeo.x1, (Nq..., nelem))
+    vgeo.x2 = reshape(vgeo.x2, (Nq..., nelem))
 
     # # bilinear blend of corners
-    @inbounds for (f, n) in zip((x1, x2), 1:d)
+    @inbounds for (f, n) in zip((vgeo.x1, vgeo.x2), 1:d)
         for e in 1:nelem, j in 1:Nq[2], i in 1:Nq[1]
             f[i, j, e] =
                 (
@@ -60,26 +60,26 @@ function creategrid!(x1, x2, e2c, ξ1, ξ2)
 end
 
 """
-    creategrid!(x1, x2, x3, elemtocoord, ξ1, ξ2, ξ3)
+    creategrid!(vgeo, elemtocoord, ξ1, ξ2, ξ3)
 
 Create a 3-D tensor product grid using `elemtocoord` (see [`brickmesh`](@ref))
 using the 1-D `(-1, 1)` reference coordinates `ξ1`. The element grids are filled
 using trilinear interpolation of the element coordinates.
 
 If `Nq = (length(ξ1), length(ξ2), length(ξ3))` and
-`nelem = size(elemtocoord, 3)` then the preallocated arrays `x1`, `x2`, and `x3`
-should be `prod(Nq) * nelem == size(x1) == size(x2) == size(x3)`.
+`nelem = size(elemtocoord, 3)` then the preallocated arrays `vgeo.x1`, `vgeo.x2`,
+and `vgeo.x3` should be `prod(Nq) * nelem == size(vgeo.x1) == size(vgeo.x2) == size(vgeo.x3)`.
 """
-function creategrid!(x1, x2, x3, e2c, ξ1, ξ2, ξ3)
+function creategrid!(vgeo::VolumeGeometry{NTuple{3,Int}, <:AbstractArray}, e2c, ξ1, ξ2, ξ3)
     (d, nvert, nelem) = size(e2c)
     @assert d == 3
     Nq = (length(ξ1), length(ξ2), length(ξ3))
-    x1 = reshape(x1, (Nq..., nelem))
-    x2 = reshape(x2, (Nq..., nelem))
-    x3 = reshape(x3, (Nq..., nelem))
+    vgeo.x1 = reshape(vgeo.x1, (Nq..., nelem))
+    vgeo.x2 = reshape(vgeo.x2, (Nq..., nelem))
+    vgeo.x3 = reshape(vgeo.x3, (Nq..., nelem))
 
     # trilinear blend of corners
-    @inbounds for (f, n) in zip((x1, x2, x3), 1:d)
+    @inbounds for (f, n) in zip((vgeo.x1, vgeo.x2, vgeo.x3), 1:d)
         for e in 1:nelem, k in 1:Nq[3], j in 1:Nq[2], i in 1:Nq[1]
             f[i, j, k, e] =
                 (
@@ -98,7 +98,7 @@ function creategrid!(x1, x2, x3, e2c, ξ1, ξ2, ξ3)
 end
 
 """
-    computemetric!(vgeo::VolumeGeometry{NTuple{1,Int}, <:AbstractArray}, sgeo::SurfaceGeometry{NTuple{1,Int}, <:AbstractArray}, D)
+    computemetric!(vgeo, sgeo, D)
 
 Input arguments:
 - vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
@@ -119,28 +119,28 @@ function computemetric!(
     D)
 
     Nq = size(D, 1)
-    nelem = div(length(vgeo.MJ), Nq)
+    nelem = div(length(vgeo.ωJ), Nq)
     vgeo.x1 = reshape(vgeo.x1, (Nq, nelem))
-    vgeo.MJ = reshape(vgeo.MJ, (Nq, nelem))
+    vgeo.ωJ = reshape(vgeo.ωJ, (Nq, nelem))
     vgeo.JcV = reshape(vgeo.JcV, (Nq, nelem))
     vgeo.ξ1x1 = reshape(vgeo.ξ1x1, (Nq, nelem))
     nface = 2
     sgeo.n1 = reshape(sgeo.n1, (1, nface, nelem))
-    sgeo.sMJ = reshape(sgeo.sMJ, (1, nface, nelem))
+    sgeo.sωJ = reshape(sgeo.sωJ, (1, nface, nelem))
 
     @inbounds for e in 1:nelem
-        vgeo.JcV[:, e] = vgeo.MJ[:, e] = D * vgeo.x1[:, e]
+        vgeo.JcV[:, e] = vgeo.ωJ[:, e] = D * vgeo.x1[:, e]
     end
-    vgeo.ξ1x1 .= 1 ./ vgeo.MJ
+    vgeo.ξ1x1 .= 1 ./ vgeo.ωJ
 
-    sgeo.n1[1, 1, :] .= -sign.(vgeo.MJ[1, :])
-    sgeo.n1[1, 2, :] .= sign.(vgeo.MJ[Nq, :])
-    sgeo.sMJ .= 1
+    sgeo.n1[1, 1, :] .= -sign.(vgeo.ωJ[1, :])
+    sgeo.n1[1, 2, :] .= sign.(vgeo.ωJ[Nq, :])
+    sgeo.sωJ .= 1
     nothing
 end
 
 """
-    computemetric!(vgeo::VolumeGeometry{NTuple{2,Int}, <:AbstractArray}, sgeo::SurfaceGeometry{NTuple{2,Int}, <:AbstractArray}, D1, D2)
+    computemetric!(vgeo, sgeo, D1, D2)
 
 Input arguments:
 - vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
@@ -154,8 +154,8 @@ arrays are preallocated by the user and the (square) derivative matrice `D1` and
 [`creategrid!`](@ref).
 
 If `Nq = (size(D1, 1), size(D2, 1))` and `nelem = div(length(vgeo.x1), prod(Nq))`
-then the volume arrays `vgeo.x1`, `vgeo.x2`, `vgeo.MJ`, `vgeo.ξ1x1`, `vgeo.ξ2x1`, `vgeo.ξ1x2`, and `vgeo.ξ2x2`
-should all be of size `(Nq..., nelem)`.  Similarly, the face arrays `sgeo.sMJ`, `sgeo.n1`,
+then the volume arrays `vgeo.x1`, `vgeo.x2`, `vgeo.ωJ`, `vgeo.ξ1x1`, `vgeo.ξ2x1`, `vgeo.ξ1x2`, and `vgeo.ξ2x2`
+should all be of size `(Nq..., nelem)`.  Similarly, the face arrays `sgeo.sωJ`, `sgeo.n1`,
 and `sgeo.n2` should be of size `(maximum(Nq), nface, nelem)` with `nface = 4`
 
 """
@@ -167,10 +167,10 @@ function computemetric!(
 )
     T = eltype(vgeo.x1)
     Nq = (size(D1, 1), size(D2, 1))
-    nelem = div(length(vgeo.MJ), prod(Nq))
+    nelem = div(length(vgeo.ωJ), prod(Nq))
     vgeo.x1 = reshape(vgeo.x1, (Nq..., nelem))
     vgeo.x2 = reshape(vgeo.x2, (Nq..., nelem))
-    vgeo.MJ = reshape(vgeo.MJ, (Nq..., nelem))
+    vgeo.ωJ = reshape(vgeo.ωJ, (Nq..., nelem))
     vgeo.JcV = reshape(vgeo.JcV, (Nq..., nelem))
     vgeo.ξ1x1 = reshape(vgeo.ξ1x1, (Nq..., nelem))
     vgeo.ξ2x1 = reshape(vgeo.ξ2x1, (Nq..., nelem))
@@ -180,7 +180,7 @@ function computemetric!(
     Nfp = div.(prod(Nq), Nq)
     sgeo.n1 = reshape(sgeo.n1, (maximum(Nfp), nface, nelem))
     sgeo.n2 = reshape(sgeo.n2, (maximum(Nfp), nface, nelem))
-    sgeo.sMJ = reshape(sgeo.sMJ, (maximum(Nfp), nface, nelem))
+    sgeo.sωJ = reshape(sgeo.sωJ, (maximum(Nfp), nface, nelem))
 
     for e in 1:nelem
         for j in 1:Nq[2], i in 1:Nq[1]
@@ -195,37 +195,37 @@ function computemetric!(
                 vgeo.x2ξ2 += D2[j, n] * vgeo.x2[i, n, e]
             end
             vgeo.JcV[i, j, e] = hypot(vgeo.x1ξ2, vgeo.x2ξ2)
-            vgeo.MJ[i, j, e] = vgeo.x1ξ1 * vgeo.x2ξ2 - vgeo.x2ξ1 * vgeo.x1ξ2
-            vgeo.ξ1x1[i, j, e] =  vgeo.x2ξ2 / vgeo.MJ[i, j, e]
-            vgeo.ξ2x1[i, j, e] = -vgeo.x2ξ1 / vgeo.MJ[i, j, e]
-            vgeo.ξ1x2[i, j, e] = -vgeo.x1ξ2 / vgeo.MJ[i, j, e]
-            vgeo.ξ2x2[i, j, e] =  vgeo.x1ξ1 / vgeo.MJ[i, j, e]
+            vgeo.ωJ[i, j, e] = vgeo.x1ξ1 * vgeo.x2ξ2 - vgeo.x2ξ1 * vgeo.x1ξ2
+            vgeo.ξ1x1[i, j, e] =  vgeo.x2ξ2 / vgeo.ωJ[i, j, e]
+            vgeo.ξ2x1[i, j, e] = -vgeo.x2ξ1 / vgeo.ωJ[i, j, e]
+            vgeo.ξ1x2[i, j, e] = -vgeo.x1ξ2 / vgeo.ωJ[i, j, e]
+            vgeo.ξ2x2[i, j, e] =  vgeo.x1ξ1 / vgeo.ωJ[i, j, e]
         end
 
         for i in 1:maximum(Nfp)
             if i <= Nfp[1]
-                sgeo.n1[i, 1, e] = -vgeo.MJ[1, i, e] * vgeo.ξ1x1[1, i, e]
-                sgeo.n2[i, 1, e] = -vgeo.MJ[1, i, e] * vgeo.ξ1x2[1, i, e]
-                sgeo.n1[i, 2, e] =  vgeo.MJ[Nq[1], i, e] * vgeo.ξ1x1[Nq[1], i, e]
-                sgeo.n2[i, 2, e] =  vgeo.MJ[Nq[1], i, e] * vgeo.ξ1x2[Nq[1], i, e]
+                sgeo.n1[i, 1, e] = -vgeo.ωJ[1, i, e] * vgeo.ξ1x1[1, i, e]
+                sgeo.n2[i, 1, e] = -vgeo.ωJ[1, i, e] * vgeo.ξ1x2[1, i, e]
+                sgeo.n1[i, 2, e] =  vgeo.ωJ[Nq[1], i, e] * vgeo.ξ1x1[Nq[1], i, e]
+                sgeo.n2[i, 2, e] =  vgeo.ωJ[Nq[1], i, e] * vgeo.ξ1x2[Nq[1], i, e]
             else
                 sgeo.n1[i, 1:2, e] .= NaN
                 sgeo.n2[i, 1:2, e] .= NaN
             end
             if i <= Nfp[2]
-                sgeo.n1[i, 3, e] = -vgeo.MJ[i, 1, e] * vgeo.ξ2x1[i, 1, e]
-                sgeo.n2[i, 3, e] = -vgeo.MJ[i, 1, e] * vgeo.ξ2x2[i, 1, e]
-                sgeo.n1[i, 4, e] =  vgeo.MJ[i, Nq[2], e] * vgeo.ξ2x1[i, Nq[2], e]
-                sgeo.n2[i, 4, e] =  vgeo.MJ[i, Nq[2], e] * vgeo.ξ2x2[i, Nq[2], e]
+                sgeo.n1[i, 3, e] = -vgeo.ωJ[i, 1, e] * vgeo.ξ2x1[i, 1, e]
+                sgeo.n2[i, 3, e] = -vgeo.ωJ[i, 1, e] * vgeo.ξ2x2[i, 1, e]
+                sgeo.n1[i, 4, e] =  vgeo.ωJ[i, Nq[2], e] * vgeo.ξ2x1[i, Nq[2], e]
+                sgeo.n2[i, 4, e] =  vgeo.ωJ[i, Nq[2], e] * vgeo.ξ2x2[i, Nq[2], e]
             else
                 sgeo.n1[i, 3:4, e] .= NaN
                 sgeo.n2[i, 3:4, e] .= NaN
             end
 
             for n in 1:nface
-                sgeo.sMJ[i, n, e] = hypot(sgeo.n1[i, n, e], sgeo.n2[i, n, e])
-                sgeo.n1[i, n, e] /= sgeo.sMJ[i, n, e]
-                sgeo.n2[i, n, e] /= sgeo.sMJ[i, n, e]
+                sgeo.sωJ[i, n, e] = hypot(sgeo.n1[i, n, e], sgeo.n2[i, n, e])
+                sgeo.n1[i, n, e] /= sgeo.sωJ[i, n, e]
+                sgeo.n2[i, n, e] /= sgeo.sωJ[i, n, e]
             end
         end
     end
@@ -234,7 +234,7 @@ function computemetric!(
 end
 
 """
-    computemetric!(vgeo::VolumeGeometry{NTuple{3,Int}, <:AbstractArray}, sgeo::SurfaceGeometry{NTuple{3,Int}, <:AbstractArray}, D1, D2, D3)
+    computemetric!(vgeo, sgeo, D1, D2, D3)
 
 - vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
 - sgeo::SurfaceGeometry, a struct containing the surface geometric factors
@@ -248,10 +248,10 @@ All the arrays are preallocated by the user and the (square) derivative matrice 
 [`creategrid!`](@ref).
 
 If `Nq = size(D1, 1)` and `nelem = div(length(vgeo.x1), Nq^3)` then the volume arrays
-`vgeo.x1`, `vgeo.x2`, `vgeo.x3`, `vgeo.MJ`, `vgeo.ξ1x1`, `vgeo.ξ2x1`, `vgeo.ξ3x1`,
+`vgeo.x1`, `vgeo.x2`, `vgeo.x3`, `vgeo.ωJ`, `vgeo.ξ1x1`, `vgeo.ξ2x1`, `vgeo.ξ3x1`,
 `vgeo.ξ1x2`, `vgeo.ξ2x2`, `vgeo.ξ3x2`, `vgeo.ξ1x3`,`vgeo.ξ2x3`, and `vgeo.ξ3x3`
 should all be of length `Nq^3 * nelem`.  Similarly, the face
-arrays `sgeo.sMJ`, `sgeo.n1`, `sgeo.n2`, and `sgeo.n3` should be of size `Nq^2 * nface * nelem` with
+arrays `sgeo.sωJ`, `sgeo.n1`, `sgeo.n2`, and `sgeo.n3` should be of size `Nq^2 * nface * nelem` with
 `nface = 6`.
 
 The curl invariant formulation of Kopriva (2006), equation 37, is used.
@@ -271,12 +271,12 @@ function computemetric!(
     Nq = (size(D1, 1), size(D2, 1), size(D3, 1))
     Np = prod(Nq)
     Nfp = div.(Np, Nq)
-    nelem = div(length(vgeo.MJ), Np)
+    nelem = div(length(vgeo.ωJ), Np)
 
     vgeo.x1 = reshape(vgeo.x1, (Nq..., nelem))
     vgeo.x2 = reshape(vgeo.x2, (Nq..., nelem))
     vgeo.x3 = reshape(vgeo.x3, (Nq..., nelem))
-    vgeo.MJ = reshape(vgeo.MJ, (Nq..., nelem))
+    vgeo.ωJ = reshape(vgeo.ωJ, (Nq..., nelem))
     vgeo.JcV = reshape(vgeo.JcV, (Nq..., nelem))
     vgeo.ξ1x1 = reshape(vgeo.ξ1x1, (Nq..., nelem))
     vgeo.ξ2x1 = reshape(vgeo.ξ2x1, (Nq..., nelem))
@@ -292,9 +292,9 @@ function computemetric!(
     sgeo.n1 = reshape(sgeo.n1, maximum(Nfp), nface, nelem)
     sgeo.n2 = reshape(sgeo.n2, maximum(Nfp), nface, nelem)
     sgeo.n3 = reshape(sgeo.n3, maximum(Nfp), nface, nelem)
-    sgeo.sMJ = reshape(sgeo.sMJ, maximum(Nfp), nface, nelem)
+    sgeo.sωJ = reshape(sgeo.sωJ, maximum(Nfp), nface, nelem)
 
-    JI2 = similar(vgeo.MJ, Nq...)
+    JI2 = similar(vgeo.ωJ, Nq...)
     (yzr, yzs, yzt) = (similar(JI2), similar(JI2), similar(JI2))
     (zxr, zxs, zxt) = (similar(JI2), similar(JI2), similar(JI2))
     (xyr, xys, xyt) = (similar(JI2), similar(JI2), similar(JI2))
@@ -312,7 +312,7 @@ function computemetric!(
     fill!(sgeo.n1, NaN)
     fill!(sgeo.n2, NaN)
     fill!(sgeo.n3, NaN)
-    fill!(sgeo.sMJ, NaN)
+    fill!(sgeo.sωJ, NaN)
 
     @inbounds for e in 1:nelem
         for k in 1:Nq[3], j in 1:Nq[2], i in 1:Nq[1]
@@ -341,7 +341,7 @@ function computemetric!(
                 vgeo.x3ξ1 * (vgeo.x1ξ2 * vgeo.x2ξ3 - vgeo.x2ξ2 * vgeo.x1ξ3)
             )
 
-            JI2[i, j, k] = 1 / (2 * vgeo.MJ[i, j, k, e])
+            JI2[i, j, k] = 1 / (2 * vgeo.ωJ[i, j, k, e])
 
             yzr[i, j, k] = vgeo.x2[i, j, k, e] * vgeo.x3ξ1 - vgeo.x3[i, j, k, e] * vgeo.x2ξ1
             yzs[i, j, k] = vgeo.x2[i, j, k, e] * vgeo.x3ξ2 - vgeo.x3[i, j, k, e] * vgeo.x2ξ2
@@ -393,49 +393,49 @@ function computemetric!(
         # faces 1 & 2
         for k in 1:Nq[3], j in 1:Nq[2]
             n = j + (k - 1) * Nq[2]
-            sgeo.n1[n, 1, e] = -vgeo.MJ[1, j, k, e] * vgeo.ξ1x1[1, j, k, e]
-            sgeo.n2[n, 1, e] = -vgeo.MJ[1, j, k, e] * vgeo.ξ1x2[1, j, k, e]
-            sgeo.n3[n, 1, e] = -vgeo.MJ[1, j, k, e] * vgeo.ξ1x3[1, j, k, e]
-            sgeo.n1[n, 2, e] =  vgeo.MJ[Nq[1], j, k, e] * vgeo.ξ1x1[Nq[1], j, k, e]
-            sgeo.n2[n, 2, e] =  vgeo.MJ[Nq[1], j, k, e] * vgeo.ξ1x2[Nq[1], j, k, e]
-            sgeo.n3[n, 2, e] =  vgeo.MJ[Nq[1], j, k, e] * vgeo.ξ1x3[Nq[1], j, k, e]
+            sgeo.n1[n, 1, e] = -vgeo.ωJ[1, j, k, e] * vgeo.ξ1x1[1, j, k, e]
+            sgeo.n2[n, 1, e] = -vgeo.ωJ[1, j, k, e] * vgeo.ξ1x2[1, j, k, e]
+            sgeo.n3[n, 1, e] = -vgeo.ωJ[1, j, k, e] * vgeo.ξ1x3[1, j, k, e]
+            sgeo.n1[n, 2, e] =  vgeo.ωJ[Nq[1], j, k, e] * vgeo.ξ1x1[Nq[1], j, k, e]
+            sgeo.n2[n, 2, e] =  vgeo.ωJ[Nq[1], j, k, e] * vgeo.ξ1x2[Nq[1], j, k, e]
+            sgeo.n3[n, 2, e] =  vgeo.ωJ[Nq[1], j, k, e] * vgeo.ξ1x3[Nq[1], j, k, e]
             for f in 1:2
-                sgeo.sMJ[n, f, e] = hypot(sgeo.n1[n, f, e], sgeo.n2[n, f, e], sgeo.n3[n, f, e])
-                sgeo.n1[n, f, e] /= sgeo.sMJ[n, f, e]
-                sgeo.n2[n, f, e] /= sgeo.sMJ[n, f, e]
-                sgeo.n3[n, f, e] /= sgeo.sMJ[n, f, e]
+                sgeo.sωJ[n, f, e] = hypot(sgeo.n1[n, f, e], sgeo.n2[n, f, e], sgeo.n3[n, f, e])
+                sgeo.n1[n, f, e] /= sgeo.sωJ[n, f, e]
+                sgeo.n2[n, f, e] /= sgeo.sωJ[n, f, e]
+                sgeo.n3[n, f, e] /= sgeo.sωJ[n, f, e]
             end
         end
         # faces 3 & 4
         for k in 1:Nq[3], i in 1:Nq[1]
             n = i + (k - 1) * Nq[1]
-            sgeo.n1[n, 3, e] = -vgeo.MJ[i, 1, k, e] * vgeo.ξ2x1[i, 1, k, e]
-            sgeo.n2[n, 3, e] = -vgeo.MJ[i, 1, k, e] * vgeo.ξ2x2[i, 1, k, e]
-            sgeo.n3[n, 3, e] = -vgeo.MJ[i, 1, k, e] * vgeo.ξ2x3[i, 1, k, e]
-            sgeo.n1[n, 4, e] =  vgeo.MJ[i, Nq[2], k, e] * vgeo.ξ2x1[i, Nq[2], k, e]
-            sgeo.n2[n, 4, e] =  vgeo.MJ[i, Nq[2], k, e] * vgeo.ξ2x2[i, Nq[2], k, e]
-            sgeo.n3[n, 4, e] =  vgeo.MJ[i, Nq[2], k, e] * vgeo.ξ2x3[i, Nq[2], k, e]
+            sgeo.n1[n, 3, e] = -vgeo.ωJ[i, 1, k, e] * vgeo.ξ2x1[i, 1, k, e]
+            sgeo.n2[n, 3, e] = -vgeo.ωJ[i, 1, k, e] * vgeo.ξ2x2[i, 1, k, e]
+            sgeo.n3[n, 3, e] = -vgeo.ωJ[i, 1, k, e] * vgeo.ξ2x3[i, 1, k, e]
+            sgeo.n1[n, 4, e] =  vgeo.ωJ[i, Nq[2], k, e] * vgeo.ξ2x1[i, Nq[2], k, e]
+            sgeo.n2[n, 4, e] =  vgeo.ωJ[i, Nq[2], k, e] * vgeo.ξ2x2[i, Nq[2], k, e]
+            sgeo.n3[n, 4, e] =  vgeo.ωJ[i, Nq[2], k, e] * vgeo.ξ2x3[i, Nq[2], k, e]
             for f in 3:4
-                sgeo.sMJ[n, f, e] = hypot(sgeo.n1[n, f, e], sgeo.n2[n, f, e], sgeo.n3[n, f, e])
-                sgeo.n1[n, f, e] /= sgeo.sMJ[n, f, e]
-                sgeo.n2[n, f, e] /= sgeo.sMJ[n, f, e]
-                sgeo.n3[n, f, e] /= sgeo.sMJ[n, f, e]
+                sgeo.sωJ[n, f, e] = hypot(sgeo.n1[n, f, e], sgeo.n2[n, f, e], sgeo.n3[n, f, e])
+                sgeo.n1[n, f, e] /= sgeo.sωJ[n, f, e]
+                sgeo.n2[n, f, e] /= sgeo.sωJ[n, f, e]
+                sgeo.n3[n, f, e] /= sgeo.sωJ[n, f, e]
             end
         end
         # faces 5 & 6
         for j in 1:Nq[2], i in 1:Nq[1]
             n = i + (j - 1) * Nq[1]
-            sgeo.n1[n, 5, e] = -vgeo.MJ[i, j, 1, e] * vgeo.ξ3x1[i, j, 1, e]
-            sgeo.n2[n, 5, e] = -vgeo.MJ[i, j, 1, e] * vgeo.ξ3x2[i, j, 1, e]
-            sgeo.n3[n, 5, e] = -vgeo.MJ[i, j, 1, e] * vgeo.ξ3x3[i, j, 1, e]
-            sgeo.n1[n, 6, e] =  vgeo.MJ[i, j, Nq[3], e] * vgeo.ξ3x1[i, j, Nq[3], e]
-            sgeo.n2[n, 6, e] =  vgeo.MJ[i, j, Nq[3], e] * vgeo.ξ3x2[i, j, Nq[3], e]
-            sgeo.n3[n, 6, e] =  vgeo.MJ[i, j, Nq[3], e] * vgeo.ξ3x3[i, j, Nq[3], e]
+            sgeo.n1[n, 5, e] = -vgeo.ωJ[i, j, 1, e] * vgeo.ξ3x1[i, j, 1, e]
+            sgeo.n2[n, 5, e] = -vgeo.ωJ[i, j, 1, e] * vgeo.ξ3x2[i, j, 1, e]
+            sgeo.n3[n, 5, e] = -vgeo.ωJ[i, j, 1, e] * vgeo.ξ3x3[i, j, 1, e]
+            sgeo.n1[n, 6, e] =  vgeo.ωJ[i, j, Nq[3], e] * vgeo.ξ3x1[i, j, Nq[3], e]
+            sgeo.n2[n, 6, e] =  vgeo.ωJ[i, j, Nq[3], e] * vgeo.ξ3x2[i, j, Nq[3], e]
+            sgeo.n3[n, 6, e] =  vgeo.ωJ[i, j, Nq[3], e] * vgeo.ξ3x3[i, j, Nq[3], e]
             for f in 5:6
-                sgeo.sMJ[n, f, e] = hypot(sgeo.n1[n, f, e], sgeo.n2[n, f, e], sgeo.n3[n, f, e])
-                sgeo.n1[n, f, e] /= sgeo.sMJ[n, f, e]
-                sgeo.n2[n, f, e] /= sgeo.sMJ[n, f, e]
-                sgeo.n3[n, f, e] /= sgeo.sMJ[n, f, e]
+                sgeo.sωJ[n, f, e] = hypot(sgeo.n1[n, f, e], sgeo.n2[n, f, e], sgeo.n3[n, f, e])
+                sgeo.n1[n, f, e] /= sgeo.sωJ[n, f, e]
+                sgeo.n2[n, f, e] /= sgeo.sωJ[n, f, e]
+                sgeo.n3[n, f, e] /= sgeo.sωJ[n, f, e]
             end
         end
     end
@@ -443,192 +443,192 @@ function computemetric!(
     nothing
 end
 
-"""
-  computemetric(x1::AbstractArray{T, 2}, D::AbstractMatrix{T}) where T
+# """
+#   computemetric(x1::AbstractArray{T, 2}, D::AbstractMatrix{T}) where T
 
-Compute the 1-D metric terms from the element grid array `x1` using the
-derivative matrix `D`. The derivative matrix `D` should be consistent with the
-reference grid `ξ1` used in [`creategrid!`](@ref).
+# Compute the 1-D metric terms from the element grid array `x1` using the
+# derivative matrix `D`. The derivative matrix `D` should be consistent with the
+# reference grid `ξ1` used in [`creategrid!`](@ref).
 
-The metric terms are returned as a 'NamedTuple` of the following arrays:
+# The metric terms are returned as a 'NamedTuple` of the following arrays:
 
-- `J` the Jacobian determinant
-- `ξ1x1` derivative ∂ξ1 / ∂x1'
-- `sJ` the surface Jacobian
-- 'n1` outward pointing unit normal in \$x1\$-direction
-"""
-function computemetric(x1::AbstractArray{T, 2}, D::AbstractMatrix{T}) where {T}
+# - `J` the Jacobian determinant
+# - `ξ1x1` derivative ∂ξ1 / ∂x1'
+# - `sJ` the surface Jacobian
+# - 'n1` outward pointing unit normal in \$x1\$-direction
+# """
+# function computemetric(x1::AbstractArray{T, 2}, D::AbstractMatrix{T}) where {T}
 
-    Nq = size(D, 1)
-    nelem = size(x1, 2)
-    nface = 2
+#     Nq = size(D, 1)
+#     nelem = size(x1, 2)
+#     nface = 2
 
-    J = similar(x1)
-    ξ1x1 = similar(x1)
+#     J = similar(x1)
+#     ξ1x1 = similar(x1)
 
-    sJ = Array{T, 3}(undef, 1, nface, nelem)
-    n1 = Array{T, 3}(undef, 1, nface, nelem)
+#     sJ = Array{T, 3}(undef, 1, nface, nelem)
+#     n1 = Array{T, 3}(undef, 1, nface, nelem)
 
-    computemetric!(x1, J, JcV, ξ1x1, sJ, n1, D)
+#     computemetric!(x1, J, JcV, ξ1x1, sJ, n1, D)
 
-    (J = J, JcV = JcV, ξ1x1 = ξ1x1, sJ = sJ, n1 = n1)
-end
+#     (J = J, JcV = JcV, ξ1x1 = ξ1x1, sJ = sJ, n1 = n1)
+# end
 
 
-"""
-  computemetric(x1::AbstractArray{T, 3}, x2::AbstractArray{T, 3},
-                D::AbstractMatrix{T}) where T
+# """
+#   computemetric(x1::AbstractArray{T, 3}, x2::AbstractArray{T, 3},
+#                 D::AbstractMatrix{T}) where T
 
-Compute the 2-D metric terms from the element grid arrays `x1` and `x2` using
-the derivative matrix `D`. The derivative matrix `D` should be consistent with
-the reference grid `ξ1` used in [`creategrid!`](@ref).
+# Compute the 2-D metric terms from the element grid arrays `x1` and `x2` using
+# the derivative matrix `D`. The derivative matrix `D` should be consistent with
+# the reference grid `ξ1` used in [`creategrid!`](@ref).
 
-The metric terms are returned as a 'NamedTuple` of the following arrays:
+# The metric terms are returned as a 'NamedTuple` of the following arrays:
 
-- `J` the Jacobian determinant
-- `ξ1x1` derivative ∂ξ1 / ∂x1'
-- `ξ2x1` derivative ∂ξ2 / ∂x1'
- - `ξ1x2` derivative ∂ξ1 / ∂x2'
- - `ξ2x2` derivative ∂ξ2 / ∂x2'
- - `sJ` the surface Jacobian
- - 'n1` outward pointing unit normal in \$x1\$-direction
- - 'n2` outward pointing unit normal in \$x2\$-direction
-"""
-function computemetric(
-    x1::AbstractArray{T, 3},
-    x2::AbstractArray{T, 3},
-    D::AbstractMatrix{T},
-) where {T}
-    @assert size(x1) == size(x2)
-    Nq = size(D, 1)
-    nelem = size(x1, 3)
-    nface = 4
+# - `J` the Jacobian determinant
+# - `ξ1x1` derivative ∂ξ1 / ∂x1'
+# - `ξ2x1` derivative ∂ξ2 / ∂x1'
+#  - `ξ1x2` derivative ∂ξ1 / ∂x2'
+#  - `ξ2x2` derivative ∂ξ2 / ∂x2'
+#  - `sJ` the surface Jacobian
+#  - 'n1` outward pointing unit normal in \$x1\$-direction
+#  - 'n2` outward pointing unit normal in \$x2\$-direction
+# """
+# function computemetric(
+#     x1::AbstractArray{T, 3},
+#     x2::AbstractArray{T, 3},
+#     D::AbstractMatrix{T},
+# ) where {T}
+#     @assert size(x1) == size(x2)
+#     Nq = size(D, 1)
+#     nelem = size(x1, 3)
+#     nface = 4
 
-    J = similar(x1)
-    JcV = similar(x1)
-    ξ1x1 = similar(x1)
-    ξ2x1 = similar(x1)
-    ξ1x2 = similar(x1)
-    ξ2x2 = similar(x1)
+#     J = similar(x1)
+#     JcV = similar(x1)
+#     ξ1x1 = similar(x1)
+#     ξ2x1 = similar(x1)
+#     ξ1x2 = similar(x1)
+#     ξ2x2 = similar(x1)
 
-    sJ = Array{T, 3}(undef, Nq, nface, nelem)
-    n1 = Array{T, 3}(undef, Nq, nface, nelem)
-    n2 = Array{T, 3}(undef, Nq, nface, nelem)
+#     sJ = Array{T, 3}(undef, Nq, nface, nelem)
+#     n1 = Array{T, 3}(undef, Nq, nface, nelem)
+#     n2 = Array{T, 3}(undef, Nq, nface, nelem)
 
-    computemetric!(x1, x2, J, JcV, ξ1x1, ξ2x1, ξ1x2, ξ2x2, sJ, n1, n2, D)
+#     computemetric!(x1, x2, J, JcV, ξ1x1, ξ2x1, ξ1x2, ξ2x2, sJ, n1, n2, D)
 
-    (
-        J = J,
-        JcV = JcV,
-        ξ1x1 = ξ1x1,
-        ξ2x1 = ξ2x1,
-        ξ1x2 = ξ1x2,
-        ξ2x2 = ξ2x2,
-        sJ = sJ,
-        n1 = n1,
-        n2 = n2,
-    )
-end
+#     (
+#         J = J,
+#         JcV = JcV,
+#         ξ1x1 = ξ1x1,
+#         ξ2x1 = ξ2x1,
+#         ξ1x2 = ξ1x2,
+#         ξ2x2 = ξ2x2,
+#         sJ = sJ,
+#         n1 = n1,
+#         n2 = n2,
+#     )
+# end
 
-"""
-    computemetric(x1::AbstractArray{T, 3}, x2::AbstractArray{T, 3},
-                  D::AbstractMatrix{T}) where T
+# """
+#     computemetric(x1::AbstractArray{T, 3}, x2::AbstractArray{T, 3},
+#                   D::AbstractMatrix{T}) where T
 
-Compute the 3-D metric terms from the element grid arrays `x1`, `x2`, and `x3`
-using the derivative matrix `D`. The derivative matrix `D` should be consistent
-with the reference grid `ξ1` used in [`creategrid!`](@ref).
+# Compute the 3-D metric terms from the element grid arrays `x1`, `x2`, and `x3`
+# using the derivative matrix `D`. The derivative matrix `D` should be consistent
+# with the reference grid `ξ1` used in [`creategrid!`](@ref).
 
-The metric terms are returned as a 'NamedTuple` of the following arrays:
+# The metric terms are returned as a 'NamedTuple` of the following arrays:
 
- - `J` the Jacobian determinant
- - `ξ1x1` derivative ∂ξ1 / ∂x1'
- - `ξ2x1` derivative ∂ξ2 / ∂x1'
- - `ξ3x1` derivative ∂ξ3 / ∂x1'
- - `ξ1x2` derivative ∂ξ1 / ∂x2'
- - `ξ2x2` derivative ∂ξ2 / ∂x2'
- - `ξ3x2` derivative ∂ξ3 / ∂x2'
- - `ξ1x3` derivative ∂ξ1 / ∂x3'
- - `ξ2x3` derivative ∂ξ2 / ∂x3'
- - `ξ3x3` derivative ∂ξ3 / ∂x3'
- - `sJ` the surface Jacobian
- - 'n1` outward pointing unit normal in \$x1\$-direction
- - 'n2` outward pointing unit normal in \$x2\$-direction
- - 'n3` outward pointing unit normal in \$x3\$-direction
+#  - `J` the Jacobian determinant
+#  - `ξ1x1` derivative ∂ξ1 / ∂x1'
+#  - `ξ2x1` derivative ∂ξ2 / ∂x1'
+#  - `ξ3x1` derivative ∂ξ3 / ∂x1'
+#  - `ξ1x2` derivative ∂ξ1 / ∂x2'
+#  - `ξ2x2` derivative ∂ξ2 / ∂x2'
+#  - `ξ3x2` derivative ∂ξ3 / ∂x2'
+#  - `ξ1x3` derivative ∂ξ1 / ∂x3'
+#  - `ξ2x3` derivative ∂ξ2 / ∂x3'
+#  - `ξ3x3` derivative ∂ξ3 / ∂x3'
+#  - `sJ` the surface Jacobian
+#  - 'n1` outward pointing unit normal in \$x1\$-direction
+#  - 'n2` outward pointing unit normal in \$x2\$-direction
+#  - 'n3` outward pointing unit normal in \$x3\$-direction
 
-!!! note
+# !!! note
 
-   The storage of the volume terms and surface terms from this function are
-   slightly different. The volume terms used Cartesian indexing whereas the
-   surface terms use linear indexing.
-"""
-function computemetric(
-    x1::AbstractArray{T, 4},
-    x2::AbstractArray{T, 4},
-    x3::AbstractArray{T, 4},
-    D::AbstractMatrix{T},
-) where {T}
+#    The storage of the volume terms and surface terms from this function are
+#    slightly different. The volume terms used Cartesian indexing whereas the
+#    surface terms use linear indexing.
+# """
+# function computemetric(
+#     x1::AbstractArray{T, 4},
+#     x2::AbstractArray{T, 4},
+#     x3::AbstractArray{T, 4},
+#     D::AbstractMatrix{T},
+# ) where {T}
 
-    @assert size(x1) == size(x2) == size(x3)
-    Nq = size(D, 1)
-    nelem = size(x1, 4)
-    nface = 6
+#     @assert size(x1) == size(x2) == size(x3)
+#     Nq = size(D, 1)
+#     nelem = size(x1, 4)
+#     nface = 6
 
-    J = similar(x1)
-    JcV = similar(x1)
-    ξ1x1 = similar(x1)
-    ξ2x1 = similar(x1)
-    ξ3x1 = similar(x1)
-    ξ1x2 = similar(x1)
-    ξ2x2 = similar(x1)
-    ξ3x2 = similar(x1)
-    ξ1x3 = similar(x1)
-    ξ2x3 = similar(x1)
-    ξ3x3 = similar(x1)
+#     J = similar(x1)
+#     JcV = similar(x1)
+#     ξ1x1 = similar(x1)
+#     ξ2x1 = similar(x1)
+#     ξ3x1 = similar(x1)
+#     ξ1x2 = similar(x1)
+#     ξ2x2 = similar(x1)
+#     ξ3x2 = similar(x1)
+#     ξ1x3 = similar(x1)
+#     ξ2x3 = similar(x1)
+#     ξ3x3 = similar(x1)
 
-    sJ = Array{T, 3}(undef, Nq^2, nface, nelem)
-    n1 = Array{T, 3}(undef, Nq^2, nface, nelem)
-    n2 = Array{T, 3}(undef, Nq^2, nface, nelem)
-    n3 = Array{T, 3}(undef, Nq^2, nface, nelem)
+#     sJ = Array{T, 3}(undef, Nq^2, nface, nelem)
+#     n1 = Array{T, 3}(undef, Nq^2, nface, nelem)
+#     n2 = Array{T, 3}(undef, Nq^2, nface, nelem)
+#     n3 = Array{T, 3}(undef, Nq^2, nface, nelem)
 
-    computemetric!(
-        x1,
-        x2,
-        x3,
-        J,
-        JcV,
-        ξ1x1,
-        ξ2x1,
-        ξ3x1,
-        ξ1x2,
-        ξ2x2,
-        ξ3x2,
-        ξ1x3,
-        ξ2x3,
-        ξ3x3,
-        sJ,
-        n1,
-        n2,
-        n3,
-        D,
-    )
+#     computemetric!(
+#         x1,
+#         x2,
+#         x3,
+#         J,
+#         JcV,
+#         ξ1x1,
+#         ξ2x1,
+#         ξ3x1,
+#         ξ1x2,
+#         ξ2x2,
+#         ξ3x2,
+#         ξ1x3,
+#         ξ2x3,
+#         ξ3x3,
+#         sJ,
+#         n1,
+#         n2,
+#         n3,
+#         D,
+#     )
 
-    (
-        J = J,
-        JcV = JcV,
-        ξ1x1 = ξ1x1,
-        ξ2x1 = ξ2x1,
-        ξ3x1 = ξ3x1,
-        ξ1x2 = ξ1x2,
-        ξ2x2 = ξ2x2,
-        ξ3x2 = ξ3x2,
-        ξ1x3 = ξ1x3,
-        ξ2x3 = ξ2x3,
-        ξ3x3 = ξ3x3,
-        sJ = sJ,
-        n1 = n1,
-        n2 = n2,
-        n3 = n3,
-    )
-end
+#     (
+#         J = J,
+#         JcV = JcV,
+#         ξ1x1 = ξ1x1,
+#         ξ2x1 = ξ2x1,
+#         ξ3x1 = ξ3x1,
+#         ξ1x2 = ξ1x2,
+#         ξ2x2 = ξ2x2,
+#         ξ3x2 = ξ3x2,
+#         ξ1x3 = ξ1x3,
+#         ξ2x3 = ξ2x3,
+#         ξ3x3 = ξ3x3,
+#         sJ = sJ,
+#         n1 = n1,
+#         n2 = n2,
+#         n3 = n3,
+#     )
+# end
 
 end # module

--- a/src/Numerics/Mesh/Metrics.jl
+++ b/src/Numerics/Mesh/Metrics.jl
@@ -2,6 +2,8 @@ module Metrics
 
 using ..GeomData
 
+export creategrid, compute_reference_to_physical_coord_jacobian, computemetric
+
 """
     creategrid!(vgeo, elemtocoord, ξ)
 

--- a/src/Numerics/Mesh/Metrics.jl
+++ b/src/Numerics/Mesh/Metrics.jl
@@ -3,45 +3,54 @@ module Metrics
 using ..GeomData
 
 """
-    creategrid!(vgeo, elemtocoord, ξ1)
+    creategrid!(vgeo, elemtocoord, ξ)
 
 Create a 1-D grid using `elemtocoord` (see [`brickmesh`](@ref)) using the 1-D
-`(-1, 1)` reference coordinates `ξ1`. The element grids are filled using linear
-interpolation of the element coordinates.
+`(-1, 1)` reference coordinates `ξ` (in 1D, `ξ = ξ1`). The element grids
+are filled using linear interpolation of the element coordinates.
 
-If `Nq = length(ξ1)` and `nelem = size(elemtocoord, 3)` then the preallocated
+If `Nq = length(ξ)` and `nelem = size(elemtocoord, 3)` then the preallocated
 array `vgeo.x1` should be `Nq * nelem == length(x1)`.
 """
-function creategrid!(vgeo::VolumeGeometry{NTuple{1,Int}, <:AbstractArray}, e2c, ξ1)
+function creategrid!(
+    vgeo::VolumeGeometry{NTuple{1, Int}, <:AbstractArray},
+    e2c,
+    ξ::NTuple{1, Int},
+)
     (d, nvert, nelem) = size(e2c)
     @assert d == 1
-    Nq = length(ξ1)
+    Nq = length(ξ)
     vgeo.x1 = reshape(vgeo.x1, (Nq, nelem))
 
     # linear blend
     @inbounds for e in 1:nelem
         for i in 1:Nq
             vgeo.x1[i, e] =
-                ((1 - ξ1[i]) * e2c[1, 1, e] + (1 + ξ1[i]) * e2c[1, 2, e]) / 2
+                ((1 - ξ[i]) * e2c[1, 1, e] + (1 + ξ[i]) * e2c[1, 2, e]) / 2
         end
     end
     nothing
 end
 
 """
-    creategrid!(vgeo, elemtocoord, ξ1, ξ2)
+    creategrid!(vgeo, elemtocoord, ξ)
 
 Create a 2-D tensor product grid using `elemtocoord` (see [`brickmesh`](@ref))
-using the 1-D `(-1, 1)` reference coordinates `ξ1` and `ξ2`. The element grids
-are filled using bilinear interpolation of the element coordinates.
+using the tuple `ξ = (ξ1, ξ2)`, composed by the 1D reference coordinates `ξ1` and `ξ2` in `(-1, 1)^2`.
+The element grids are filled using bilinear interpolation of the element coordinates.
 
 If `Nq = (length(ξ1), length(ξ2))` and `nelem = size(elemtocoord, 3)` then the
 preallocated arrays `vgeo.x1` and `vgeo.x2` should be
 `prod(Nq) * nelem == size(vgeo.x1) == size(vgeo.x2)`.
 """
-function creategrid!(vgeo::VolumeGeometry{NTuple{2,Int}, <:AbstractArray}, e2c, ξ1, ξ2)
+function creategrid!(
+    vgeo::VolumeGeometry{NTuple{2, Int}, <:AbstractArray},
+    e2c,
+    ξ::NTuple{2, Int},
+)
     (d, nvert, nelem) = size(e2c)
     @assert d == 2
+    (ξ1, ξ2) = ξ
     Nq = (length(ξ1), length(ξ2))
     vgeo.x1 = reshape(vgeo.x1, (Nq..., nelem))
     vgeo.x2 = reshape(vgeo.x2, (Nq..., nelem))
@@ -62,19 +71,24 @@ function creategrid!(vgeo::VolumeGeometry{NTuple{2,Int}, <:AbstractArray}, e2c, 
 end
 
 """
-    creategrid!(vgeo, elemtocoord, ξ1, ξ2, ξ3)
+    creategrid!(vgeo, elemtocoord, ξ)
 
 Create a 3-D tensor product grid using `elemtocoord` (see [`brickmesh`](@ref))
-using the 1-D `(-1, 1)` reference coordinates `ξ1`. The element grids are filled
-using trilinear interpolation of the element coordinates.
+using the tuple `ξ = (ξ1, ξ2, ξ3)`, composed by the 1D reference coordinates `ξ1`, `ξ2`, `ξ3` in `(-1, 1)^3`.
+The element grids are filled using trilinear interpolation of the element coordinates.
 
 If `Nq = (length(ξ1), length(ξ2), length(ξ3))` and
 `nelem = size(elemtocoord, 3)` then the preallocated arrays `vgeo.x1`, `vgeo.x2`,
 and `vgeo.x3` should be `prod(Nq) * nelem == size(vgeo.x1) == size(vgeo.x2) == size(vgeo.x3)`.
 """
-function creategrid!(vgeo::VolumeGeometry{NTuple{3,Int}, <:AbstractArray}, e2c, ξ1, ξ2, ξ3)
+function creategrid!(
+    vgeo::VolumeGeometry{NTuple{3, Int}, <:AbstractArray},
+    e2c,
+    ξ::NTuple{3, Int},
+)
     (d, nvert, nelem) = size(e2c)
     @assert d == 3
+    (ξ1, ξ2, ξ3) = ξ
     Nq = (length(ξ1), length(ξ2), length(ξ3))
     vgeo.x1 = reshape(vgeo.x1, (Nq..., nelem))
     vgeo.x2 = reshape(vgeo.x2, (Nq..., nelem))
@@ -100,112 +114,24 @@ function creategrid!(vgeo::VolumeGeometry{NTuple{3,Int}, <:AbstractArray}, e2c, 
 end
 
 """
-    setup_geom_factors_data!(vgeo, D)
+    compute_reference_to_physical_coord_jacobian!(vgeo, D1, D2)
 
 Input arguments:
 - vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
-- D::DAT2, 1-D derivative operator on the device in the first dimension
+- D::NTuple{2,Int}, a tuple of derivative matrices, i.e., D = (D1, D2), where:
+    - D1::DAT2, 1-D derivative operator on the device in the first dimension
+    - D2::DAT2, 1-D derivative operator on the device in the second dimension
 
-Setup the variable needed for geometric factors data in vgeo.
-"""
-function setup_geom_factors_data!(
-    vgeo::VolumeGeometry{NTuple{3,Int}, <:AbstractArray},
-    D
-)
-    Nq = size(D, 1)
-    nelem = div(length(vgeo.ωJ), Nq)
-
-    vgeo.x1 = reshape(vgeo.x1, (Nq, nelem))
-    vgeo.ωJ = reshape(vgeo.ωJ, (Nq, nelem))
-    vgeo.JcV = reshape(vgeo.JcV, (Nq, nelem))
-    vgeo.ξ1x1 = reshape(vgeo.ξ1x1, (Nq, nelem))
-
-end
-
-"""
-    setup_geom_factors_data!(vgeo, D1, D2)
-
-Input arguments:
-- vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
-- D1::DAT2, 1-D derivative operator on the device in the first dimension
-- D2::DAT2, 1-D derivative operator on the device in the second dimension
-
-Setup the variable needed for geometric factors data in vgeo.
-"""
-function setup_geom_factors_data!(
-    vgeo::VolumeGeometry{NTuple{3,Int}, <:AbstractArray},
-    D1,
-    D2
-)
-    Nq = (size(D1, 1), size(D2, 1))
-    nelem = div(length(vgeo.ωJ), prod(Nq))
-
-    vgeo.x1 = reshape(vgeo.x1, (Nq..., nelem))
-    vgeo.x2 = reshape(vgeo.x2, (Nq..., nelem))
-    vgeo.ωJ = reshape(vgeo.ωJ, (Nq..., nelem))
-    vgeo.JcV = reshape(vgeo.JcV, (Nq..., nelem))
-    vgeo.ξ1x1 = reshape(vgeo.ξ1x1, (Nq..., nelem))
-    vgeo.ξ2x1 = reshape(vgeo.ξ2x1, (Nq..., nelem))
-    vgeo.ξ1x2 = reshape(vgeo.ξ1x2, (Nq..., nelem))
-    vgeo.ξ2x2 = reshape(vgeo.ξ2x2, (Nq..., nelem))
-
-end
-
-"""
-    setup_geom_factors_data!(vgeo, D1, D2, D3)
-
-Input arguments:
-- vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
-- D1::DAT2, 1-D derivative operator on the device in the first dimension
-- D2::DAT2, 1-D derivative operator on the device in the second dimension
-- D3::DAT2, 1-D derivative operator on the device in the third dimension
-
-Setup the variable needed for geometric factors data in vgeo.
-"""
-function setup_geom_factors_data!(
-    vgeo::VolumeGeometry{NTuple{3,Int}, <:AbstractArray},
-    D1,
-    D2,
-    D3,
-)
-    Nq = (size(D1, 1), size(D2, 1), size(D3, 1))
-    nelem = div(length(vgeo.ωJ), prod(Nq))
-
-    vgeo.x1 = reshape(vgeo.x1, (Nq..., nelem))
-    vgeo.x2 = reshape(vgeo.x2, (Nq..., nelem))
-    vgeo.x3 = reshape(vgeo.x3, (Nq..., nelem))
-    vgeo.ωJ = reshape(vgeo.ωJ, (Nq..., nelem))
-    vgeo.JcV = reshape(vgeo.JcV, (Nq..., nelem))
-    vgeo.ξ1x1 = reshape(vgeo.ξ1x1, (Nq..., nelem))
-    vgeo.ξ2x1 = reshape(vgeo.ξ2x1, (Nq..., nelem))
-    vgeo.ξ3x1 = reshape(vgeo.ξ3x1, (Nq..., nelem))
-    vgeo.ξ1x2 = reshape(vgeo.ξ1x2, (Nq..., nelem))
-    vgeo.ξ2x2 = reshape(vgeo.ξ2x2, (Nq..., nelem))
-    vgeo.ξ3x2 = reshape(vgeo.ξ3x2, (Nq..., nelem))
-    vgeo.ξ1x3 = reshape(vgeo.ξ1x3, (Nq..., nelem))
-    vgeo.ξ2x3 = reshape(vgeo.ξ2x3, (Nq..., nelem))
-    vgeo.ξ3x3 = reshape(vgeo.ξ3x3, (Nq..., nelem))
-
-end
-
-"""
-    compute_dxdxi_jacobian!(vgeo, D1, D2)
-
-Input arguments:
-- vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
-- D1::DAT2, 1-D derivative operator on the device in the first dimension
-- D2::DAT2, 1-D derivative operator on the device in the second dimension
-
-Compute the Jacobian matrix of the mapping from physical coordinates,
-`vgeo.x1`, `vgeo.x2` with respect to reference coordinates `ξ1`, `ξ2`,
+Compute the Jacobian matrix, ∂x / ∂ξ, of the transformation from reference coordinates,
+`ξ1`, `ξ2`, to physical coordinates, `vgeo.x1`, `vgeo.x2`,
 for each quadrature point in element e.
 """
-function compute_dxdxi_jacobian!(
-    vgeo::VolumeGeometry{NTuple{2,Int}, <:AbstractArray},
-    D1,
-    D2
+function compute_reference_to_physical_coord_jacobian!(
+    vgeo::VolumeGeometry{NTuple{2, Int}, <:AbstractArray},
+    D::NTuple{2, Int},
 )
     T = eltype(vgeo.x1)
+    (D1, D2) = D
     Nq = (size(D1, 1), size(D2, 1))
 
     vgeo.x1ξ1 .= vgeo.x1ξ2 .= zero(T)
@@ -228,26 +154,26 @@ function compute_dxdxi_jacobian!(
 end
 
 """
-    compute_dxdxi_jacobian!(vgeo, D1, D2, D3)
+    compute_reference_to_physical_coord_jacobian!(vgeo, D1, D2, D3)
 
 Input arguments:
 - vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
-- D1::DAT2, 1-D derivative operator on the device in the first dimension
-- D2::DAT2, 1-D derivative operator on the device in the second dimension
-- D3::DAT2, 1-D derivative operator on the device in the third dimension
+- D::NTuple{3,Int}, a tuple of derivative matrices, i.e., D = (D1, D2, D3), where:
+    - D1::DAT2, 1-D derivative operator on the device in the first dimension
+    - D2::DAT2, 1-D derivative operator on the device in the second dimension
+    - D3::DAT2, 1-D derivative operator on the device in the third dimension
 
-Compute the Jacobian matrix of the mapping from physical coordinates,
-`vgeo.x1`, `vgeo.x2`, `vgeo.x3`, with respect to reference coordinates `ξ1`,
-`ξ2`, `ξ3`, for each quadrature point in element e.
+Compute the Jacobian matrix, ∂x / ∂ξ, of the transformation from reference coordinates,
+`ξ1`, `ξ2`, `ξ3` to physical coordinates, `vgeo.x1`, `vgeo.x2`, `vgeo.x3` for
+each quadrature point in element e.
 """
-function compute_dxdxi_jacobian!(
-    vgeo::VolumeGeometry{NTuple{3,Int}, <:AbstractArray},
-    D1,
-    D2,
-    D3
+function compute_reference_to_physical_coord_jacobian!(
+    vgeo::VolumeGeometry{NTuple{3, Int}, <:AbstractArray},
+    D::NTuple{3, Int},
 )
 
     T = eltype(vgeo.x1)
+    (D1, D2, D3) = D
     Nq = (size(D1, 1), size(D2, 1), size(D3, 1))
 
     vgeo.x1ξ1 .= vgeo.x1ξ2 .= vgeo.x1ξ3 .= zero(T)
@@ -256,7 +182,6 @@ function compute_dxdxi_jacobian!(
 
     @inbounds for e in 1:nelem
         for k in 1:Nq[3], j in 1:Nq[2], i in 1:Nq[1]
-
             for n in 1:Nq[1]
                 vgeo.x1ξ1[i, j, k, e] += D1[i, n] * vgeo.x1[n, j, k, e]
                 vgeo.x2ξ1[i, j, k, e] += D1[i, n] * vgeo.x2[n, j, k, e]
@@ -285,7 +210,7 @@ end
 Input arguments:
 - vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
 - sgeo::SurfaceGeometry, a struct containing the surface geometric factors
-- D::DAT2, 1-D derivative operator on the device
+- D::NTuple{1,Int}, tuple with 1-D derivative operator on the device
 
 Compute the 1-D metric terms from the element grid arrays `vgeo.x1`. All the arrays
 are preallocated by the user and the (square) derivative matrix `D` should be
@@ -296,21 +221,31 @@ If `Nq = size(D, 1)` and `nelem = div(length(x1), Nq)` then the volume arrays
 arrays `sJ` and `n1` should be of length `nface * nelem` with `nface = 2`.
 """
 function computemetric!(
-    vgeo::VolumeGeometry{NTuple{1,Int}, <:AbstractArray},
-    sgeo::SurfaceGeometry{NTuple{1,Int}, <:AbstractArray},
-    D
+    vgeo::VolumeGeometry{NTuple{1, Int}, <:AbstractArray},
+    sgeo::SurfaceGeometry{NTuple{1, Int}, <:AbstractArray},
+    D::NTuple{1, Int},
 )
 
     Nq = size(D, 1)
     nelem = div(length(vgeo.ωJ), Nq)
-
+    x1 = reshape(vgeo.x1, (Nq, nelem))
+    ωJ = reshape(vgeo.ωJ, (Nq, nelem))
+    JcV = reshape(vgeo.JcV, (Nq, nelem))
+    ξ1x1 = reshape(vgeo.ξ1x1, (Nq, nelem))
     nface = 2
-    sgeo.n1 = reshape(sgeo.n1, (1, nface, nelem))
-    sgeo.sωJ = reshape(sgeo.sωJ, (1, nface, nelem))
+    n1 = reshape(sgeo.n1, (1, nface, nelem))
+    sωJ = reshape(sgeo.sωJ, (1, nface, nelem))
 
     @inbounds for e in 1:nelem
-        vgeo.JcV[:, e] = vgeo.ωJ[:, e] = D * vgeo.x1[:, e]
+        JcV[:, e] = ωJ[:, e] = D * x1[:, e]
+
+        # Update struct field entries
+        for i in 1:Nq
+            vgeo.JcV[i, e] = JcV[i, e]
+            vgeo.ωJ[i, e] = ωJ[i, e]
+        end
     end
+
     vgeo.ξ1x1 .= 1 ./ vgeo.ωJ
 
     sgeo.n1[1, 1, :] .= -sign.(vgeo.ωJ[1, :])
@@ -320,13 +255,14 @@ function computemetric!(
 end
 
 """
-    computemetric!(vgeo, sgeo, D1, D2)
+    computemetric!(vgeo, sgeo, D)
 
 Input arguments:
 - vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
 - sgeo::SurfaceGeometry, a struct containing the surface geometric factors
-- D1::DAT2, 1-D derivative operator on the device in the first dimension
-- D2::DAT2, 1-D derivative operator on the device in the second dimension
+- D::NTuple{2,Int}, a tuple of derivative matrices, i.e., D = (D1, D2), where:
+    - D1::DAT2, 1-D derivative operator on the device in the first dimension
+    - D2::DAT2, 1-D derivative operator on the device in the second dimension
 
 Compute the 2-D metric terms from the element grid arrays `vgeo.x1` and `vgeo.x2`. All the
 arrays are preallocated by the user and the (square) derivative matrice `D1` and
@@ -340,74 +276,92 @@ and `sgeo.n2` should be of size `(maximum(Nq), nface, nelem)` with `nface = 4`
 
 """
 function computemetric!(
-    vgeo::VolumeGeometry{NTuple{2,Int}, <:AbstractArray},
-    sgeo::SurfaceGeometry{NTuple{2,Int}, <:AbstractArray},
-    D1,
-    D2,
+    vgeo::VolumeGeometry{NTuple{2, Int}, <:AbstractArray},
+    sgeo::SurfaceGeometry{NTuple{2, Int}, <:AbstractArray},
+    D::NTuple{2, Int},
 )
     T = eltype(vgeo.x1)
-    Nq = (size(D1, 1), size(D2, 1))
+    Nq = (size(D[1], 1), size(D[2], 1))
     nelem = div(length(vgeo.ωJ), prod(Nq))
+    x1 = reshape(vgeo.x1, (Nq..., nelem))
+    x2 = reshape(vgeo.x2, (Nq..., nelem))
+    ωJ = reshape(vgeo.ωJ, (Nq..., nelem))
+    JcV = reshape(vgeo.JcV, (Nq..., nelem))
+    ξ1x1 = reshape(vgeo.ξ1x1, (Nq..., nelem))
+    ξ2x1 = reshape(vgeo.ξ2x1, (Nq..., nelem))
+    ξ1x2 = reshape(vgeo.ξ1x2, (Nq..., nelem))
+    ξ2x2 = reshape(vgeo.ξ2x2, (Nq..., nelem))
     nface = 4
     Nfp = div.(prod(Nq), Nq)
-    sgeo.n1 = reshape(sgeo.n1, (maximum(Nfp), nface, nelem))
-    sgeo.n2 = reshape(sgeo.n2, (maximum(Nfp), nface, nelem))
-    sgeo.sωJ = reshape(sgeo.sωJ, (maximum(Nfp), nface, nelem))
+    n1 = reshape(sgeo.n1, (maximum(Nfp), nface, nelem))
+    n2 = reshape(sgeo.n2, (maximum(Nfp), nface, nelem))
+    sωJ = reshape(sgeo.sωJ, (maximum(Nfp), nface, nelem))
 
     for e in 1:nelem
         for j in 1:Nq[2], i in 1:Nq[1]
 
             # Compute vertical Jacobian determinant per quadrature point
-            vgeo.JcV[i, j, e] = hypot(vgeo.x1ξ2, vgeo.x2ξ2)
+            JcV[i, j, e] = hypot(x1ξ2, x2ξ2)
             # Compute Jacobian determinant, det(∂x/∂ξ), per quadrature point
-            vgeo.ωJ[i, j, e] = vgeo.x1ξ1 * vgeo.x2ξ2 - vgeo.x2ξ1 * vgeo.x1ξ2
+            ωJ[i, j, e] = x1ξ1 * x2ξ2 - x2ξ1 * x1ξ2
 
-            vgeo.ξ1x1[i, j, e] =  vgeo.x2ξ2 / vgeo.ωJ[i, j, e]
-            vgeo.ξ2x1[i, j, e] = -vgeo.x2ξ1 / vgeo.ωJ[i, j, e]
-            vgeo.ξ1x2[i, j, e] = -vgeo.x1ξ2 / vgeo.ωJ[i, j, e]
-            vgeo.ξ2x2[i, j, e] =  vgeo.x1ξ1 / vgeo.ωJ[i, j, e]
+            ξ1x1[i, j, e] = x2ξ2 / ωJ[i, j, e]
+            ξ2x1[i, j, e] = -x2ξ1 / ωJ[i, j, e]
+            ξ1x2[i, j, e] = -x1ξ2 / ωJ[i, j, e]
+            ξ2x2[i, j, e] = x1ξ1 / ωJ[i, j, e]
+
+            # Update volume struct field entries
+            vgeo.JcV[i + (j - 1) * Nq[1], e] = JcV[i, j, e]
+            vgeo.ωJ[i + (j - 1) * Nq[1], e] = ωJ[i, j, e]
+            vgeo.ξ1x1[i + (j - 1) * Nq[1], e] = ξ1x1[i, j, e]
+            vgeo.ξ2x1[i + (j - 1) * Nq[1], e] = ξ2x1[i, j, e]
+            vgeo.ξ1x2[i + (j - 1) * Nq[1], e] = ξ1x2[i, j, e]
+            vgeo.ξ2x2[i + (j - 1) * Nq[1], e] = ξ2x2[i, j, e]
         end
 
+        # Compute and update surface struct field entries
         for i in 1:maximum(Nfp)
             if i <= Nfp[1]
-                sgeo.n1[i, 1, e] = -vgeo.ωJ[1, i, e] * vgeo.ξ1x1[1, i, e]
-                sgeo.n2[i, 1, e] = -vgeo.ωJ[1, i, e] * vgeo.ξ1x2[1, i, e]
-                sgeo.n1[i, 2, e] =  vgeo.ωJ[Nq[1], i, e] * vgeo.ξ1x1[Nq[1], i, e]
-                sgeo.n2[i, 2, e] =  vgeo.ωJ[Nq[1], i, e] * vgeo.ξ1x2[Nq[1], i, e]
+                sgeo.n1[i, 1, e] = -ωJ[1, i, e] * ξ1x1[1, i, e]
+                sgeo.n2[i, 1, e] = -ωJ[1, i, e] * ξ1x2[1, i, e]
+                sgeo.n1[i, 2, e] = ωJ[Nq[1], i, e] * ξ1x1[Nq[1], i, e]
+                sgeo.n2[i, 2, e] = ωJ[Nq[1], i, e] * ξ1x2[Nq[1], i, e]
             else
                 sgeo.n1[i, 1:2, e] .= NaN
                 sgeo.n2[i, 1:2, e] .= NaN
             end
             if i <= Nfp[2]
-                sgeo.n1[i, 3, e] = -vgeo.ωJ[i, 1, e] * vgeo.ξ2x1[i, 1, e]
-                sgeo.n2[i, 3, e] = -vgeo.ωJ[i, 1, e] * vgeo.ξ2x2[i, 1, e]
-                sgeo.n1[i, 4, e] =  vgeo.ωJ[i, Nq[2], e] * vgeo.ξ2x1[i, Nq[2], e]
-                sgeo.n2[i, 4, e] =  vgeo.ωJ[i, Nq[2], e] * vgeo.ξ2x2[i, Nq[2], e]
+                sgeo.n1[i, 3, e] = -ωJ[i, 1, e] * ξ2x1[i, 1, e]
+                sgeo.n2[i, 3, e] = -ωJ[i, 1, e] * ξ2x2[i, 1, e]
+                sgeo.n1[i, 4, e] = ωJ[i, Nq[2], e] * ξ2x1[i, Nq[2], e]
+                sgeo.n2[i, 4, e] = ωJ[i, Nq[2], e] * ξ2x2[i, Nq[2], e]
             else
                 sgeo.n1[i, 3:4, e] .= NaN
                 sgeo.n2[i, 3:4, e] .= NaN
             end
 
             for n in 1:nface
-                sgeo.sωJ[i, n, e] = hypot(sgeo.n1[i, n, e], sgeo.n2[i, n, e])
-                sgeo.n1[i, n, e] /= sgeo.sωJ[i, n, e]
-                sgeo.n2[i, n, e] /= sgeo.sωJ[i, n, e]
+                sgeo.sωJ[i, n, e] = hypot(n1[i, n, e], n2[i, n, e])
+                sgeo.n1[i, n, e] /= sωJ[i, n, e]
+                sgeo.n2[i, n, e] /= sωJ[i, n, e]
             end
         end
+
     end
 
     nothing
 end
 
 """
-    computemetric!(vgeo, sgeo, D1, D2, D3)
+    computemetric!(vgeo, sgeo, D)
 
 Input arguments:
 - vgeo::VolumeGeometry, a struct containing the volumetric geometric factors
 - sgeo::SurfaceGeometry, a struct containing the surface geometric factors
-- D1::DAT2, 1-D derivative operator on the device in the first dimension
-- D2::DAT2, 1-D derivative operator on the device in the second dimension
-- D3::DAT2, 1-D derivative operator on the device in the third dimension
+- D::NTuple{3,Int}, a tuple of derivative matrices, i.e., D = (D1, D2, D3), where:
+    - D1::DAT2, 1-D derivative operator on the device in the first dimension
+    - D2::DAT2, 1-D derivative operator on the device in the second dimension
+    - D3::DAT2, 1-D derivative operator on the device in the third dimension
 
 Compute the 3-D metric terms from the element grid arrays `vgeo.x1`, `vgeo.x2`, and `vgeo.x3`.
 All the arrays are preallocated by the user and the (square) derivative matrice `D1`,
@@ -427,146 +381,184 @@ Reference:
  - [Kopriva2006](@cite)
 """
 function computemetric!(
-    vgeo::VolumeGeometry{NTuple{3,Int}, <:AbstractArray},
-    sgeo::SurfaceGeometry{NTuple{3,Int}, <:AbstractArray},
-    D1,
-    D2,
-    D3
+    vgeo::VolumeGeometry{NTuple{3, Int}, <:AbstractArray},
+    sgeo::SurfaceGeometry{NTuple{3, Int}, <:AbstractArray},
+    D::NTuple{3, Int},
 )
     T = eltype(vgeo.x1)
 
-    Nq = (size(D1, 1), size(D2, 1), size(D3, 1))
+    Nq = (size(D[1], 1), size(D[2], 1), size(D[3], 1))
     Np = prod(Nq)
     Nfp = div.(Np, Nq)
     nelem = div(length(vgeo.ωJ), Np)
 
+    x1 = reshape(vgeo.x1, (Nq..., nelem))
+    x2 = reshape(vgeo.x2, (Nq..., nelem))
+    x3 = reshape(vgeo.x3, (Nq..., nelem))
+    ωJ = reshape(vgeo.ωJ, (Nq..., nelem))
+    JcV = reshape(vgeo.JcV, (Nq..., nelem))
+    ξ1x1 = reshape(vgeo.ξ1x1, (Nq..., nelem))
+    ξ2x1 = reshape(vgeo.ξ2x1, (Nq..., nelem))
+    ξ3x1 = reshape(vgeo.ξ3x1, (Nq..., nelem))
+    ξ1x2 = reshape(vgeo.ξ1x2, (Nq..., nelem))
+    ξ2x2 = reshape(vgeo.ξ2x2, (Nq..., nelem))
+    ξ3x2 = reshape(vgeo.ξ3x2, (Nq..., nelem))
+    ξ1x3 = reshape(vgeo.ξ1x3, (Nq..., nelem))
+    ξ2x3 = reshape(vgeo.ξ2x3, (Nq..., nelem))
+    ξ3x3 = reshape(vgeo.ξ3x3, (Nq..., nelem))
+
     nface = 6
-    sgeo.n1 = reshape(sgeo.n1, maximum(Nfp), nface, nelem)
-    sgeo.n2 = reshape(sgeo.n2, maximum(Nfp), nface, nelem)
-    sgeo.n3 = reshape(sgeo.n3, maximum(Nfp), nface, nelem)
-    sgeo.sωJ = reshape(sgeo.sωJ, maximum(Nfp), nface, nelem)
+    n1 = reshape(sgeo.n1, maximum(Nfp), nface, nelem)
+    n2 = reshape(sgeo.n2, maximum(Nfp), nface, nelem)
+    n3 = reshape(sgeo.n3, maximum(Nfp), nface, nelem)
+    sωJ = reshape(sgeo.sωJ, maximum(Nfp), nface, nelem)
 
     JI2 = similar(vgeo.ωJ, Nq...)
     (yzr, yzs, yzt) = (similar(JI2), similar(JI2), similar(JI2))
     (zxr, zxs, zxt) = (similar(JI2), similar(JI2), similar(JI2))
     (xyr, xys, xyt) = (similar(JI2), similar(JI2), similar(JI2))
 
-    vgeo.ξ1x1 .= vgeo.ξ2x1 .= vgeo.ξ3x1 .= zero(T)
-    vgeo.ξ1x2 .= vgeo.ξ2x2 .= vgeo.ξ3x2 .= zero(T)
-    vgeo.ξ1x3 .= vgeo.ξ2x3 .= vgeo.ξ3x3 .= zero(T)
+    ξ1x1 .= ξ2x1 .= ξ3x1 .= zero(T)
+    ξ1x2 .= ξ2x2 .= ξ3x2 .= zero(T)
+    ξ1x3 .= ξ2x3 .= ξ3x3 .= zero(T)
 
-    fill!(sgeo.n1, NaN)
-    fill!(sgeo.n2, NaN)
-    fill!(sgeo.n3, NaN)
-    fill!(sgeo.sωJ, NaN)
+    fill!(n1, NaN)
+    fill!(n2, NaN)
+    fill!(n3, NaN)
+    fill!(sωJ, NaN)
 
     @inbounds for e in 1:nelem
         for k in 1:Nq[3], j in 1:Nq[2], i in 1:Nq[1]
 
             # Compute vertical Jacobian determinant per quadrature point
-            vgeo.JcV[i, j, k, e] = hypot(vgeo.x1ξ3, vgeo.x2ξ3, vgeo.x3ξ3)
+            JcV[i, j, k, e] = hypot(x1ξ3, x2ξ3, x3ξ3)
             # Compute Jacobian determinant, det(∂x/∂ξ), per quadrature point
             J[i, j, k, e] = (
-                vgeo.x1ξ1 * (vgeo.x2ξ2 * vgeo.x3ξ3 - vgeo.x3ξ2 * vgeo.x2ξ3) +
-                vgeo.x2ξ1 * (vgeo.x3ξ2 * vgeo.x1ξ3 - vgeo.x1ξ2 * vgeo.x3ξ3) +
-                vgeo.x3ξ1 * (vgeo.x1ξ2 * vgeo.x2ξ3 - vgeo.x2ξ2 * vgeo.x1ξ3)
+                x1ξ1 * (x2ξ2 * x3ξ3 - x3ξ2 * x2ξ3) +
+                x2ξ1 * (x3ξ2 * x1ξ3 - x1ξ2 * x3ξ3) +
+                x3ξ1 * (x1ξ2 * x2ξ3 - x2ξ2 * x1ξ3)
             )
 
-            JI2[i, j, k] = 1 / (2 * vgeo.ωJ[i, j, k, e])
+            # Update volume struct field entries
+            vgeo.JcV[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] = JcV[i, j, k, e]
+            vgeo.J[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] = J[i, j, k, e]
 
-            yzr[i, j, k] = vgeo.x2[i, j, k, e] * vgeo.x3ξ1 - vgeo.x3[i, j, k, e] * vgeo.x2ξ1
-            yzs[i, j, k] = vgeo.x2[i, j, k, e] * vgeo.x3ξ2 - vgeo.x3[i, j, k, e] * vgeo.x2ξ2
-            yzt[i, j, k] = vgeo.x2[i, j, k, e] * vgeo.x3ξ3 - vgeo.x3[i, j, k, e] * vgeo.x2ξ3
-            zxr[i, j, k] = vgeo.x3[i, j, k, e] * vgeo.x1ξ1 - vgeo.x1[i, j, k, e] * vgeo.x3ξ1
-            zxs[i, j, k] = vgeo.x3[i, j, k, e] * vgeo.x1ξ2 - vgeo.x1[i, j, k, e] * vgeo.x3ξ2
-            zxt[i, j, k] = vgeo.x3[i, j, k, e] * vgeo.x1ξ3 - vgeo.x1[i, j, k, e] * vgeo.x3ξ3
-            xyr[i, j, k] = vgeo.x1[i, j, k, e] * vgeo.x2ξ1 - vgeo.x2[i, j, k, e] * vgeo.x1ξ1
-            xys[i, j, k] = vgeo.x1[i, j, k, e] * vgeo.x2ξ2 - vgeo.x2[i, j, k, e] * vgeo.x1ξ2
-            xyt[i, j, k] = vgeo.x1[i, j, k, e] * vgeo.x2ξ3 - vgeo.x2[i, j, k, e] * vgeo.x1ξ3
+            JI2[i, j, k] = 1 / (2 * ωJ[i, j, k, e])
+
+            yzr[i, j, k] = x2[i, j, k, e] * x3ξ1 - x3[i, j, k, e] * x2ξ1
+            yzs[i, j, k] = x2[i, j, k, e] * x3ξ2 - x3[i, j, k, e] * x2ξ2
+            yzt[i, j, k] = x2[i, j, k, e] * x3ξ3 - x3[i, j, k, e] * x2ξ3
+            zxr[i, j, k] = x3[i, j, k, e] * x1ξ1 - x1[i, j, k, e] * x3ξ1
+            zxs[i, j, k] = x3[i, j, k, e] * x1ξ2 - x1[i, j, k, e] * x3ξ2
+            zxt[i, j, k] = x3[i, j, k, e] * x1ξ3 - x1[i, j, k, e] * x3ξ3
+            xyr[i, j, k] = x1[i, j, k, e] * x2ξ1 - x2[i, j, k, e] * x1ξ1
+            xys[i, j, k] = x1[i, j, k, e] * x2ξ2 - x2[i, j, k, e] * x1ξ2
+            xyt[i, j, k] = x1[i, j, k, e] * x2ξ3 - x2[i, j, k, e] * x1ξ3
         end
 
         for k in 1:Nq[3], j in 1:Nq[2], i in 1:Nq[1]
             for n in 1:Nq[1]
-                vgeo.ξ2x1[i, j, k, e] -= D1[i, n] * yzt[n, j, k]
-                vgeo.ξ3x1[i, j, k, e] += D1[i, n] * yzs[n, j, k]
-                vgeo.ξ2x2[i, j, k, e] -= D1[i, n] * zxt[n, j, k]
-                vgeo.ξ3x2[i, j, k, e] += D1[i, n] * zxs[n, j, k]
-                vgeo.ξ2x3[i, j, k, e] -= D1[i, n] * xyt[n, j, k]
-                vgeo.ξ3x3[i, j, k, e] += D1[i, n] * xys[n, j, k]
+                ξ2x1[i, j, k, e] -= D1[i, n] * yzt[n, j, k]
+                ξ3x1[i, j, k, e] += D1[i, n] * yzs[n, j, k]
+                ξ2x2[i, j, k, e] -= D1[i, n] * zxt[n, j, k]
+                ξ3x2[i, j, k, e] += D1[i, n] * zxs[n, j, k]
+                ξ2x3[i, j, k, e] -= D1[i, n] * xyt[n, j, k]
+                ξ3x3[i, j, k, e] += D1[i, n] * xys[n, j, k]
             end
             for n in 1:Nq[2]
-                vgeo.ξ1x1[i, j, k, e] += D2[j, n] * yzt[i, n, k]
-                vgeo.ξ3x1[i, j, k, e] -= D2[j, n] * yzr[i, n, k]
-                vgeo.ξ1x2[i, j, k, e] += D2[j, n] * zxt[i, n, k]
-                vgeo.ξ3x2[i, j, k, e] -= D2[j, n] * zxr[i, n, k]
-                vgeo.ξ1x3[i, j, k, e] += D2[j, n] * xyt[i, n, k]
-                vgeo.ξ3x3[i, j, k, e] -= D2[j, n] * xyr[i, n, k]
+                ξ1x1[i, j, k, e] += D2[j, n] * yzt[i, n, k]
+                ξ3x1[i, j, k, e] -= D2[j, n] * yzr[i, n, k]
+                ξ1x2[i, j, k, e] += D2[j, n] * zxt[i, n, k]
+                ξ3x2[i, j, k, e] -= D2[j, n] * zxr[i, n, k]
+                ξ1x3[i, j, k, e] += D2[j, n] * xyt[i, n, k]
+                ξ3x3[i, j, k, e] -= D2[j, n] * xyr[i, n, k]
             end
             for n in 1:Nq[3]
-                vgeo.ξ1x1[i, j, k, e] -= D3[k, n] * yzs[i, j, n]
-                vgeo.ξ2x1[i, j, k, e] += D3[k, n] * yzr[i, j, n]
-                vgeo.ξ1x2[i, j, k, e] -= D3[k, n] * zxs[i, j, n]
-                vgeo.ξ2x2[i, j, k, e] += D3[k, n] * zxr[i, j, n]
-                vgeo.ξ1x3[i, j, k, e] -= D3[k, n] * xys[i, j, n]
-                vgeo.ξ2x3[i, j, k, e] += D3[k, n] * xyr[i, j, n]
+                ξ1x1[i, j, k, e] -= D3[k, n] * yzs[i, j, n]
+                ξ2x1[i, j, k, e] += D3[k, n] * yzr[i, j, n]
+                ξ1x2[i, j, k, e] -= D3[k, n] * zxs[i, j, n]
+                ξ2x2[i, j, k, e] += D3[k, n] * zxr[i, j, n]
+                ξ1x3[i, j, k, e] -= D3[k, n] * xys[i, j, n]
+                ξ2x3[i, j, k, e] += D3[k, n] * xyr[i, j, n]
             end
-            vgeo.ξ1x1[i, j, k, e] *= JI2[i, j, k]
-            vgeo.ξ2x1[i, j, k, e] *= JI2[i, j, k]
-            vgeo.ξ3x1[i, j, k, e] *= JI2[i, j, k]
-            vgeo.ξ1x2[i, j, k, e] *= JI2[i, j, k]
-            vgeo.ξ2x2[i, j, k, e] *= JI2[i, j, k]
-            vgeo.ξ3x2[i, j, k, e] *= JI2[i, j, k]
-            vgeo.ξ1x3[i, j, k, e] *= JI2[i, j, k]
-            vgeo.ξ2x3[i, j, k, e] *= JI2[i, j, k]
-            vgeo.ξ3x3[i, j, k, e] *= JI2[i, j, k]
+            ξ1x1[i, j, k, e] *= JI2[i, j, k]
+            ξ2x1[i, j, k, e] *= JI2[i, j, k]
+            ξ3x1[i, j, k, e] *= JI2[i, j, k]
+            ξ1x2[i, j, k, e] *= JI2[i, j, k]
+            ξ2x2[i, j, k, e] *= JI2[i, j, k]
+            ξ3x2[i, j, k, e] *= JI2[i, j, k]
+            ξ1x3[i, j, k, e] *= JI2[i, j, k]
+            ξ2x3[i, j, k, e] *= JI2[i, j, k]
+            ξ3x3[i, j, k, e] *= JI2[i, j, k]
+
+            # Update volume struct field entries
+            vgeo.ξ1x1[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] =
+                ξ1x1[i, j, k, e]
+            vgeo.ξ2x1[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] =
+                ξ2x1[i, j, k, e]
+            vgeo.ξ3x1[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] =
+                ξ3x1[i, j, k, e]
+            vgeo.ξ1x2[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] =
+                ξ1x2[i, j, k, e]
+            vgeo.ξ2x2[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] =
+                ξ2x2[i, j, k, e]
+            vgeo.ξ3x2[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] =
+                ξ3x2[i, j, k, e]
+            vgeo.ξ1x3[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] =
+                ξ1x3[i, j, k, e]
+            vgeo.ξ2x3[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] =
+                ξ2x3[i, j, k, e]
+            vgeo.ξ3x3[i + (j - 1) * Nq[1] + (k - 1) * Nq[3], e] =
+                ξ3x3[i, j, k, e]
         end
 
+        # Compute and update surface struct field entries
         # faces 1 & 2
         for k in 1:Nq[3], j in 1:Nq[2]
             n = j + (k - 1) * Nq[2]
-            sgeo.n1[n, 1, e] = -vgeo.ωJ[1, j, k, e] * vgeo.ξ1x1[1, j, k, e]
-            sgeo.n2[n, 1, e] = -vgeo.ωJ[1, j, k, e] * vgeo.ξ1x2[1, j, k, e]
-            sgeo.n3[n, 1, e] = -vgeo.ωJ[1, j, k, e] * vgeo.ξ1x3[1, j, k, e]
-            sgeo.n1[n, 2, e] =  vgeo.ωJ[Nq[1], j, k, e] * vgeo.ξ1x1[Nq[1], j, k, e]
-            sgeo.n2[n, 2, e] =  vgeo.ωJ[Nq[1], j, k, e] * vgeo.ξ1x2[Nq[1], j, k, e]
-            sgeo.n3[n, 2, e] =  vgeo.ωJ[Nq[1], j, k, e] * vgeo.ξ1x3[Nq[1], j, k, e]
+            sgeo.n1[n, 1, e] = -ωJ[1, j, k, e] * ξ1x1[1, j, k, e]
+            sgeo.n2[n, 1, e] = -ωJ[1, j, k, e] * ξ1x2[1, j, k, e]
+            sgeo.n3[n, 1, e] = -ωJ[1, j, k, e] * ξ1x3[1, j, k, e]
+            sgeo.n1[n, 2, e] = ωJ[Nq[1], j, k, e] * ξ1x1[Nq[1], j, k, e]
+            sgeo.n2[n, 2, e] = ωJ[Nq[1], j, k, e] * ξ1x2[Nq[1], j, k, e]
+            sgeo.n3[n, 2, e] = ωJ[Nq[1], j, k, e] * ξ1x3[Nq[1], j, k, e]
             for f in 1:2
-                sgeo.sωJ[n, f, e] = hypot(sgeo.n1[n, f, e], sgeo.n2[n, f, e], sgeo.n3[n, f, e])
-                sgeo.n1[n, f, e] /= sgeo.sωJ[n, f, e]
-                sgeo.n2[n, f, e] /= sgeo.sωJ[n, f, e]
-                sgeo.n3[n, f, e] /= sgeo.sωJ[n, f, e]
+                sgeo.sωJ[n, f, e] = hypot(n1[n, f, e], n2[n, f, e], n3[n, f, e])
+                sgeo.n1[n, f, e] /= sωJ[n, f, e]
+                sgeo.n2[n, f, e] /= sωJ[n, f, e]
+                sgeo.n3[n, f, e] /= sωJ[n, f, e]
             end
         end
         # faces 3 & 4
         for k in 1:Nq[3], i in 1:Nq[1]
             n = i + (k - 1) * Nq[1]
-            sgeo.n1[n, 3, e] = -vgeo.ωJ[i, 1, k, e] * vgeo.ξ2x1[i, 1, k, e]
-            sgeo.n2[n, 3, e] = -vgeo.ωJ[i, 1, k, e] * vgeo.ξ2x2[i, 1, k, e]
-            sgeo.n3[n, 3, e] = -vgeo.ωJ[i, 1, k, e] * vgeo.ξ2x3[i, 1, k, e]
-            sgeo.n1[n, 4, e] =  vgeo.ωJ[i, Nq[2], k, e] * vgeo.ξ2x1[i, Nq[2], k, e]
-            sgeo.n2[n, 4, e] =  vgeo.ωJ[i, Nq[2], k, e] * vgeo.ξ2x2[i, Nq[2], k, e]
-            sgeo.n3[n, 4, e] =  vgeo.ωJ[i, Nq[2], k, e] * vgeo.ξ2x3[i, Nq[2], k, e]
+            sgeo.n1[n, 3, e] = -ωJ[i, 1, k, e] * ξ2x1[i, 1, k, e]
+            sgeo.n2[n, 3, e] = -ωJ[i, 1, k, e] * ξ2x2[i, 1, k, e]
+            sgeo.n3[n, 3, e] = -ωJ[i, 1, k, e] * ξ2x3[i, 1, k, e]
+            sgeo.n1[n, 4, e] = ωJ[i, Nq[2], k, e] * ξ2x1[i, Nq[2], k, e]
+            sgeo.n2[n, 4, e] = ωJ[i, Nq[2], k, e] * ξ2x2[i, Nq[2], k, e]
+            sgeo.n3[n, 4, e] = ωJ[i, Nq[2], k, e] * ξ2x3[i, Nq[2], k, e]
             for f in 3:4
-                sgeo.sωJ[n, f, e] = hypot(sgeo.n1[n, f, e], sgeo.n2[n, f, e], sgeo.n3[n, f, e])
-                sgeo.n1[n, f, e] /= sgeo.sωJ[n, f, e]
-                sgeo.n2[n, f, e] /= sgeo.sωJ[n, f, e]
-                sgeo.n3[n, f, e] /= sgeo.sωJ[n, f, e]
+                sgeo.sωJ[n, f, e] = hypot(n1[n, f, e], n2[n, f, e], n3[n, f, e])
+                sgeo.n1[n, f, e] /= sωJ[n, f, e]
+                sgeo.n2[n, f, e] /= sωJ[n, f, e]
+                sgeo.n3[n, f, e] /= sωJ[n, f, e]
             end
         end
         # faces 5 & 6
         for j in 1:Nq[2], i in 1:Nq[1]
             n = i + (j - 1) * Nq[1]
-            sgeo.n1[n, 5, e] = -vgeo.ωJ[i, j, 1, e] * vgeo.ξ3x1[i, j, 1, e]
-            sgeo.n2[n, 5, e] = -vgeo.ωJ[i, j, 1, e] * vgeo.ξ3x2[i, j, 1, e]
-            sgeo.n3[n, 5, e] = -vgeo.ωJ[i, j, 1, e] * vgeo.ξ3x3[i, j, 1, e]
-            sgeo.n1[n, 6, e] =  vgeo.ωJ[i, j, Nq[3], e] * vgeo.ξ3x1[i, j, Nq[3], e]
-            sgeo.n2[n, 6, e] =  vgeo.ωJ[i, j, Nq[3], e] * vgeo.ξ3x2[i, j, Nq[3], e]
-            sgeo.n3[n, 6, e] =  vgeo.ωJ[i, j, Nq[3], e] * vgeo.ξ3x3[i, j, Nq[3], e]
+            sgeo.n1[n, 5, e] = -ωJ[i, j, 1, e] * ξ3x1[i, j, 1, e]
+            sgeo.n2[n, 5, e] = -ωJ[i, j, 1, e] * ξ3x2[i, j, 1, e]
+            sgeo.n3[n, 5, e] = -ωJ[i, j, 1, e] * ξ3x3[i, j, 1, e]
+            sgeo.n1[n, 6, e] = ωJ[i, j, Nq[3], e] * ξ3x1[i, j, Nq[3], e]
+            sgeo.n2[n, 6, e] = ωJ[i, j, Nq[3], e] * ξ3x2[i, j, Nq[3], e]
+            sgeo.n3[n, 6, e] = ωJ[i, j, Nq[3], e] * ξ3x3[i, j, Nq[3], e]
             for f in 5:6
-                sgeo.sωJ[n, f, e] = hypot(sgeo.n1[n, f, e], sgeo.n2[n, f, e], sgeo.n3[n, f, e])
-                sgeo.n1[n, f, e] /= sgeo.sωJ[n, f, e]
-                sgeo.n2[n, f, e] /= sgeo.sωJ[n, f, e]
-                sgeo.n3[n, f, e] /= sgeo.sωJ[n, f, e]
+                sgeo.sωJ[n, f, e] = hypot(n1[n, f, e], n2[n, f, e], n3[n, f, e])
+                sgeo.n1[n, f, e] /= sωJ[n, f, e]
+                sgeo.n2[n, f, e] /= sωJ[n, f, e]
+                sgeo.n3[n, f, e] /= sωJ[n, f, e]
             end
         end
     end

--- a/test/Numerics/Mesh/Metrics.jl
+++ b/test/Numerics/Mesh/Metrics.jl
@@ -42,7 +42,7 @@ const _nsgeo = Grids._nsgeo
 
             (vgeo, sgeo, _) =
                 Grids.computegeometry(e2c, D, ξ, ω, (x...) -> identity(x))
-            vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
             @test vgeo[:, _x1, 1] ≈ (ξ[1] .- 1) / 2
             @test vgeo[:, _x1, 2] ≈ 5 * (ξ[1] .+ 1)
 
@@ -83,7 +83,7 @@ const _nsgeo = Grids._nsgeo
 
             (vgeo, sgeo, _) =
                 Grids.computegeometry(e2c, D, ξ, ω, (x...) -> identity(x))
-            vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
             @test vgeo[1, _x1, 1] ≈ sum(e2c[:, :, 1]) / 2
             @test vgeo[1, _x1, 2] ≈ sum(e2c[:, :, 2]) / 2
 
@@ -203,7 +203,7 @@ end
 
             (vgeo, sgeo, _) =
                 Grids.computegeometry(e2c, D, ξ, ω, (x...) -> identity(x))
-            vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
 
             @test (@view vgeo[:, :, _x1, :]) ≈ x_exact
             @test (@view vgeo[:, :, _x2, :]) ≈ y_exact
@@ -252,7 +252,7 @@ end
                     ω,
                     (x...) -> identity(x),
                 )
-                vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+                vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
                 ξ1, ξ2 = vgeo[:, :, _x1, :], vgeo[:, :, _x2, :]
                 (fx1ξ1(ξ1, ξ2), fx1ξ2(ξ1, ξ2), fx2ξ1(ξ1, ξ2), fx2ξ2(ξ1, ξ2))
             end
@@ -261,7 +261,7 @@ end
 
             meshwarp(ξ1, ξ2, _) = (f(ξ1, ξ2)..., 0)
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
-            vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
             x1 = @view vgeo[:, :, _x1, :]
             x2 = @view vgeo[:, :, _x2, :]
 
@@ -311,7 +311,7 @@ end
 
             meshwarp(ξ1, ξ2, _) = (f(ξ1, ξ2)..., 0)
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
-            vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
             x1 = @view vgeo[:, :, _x1, :]
             x2 = @view vgeo[:, :, _x2, :]
 
@@ -391,7 +391,7 @@ end
 
             meshwarp(ξ1, ξ2, _) = (fx1(ξ1, ξ2), fx2(ξ1, ξ2), 0)
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
-            vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+            vgeo = reshape(vgeo.array.array, Nq..., _nvgeo, nelem)
             @test x1 ≈ vgeo[:, :, _x1, :]
             @test x2 ≈ vgeo[:, :, _x2, :]
 
@@ -586,7 +586,7 @@ end
 
         (vgeo, sgeo, _) =
             Grids.computegeometry(e2c, D, ξ, ω, (x...) -> identity(x))
-        vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+        vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
 
         @test (@view vgeo[:, :, :, _x1, :]) ≈ x_exact
         @test (@view vgeo[:, :, :, _x2, :]) ≈ y_exact
@@ -685,7 +685,7 @@ end
         (x1ξ1, x1ξ2, x1ξ3, x2ξ1, x2ξ2, x2ξ3, x3ξ1, x3ξ2, x3ξ3) = let
             (vgeo, _) =
                 Grids.computegeometry(e2c, D, ξ, ω, (x...) -> identity(x))
-            vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
             ξ1 = vgeo[:, :, :, _x1, :]
             ξ2 = vgeo[:, :, :, _x2, :]
             ξ3 = vgeo[:, :, :, _x3, :]
@@ -718,7 +718,7 @@ end
         ξ3x3 = (x1ξ1 .* x2ξ2 - x1ξ2 .* x2ξ1) ./ J
 
         (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, f)
-        vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+        vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
 
         @test (@view vgeo[:, :, :, _M, :]) ≈
               J .* reshape(kron(reverse(ω)...), Nq..., 1)
@@ -846,7 +846,7 @@ end
         nelem = size(e2c, 3)
 
         (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, f)
-        vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+        vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
 
         (Cx1, Cx2, Cx3) = (zeros(FT, Nq...), zeros(FT, Nq...), zeros(FT, Nq...))
 
@@ -981,7 +981,7 @@ end
             meshwarp(ξ1, ξ2, ξ3) =
                 (fx1(ξ1, ξ2, ξ3), fx2(ξ1, ξ2, ξ3), fx3(ξ1, ξ2, ξ3))
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
-            vgeo = reshape(vgeo, Nq..., _nvgeo, nelem)
+            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
 
             @test x1 ≈ vgeo[:, :, :, _x1, :]
             @test x2 ≈ vgeo[:, :, :, _x2, :]

--- a/test/Numerics/Mesh/Metrics.jl
+++ b/test/Numerics/Mesh/Metrics.jl
@@ -46,7 +46,8 @@ const _nsgeo = Grids._nsgeo
             vgeo = reshape(
                 vgeo.array,
                 Nq...,
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
             @test vgeo[:, _x1, 1] ≈ (ξ[1] .- 1) / 2
@@ -92,7 +93,8 @@ const _nsgeo = Grids._nsgeo
             vgeo = reshape(
                 vgeo.array,
                 Nq...,
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
             @test vgeo[1, _x1, 1] ≈ sum(e2c[:, :, 1]) / 2
@@ -217,7 +219,8 @@ end
             vgeo = reshape(
                 vgeo.array,
                 Nq...,
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
 
@@ -271,7 +274,8 @@ end
                 vgeo = reshape(
                     vgeo.array,
                     Nq...,
-                    fieldcount(GeometricFactors.VolumeGeometry),
+                    # - 1 after fieldcount is to remove the `array` field from the array allocation
+                    fieldcount(GeometricFactors.VolumeGeometry) - 1,
                     nelem,
                 )
                 ξ1, ξ2 = vgeo[:, :, _x1, :], vgeo[:, :, _x2, :]
@@ -285,7 +289,8 @@ end
             vgeo = reshape(
                 vgeo.array,
                 Nq...,
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
             x1 = @view vgeo[:, :, _x1, :]
@@ -340,7 +345,8 @@ end
             vgeo = reshape(
                 vgeo.array,
                 Nq...,
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
             x1 = @view vgeo[:, :, _x1, :]
@@ -424,7 +430,8 @@ end
             vgeo = reshape(
                 vgeo.array,
                 Nq...,
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
             @test x1 ≈ vgeo[:, :, _x1, :]
@@ -513,7 +520,8 @@ end
             vgeo = reshape(
                 vgeo.array,
                 prod(Nq),
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
             M = vgeo[:, _M, :]
@@ -631,7 +639,8 @@ end
         vgeo = reshape(
             vgeo.array,
             Nq...,
-            fieldcount(GeometricFactors.VolumeGeometry),
+            # - 1 after fieldcount is to remove the `array` field from the array allocation
+            fieldcount(GeometricFactors.VolumeGeometry) - 1,
             nelem,
         )
 
@@ -735,7 +744,8 @@ end
             vgeo = reshape(
                 vgeo.array,
                 Nq...,
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
             ξ1 = vgeo[:, :, :, _x1, :]
@@ -773,7 +783,8 @@ end
         vgeo = reshape(
             vgeo.array,
             Nq...,
-            fieldcount(GeometricFactors.VolumeGeometry),
+            # - 1 after fieldcount is to remove the `array` field from the array allocation
+            fieldcount(GeometricFactors.VolumeGeometry) - 1,
             nelem,
         )
 
@@ -906,7 +917,8 @@ end
         vgeo = reshape(
             vgeo.array,
             Nq...,
-            fieldcount(GeometricFactors.VolumeGeometry),
+            # - 1 after fieldcount is to remove the `array` field from the array allocation
+            fieldcount(GeometricFactors.VolumeGeometry) - 1,
             nelem,
         )
 
@@ -1049,7 +1061,8 @@ end
             vgeo = reshape(
                 vgeo.array,
                 Nq...,
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
 
@@ -1248,7 +1261,8 @@ end
             vgeo = reshape(
                 vgeo.array,
                 prod(Nq),
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
 
@@ -1345,7 +1359,8 @@ end
             vgeo = reshape(
                 vgeo.array,
                 prod(Nq),
-                fieldcount(GeometricFactors.VolumeGeometry),
+                # - 1 after fieldcount is to remove the `array` field from the array allocation
+                fieldcount(GeometricFactors.VolumeGeometry) - 1,
                 nelem,
             )
 

--- a/test/Numerics/Mesh/Metrics.jl
+++ b/test/Numerics/Mesh/Metrics.jl
@@ -1,5 +1,6 @@
 using ClimateMachine.Mesh.Elements
 using ClimateMachine.Mesh.Grids
+using ClimateMachine.Mesh.GeometricFactors
 using ClimateMachine.Mesh.Metrics
 using LinearAlgebra: I
 using Test
@@ -31,7 +32,6 @@ const _nsgeo = Grids._nsgeo
             # Create element operators for each polynomial order
             ξω = ntuple(j -> Elements.lglpoints(FT, N[j]), dim)
             ξ, ω = ntuple(j -> map(x -> x[j], ξω), 2)
-
             D = ntuple(j -> Elements.spectralderivative(ξ[j]), dim)
 
             dim = 1
@@ -42,7 +42,13 @@ const _nsgeo = Grids._nsgeo
 
             (vgeo, sgeo, _) =
                 Grids.computegeometry(e2c, D, ξ, ω, (x...) -> identity(x))
-            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+
+            vgeo = reshape(
+                vgeo.array,
+                Nq...,
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
             @test vgeo[:, _x1, 1] ≈ (ξ[1] .- 1) / 2
             @test vgeo[:, _x1, 2] ≈ 5 * (ξ[1] .+ 1)
 
@@ -50,10 +56,10 @@ const _nsgeo = Grids._nsgeo
             @test vgeo[:, _M, 2] ≈ 5 * ω[1] .* ones(FT, Nq)
             @test vgeo[:, _ξ1x1, 1] ≈ 2 * ones(FT, Nq)
             @test vgeo[:, _ξ1x1, 2] ≈ ones(FT, Nq) / 5
-            @test sgeo[_n1, 1, 1, :] ≈ -ones(FT, nelem)
-            @test sgeo[_n1, 1, 2, :] ≈ ones(FT, nelem)
-            @test sgeo[_sM, 1, 1, :] ≈ ones(FT, nelem)
-            @test sgeo[_sM, 1, 2, :] ≈ ones(FT, nelem)
+            @test sgeo.n1[1, 1, :] ≈ -ones(FT, nelem)
+            @test sgeo.n1[1, 2, :] ≈ ones(FT, nelem)
+            @test sgeo.sωJ[1, 1, :] ≈ ones(FT, nelem)
+            @test sgeo.sωJ[1, 2, :] ≈ ones(FT, nelem)
         end
         #}}}
     end
@@ -83,7 +89,12 @@ const _nsgeo = Grids._nsgeo
 
             (vgeo, sgeo, _) =
                 Grids.computegeometry(e2c, D, ξ, ω, (x...) -> identity(x))
-            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+            vgeo = reshape(
+                vgeo.array,
+                Nq...,
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
             @test vgeo[1, _x1, 1] ≈ sum(e2c[:, :, 1]) / 2
             @test vgeo[1, _x1, 2] ≈ sum(e2c[:, :, 2]) / 2
 
@@ -92,17 +103,16 @@ const _nsgeo = Grids._nsgeo
             @test vgeo[:, _ξ1x1, 1] ≈ 2 * ones(FT, Nq)
             @test vgeo[:, _ξ1x1, 2] ≈ ones(FT, Nq) / 5
 
-            @test sgeo[_n1, 1, 1, :] ≈ -ones(FT, nelem)
-            @test sgeo[_n1, 1, 2, :] ≈ ones(FT, nelem)
-            @test sgeo[_sM, 1, 1, :] ≈ ones(FT, nelem)
-            @test sgeo[_sM, 1, 2, :] ≈ ones(FT, nelem)
+            @test sgeo.n1[1, 1, :] ≈ -ones(FT, nelem)
+            @test sgeo.n1[1, 2, :] ≈ ones(FT, nelem)
+            @test sgeo.sωJ[1, 1, :] ≈ ones(FT, nelem)
+            @test sgeo.sωJ[1, 2, :] ≈ ones(FT, nelem)
         end
         #}}}
     end
 end
 
 @testset "2-D Metric terms" begin
-    # for FT in (Float32, Float64)
     for FT in (Float32, Float64), N in ((4, 4), (4, 6), (6, 4))
         Nq = N .+ 1
         Np = prod(Nq)
@@ -138,34 +148,34 @@ end
             ]
             nelem = size(e2c, 3)
 
-            x_exact = Array{FT, 3}(undef, Nq..., 4)
+            x_exact = Array{FT, 3}(undef, Nq..., nelem)
             x_exact[:, :, 1] .= 1 .+ ξ[1]
             x_exact[:, :, 2] .= 1 .- ξ[2]'
             x_exact[:, :, 3] .= 1 .- ξ[1]
             x_exact[:, :, 4] .= 1 .+ ξ[2]'
 
-            y_exact = Array{FT, 3}(undef, Nq..., 4)
+            y_exact = Array{FT, 3}(undef, Nq..., nelem)
             y_exact[:, :, 1] .= 1 .+ ξ[2]'
             y_exact[:, :, 2] .= 1 .+ ξ[1]
             y_exact[:, :, 3] .= 1 .- ξ[2]'
             y_exact[:, :, 4] .= 1 .- ξ[1]
 
             M_exact =
-                ones(FT, Nq..., 4) .* reshape(kron(reverse(ω)...), Nq..., 1)
+                ones(FT, Nq..., nelem) .* reshape(kron(reverse(ω)...), Nq..., 1)
 
-            ξ1x1_exact = zeros(FT, Nq..., 4)
+            ξ1x1_exact = zeros(FT, Nq..., nelem)
             ξ1x1_exact[:, :, 1] .= 1
             ξ1x1_exact[:, :, 3] .= -1
 
-            ξ1x2_exact = zeros(FT, Nq..., 4)
+            ξ1x2_exact = zeros(FT, Nq..., nelem)
             ξ1x2_exact[:, :, 2] .= 1
             ξ1x2_exact[:, :, 4] .= -1
 
-            ξ2x1_exact = zeros(FT, Nq..., 4)
+            ξ2x1_exact = zeros(FT, Nq..., nelem)
             ξ2x1_exact[:, :, 2] .= -1
             ξ2x1_exact[:, :, 4] .= 1
 
-            ξ2x2_exact = zeros(FT, Nq..., 4)
+            ξ2x2_exact = zeros(FT, Nq..., nelem)
             ξ2x2_exact[:, :, 1] .= 1
             ξ2x2_exact[:, :, 3] .= -1
 
@@ -203,7 +213,13 @@ end
 
             (vgeo, sgeo, _) =
                 Grids.computegeometry(e2c, D, ξ, ω, (x...) -> identity(x))
-            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+
+            vgeo = reshape(
+                vgeo.array,
+                Nq...,
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
 
             @test (@view vgeo[:, :, _x1, :]) ≈ x_exact
             @test (@view vgeo[:, :, _x2, :]) ≈ y_exact
@@ -213,9 +229,9 @@ end
             @test (@view vgeo[:, :, _ξ2x1, :]) ≈ ξ2x1_exact
             @test (@view vgeo[:, :, _ξ2x2, :]) ≈ ξ2x2_exact
             msk = isfinite.(sM_exact)
-            @test sgeo[_sM, :, :, :][msk] ≈ sM_exact[msk]
-            @test sgeo[_n1, :, :, :][msk] ≈ nx_exact[msk]
-            @test sgeo[_n2, :, :, :][msk] ≈ ny_exact[msk]
+            @test sgeo.sωJ[:, :, :][msk] ≈ sM_exact[msk]
+            @test sgeo.n1[:, :, :][msk] ≈ nx_exact[msk]
+            @test sgeo.n2[:, :, :][msk] ≈ ny_exact[msk]
 
             nothing
         end
@@ -252,7 +268,12 @@ end
                     ω,
                     (x...) -> identity(x),
                 )
-                vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+                vgeo = reshape(
+                    vgeo.array,
+                    Nq...,
+                    fieldcount(GeometricFactors.VolumeGeometry),
+                    nelem,
+                )
                 ξ1, ξ2 = vgeo[:, :, _x1, :], vgeo[:, :, _x2, :]
                 (fx1ξ1(ξ1, ξ2), fx1ξ2(ξ1, ξ2), fx2ξ1(ξ1, ξ2), fx2ξ2(ξ1, ξ2))
             end
@@ -261,7 +282,12 @@ end
 
             meshwarp(ξ1, ξ2, _) = (f(ξ1, ξ2)..., 0)
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
-            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+            vgeo = reshape(
+                vgeo.array,
+                Nq...,
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
             x1 = @view vgeo[:, :, _x1, :]
             x2 = @view vgeo[:, :, _x2, :]
 
@@ -272,9 +298,9 @@ end
             @test (@view vgeo[:, :, _ξ2x2, :]) ≈ x1ξ1 ./ J
 
             # check the normals?
-            sM = @view sgeo[_sM, :, :, :]
-            n1 = @view sgeo[_n1, :, :, :]
-            n2 = @view sgeo[_n2, :, :, :]
+            sM = @view sgeo.sωJ[:, :, :]
+            n1 = @view sgeo.n1[:, :, :]
+            n2 = @view sgeo.n2[:, :, :]
             @test all(hypot.(n1[1:Nfp[1], 1:2, :], n2[1:Nfp[1], 1:2, :]) .≈ 1)
             @test all(hypot.(n1[1:Nfp[2], 3:4, :], n2[1:Nfp[2], 3:4, :]) .≈ 1)
             @test sM[1:Nfp[1], 1, :] .* n1[1:Nfp[1], 1, :] ≈
@@ -311,7 +337,12 @@ end
 
             meshwarp(ξ1, ξ2, _) = (f(ξ1, ξ2)..., 0)
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
-            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+            vgeo = reshape(
+                vgeo.array,
+                Nq...,
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
             x1 = @view vgeo[:, :, _x1, :]
             x2 = @view vgeo[:, :, _x2, :]
 
@@ -373,16 +404,15 @@ end
 
             # Create the metrics
             (x1, x2, x1ξ1, x1ξ2, x2ξ1, x2ξ2) = let
-                ξ1 = zeros(FT, Np, nelem)
-                ξ2 = zeros(FT, Np, nelem)
-                Metrics.creategrid!(ξ1, ξ2, e2c, ξ...)
+                vgeo = VolumeGeometry(FT, Nq, nelem)
+                Metrics.creategrid!(vgeo, e2c, ξ)
                 (
-                    fx1.(ξ1, ξ2),
-                    fx2.(ξ1, ξ2),
-                    fx1ξ1.(ξ1, ξ2),
-                    fx1ξ2.(ξ1, ξ2),
-                    fx2ξ1.(ξ1, ξ2),
-                    fx2ξ2.(ξ1, ξ2),
+                    fx1.(vgeo.x1, vgeo.x2),
+                    fx2.(vgeo.x1, vgeo.x2),
+                    fx1ξ1.(vgeo.x1, vgeo.x2),
+                    fx1ξ2.(vgeo.x1, vgeo.x2),
+                    fx2ξ1.(vgeo.x1, vgeo.x2),
+                    fx2ξ2.(vgeo.x1, vgeo.x2),
                 )
             end
             J = (x1ξ1 .* x2ξ2 - x1ξ2 .* x2ξ1)
@@ -391,7 +421,12 @@ end
 
             meshwarp(ξ1, ξ2, _) = (fx1(ξ1, ξ2), fx2(ξ1, ξ2), 0)
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
-            vgeo = reshape(vgeo.array.array, Nq..., _nvgeo, nelem)
+            vgeo = reshape(
+                vgeo.array,
+                Nq...,
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
             @test x1 ≈ vgeo[:, :, _x1, :]
             @test x2 ≈ vgeo[:, :, _x2, :]
 
@@ -402,9 +437,9 @@ end
             @test (@view vgeo[:, :, _ξ1x2, :]) .* J ≈ -x1ξ2
 
             # check the normals?
-            sM = @view sgeo[_sM, :, :, :]
-            n1 = @view sgeo[_n1, :, :, :]
-            n2 = @view sgeo[_n2, :, :, :]
+            sM = @view sgeo.sωJ[:, :, :]
+            n1 = @view sgeo.n1[:, :, :]
+            n2 = @view sgeo.n2[:, :, :]
             @test all(hypot.(n1[1:Nfp[1], 1:2, :], n2[1:Nfp[1], 1:2, :]) .≈ 1)
             @test all(hypot.(n1[1:Nfp[2], 3:4, :], n2[1:Nfp[2], 3:4, :]) .≈ 1)
             @test sM[1:Nfp[1], 1, :] .* n1[1:Nfp[1], 1, :] ≈
@@ -420,17 +455,17 @@ end
             (x1ξ1, x2ξ1) = let
                 @assert Nq[2] == 1 && Nq[1] != 1
                 Nq_N1 = max.(2, Nq)
-                ξ1 = zeros(FT, Nq_N1..., nelem)
-                ξ2 = zeros(FT, Nq_N1..., nelem)
+                vgeo_N1 = VolumeGeometry(FT, Nq_N1, nelem)
                 Metrics.creategrid!(
-                    ξ1,
-                    ξ2,
+                    vgeo_N1,
                     e2c,
-                    ξ[1],
-                    Elements.lglpoints(FT, 1)[1],
+                    (ξ[1], Elements.lglpoints(FT, 1)[1]),
                 )
-                (fx1ξ1.(ξ1, ξ2), fx2ξ1.(ξ1, ξ2))
+                x1 = reshape(vgeo_N1.x1, (Nq_N1..., nelem))
+                x2 = reshape(vgeo_N1.x2, (Nq_N1..., nelem))
+                (fx1ξ1.(x1, x2), fx2ξ1.(x1, x2))
             end
+
             @test sM[1:Nfp[2], 3, :] .* n1[1:Nfp[2], 3, :] ≈
                   x2ξ1[:, 1, :] .* ω[1]
             @test sM[1:Nfp[2], 3, :] .* n2[1:Nfp[2], 3, :] ≈
@@ -475,6 +510,12 @@ end
             meshwarp(ξ1, ξ2, _) = (fx1(ξ1, ξ2), fx2(ξ1, ξ2), 0)
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
 
+            vgeo = reshape(
+                vgeo.array,
+                prod(Nq),
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
             M = vgeo[:, _M, :]
             ξ1x1 = vgeo[:, _ξ1x1, :]
             ξ2x1 = vgeo[:, _ξ2x1, :]
@@ -493,9 +534,9 @@ end
                 kron(I2[1, :]', I1),
                 kron(I2[Nq[2], :]', I1),
             )
-            sM = ntuple(f -> sgeo[_sM, 1:Nfp[cld(f, 2)], f, :], nface)
-            n1 = ntuple(f -> sgeo[_n1, 1:Nfp[cld(f, 2)], f, :], nface)
-            n2 = ntuple(f -> sgeo[_n2, 1:Nfp[cld(f, 2)], f, :], nface)
+            sM = ntuple(f -> sgeo.sωJ[1:Nfp[cld(f, 2)], f, :], nface)
+            n1 = ntuple(f -> sgeo.n1[1:Nfp[cld(f, 2)], f, :], nface)
+            n2 = ntuple(f -> sgeo.n2[1:Nfp[cld(f, 2)], f, :], nface)
 
             # If constant preserving then:
             #   \sum_{j} = D' * M * ξjxk = \sum_{f} L_f' * sM_f * n1_f
@@ -586,7 +627,13 @@ end
 
         (vgeo, sgeo, _) =
             Grids.computegeometry(e2c, D, ξ, ω, (x...) -> identity(x))
-        vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+
+        vgeo = reshape(
+            vgeo.array,
+            Nq...,
+            fieldcount(GeometricFactors.VolumeGeometry),
+            nelem,
+        )
 
         @test (@view vgeo[:, :, :, _x1, :]) ≈ x_exact
         @test (@view vgeo[:, :, :, _x2, :]) ≈ y_exact
@@ -609,25 +656,25 @@ end
                 end
                 Mf = kron(1, ωf...)
                 @test isapprox(
-                    (@view sgeo[_sM, 1:Nfp[d], f, :]),
+                    (@view sgeo.sωJ[1:Nfp[d], f, :]),
                     sJ_exact[1:Nfp[d], f, :] .* Mf,
                     atol = √eps(FT),
                     rtol = √eps(FT),
                 )
                 @test isapprox(
-                    (@view sgeo[_n1, 1:Nfp[d], f, :]),
+                    (@view sgeo.n1[1:Nfp[d], f, :]),
                     nx_exact[1:Nfp[d], f, :];
                     atol = √eps(FT),
                     rtol = √eps(FT),
                 )
                 @test isapprox(
-                    (@view sgeo[_n2, 1:Nfp[d], f, :]),
+                    (@view sgeo.n2[1:Nfp[d], f, :]),
                     ny_exact[1:Nfp[d], f, :];
                     atol = √eps(FT),
                     rtol = √eps(FT),
                 )
                 @test isapprox(
-                    (@view sgeo[_n3, 1:Nfp[d], f, :]),
+                    (@view sgeo.n3[1:Nfp[d], f, :]),
                     nz_exact[1:Nfp[d], f, :];
                     atol = √eps(FT),
                     rtol = √eps(FT),
@@ -685,7 +732,12 @@ end
         (x1ξ1, x1ξ2, x1ξ3, x2ξ1, x2ξ2, x2ξ3, x3ξ1, x3ξ2, x3ξ3) = let
             (vgeo, _) =
                 Grids.computegeometry(e2c, D, ξ, ω, (x...) -> identity(x))
-            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+            vgeo = reshape(
+                vgeo.array,
+                Nq...,
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
             ξ1 = vgeo[:, :, :, _x1, :]
             ξ2 = vgeo[:, :, :, _x2, :]
             ξ3 = vgeo[:, :, :, _x3, :]
@@ -718,7 +770,12 @@ end
         ξ3x3 = (x1ξ1 .* x2ξ2 - x1ξ2 .* x2ξ1) ./ J
 
         (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, f)
-        vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+        vgeo = reshape(
+            vgeo.array,
+            Nq...,
+            fieldcount(GeometricFactors.VolumeGeometry),
+            nelem,
+        )
 
         @test (@view vgeo[:, :, :, _M, :]) ≈
               J .* reshape(kron(reverse(ω)...), Nq..., 1)
@@ -731,10 +788,10 @@ end
         @test (@view vgeo[:, :, :, _ξ3x1, :]) ≈ ξ3x1
         @test (@view vgeo[:, :, :, _ξ3x2, :]) ≈ ξ3x2
         @test (@view vgeo[:, :, :, _ξ3x3, :]) ≈ ξ3x3
-        n1 = @view sgeo[_n1, :, :, :]
-        n2 = @view sgeo[_n2, :, :, :]
-        n3 = @view sgeo[_n3, :, :, :]
-        sM = @view sgeo[_sM, :, :, :]
+        n1 = @view sgeo.n1[:, :, :]
+        n2 = @view sgeo.n2[:, :, :]
+        n3 = @view sgeo.n3[:, :, :]
+        sM = @view sgeo.sωJ[:, :, :]
         for d in 1:dim
             for f in (2d - 1):(2d)
                 @test all(
@@ -846,7 +903,12 @@ end
         nelem = size(e2c, 3)
 
         (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, f)
-        vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+        vgeo = reshape(
+            vgeo.array,
+            Nq...,
+            fieldcount(GeometricFactors.VolumeGeometry),
+            nelem,
+        )
 
         (Cx1, Cx2, Cx3) = (zeros(FT, Nq...), zeros(FT, Nq...), zeros(FT, Nq...))
 
@@ -942,30 +1004,33 @@ end
             # Create the metrics
             (x1, x2, x3, x1ξ1, x1ξ2, x1ξ3, x2ξ1, x2ξ2, x2ξ3, x3ξ1, x3ξ2, x3ξ3) =
                 let
-                    ξ1 = zeros(FT, Nq..., nelem)
-                    ξ2 = zeros(FT, Nq..., nelem)
-                    ξ3 = zeros(FT, Nq..., nelem)
-                    Metrics.creategrid!(ξ1, ξ2, ξ3, e2c, ξ...)
+                    vgeo = VolumeGeometry(FT, Nq, nelem)
+                    Metrics.creategrid!(vgeo, e2c, ξ)
+                    x1 = reshape(vgeo.x1, (Nq..., nelem))
+                    x2 = reshape(vgeo.x2, (Nq..., nelem))
+                    x3 = reshape(vgeo.x3, (Nq..., nelem))
                     (
-                        fx1.(ξ1, ξ2, ξ3),
-                        fx2.(ξ1, ξ2, ξ3),
-                        fx3.(ξ1, ξ2, ξ3),
-                        fx1ξ1.(ξ1, ξ2, ξ3),
-                        fx1ξ2.(ξ1, ξ2, ξ3),
-                        fx1ξ3.(ξ1, ξ2, ξ3),
-                        fx2ξ1.(ξ1, ξ2, ξ3),
-                        fx2ξ2.(ξ1, ξ2, ξ3),
-                        fx2ξ3.(ξ1, ξ2, ξ3),
-                        fx3ξ1.(ξ1, ξ2, ξ3),
-                        fx3ξ2.(ξ1, ξ2, ξ3),
-                        fx3ξ3.(ξ1, ξ2, ξ3),
+                        fx1.(x1, x2, x3),
+                        fx2.(x1, x2, x3),
+                        fx3.(x1, x2, x3),
+                        fx1ξ1.(x1, x2, x3),
+                        fx1ξ2.(x1, x2, x3),
+                        fx1ξ3.(x1, x2, x3),
+                        fx2ξ1.(x1, x2, x3),
+                        fx2ξ2.(x1, x2, x3),
+                        fx2ξ3.(x1, x2, x3),
+                        fx3ξ1.(x1, x2, x3),
+                        fx3ξ2.(x1, x2, x3),
+                        fx3ξ3.(x1, x2, x3),
                     )
                 end
+
             J = @.(
                 x1ξ1 * (x2ξ2 * x3ξ3 - x3ξ2 * x2ξ3) +
                 x2ξ1 * (x3ξ2 * x1ξ3 - x1ξ2 * x3ξ3) +
                 x3ξ1 * (x1ξ2 * x2ξ3 - x2ξ2 * x1ξ3)
             )
+
             ξ1x1 = (x2ξ2 .* x3ξ3 - x2ξ3 .* x3ξ2) ./ J
             ξ1x2 = (x3ξ2 .* x1ξ3 - x3ξ3 .* x1ξ2) ./ J
             ξ1x3 = (x1ξ2 .* x2ξ3 - x1ξ3 .* x2ξ2) ./ J
@@ -981,7 +1046,12 @@ end
             meshwarp(ξ1, ξ2, ξ3) =
                 (fx1(ξ1, ξ2, ξ3), fx2(ξ1, ξ2, ξ3), fx3(ξ1, ξ2, ξ3))
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
-            vgeo = reshape(vgeo.array, Nq..., _nvgeo, nelem)
+            vgeo = reshape(
+                vgeo.array,
+                Nq...,
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
 
             @test x1 ≈ vgeo[:, :, :, _x1, :]
             @test x2 ≈ vgeo[:, :, :, _x2, :]
@@ -1002,10 +1072,10 @@ end
             @test (@view vgeo[:, :, :, _ξ3x3, :]) ≈ ξ3x3
 
             # check the normals?
-            sM = @view sgeo[_sM, :, :, :]
-            n1 = @view sgeo[_n1, :, :, :]
-            n2 = @view sgeo[_n2, :, :, :]
-            n3 = @view sgeo[_n3, :, :, :]
+            sM = @view sgeo.sωJ[:, :, :]
+            n1 = @view sgeo.n1[:, :, :]
+            n2 = @view sgeo.n2[:, :, :]
+            n3 = @view sgeo.n3[:, :, :]
             @test all(
                 hypot.(
                     n1[1:Nfp[1], 1:2, :],
@@ -1077,28 +1147,25 @@ end
             (x1ξ1, x1ξ2, x1ξ3, x2ξ1, x2ξ2, x2ξ3, x3ξ1, x3ξ2, x3ξ3) = let
                 @assert Nq[1] != 1 && Nq[2] != 1 && Nq[3] == 1
                 Nq_N1 = max.(2, Nq)
-                ξ1 = zeros(FT, Nq_N1..., nelem)
-                ξ2 = zeros(FT, Nq_N1..., nelem)
-                ξ3 = zeros(FT, Nq_N1..., nelem)
+                vgeo_N1 = VolumeGeometry(FT, Nq_N1, nelem)
                 Metrics.creategrid!(
-                    ξ1,
-                    ξ2,
-                    ξ3,
+                    vgeo_N1,
                     e2c,
-                    ξ[1],
-                    ξ[2],
-                    Elements.lglpoints(FT, 1)[1],
+                    (ξ[1], ξ[2], Elements.lglpoints(FT, 1)[1]),
                 )
+                x1 = reshape(vgeo_N1.x1, (Nq_N1..., nelem))
+                x2 = reshape(vgeo_N1.x2, (Nq_N1..., nelem))
+                x3 = reshape(vgeo_N1.x3, (Nq_N1..., nelem))
                 (
-                    fx1ξ1.(ξ1, ξ2, ξ3),
-                    fx1ξ2.(ξ1, ξ2, ξ3),
-                    fx1ξ3.(ξ1, ξ2, ξ3),
-                    fx2ξ1.(ξ1, ξ2, ξ3),
-                    fx2ξ2.(ξ1, ξ2, ξ3),
-                    fx2ξ3.(ξ1, ξ2, ξ3),
-                    fx3ξ1.(ξ1, ξ2, ξ3),
-                    fx3ξ2.(ξ1, ξ2, ξ3),
-                    fx3ξ3.(ξ1, ξ2, ξ3),
+                    fx1ξ1.(x1, x2, x3),
+                    fx1ξ2.(x1, x2, x3),
+                    fx1ξ3.(x1, x2, x3),
+                    fx2ξ1.(x1, x2, x3),
+                    fx2ξ2.(x1, x2, x3),
+                    fx2ξ3.(x1, x2, x3),
+                    fx3ξ1.(x1, x2, x3),
+                    fx3ξ2.(x1, x2, x3),
+                    fx3ξ3.(x1, x2, x3),
                 )
             end
             J = @.(
@@ -1178,6 +1245,13 @@ end
                 (fx1(ξ1, ξ2, ξ3), fx2(ξ1, ξ2, ξ3), fx2(ξ1, ξ2, ξ3))
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
 
+            vgeo = reshape(
+                vgeo.array,
+                prod(Nq),
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
+
             M = vgeo[:, _M, :]
             ξ1x1 = vgeo[:, _ξ1x1, :]
             ξ2x1 = vgeo[:, _ξ2x1, :]
@@ -1211,10 +1285,10 @@ end
                 kron(I3[1, :]', I2, I1),
                 kron(I3[Nq[3], :]', I2, I1),
             )
-            sM = ntuple(f -> sgeo[_sM, 1:Nfp[cld(f, 2)], f, :], nface)
-            n1 = ntuple(f -> sgeo[_n1, 1:Nfp[cld(f, 2)], f, :], nface)
-            n2 = ntuple(f -> sgeo[_n2, 1:Nfp[cld(f, 2)], f, :], nface)
-            n3 = ntuple(f -> sgeo[_n3, 1:Nfp[cld(f, 2)], f, :], nface)
+            sM = ntuple(f -> sgeo.sωJ[1:Nfp[cld(f, 2)], f, :], nface)
+            n1 = ntuple(f -> sgeo.n1[1:Nfp[cld(f, 2)], f, :], nface)
+            n2 = ntuple(f -> sgeo.n2[1:Nfp[cld(f, 2)], f, :], nface)
+            n3 = ntuple(f -> sgeo.n3[1:Nfp[cld(f, 2)], f, :], nface)
 
             # If constant preserving then:
             #   \sum_{j} = D' * M * ξjxk = \sum_{f} L_f' * sM_f * n1_f
@@ -1268,6 +1342,13 @@ end
                 (fx1(ξ1, ξ2, ξ3), fx2(ξ1, ξ2, ξ3), fx2(ξ1, ξ2, ξ3))
             (vgeo, sgeo, _) = Grids.computegeometry(e2c, D, ξ, ω, meshwarp)
 
+            vgeo = reshape(
+                vgeo.array,
+                prod(Nq),
+                fieldcount(GeometricFactors.VolumeGeometry),
+                nelem,
+            )
+
             M = vgeo[:, _M, :]
             ξ1x1 = vgeo[:, _ξ1x1, :]
             ξ2x1 = vgeo[:, _ξ2x1, :]
@@ -1301,10 +1382,10 @@ end
                 kron(I3[1, :]', I2, I1),
                 kron(I3[Nq[3], :]', I2, I1),
             )
-            sM = ntuple(f -> sgeo[_sM, 1:Nfp[cld(f, 2)], f, :], nface)
-            n1 = ntuple(f -> sgeo[_n1, 1:Nfp[cld(f, 2)], f, :], nface)
-            n2 = ntuple(f -> sgeo[_n2, 1:Nfp[cld(f, 2)], f, :], nface)
-            n3 = ntuple(f -> sgeo[_n3, 1:Nfp[cld(f, 2)], f, :], nface)
+            sM = ntuple(f -> sgeo.sωJ[1:Nfp[cld(f, 2)], f, :], nface)
+            n1 = ntuple(f -> sgeo.n1[1:Nfp[cld(f, 2)], f, :], nface)
+            n2 = ntuple(f -> sgeo.n2[1:Nfp[cld(f, 2)], f, :], nface)
+            n3 = ntuple(f -> sgeo.n3[1:Nfp[cld(f, 2)], f, :], nface)
 
             # If constant preserving then \sum_{f} L_f' * sM_f * n1_f ≈ 0
             @test abs(mapreduce(


### PR DESCRIPTION
### Description

This ~~WIP~~ PR provides a clean-up of the interface to store and access geometric factors data at quadrature points. It adds two structures `VolumeGeometry` and `SurfaceGeometry` for easy access of the metric terms data in different modules. These structures are defined in an independent module, called `GeomData.jl` to avoid the issue of circular dependency between the `Metrics.jl` and the `Grids.jl` modules. 

Things left TODO:
- [x] Modify also the `computegeometry_fvm` function ~~?~~
- [x]  ~~Clean-up existing definitions of loose const variables in place of structs ?~~ Edit: This can be left for a subsequent PR since there is a more compelling Core revamp in the making
- [x] Update the `Base.getproperty` and `Base.propertynames` functions ~~?~~ 
- [x] Re-compute inverse of discrete Jacobian, `∂x/∂ξ`, for the 3D case, since the discrete curl-invariant form of `∂ξ/∂x` is *not* equal the inverse of `∂x/∂ξ` (credits to @jkozdon for this observation)  
- [x] Debug and Test

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
