### PR TITLE
Dispatch on coupling mode

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1803,6 +1803,15 @@ steps:
       slurm_ntasks: 1
       slurm_gres: "gpu:1"
 
+  - label: "cpu_sbl_edmf_coupled"
+    key: "cpu_sbl_edmf_coupled"
+    command:
+      - "mpiexec julia --color=yes --project test/Atmos/EDMF/stable_bl_coupled_edmf_an1d.jl --fix-rng-seed"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: "gpu_bomex_bulk_sfc_flux"
     key: "gpu_bomex_bulk_sfc_flux"
     command:

--- a/test/Atmos/EDMF/edmf_kernels.jl
+++ b/test/Atmos/EDMF/edmf_kernels.jl
@@ -229,9 +229,20 @@ PressSource(m::EDMF) = PressSource{n_updrafts(m)}()
 eq_tends(
     pv::Union{Momentum, Energy, TotalMoisture},
     m::EDMF,
+    flux::Flux{SecondOrder},
+) = eq_tends(pv, m.coupling, flux)
+
+eq_tends(
+    pv::Union{Momentum, Energy, TotalMoisture},
+    ::Decoupled,
     ::Flux{SecondOrder},
-) = ()  # do _not_ add SGSFlux back to grid-mean
-# (SGSFlux(),) # add SGSFlux back to grid-mean
+) = ()
+
+eq_tends(
+    pv::Union{Momentum, Energy, TotalMoisture},
+    ::Coupled,
+    ::Flux{SecondOrder},
+) = (SGSFlux(),)
 
 # Turbconv tendencies
 eq_tends(pv::EDMFPrognosticVariable, m::AtmosModel, tt::Flux{O}) where {O} =

--- a/test/Atmos/EDMF/report_mse_sbl_coupled_edmf_an1d.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_coupled_edmf_an1d.jl
@@ -1,0 +1,49 @@
+using ClimateMachine
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+
+if parse(Bool, get(ENV, "CLIMATEMACHINE_PLOT_EDMF_COMPARISON", "false"))
+    plot_dir = joinpath(clima_dir, "output", "sbl_edmf", "pycles_comparison")
+else
+    plot_dir = nothing
+end
+
+include(joinpath(@__DIR__, "compute_mse.jl"))
+
+data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
+
+#! format: off
+best_mse = OrderedDict()
+best_mse["prog_ρ"] = 9.3808122133551899e-03
+best_mse["prog_ρu_1"] = 6.7648718002912910e+03
+best_mse["prog_ρu_2"] = 8.9568591962189448e-01
+best_mse["prog_turbconv_environment_ρatke"] = 3.9877808420252154e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.1270320241616531e+01
+best_mse["prog_turbconv_updraft_1_ρa"] = 2.7223017351724246e+02
+best_mse["prog_turbconv_updraft_1_ρaw"] = 5.5909371368198686e+02
+best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 2.7933498788454813e+02
+#! format: on
+
+computed_mse = compute_mse(
+    solver_config.dg.grid,
+    solver_config.dg.balance_law,
+    time_data,
+    dons_arr,
+    data_file,
+    "Gabls",
+    best_mse,
+    1800,
+    plot_dir,
+)
+
+@testset "SBL Coupled EDMF Solution Quality Assurance (QA) tests" begin
+    #! format: off
+    test_mse(computed_mse, best_mse, "prog_ρ")
+    test_mse(computed_mse, best_mse, "prog_ρu_1")
+    test_mse(computed_mse, best_mse, "prog_ρu_2")
+    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρatke")
+    test_mse(computed_mse, best_mse, "prog_turbconv_environment_ρaθ_liq_cv")
+    test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρa")
+    test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρaw")
+    test_mse(computed_mse, best_mse, "prog_turbconv_updraft_1_ρaθ_liq")
+    #! format: on
+end

