### PR TITLE
do not render notebook output as the default is to execute it

### DIFF
--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -122,7 +122,6 @@ if generate_tutorials
                 documenter = false,
                 preprocess = mdpre,
             )
-            Literate.notebook(input)
         end
     end
 


### PR DESCRIPTION
### Description

Looking at the generation of https://github.com/CliMA/ClimateMachine.jl/pull/2157 we are actually (still) executing the tutorials multiple times because the default for notebook generation is to execute the notebook and we already do that for the markdown output.

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
