### PR TITLE
Add physics to AtmosBC constructor

### DIFF
--- a/docs/src/GettingStarted/Atmos.md
+++ b/docs/src/GettingStarted/Atmos.md
@@ -7,25 +7,35 @@ below. In this implementation of the `AtmosModel` we concern ourselves
 with the conservative form of the compressible equations of moist fluid
 motion given a set of initial, boundary and forcing(source) conditions.
 
+First, we construct the atmospheric physics via `AtmosPhysics`:
+
+```
+physics = AtmosPhysics{FT}(;
+    param_set::AbstractParameterSet;
+    ref_state = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),)
+    turbulence = SmagorinskyLilly{FT}(0.21),
+    hyperdiffusion = NoHyperDiffusion(),
+    moisture = EquilMoist(),
+    precipitation = NoPrecipitation(),
+    radiation = NoRadiation(),
+    tracers = NoTracers(),
+)
+```
+
 ### LES Configuration (with defaults)
 Default field values for the LES `AtmosModel` definition are included
 below. Users are directed to the model subcomponent pages to view the
 possible options for each subcomponent.
 ```
+atmos = AtmosModel{FT}(
     ::Type{AtmosLESConfigType},
-    param_set::AbstractParameterSet;
-    orientation::O = FlatOrientation(),
-    ref_state::RS = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),)
-    turbulence::T = SmagorinskyLilly{FT}(0.21),
-    hyperdiffusion::HD = NoHyperDiffusion(),
-    moisture::M = EquilMoist(),
-    precipitation::P = NoPrecipitation(),
-    radiation::R = NoRadiation(),
-    source::S = (Gravity(), Coriolis(), GeostrophicForcing{FT}(7.62e-5, 0, 0)),
-    tracers::TR = NoTracers(),
-    boundarycondition::BC = AtmosBC(),
-    init_state_prognostic::IS = nothing,
-    data_config::DC = nothing,
+    physics::AtmosPhysics;
+    orientation = FlatOrientation(),
+    source = (Gravity(), Coriolis(), GeostrophicForcing{FT}(7.62e-5, 0, 0)),
+    problem = AtmosBC(physics),
+    init_state_prognostic = nothing,
+    data_config = nothing,
+)
 ```
 
 !!! note
@@ -43,16 +53,9 @@ possible options for each subcomponent.
 
 ```
     ::Type{AtmosGCMConfigType},
-    param_set::AbstractParameterSet;
-    ref_state::RS = HydrostaticState(DecayingTemperatureProfile{FT}(param_set),)
-    turbulence::T = SmagorinskyLilly{FT}(C_smag(param_set)),
-    hyperdiffusion::HD = NoHyperDiffusion(),
-    moisture::M = EquilMoist(),
-    precipitation::P = NoPrecipitation(),
-    radiation::R = NoRadiation(),
+    physics::AtmosPhysics;
     source::S = (Gravity(), Coriolis()),
-    tracers::TR = NoTracers(),
-    boundarycondition::BC = AtmosBC(),
+    boundarycondition::BC = AtmosBC(physics),
     init_state_prognostic::IS = nothing,
     data_config::DC = nothing,
 ```