--- a/test/Atmos/EDMF/stable_bl_coupled_edmf_an1d.jl
+++ b/test/Atmos/EDMF/stable_bl_coupled_edmf_an1d.jl
@@ -1,0 +1,293 @@
+using JLD2, FileIO
+using ClimateMachine
+using ClimateMachine.SingleStackUtils
+using ClimateMachine.Checkpoint
+using ClimateMachine.BalanceLaws: vars_state
+import ClimateMachine.BalanceLaws: projection
+import ClimateMachine.DGMethods
+using ClimateMachine.Atmos
+const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+import CLIMAParameters
+
+include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))
+include("edmf_model.jl")
+include("edmf_kernels.jl")
+
+CLIMAParameters.Planet.T_surf_ref(::EarthParameterSet) = 265
+CLIMAParameters.Atmos.EDMF.a_surf(::EarthParameterSet) = 0.0
+function set_clima_parameters(filename)
+    eval(:(include($filename)))
+end
+
+"""
+    init_state_prognostic!(
+            turbconv::EDMF{FT},
+            m::AtmosModel{FT},
+            state::Vars,
+            aux::Vars,
+            localgeo,
+            t::Real,
+        ) where {FT}
+
+Initialize EDMF state variables.
+This method is only called at `t=0`.
+"""
+function init_state_prognostic!(
+    turbconv::EDMF{FT},
+    m::AtmosModel{FT},
+    state::Vars,
+    aux::Vars,
+    localgeo,
+    t::Real,
+) where {FT}
+    # Aliases:
+    gm = state
+    en = state.turbconv.environment
+    up = state.turbconv.updraft
+    N_up = n_updrafts(turbconv)
+    # GCM setting - Initialize the grid mean profiles of prognostic variables (ρ,e_int,q_tot,u,v,w)
+    z = altitude(m, aux)
+
+    # SCM setting - need to have separate cases coded and called from a folder - see what LES does
+    # a thermo state is used here to convert the input θ to e_int profile
+    e_int = internal_energy(m, state, aux)
+    param_set = parameter_set(m)
+    ts = PhaseDry(param_set, e_int, state.ρ)
+    T = air_temperature(ts)
+    p = air_pressure(ts)
+    q = PhasePartition(ts)
+    θ_liq = liquid_ice_pottemp(ts)
+
+    a_min = turbconv.subdomains.a_min
+    @unroll_map(N_up) do i
+        up[i].ρa = gm.ρ * a_min
+        up[i].ρaw = gm.ρu[3] * a_min
+        up[i].ρaθ_liq = gm.ρ * a_min * θ_liq
+        up[i].ρaq_tot = FT(0)
+    end
+
+    # initialize environment covariance with zero for now
+    if z <= FT(250)
+        en.ρatke =
+            gm.ρ *
+            FT(0.4) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0)
+        en.ρaθ_liq_cv =
+            gm.ρ *
+            FT(0.4) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0) *
+            FT(1 - z / 250.0)
+    else
+        en.ρatke = FT(0)
+        en.ρaθ_liq_cv = FT(0)
+    end
+    en.ρaq_tot_cv = FT(0)
+    en.ρaθ_liq_q_tot_cv = FT(0)
+    return nothing
+end;
+
+function main(::Type{FT}, cl_args) where {FT}
+
+    surface_flux = cl_args["surface_flux"]
+
+    # Choice of compressibility and CFL
+    # compressibility = Compressible()
+    compressibility = Anelastic1D()
+    str_comp = compressibility == Compressible() ? "COMPRESS" : "ANELASTIC"
+
+    # DG polynomial order
+    N = 4
+    nelem_vert = 20
+
+    # Prescribe domain parameters
+    zmax = FT(400)
+    # Simulation time
+    t0 = FT(0)
+    timeend = FT(1800 * 1)
+    CFLmax = compressibility == Compressible() ? FT(1) : FT(100)
+
+    config_type = SingleStackConfigType
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
+    # Choice of SGS model
+    N_updrafts = 1
+    N_quad = 3
+    turbconv = EDMF(
+        FT,
+        N_updrafts,
+        N_quad,
+        param_set,
+        surface = NeutralDrySurfaceModel{FT}(param_set),
+        coupling = Coupled(),
+    )
+
+    turbulence = ConstantKinematicViscosity(FT(0.0))
+    model = stable_bl_model(
+        FT,
+        config_type,
+        zmax,
+        surface_flux;
+        turbulence = turbulence,
+        turbconv = turbconv,
+        compressibility = compressibility,
+    )
+
+    # Assemble configuration
+    driver_config = ClimateMachine.SingleStackConfiguration(
+        string("SBL_COUPLED_", str_comp, "_1D"),
+        N,
+        nelem_vert,
+        zmax,
+        param_set,
+        model;
+        hmax = FT(40),
+        solver_type = ode_solver_type,
+    )
+
+    solver_config = ClimateMachine.SolverConfiguration(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFLmax,
+    )
+
+    # --- Zero-out horizontal variations:
+    vsp = vars_state(model, Prognostic(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :turbconv),
+    )
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.Q,
+        varsindex(vsp, :energy, :ρe),
+    )
+    vsa = vars_state(model, Auxiliary(), FT)
+    horizontally_average!(
+        driver_config.grid,
+        solver_config.dg.state_auxiliary,
+        varsindex(vsa, :turbconv),
+    )
+    # ---
+
+    dgn_config = config_diagnostics(driver_config)
+
+    # boyd vandeven filter
+    num_state_prognostic = number_states(driver_config.bl, Prognostic())
+    cb_boyd = GenericCallbacks.EveryXSimulationSteps(1) do
+        Filters.apply!(
+            solver_config.Q,
+            1:num_state_prognostic,
+            solver_config.dg.grid,
+            BoydVandevenFilter(
+                solver_config.dg.grid,
+                1, #default=0
+                4, #default=32
+            ),
+        )
+        nothing
+    end
+
+    diag_arr = [single_stack_diagnostics(solver_config)]
+    time_data = FT[0]
+
+    # Define the number of outputs from `t0` to `timeend`
+    n_outputs = 5
+    # This equates to exports every ceil(Int, timeend/n_outputs) time-step:
+    every_x_simulation_time = ceil(Int, timeend / n_outputs)
+
+    cb_data_vs_time =
+        GenericCallbacks.EveryXSimulationTime(every_x_simulation_time) do
+            diag_vs_z = single_stack_diagnostics(solver_config)
+
+            nstep = getsteps(solver_config.solver)
+
+            push!(diag_arr, diag_vs_z)
+            push!(time_data, gettime(solver_config.solver))
+            nothing
+        end
+
+    # Mass tendencies = 0 for Anelastic1D model,
+    # so mass should be completely conserved:
+    check_cons =
+        (ClimateMachine.ConservationCheck("ρ", "3000steps", FT(0.00000001)),)
+
+    cb_print_step = GenericCallbacks.EveryXSimulationSteps(100) do
+        @show getsteps(solver_config.solver)
+        nothing
+    end
+
+    if !isnothing(cl_args["cparam_file"])
+        ClimateMachine.Settings.output_dir = cl_args["cparam_file"] * ".output"
+    end
+    result = ClimateMachine.invoke!(
+        solver_config;
+        diagnostics_config = dgn_config,
+        check_cons = check_cons,
+        user_callbacks = (cb_boyd, cb_data_vs_time, cb_print_step),
+        check_euclidean_distance = true,
+    )
+
+    diag_vs_z = single_stack_diagnostics(solver_config)
+    push!(diag_arr, diag_vs_z)
+    push!(time_data, gettime(solver_config.solver))
+
+    return solver_config, diag_arr, time_data
+end
+
+# ArgParse in global scope to modify Clima Parameters
+sbl_args = ArgParseSettings(autofix_names = true)
+add_arg_group!(sbl_args, "StableBoundaryLayer")
+@add_arg_table! sbl_args begin
+    "--cparam-file"
+    help = "specify CLIMAParameters file"
+    arg_type = Union{String, Nothing}
+    default = nothing
+
+    "--surface-flux"
+    help = "specify surface flux for energy and moisture"
+    metavar = "prescribed|bulk|custom_sbl"
+    arg_type = String
+    default = "custom_sbl"
+end
+
+cl_args = ClimateMachine.init(parse_clargs = true, custom_clargs = sbl_args)
+if !isnothing(cl_args["cparam_file"])
+    filename = cl_args["cparam_file"]
+    set_clima_parameters(filename)
+end
+
+solver_config, diag_arr, time_data = main(Float64, cl_args)
+
+# Uncomment lines to save output using JLD2
+output_dir = @__DIR__;
+mkpath(output_dir);
+function dons(diag_vs_z)
+    return Dict(map(keys(first(diag_vs_z))) do k
+        string(k) => [getproperty(ca, k) for ca in diag_vs_z]
+    end)
+end
+get_dons_arr(diag_arr) = [dons(diag_vs_z) for diag_vs_z in diag_arr]
+dons_arr = get_dons_arr(diag_arr)
+println(dons_arr[1].keys)
+z = get_z(solver_config.dg.grid; rm_dupes = true);
+save(
+    string(output_dir, "/sbl_coupled.jld2"),
+    "dons_arr",
+    dons_arr,
+    "time_data",
+    time_data,
+    "z",
+    z,
+)
+
+include(joinpath(@__DIR__, "report_mse_sbl_coupled_edmf_an1d.jl"))
+
+nothing


### PR DESCRIPTION
### Description

The EDMF is finally getting to the stage where coupled (as well as decoupled) simulations are functional. This will require to test the EDMF model in coupled and decoupled modes for different settings (e.g., coupled Ekman, decoupled Bomex) and the current code structure does not allow this. To this purpose, I add the coupling type to the EDMF model, which allows dispatching simulations with or without coupling of the EDMF tendencies to the grid-mean.

Along with this, this PR adds a coupled SBL simulation test with MSE tracking.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