--- a/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
+++ b/experiments/AtmosGCM/GCMDriver/GCMDriver.jl
@@ -173,8 +173,18 @@ function config_gcm_experiment(
         moisture = EquilMoist()
     end
 
+    # Define the Atmosphere physics
+    physics = AtmosPhysics{FT}(
+        param_set;
+        ref_state = ref_state,
+        turbulence = ConstantKinematicViscosity(FT(0)),
+        hyperdiffusion = hyperdiffusion,
+        moisture = moisture,
+    )
+
     # Set up the boundary conditions
     boundaryconditions = parse_surface_flux_arg(
+        physics,
         surface_flux_arg,
         FT,
         param_set,
@@ -184,6 +194,7 @@ function config_gcm_experiment(
 
     # Set up the problem
     problem = problem_type(
+        physics;
         boundaryconditions = boundaryconditions,
         perturbation = perturbation,
         base_state = base_state,
@@ -191,14 +202,6 @@ function config_gcm_experiment(
     )
 
     # Create the Atmosphere model
-    physics = AtmosPhysics{FT}(
-        param_set;
-        ref_state = ref_state,
-        turbulence = ConstantKinematicViscosity(FT(0)),
-        hyperdiffusion = hyperdiffusion,
-        moisture = moisture,
-    )
-
     model = AtmosModel{FT}(
         AtmosGCMConfigType,
         physics;

--- a/experiments/AtmosGCM/GCMDriver/baroclinicwave_problem.jl
+++ b/experiments/AtmosGCM/GCMDriver/baroclinicwave_problem.jl
@@ -12,8 +12,9 @@ struct BaroclinicWaveProblem{BCS, ISP, ISA, WP, BS, MP} <: AbstractAtmosProblem
     base_state::BS
     moisture_profile::MP
 end
-function BaroclinicWaveProblem(;
-    boundaryconditions = (AtmosBC(), AtmosBC()),
+function BaroclinicWaveProblem(
+    physics::AtmosPhysics;
+    boundaryconditions = (AtmosBC(physics;), AtmosBC(physics;)),
     perturbation = nothing,
     base_state = nothing,
     moisture_profile = nothing,

--- a/experiments/AtmosGCM/GCMDriver/gcm_bcs.jl
+++ b/experiments/AtmosGCM/GCMDriver/gcm_bcs.jl
@@ -3,6 +3,7 @@
 
 # Helper for parsing `--surface-flux` command line argument
 function parse_surface_flux_arg(
+    physics::AtmosPhysics,
     arg,
     ::Type{FT},
     param_set,
@@ -10,7 +11,7 @@ function parse_surface_flux_arg(
     moisture,
 ) where {FT}
     if arg === nothing || arg == "default"
-        boundaryconditions = (AtmosBC(), AtmosBC())
+        boundaryconditions = (AtmosBC(physics;), AtmosBC(physics;))
     elseif arg == "bulk"
         if !isa(moisture, EquilMoist)
             error("need a moisture model for surface-flux: bulk")
@@ -20,6 +21,7 @@ function parse_surface_flux_arg(
         #bulk_flux = (T_sfc, q_sfc) # prescribed constant T_sfc, q_sfc
         boundaryconditions = (
             AtmosBC(
+                physics;
                 energy = BulkFormulaEnergy(
                     (bl, state, aux, t, normPu_int) -> _C_drag,
                     (bl, state, aux, t) -> bulk_flux(state, aux, t),
@@ -32,7 +34,7 @@ function parse_surface_flux_arg(
                     end,
                 ),
             ),
-            AtmosBC(),
+            AtmosBC(physics;),
         )
     else
         error("unknown surface flux: " * arg)

--- a/experiments/AtmosGCM/GCMDriver/heldsuarez_problem.jl
+++ b/experiments/AtmosGCM/GCMDriver/heldsuarez_problem.jl
@@ -22,8 +22,9 @@ struct HeldSuarezProblem{BC, ISP, ISA, WP, BS, MP} <: AbstractAtmosProblem
     base_state::BS
     moisture_profile::MP
 end
-function HeldSuarezProblem(;
-    boundaryconditions = (AtmosBC(), AtmosBC()),
+function HeldSuarezProblem(
+    physics::AtmosPhysics;
+    boundaryconditions = (AtmosBC(physics;), AtmosBC(physics;)),
     perturbation = nothing,
     base_state = nothing,
     moisture_profile = nothing,

--- a/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
+++ b/experiments/AtmosGCM/moist_baroclinic_wave_bulksfcflux.jl
@@ -242,9 +242,19 @@ function config_baroclinic_wave(
 
     _C_drag = C_drag(param_set)::FT
     bulk_flux = Varying_SST_TJ16(param_set, SphericalOrientation(), moisture)
+
+    physics = AtmosPhysics{FT}(
+        param_set;
+        ref_state = ref_state,
+        turbulence = ConstantKinematicViscosity(FT(0)),
+        hyperdiffusion = hyperdiffusion,
+        moisture = moisture,
+    )
+
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
+                physics;
                 energy = BulkFormulaEnergy(
                     (bl, state, aux, t, normPu_int) -> _C_drag,
                     (bl, state, aux, t) -> bulk_flux(state, aux, t),
@@ -257,17 +267,9 @@ function config_baroclinic_wave(
                     end,
                 ),
             ),
-            AtmosBC(),
+            AtmosBC(physics;),
         ),
         init_state_prognostic = init_baroclinic_wave!,
-    )
-
-    physics = AtmosPhysics{FT}(
-        param_set;
-        ref_state = ref_state,
-        turbulence = ConstantKinematicViscosity(FT(0)),
-        hyperdiffusion = hyperdiffusion,
-        moisture = moisture,
     )
 
     model = AtmosModel{FT}(

--- a/experiments/AtmosLES/bomex_model.jl
+++ b/experiments/AtmosLES/bomex_model.jl
@@ -448,9 +448,18 @@ function bomex_model(
         )
     end
 
+    # Assemble model components
+    physics = AtmosPhysics{FT}(
+        param_set;
+        turbulence = SmagorinskyLilly{FT}(C_smag),
+        moisture = moisture,
+        turbconv = turbconv,
+    )
+
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
+                physics;
                 momentum = Impenetrable(DragLaw(
                     # normPu_int is the internal horizontal speed
                     # P represents the projection onto the horizontal
@@ -460,19 +469,12 @@ function bomex_model(
                 moisture = moisture_bc,
                 turbconv = turbconv_bcs(turbconv)[1],
             ),
-            AtmosBC(turbconv = turbconv_bcs(turbconv)[2]),
+            AtmosBC(physics; turbconv = turbconv_bcs(turbconv)[2]),
         ),
         init_state_prognostic = ics,
     )
 
     # Assemble model components
-    physics = AtmosPhysics{FT}(
-        param_set;
-        turbulence = SmagorinskyLilly{FT}(C_smag),
-        moisture = moisture,
-        turbconv = turbconv,
-    )
-
     model =
         AtmosModel{FT}(config_type, physics; problem = problem, source = source)
 

--- a/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
+++ b/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
@@ -396,9 +396,17 @@ function config_cfsites(
     # Boundary Conditions
     u_star = FT(0.28)
 
+    physics = AtmosPhysics{FT}(
+        param_set;
+        turbulence = Vreman{FT}(0.23),
+        moisture = EquilMoist(; maxiter = 5, tolerance = FT(2)),
+        lsforcing = HadGEMVertical(),
+    )
+
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
+                physics;
                 momentum = Impenetrable(DragLaw(
                     (state, aux, t, normPu_int) -> (u_star / normPu_int)^2,
                 )),
@@ -408,15 +416,9 @@ function config_cfsites(
                         hfls / latent_heat_vapor(param_set, ts),
                 ),
             ),
-            AtmosBC(),
+            AtmosBC(physics;),
         ),
         init_state_prognostic = init_cfsites!,
-    )
-    physics = AtmosPhysics{FT}(
-        param_set;
-        turbulence = Vreman{FT}(0.23),
-        moisture = EquilMoist(; maxiter = 5, tolerance = FT(2)),
-        lsforcing = HadGEMVertical(),
     )
 
     model = AtmosModel{FT}(

--- a/experiments/AtmosLES/convective_bl_model.jl
+++ b/experiments/AtmosLES/convective_bl_model.jl
@@ -270,9 +270,18 @@ function convective_bl_model(
         )
     end
 
+    # Define the physics
+    physics = AtmosPhysics{FT}(
+        param_set;
+        turbulence = SmagorinskyLilly{FT}(C_smag),
+        moisture = moisture,
+        turbconv = turbconv,
+    )
+
     moisture_bcs = moisture_model == "dry" ? () : (; moisture = moisture_bc)
     boundary_conditions = (
-        AtmosBC(;
+        AtmosBC(
+            physics;
             momentum = Impenetrable(DragLaw(
                 # normPu_int is the internal horizontal speed
                 # P represents the projection onto the horizontal
@@ -282,7 +291,7 @@ function convective_bl_model(
             moisture_bcs...,
             turbconv = turbconv_bcs(turbconv)[1],
         ),
-        AtmosBC(; turbconv = turbconv_bcs(turbconv)[2]),
+        AtmosBC(physics; turbconv = turbconv_bcs(turbconv)[2]),
     )
 
     problem = AtmosProblem(
@@ -291,13 +300,6 @@ function convective_bl_model(
     )
 
     # Assemble model components
-    physics = AtmosPhysics{FT}(
-        param_set;
-        turbulence = SmagorinskyLilly{FT}(C_smag),
-        moisture = moisture,
-        turbconv = turbconv,
-    )
-
     model =
         AtmosModel{FT}(config_type, physics; problem = problem, source = source)
 

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -347,9 +347,19 @@ function config_dycoms(
         precipitation = NoPrecipitation()
     end
 
+    physics = AtmosPhysics{FT}(
+        param_set;
+        ref_state = ref_state,
+        turbulence = Vreman{FT}(C_smag),
+        moisture = moisture,
+        precipitation = precipitation,
+        radiation = radiation,
+    )
+
     problem = AtmosProblem(
         boundaryconditions = (
             AtmosBC(
+                physics;
                 momentum = Impenetrable(DragLaw(
                     (state, aux, t, normPu) -> C_drag,
                 )),
@@ -358,18 +368,9 @@ function config_dycoms(
                     (state, aux, t) -> moisture_flux,
                 ),
             ),
-            AtmosBC(),
+            AtmosBC(physics;),
         ),
         init_state_prognostic = init_dycoms!,
-    )
-
-    physics = AtmosPhysics{FT}(
-        param_set;
-        ref_state = ref_state,
-        turbulence = Vreman{FT}(C_smag),
-        moisture = moisture,
-        precipitation = precipitation,
-        radiation = radiation,
     )
 
     model = AtmosModel{FT}(

--- a/experiments/AtmosLES/ekman_layer_model.jl
+++ b/experiments/AtmosLES/ekman_layer_model.jl
@@ -235,9 +235,19 @@ function ekman_layer_model(
         )
     end
 
+    physics = AtmosPhysics{FT}(
+        param_set;
+        ref_state = ref_state,
+        turbulence = turbulence,
+        moisture = DryModel(),
+        turbconv = turbconv,
+        compressibility = compressibility,
+    )
+
     moisture_bcs = ()
     boundary_conditions = (
-        AtmosBC(;
+        AtmosBC(
+            physics;
             momentum = Impenetrable(DragLaw(
                 # normPu_int is the internal horizontal speed
                 # P represents the projection onto the horizontal
@@ -247,16 +257,7 @@ function ekman_layer_model(
             moisture_bcs...,
             turbconv = turbconv_bcs(turbconv)[1],
         ),
-        AtmosBC(; turbconv = turbconv_bcs(turbconv)[2]),
-    )
-
-    physics = AtmosPhysics{FT}(
-        param_set;
-        ref_state = ref_state,
-        turbulence = turbulence,
-        moisture = DryModel(),
-        turbconv = turbconv,
-        compressibility = compressibility,
+        AtmosBC(physics; turbconv = turbconv_bcs(turbconv)[2]),
     )
 
     problem = AtmosProblem(

--- a/experiments/AtmosLES/rising_bubble_theta_formulation.jl
+++ b/experiments/AtmosLES/rising_bubble_theta_formulation.jl
@@ -224,21 +224,7 @@ function config_risingbubble(
     T_min_ref = FT(0)
     T_profile = DryAdiabaticProfile{FT}(param_set, T_surface, T_min_ref)
 
-    problem = AtmosProblem(
-        boundaryconditions = (
-            AtmosBC(
-                momentum = Impenetrable(FreeSlip()),
-                energy = Adiabaticθ((state, aux, t) -> FT(0)),
-            ),
-            AtmosBC(
-                momentum = Impenetrable(FreeSlip()),
-                energy = Adiabaticθ((state, aux, t) -> FT(0)),
-            ),
-        ),
-        init_state_prognostic = init_risingbubble!,
-    )
-
-    ## Here we assemble the `AtmosModel`.
+    ## Here we define the physics:
     _C_smag = FT(0)
     physics = AtmosPhysics{FT}(
         param_set;                                     ## Parameter set corresponding to earth parameters
@@ -249,6 +235,23 @@ function config_risingbubble(
         tracers = NTracers{ntracers, FT}(δ_χ),         ## Tracer model with diffusivity coefficients
     )
 
+    problem = AtmosProblem(
+        boundaryconditions = (
+            AtmosBC(
+                physics;
+                momentum = Impenetrable(FreeSlip()),
+                energy = Adiabaticθ((state, aux, t) -> FT(0)),
+            ),
+            AtmosBC(
+                physics;
+                momentum = Impenetrable(FreeSlip()),
+                energy = Adiabaticθ((state, aux, t) -> FT(0)),
+            ),
+        ),
+        init_state_prognostic = init_risingbubble!,
+    )
+
+    ## Here we assemble the `AtmosModel`.
     model = AtmosModel{FT}(
         AtmosLESConfigType,                            ## Flow in a box, requires the AtmosLESConfigType
         physics;                                       ## Atmos physics

--- a/experiments/AtmosLES/squall_line.jl
+++ b/experiments/AtmosLES/squall_line.jl
@@ -274,17 +274,17 @@ function config_squall_line(
         precipitation = RainSnowModel()
     end
 
-    problem = AtmosProblem(
-        boundaryconditions = (AtmosBC(), AtmosBC()),
-        init_state_prognostic = ics,
-    )
-
     physics = AtmosPhysics{FT}(
         param_set;
         ref_state = ref_state,
         moisture = moisture,
         precipitation = precipitation,
         turbulence = SmagorinskyLilly{FT}(C_smag),
+    )
+
+    problem = AtmosProblem(
+        boundaryconditions = (AtmosBC(physics), AtmosBC(physics)),
+        init_state_prognostic = ics,
     )
 
     model = AtmosModel{FT}(

--- a/experiments/AtmosLES/stable_bl_model.jl
+++ b/experiments/AtmosLES/stable_bl_model.jl
@@ -289,9 +289,20 @@ function stable_bl_model(
         )
     end
 
+    # Define the physics
+    physics = AtmosPhysics{FT}(
+        param_set;
+        ref_state = ref_state,
+        turbulence = turbulence,
+        moisture = moisture,
+        turbconv = turbconv,
+        compressibility = compressibility,
+    )
+
     moisture_bcs = moisture_model == "dry" ? () : (; moisture = moisture_bc)
     boundary_conditions = (
-        AtmosBC(;
+        AtmosBC(
+            physics;
             momentum = Impenetrable(DragLaw(
                 # normPu_int is the internal horizontal speed
                 # P represents the projection onto the horizontal
@@ -301,7 +312,7 @@ function stable_bl_model(
             moisture_bcs...,
             turbconv = turbconv_bcs(turbconv)[1],
         ),
-        AtmosBC(; turbconv = turbconv_bcs(turbconv)[2]),
+        AtmosBC(physics; turbconv = turbconv_bcs(turbconv)[2]),
     )
 
     moisture_flux = FT(0)
@@ -311,14 +322,6 @@ function stable_bl_model(
     )
 
     # Assemble model components
-    physics = AtmosPhysics{FT}(
-        param_set;
-        ref_state = ref_state,
-        turbulence = turbulence,
-        moisture = moisture,
-        turbconv = turbconv,
-        compressibility = compressibility,
-    )
 
     model =
         AtmosModel{FT}(config_type, physics; problem = problem, source = source)

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -98,17 +98,18 @@ function config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
         solver_method = LSRK144NiegemannDiehlBusch,
     )
 
-    problem = AtmosProblem(
-        boundaryconditions = (
-            AtmosBC(energy = PrescribedEnergyFlux(energyflux)),
-            AtmosBC(),
-        ),
-        init_state_prognostic = init_surfacebubble!,
-    )
     physics = AtmosPhysics{FT}(
         param_set;
         turbulence = SmagorinskyLilly{FT}(C_smag),
         moisture = EquilMoist(),
+    )
+
+    problem = AtmosProblem(
+        boundaryconditions = (
+            AtmosBC(physics; energy = PrescribedEnergyFlux(energyflux)),
+            AtmosBC(physics;),
+        ),
+        init_state_prognostic = init_surfacebubble!,
     )
     model = AtmosModel{FT}(
         AtmosLESConfigType,

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -314,7 +314,10 @@ function AtmosModel{FT}(
     orientation::Orientation,
     physics::AtmosPhysics;
     init_state_prognostic = nothing,
-    problem = AtmosProblem(init_state_prognostic = init_state_prognostic),
+    problem = AtmosProblem(;
+        physics = physics,
+        init_state_prognostic = init_state_prognostic,
+    ),
     source = (
         Gravity(),
         Coriolis(),

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -31,14 +31,28 @@ export average_density_sfc_int
 
 The standard boundary condition for [`AtmosModel`](@ref). The default options imply a "no flux" boundary condition.
 """
-Base.@kwdef struct AtmosBC{M, E, Q, P, TR, TC}
-    momentum::M = Impenetrable(FreeSlip())
-    energy::E = Insulating()
-    moisture::Q = Impermeable()
-    precipitation::P = OutflowPrecipitation()
-    tracer::TR = ImpermeableTracer()
-    turbconv::TC = NoTurbConvBC()
+struct AtmosBC{M, E, Q, P, TR, TC}
+    momentum::M
+    energy::E
+    moisture::Q
+    precipitation::P
+    tracer::TR
+    turbconv::TC
 end
+
+function AtmosBC(
+    physics::AtmosPhysics;
+    momentum = Impenetrable(FreeSlip()),
+    energy = Insulating(),
+    moisture = Impermeable(),
+    precipitation = OutflowPrecipitation(),
+    tracer = ImpermeableTracer(),
+    turbconv = NoTurbConvBC(),
+)
+    args = (momentum, energy, moisture, precipitation, tracer, turbconv)
+    return AtmosBC{typeof.(args)...}(args...)
+end
+
 
 boundary_conditions(atmos::AtmosModel) = atmos.problem.boundaryconditions
 

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -167,7 +167,8 @@ function wavespeed(
     return soundspeed_air(parameter_set(lm.atmos), ref.T)
 end
 
-boundary_conditions(atmoslm::AtmosLinearModel) = (AtmosBC(), AtmosBC())
+boundary_conditions(atmoslm::AtmosLinearModel) =
+    (AtmosBC(atmoslm.atmos.physics), AtmosBC(atmoslm.atmos.physics))
 
 function boundary_state!(
     nf::NumericalFluxFirstOrder,

--- a/src/Atmos/Model/problem.jl
+++ b/src/Atmos/Model/problem.jl
@@ -20,11 +20,16 @@ struct AtmosProblem{BCS, ISP, ISA} <: AbstractAtmosProblem
 end
 
 function AtmosProblem(;
-    boundaryconditions::BCS = (AtmosBC(), AtmosBC()),
+    physics = nothing,
+    boundaryconditions = nothing,
     init_state_prognostic::ISP = nothing,
     init_state_auxiliary::ISA = atmos_problem_init_state_auxiliary,
-) where {BCS, ISP, ISA}
+) where {ISP, ISA}
     @assert init_state_prognostic ≠ nothing
+    if boundaryconditions == nothing
+        @assert physics ≠ nothing
+        boundaryconditions = (AtmosBC(physics), AtmosBC(physics))
+    end
 
     problem = (boundaryconditions, init_state_prognostic, init_state_auxiliary)
 

--- a/test/Numerics/DGMethods/Euler/fvm_balance.jl
+++ b/test/Numerics/DGMethods/Euler/fvm_balance.jl
@@ -97,11 +97,21 @@ function test_run(
         meshwarp = meshwarp,
     )
 
-    problem = AtmosProblem(init_state_prognostic = initialcondition!)
-
     T0 = FT(300)
     temp_profile = IsothermalProfile(param_set, T0)
     ref_state = HydrostaticState(temp_profile; subtract_off = false)
+
+    physics = AtmosPhysics{FT}(
+        param_set;
+        ref_state = ref_state,
+        turbulence = ConstantDynamicViscosity(FT(0)),
+        moisture = DryModel(),
+    )
+
+    problem = AtmosProblem(;
+        physics = physics,
+        init_state_prognostic = initialcondition!,
+    )
 
     if domain_type === :box
         configtype = AtmosLESConfigType
@@ -111,12 +121,6 @@ function test_run(
         source = (Gravity(), Coriolis())
     end
 
-    physics = AtmosPhysics{FT}(
-        param_set;
-        ref_state = ref_state,
-        turbulence = ConstantDynamicViscosity(FT(0)),
-        moisture = DryModel(),
-    )
     model =
         AtmosModel{FT}(configtype, physics; problem = problem, source = source)
 

--- a/test/Numerics/DGMethods/fv_reconstruction_test.jl
+++ b/test/Numerics/DGMethods/fv_reconstruction_test.jl
@@ -72,7 +72,10 @@ end
         model = AtmosModel{FT}(
             AtmosLESConfigType,
             physics;
-            problem = AtmosProblem(init_state_prognostic = initialcondition!),
+            problem = AtmosProblem(;
+                physics = physics,
+                init_state_prognostic = initialcondition!,
+            ),
             orientation = FlatOrientation(),
         )
 

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -136,14 +136,24 @@ function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
         FT(T_bot - T_lapse * zmax),
     )
 
+    ## Define the physics
+    physics = AtmosPhysics{FT}(
+        param_set;
+        turbulence = Vreman(C_smag),
+        tracers = NTracers{ntracers, FT}(δ_χ),
+    )
+
     ## Set up the problem
-    problem = AtmosProblem(
+    problem = AtmosProblem(;
+        physics = physics,
         boundaryconditions = (
             AtmosBC(
+                physics;
                 momentum = Impenetrable(NoSlip()),
                 energy = PrescribedTemperature((state, aux, t) -> T_bot),
             ),
             AtmosBC(
+                physics;
                 momentum = Impenetrable(NoSlip()),
                 energy = PrescribedTemperature((state, aux, t) -> T_top),
             ),
@@ -152,12 +162,6 @@ function config_problem(::Type{FT}, N, resolution, xmax, ymax, zmax) where {FT}
     )
 
     ## Set up the model
-    physics = AtmosPhysics{FT}(
-        param_set;
-        turbulence = Vreman(C_smag),
-        tracers = NTracers{ntracers, FT}(δ_χ),
-    )
-
     model = AtmosModel{FT}(
         AtmosLESConfigType,
         physics;


### PR DESCRIPTION
### Description

In preparation for #2122, this PR adds `physics` to the `AtmosBC` constructor, so that we can loop over the prognostic variables and slowly remove all other `AtmosBC` (e.g., `momentum`, `energy`, etc.).

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
