### PR TITLE
Rename `DiscontinuousSpectralElementGrid` to `SpectralElementGrid`

### DIFF
--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -75,7 +75,7 @@ Grids specify the approximation within each element, and any necessary warping.
 Grids.get_z
 Grids.referencepoints
 Grids.min_node_distance
-Grids.DiscontinuousSpectralElementGrid
+Grids.SpectralElementGrid
 ```
 
 ## DSS

--- a/experiments/OceanSplitExplicit/simple_box.jl
+++ b/experiments/OceanSplitExplicit/simple_box.jl
@@ -31,7 +31,7 @@ const param_set = EarthParameterSet()
 
 struct OceanSplitExplicitSpecificInfo <: ConfigSpecificInfo
     model_2D::BalanceLaw
-    grid_2D::DiscontinuousSpectralElementGrid
+    grid_2D::SpectralElementGrid
     dg::DGModel
 end
 
@@ -75,13 +75,13 @@ function OceanSplitExplicitConfiguration(
         boundary = boundary,
     )
 
-    grid_2D = DiscontinuousSpectralElementGrid(
+    grid_2D = SpectralElementGrid(
         topology_2D,
         FloatType = FT,
         DeviceArray = array_type,
         polynomialorder = polyorder_horz,
     )
-    grid_3D = DiscontinuousSpectralElementGrid(
+    grid_3D = SpectralElementGrid(
         topology_3D,
         FloatType = FT,
         DeviceArray = array_type,

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -123,7 +123,7 @@ struct DriverConfiguration{FT}
     mpicomm::MPI.Comm
     #
     # Mesh details
-    grid::DiscontinuousSpectralElementGrid
+    grid::SpectralElementGrid
     #
     # DGModel details
     numerical_flux_first_order::NumericalFluxFirstOrder
@@ -147,7 +147,7 @@ struct DriverConfiguration{FT}
         param_set::AbstractParameterSet,
         bl::BalanceLaw,
         mpicomm::MPI.Comm,
-        grid::DiscontinuousSpectralElementGrid,
+        grid::SpectralElementGrid,
         numerical_flux_first_order::NumericalFluxFirstOrder,
         numerical_flux_second_order::NumericalFluxSecondOrder,
         numerical_flux_gradient::NumericalFluxGradient,
@@ -276,7 +276,7 @@ function AtmosLESConfiguration(
         boundary = boundary,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = array_type,
@@ -405,7 +405,7 @@ function AtmosGCMConfiguration(
         boundary = (1, 2),
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = array_type,
@@ -517,7 +517,7 @@ function OceanBoxGCMConfiguration(
         boundary = boundary,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = array_type,
@@ -616,7 +616,7 @@ function SingleStackConfiguration(
         boundary = boundary,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = array_type,
@@ -728,7 +728,7 @@ function MultiColumnLandModel(
         boundary = boundary,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = array_type,

--- a/src/Numerics/DGMethods/custom_filter.jl
+++ b/src/Numerics/DGMethods/custom_filter.jl
@@ -30,7 +30,7 @@ function custom_filter!(::AbstractCustomFilter, balance_law, state, aux) end
 
 function apply!(
     custom_filter::AbstractCustomFilter,
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     m::BalanceLaw,
     state_prognostic::MPIStateArray,
     state_auxiliary::MPIStateArray,

--- a/src/Numerics/Mesh/DSS.jl
+++ b/src/Numerics/Mesh/DSS.jl
@@ -10,7 +10,7 @@ export dss!
 
 """
     dss3d(Q::MPIStateArray,
-        grid::DiscontinuousSpectralElementGrid)
+        grid::SpectralElementGrid)
 
 This function computes the 3D direct stiffness summation for all variables in the MPIStateArray.
 
@@ -20,7 +20,7 @@ This function computes the 3D direct stiffness summation for all variables in th
 """
 function dss!(
     Q::MPIStateArray,
-    grid::DiscontinuousSpectralElementGrid{FT, 3};
+    grid::SpectralElementGrid{FT, 3};
     max_threads = 256,
 ) where {FT}
     DA = arraytype(grid)                                      # device array

--- a/src/Numerics/Mesh/Filters.jl
+++ b/src/Numerics/Mesh/Filters.jl
@@ -362,14 +362,14 @@ with the code
 Filters.apply!(Q, (3, 4), grid, TMARFilter())
 ```
 
-where `grid` is the associated `DiscontinuousSpectralElementGrid`.
+where `grid` is the associated `SpectralElementGrid`.
 """
 struct TMARFilter <: AbstractFilter end
 
 """
     Filters.apply!(Q::MPIStateArray,
         target,
-        grid::DiscontinuousSpectralElementGrid,
+        grid::SpectralElementGrid,
         filter::AbstractSpectralFilter;
         kwargs...)
 
@@ -406,7 +406,7 @@ Filters.apply!(Q, ("moisture.ρq_tot",), grid, CutoffFilter(grid);
 function apply!(
     Q,
     target,
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     filter::AbstractFilter;
     kwargs...,
 )
@@ -419,7 +419,7 @@ end
 
 
 """
-    Filters.apply_async!(Q, target, grid::DiscontinuousSpectralElementGrid,
+    Filters.apply_async!(Q, target, grid::SpectralElementGrid,
         filter::AbstractFilter;
         dependencies,
         kwargs...)
@@ -438,7 +438,7 @@ function apply_async! end
 function apply_async!(
     Q,
     target::AbstractFilterTarget,
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     filter::AbstractSpectralFilter;
     dependencies,
     state_auxiliary = nothing,
@@ -505,7 +505,7 @@ end
 function apply_async!(
     Q,
     target::AbstractFilterTarget,
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     ::TMARFilter;
     dependencies,
 )
@@ -540,7 +540,7 @@ end
 function apply_async!(
     Q,
     target::AbstractFilterTarget,
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     filter::MassPreservingCutoffFilter;
     dependencies,
     state_auxiliary = nothing,
@@ -607,7 +607,7 @@ end
 function apply_async!(
     Q,
     indices::Union{Colon, AbstractRange, Tuple{Vararg{Integer}}},
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     filter::AbstractFilter;
     kwargs...,
 )
@@ -620,7 +620,7 @@ end
 function apply_async!(
     Q,
     vs::Tuple,
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     filter::AbstractFilter;
     kwargs...,
 )

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -416,9 +416,7 @@ end
 
 Returns the 1D interpolation points used for the reference element.
 """
-function referencepoints(
-    ::SpectralElementGrid{FT, dim, N},
-) where {FT, dim, N}
+function referencepoints(::SpectralElementGrid{FT, dim, N}) where {FT, dim, N}
     ξω = ntuple(
         j ->
             N[j] == 0 ? Elements.glpoints(FT, N[j]) :
@@ -531,11 +529,7 @@ function Base.getproperty(G::SpectralElementGrid, s::Symbol)
 end
 
 function Base.propertynames(G::SpectralElementGrid)
-    (
-        fieldnames(SpectralElementGrid)...,
-        keys(vgeoid)...,
-        keys(sgeoid)...,
-    )
+    (fieldnames(SpectralElementGrid)..., keys(vgeoid)..., keys(sgeoid)...)
 end
 
 # {{{ mappings

--- a/src/Numerics/Mesh/Grids.jl
+++ b/src/Numerics/Mesh/Grids.jl
@@ -9,7 +9,7 @@ using LinearAlgebra
 using KernelAbstractions
 using DocStringExtensions
 
-export DiscontinuousSpectralElementGrid, AbstractGrid
+export SpectralElementGrid, AbstractGrid
 export dofs_per_element, arraytype, dimensionality, polynomialorders
 export referencepoints, min_node_distance, get_z
 export EveryDirection, HorizontalDirection, VerticalDirection, Direction
@@ -147,7 +147,7 @@ const sgeoid = (
 # }}}
 
 """
-    DiscontinuousSpectralElementGrid(topology; FloatType, DeviceArray,
+    SpectralElementGrid(topology; FloatType, DeviceArray,
                                      polynomialorder,
                                      meshwarp = (x...)->identity(x))
 
@@ -167,7 +167,7 @@ The optional `meshwarp` function allows the coordinate points to be warped after
 the mesh is created; the mesh degrees of freedom are orginally assigned using a
 trilinear blend of the element corner locations.
 """
-struct DiscontinuousSpectralElementGrid{
+struct SpectralElementGrid{
     T,
     dim,
     N,
@@ -264,7 +264,7 @@ struct DiscontinuousSpectralElementGrid{
     facemap::Union{DAI3, Nothing}
 
     # Constructor for a tuple of polynomial orders
-    function DiscontinuousSpectralElementGrid(
+    function SpectralElementGrid(
         topology::AbstractTopology{dim};
         polynomialorder,
         FloatType,
@@ -412,12 +412,12 @@ struct DiscontinuousSpectralElementGrid{
 end
 
 """
-    referencepoints(::DiscontinuousSpectralElementGrid)
+    referencepoints(::SpectralElementGrid)
 
 Returns the 1D interpolation points used for the reference element.
 """
 function referencepoints(
-    ::DiscontinuousSpectralElementGrid{FT, dim, N},
+    ::SpectralElementGrid{FT, dim, N},
 ) where {FT, dim, N}
     ξω = ntuple(
         j ->
@@ -431,7 +431,7 @@ end
 
 """
     min_node_distance(
-        ::DiscontinuousSpectralElementGrid,
+        ::SpectralElementGrid,
         direction::Direction=EveryDirection())
     )
 
@@ -440,7 +440,7 @@ the reference coordinate directions.  The direction controls which reference
 directions are considered.
 """
 min_node_distance(
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     direction::Direction = EveryDirection(),
 ) = min_node_distance(grid.minΔ, direction)
 
@@ -493,7 +493,7 @@ Get the Gauss-Lobatto points along the Z-coordinate.
  - `rm_dupes`: removes duplicate Gauss-Lobatto points
 """
 function get_z(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N};
+    grid::SpectralElementGrid{T, dim, N};
     z_scale = 1,
     rm_dupes = false,
 ) where {T, dim, N}
@@ -520,7 +520,7 @@ function get_z(
     return reshape(grid.vgeo[(1:Nph:Np), _x3, :], :) * z_scale
 end
 
-function Base.getproperty(G::DiscontinuousSpectralElementGrid, s::Symbol)
+function Base.getproperty(G::SpectralElementGrid, s::Symbol)
     if s ∈ keys(vgeoid)
         vgeoid[s]
     elseif s ∈ keys(sgeoid)
@@ -530,9 +530,9 @@ function Base.getproperty(G::DiscontinuousSpectralElementGrid, s::Symbol)
     end
 end
 
-function Base.propertynames(G::DiscontinuousSpectralElementGrid)
+function Base.propertynames(G::SpectralElementGrid)
     (
-        fieldnames(DiscontinuousSpectralElementGrid)...,
+        fieldnames(SpectralElementGrid)...,
         keys(vgeoid)...,
         keys(sgeoid)...,
     )

--- a/src/Numerics/Mesh/Interpolation.jl
+++ b/src/Numerics/Mesh/Interpolation.jl
@@ -47,7 +47,7 @@ $(DocStringExtensions.FIELDS)
 # Usage
 
     InterpolationBrick(
-        grid::DiscontinuousSpectralElementGrid{FT},
+        grid::SpectralElementGrid{FT},
         xbnd::Array{FT,2},
         xres,
     ) where FT <: AbstractFloat
@@ -130,7 +130,7 @@ struct InterpolationBrick{
     x3i_all::UI16VD
 
     function InterpolationBrick(
-        grid::DiscontinuousSpectralElementGrid{FT},
+        grid::SpectralElementGrid{FT},
         xbnd::Array{FT, 2},
         x1g::AbstractArray{FT, 1},
         x2g::AbstractArray{FT, 1},
@@ -612,7 +612,7 @@ $(DocStringExtensions.FIELDS)
 
 # Usage
 
-    InterpolationCubedSphere(grid::DiscontinuousSpectralElementGrid, vert_range::AbstractArray{FT}, nhor::Int, lat_res::FT, long_res::FT, rad_res::FT) where {FT <: AbstractFloat}
+    InterpolationCubedSphere(grid::SpectralElementGrid, vert_range::AbstractArray{FT}, nhor::Int, lat_res::FT, long_res::FT, rad_res::FT) where {FT <: AbstractFloat}
 
 This interpolation structure and the corresponding functions works for a cubed sphere topology. The data is interpolated along a lat/long/rad grid.
 
@@ -698,7 +698,7 @@ struct InterpolationCubedSphere{
     longi_all::UI16VD
 
     function InterpolationCubedSphere(
-        grid::DiscontinuousSpectralElementGrid,
+        grid::SpectralElementGrid,
         vert_range::AbstractArray{FT},
         nhor::Int,
         lat_grd::AbstractArray{FT, 1},

--- a/src/Ocean/Domains/rectangular_domain.jl
+++ b/src/Ocean/Domains/rectangular_domain.jl
@@ -4,7 +4,7 @@ using ClimateMachine: Settings
 
 using ClimateMachine.Mesh.Topologies: StackedBrickTopology
 
-import ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
+import ClimateMachine.Mesh.Grids: SpectralElementGrid
 
 #####
 ##### RectangularDomain
@@ -49,7 +49,7 @@ name_it(Ne) = (x = Ne[1], y = Ne[2], z = Ne[3])
 Returns a `RectangularDomain` representing the product of `x, y, z` intervals,
 specified by 2-tuples.
 
-The `RectangularDomain` is meshed with a simple `DiscontinuousSpectralElementGrid`
+The `RectangularDomain` is meshed with a simple `SpectralElementGrid`
 with an isotropic polynomial order `Np` and a 3-tuple of `Ne`lements
 giving the number of elements in `x, y, z`.
 
@@ -119,7 +119,7 @@ end
 array_type(domain::RectangularDomain) = Settings.array_type
 eltype(::RectangularDomain{FT}) where {FT} = FT
 
-function DiscontinuousSpectralElementGrid(
+function SpectralElementGrid(
     domain::RectangularDomain{FT};
     boundary_tags = ((0, 0), (0, 0), (1, 2)),
     array_type = Settings.array_type,
@@ -143,7 +143,7 @@ function DiscontinuousSpectralElementGrid(
         boundary = boundary_tags,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = array_type,

--- a/src/Ocean/Fields/Fields.jl
+++ b/src/Ocean/Fields/Fields.jl
@@ -5,7 +5,7 @@ export SpectralElementField, assemble, data
 using CUDA
 using Printf
 
-using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
+using ClimateMachine.Mesh.Grids: SpectralElementGrid
 using ClimateMachine.MPIStateArrays: MPIStateArray
 using ..Domains: AbstractDomain
 
@@ -32,7 +32,7 @@ assuming that `state.realdata` lives on `RectangularDomain`.
 """
 function SpectralElementField(
     domain::AbstractDomain,
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     state::MPIStateArray,
     variable_index::Int,
 )

--- a/src/Ocean/Fields/rectangular_spectral_element_fields.jl
+++ b/src/Ocean/Fields/rectangular_spectral_element_fields.jl
@@ -28,7 +28,7 @@ into `realdata`, assuming that `realdata` lives on `domain::RectangularDomain`.
 """
 function SpectralElementField(
     domain::RectangularDomain{FT},
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     realdata::AbstractArray,
     data::Union{AbstractArray, Nothing} = nothing,
     realelems::Union{UnitRange, Nothing} = nothing,

--- a/src/Ocean/JLD2Writer.jl
+++ b/src/Ocean/JLD2Writer.jl
@@ -43,8 +43,7 @@ function JLD2Writer(
 )
 
     # Convert grid to CPU
-    cpu_grid =
-        SpectralElementGrid(model.domain, array_type = array_type)
+    cpu_grid = SpectralElementGrid(model.domain, array_type = array_type)
 
     # Initialize output
     overwrite_existing && isfile(filepath) && rm(filepath; force = true)

--- a/src/Ocean/JLD2Writer.jl
+++ b/src/Ocean/JLD2Writer.jl
@@ -2,7 +2,7 @@ module JLD2Writers
 
 using JLD2
 
-using ClimateMachine.Ocean.Domains: DiscontinuousSpectralElementGrid
+using ClimateMachine.Ocean.Domains: SpectralElementGrid
 using ClimateMachine.Ocean: current_step, current_time
 using ..Fields: SpectralElementField
 
@@ -44,7 +44,7 @@ function JLD2Writer(
 
     # Convert grid to CPU
     cpu_grid =
-        DiscontinuousSpectralElementGrid(model.domain, array_type = array_type)
+        SpectralElementGrid(model.domain, array_type = array_type)
 
     # Initialize output
     overwrite_existing && isfile(filepath) && rm(filepath; force = true)

--- a/src/Ocean/SuperModels.jl
+++ b/src/Ocean/SuperModels.jl
@@ -18,7 +18,7 @@ using ..Ocean: FreeSlip, Impenetrable, Insulating, OceanBC, Penetrable
 using ..Ocean.Fields: SpectralElementField
 
 using ...Mesh.Filters: CutoffFilter, ExponentialFilter
-using ...Mesh.Grids: polynomialorders, DiscontinuousSpectralElementGrid
+using ...Mesh.Grids: polynomialorders, SpectralElementGrid
 
 using ClimateMachine:
     LS3NRK33Heuns,
@@ -100,7 +100,7 @@ function HydrostaticBoussinesqSuperModel(;
     # Change global setting if its set here
     Settings.array_type = array_type
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         domain;
         boundary_tags = boundary_tags,
         mpicomm = mpicomm,

--- a/src/Utilities/SingleStackUtils/SingleStackUtils.jl
+++ b/src/Utilities/SingleStackUtils/SingleStackUtils.jl
@@ -24,7 +24,7 @@ using ..VariableTemplates
 
 """
     get_vars_from_nodal_stack(
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::SpectralElementGrid{T, dim, N},
         Q::MPIStateArray,
         vars;
         vrange::UnitRange = 1:size(Q, 3),
@@ -44,7 +44,7 @@ the horizontal nodal coordinates.
 Variables listed in `exclude` are skipped.
 """
 function get_vars_from_nodal_stack(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::SpectralElementGrid{T, dim, N},
     Q::MPIStateArray,
     vars;
     vrange::UnitRange = 1:size(Q, 3),
@@ -125,7 +125,7 @@ end
 
 """
     get_vars_from_element_stack(
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::SpectralElementGrid{T, dim, N},
         Q::MPIStateArray,
         vars;
         vrange::UnitRange = 1:size(Q, 3),
@@ -139,7 +139,7 @@ are the number of nodal points per element in the horizontal plane.
 Variables listed in `exclude` are skipped.
 """
 function get_vars_from_element_stack(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::SpectralElementGrid{T, dim, N},
     Q::MPIStateArray,
     vars;
     vrange::UnitRange = 1:size(Q, 3),
@@ -167,7 +167,7 @@ end
 
 """
     get_horizontal_mean(
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::SpectralElementGrid{T, dim, N},
         Q::MPIStateArray,
         vars;
         vrange::UnitRange = 1:size(Q, 3),
@@ -184,7 +184,7 @@ horizontal as this is intended for the single stack configuration.
 Variables listed in `exclude` are skipped.
 """
 function get_horizontal_mean(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::SpectralElementGrid{T, dim, N},
     Q::MPIStateArray,
     vars;
     vrange::UnitRange = 1:size(Q, 3),
@@ -219,7 +219,7 @@ end
 
 """
     get_horizontal_variance(
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::SpectralElementGrid{T, dim, N},
         Q::MPIStateArray,
         vars;
         vrange::UnitRange = 1:size(Q, 3),
@@ -236,7 +236,7 @@ horizontal as this is intended for the single stack configuration.
 Variables listed in `exclude` are skipped.
 """
 function get_horizontal_variance(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::SpectralElementGrid{T, dim, N},
     Q::MPIStateArray,
     vars;
     vrange::UnitRange = 1:size(Q, 3),
@@ -277,7 +277,7 @@ end
 """
     reduce_nodal_stack(
         op::Function,
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::SpectralElementGrid{T, dim, N},
         Q::MPIStateArray,
         vars::NamedTuple,
         var::String;
@@ -291,7 +291,7 @@ the final value returned by `op` and `z` is the index within `vrange` where the
 """
 function reduce_nodal_stack(
     op::Function,
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::SpectralElementGrid{T, dim, N},
     Q::MPIStateArray,
     vars::Type,
     var::String;
@@ -347,7 +347,7 @@ end
 """
     reduce_element_stack(
         op::Function,
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::SpectralElementGrid{T, dim, N},
         Q::MPIStateArray,
         vars::NamedTuple,
         var::String;
@@ -361,7 +361,7 @@ the final value returned by `op` and `z` is the index within `vrange` where the
 """
 function reduce_element_stack(
     op::Function,
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::SpectralElementGrid{T, dim, N},
     Q::MPIStateArray,
     vars::Type,
     var::String;
@@ -388,7 +388,7 @@ end
 
 """
     horizontally_average!(
-        grid::DiscontinuousSpectralElementGrid{T, dim, N},
+        grid::SpectralElementGrid{T, dim, N},
         Q::MPIStateArray,
         i_vars,
     ) where {T, dim, N}
@@ -402,7 +402,7 @@ indexes `i_vars`, in `MPIStateArray` `Q`.
     no horizontal fluxes for a single stack configuration.
 """
 function horizontally_average!(
-    grid::DiscontinuousSpectralElementGrid{T, dim, N},
+    grid::SpectralElementGrid{T, dim, N},
     Q::MPIStateArray,
     i_vars,
 ) where {T, dim, N}
@@ -482,7 +482,7 @@ end
 """
     NodalStack(
             bl::BalanceLaw,
-            grid::DiscontinuousSpectralElementGrid,
+            grid::SpectralElementGrid,
             prognostic,
             auxiliary,
             diffusive,
@@ -540,7 +540,7 @@ struct NodalStack{N, BL, G, S, VR, TI, TJ, CI, IN}
     interp::IN
     function NodalStack(
         bl::BalanceLaw,
-        grid::DiscontinuousSpectralElementGrid;
+        grid::SpectralElementGrid;
         prognostic,
         auxiliary,
         diffusive,

--- a/src/Utilities/SingleStackUtils/single_stack_diagnostics.jl
+++ b/src/Utilities/SingleStackUtils/single_stack_diagnostics.jl
@@ -10,7 +10,7 @@ flattened_named_tuple(v::Nothing, ft::FlattenType = FlattenArr()) = nothing
 
 """
     single_stack_diagnostics(
-        grid::DiscontinuousSpectralElementGrid,
+        grid::SpectralElementGrid,
         bl::BalanceLaw,
         t::Real,
         direction;
@@ -35,7 +35,7 @@ and all the nested NamedTuples, merged together,
 from the `precompute` methods.
 """
 function single_stack_diagnostics(
-    grid::DiscontinuousSpectralElementGrid,
+    grid::SpectralElementGrid,
     bl::BalanceLaw,
     t::Real,
     direction;

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -136,7 +136,7 @@ function main()
                 x3 + x1 / 4 + x2^2 / 2 + sin(x1 * x2 * x3),
             )
         end
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ClimateMachine.array_type(),

--- a/test/InputOutput/VTK/runtests.jl
+++ b/test/InputOutput/VTK/runtests.jl
@@ -94,7 +94,7 @@ end
 using MPI
 MPI.Initialized() || MPI.Init()
 using ClimateMachine.Mesh.Topologies: BrickTopology
-using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
+using ClimateMachine.Mesh.Grids: SpectralElementGrid
 using ClimateMachine.VTK: writevtk_helper
 
 let
@@ -141,7 +141,7 @@ let
                             )
                         end
                 end
-                grid = DiscontinuousSpectralElementGrid(
+                grid = SpectralElementGrid(
                     topl,
                     FloatType = FT,
                     DeviceArray = Array,

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -2,8 +2,7 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
     StackedCubedSphereTopology, equiangular_cubed_sphere_warp, grid1d
-using ClimateMachine.Mesh.Grids:
-    SpectralElementGrid, VerticalDirection
+using ClimateMachine.Mesh.Grids: SpectralElementGrid, VerticalDirection
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.DGMethods: DGModel, init_ode_state, remainder_DGModel
 using ClimateMachine.DGMethods.NumericalFluxes:

--- a/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_1d_imex.jl
@@ -3,7 +3,7 @@ using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
     StackedCubedSphereTopology, equiangular_cubed_sphere_warp, grid1d
 using ClimateMachine.Mesh.Grids:
-    DiscontinuousSpectralElementGrid, VerticalDirection
+    SpectralElementGrid, VerticalDirection
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.DGMethods: DGModel, init_ode_state, remainder_DGModel
 using ClimateMachine.DGMethods.NumericalFluxes:
@@ -104,7 +104,7 @@ function test_run(
     )
     topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_mrigark.jl
@@ -3,7 +3,7 @@ using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
     StackedCubedSphereTopology, equiangular_cubed_sphere_warp, grid1d
 using ClimateMachine.Mesh.Grids:
-    DiscontinuousSpectralElementGrid,
+    SpectralElementGrid,
     VerticalDirection,
     HorizontalDirection,
     EveryDirection,
@@ -111,7 +111,7 @@ function test_run(
     )
     topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
@@ -2,8 +2,7 @@ using ClimateMachine
 using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
     StackedCubedSphereTopology, equiangular_cubed_sphere_warp, grid1d
-using ClimateMachine.Mesh.Grids:
-    SpectralElementGrid, VerticalDirection
+using ClimateMachine.Mesh.Grids: SpectralElementGrid, VerticalDirection
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.DGMethods: DGModel, init_ode_state, remainder_DGModel
 using ClimateMachine.DGMethods.NumericalFluxes:

--- a/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
+++ b/test/Numerics/DGMethods/Euler/acousticwave_variable_degree.jl
@@ -3,7 +3,7 @@ using ClimateMachine.ConfigTypes
 using ClimateMachine.Mesh.Topologies:
     StackedCubedSphereTopology, equiangular_cubed_sphere_warp, grid1d
 using ClimateMachine.Mesh.Grids:
-    DiscontinuousSpectralElementGrid, VerticalDirection
+    SpectralElementGrid, VerticalDirection
 using ClimateMachine.Mesh.Filters
 using ClimateMachine.DGMethods: DGModel, init_ode_state, remainder_DGModel
 using ClimateMachine.DGMethods.NumericalFluxes:
@@ -103,7 +103,7 @@ function test_run(
     )
     topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/Euler/fvm_balance.jl
+++ b/test/Numerics/DGMethods/Euler/fvm_balance.jl
@@ -89,7 +89,7 @@ function test_run(
         meshwarp = equiangular_cubed_sphere_warp
     end
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/Euler/fvm_isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/fvm_isentropicvortex.jl
@@ -148,7 +148,7 @@ function test_run(
         connectivity = connectivity,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex.jl
@@ -328,7 +328,7 @@ function test_run(
         periodicity = ntuple(_ -> true, dims),
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_imex.jl
@@ -134,7 +134,7 @@ function test_run(
         periodicity = ntuple(_ -> true, dims),
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_lmars.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_lmars.jl
@@ -113,7 +113,7 @@ function test_run(
         periodicity = ntuple(_ -> true, dims),
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark.jl
@@ -127,7 +127,7 @@ function test_run(
         periodicity = ntuple(_ -> true, dims),
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -128,7 +128,7 @@ function test_run(
         periodicity = ntuple(_ -> true, dims),
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGMethods/Euler/isentropicvortex_multirate.jl
@@ -131,7 +131,7 @@ function test_run(
         periodicity = ntuple(_ -> true, dims),
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bgmres.jl
@@ -130,7 +130,7 @@ function test_run(
     fluxBC,
 )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bjfnks.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_diffusion_model_1dimex_bjfnks.jl
@@ -130,7 +130,7 @@ function test_run(
     fluxBC,
 )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/advection_sphere.jl
@@ -181,7 +181,7 @@ function test_run(
     vtkdir,
     outputtime,
 )
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/diffusion_hyperdiffusion_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/diffusion_hyperdiffusion_sphere.jl
@@ -95,7 +95,7 @@ end
 
 function run(mpicomm, ArrayType, topl, N, timeend, FT, vtkdir, outputtime)
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/direction_splitting_advection_diffusion.jl
@@ -105,7 +105,7 @@ function test_run(
     level,
 )
     topology = create_topology(topo(), mpicomm, Ne, FT)
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl
@@ -14,7 +14,7 @@ import ClimateMachine.GenericCallbacks:
     EveryXWallTimeSeconds, EveryXSimulationSteps
 import ClimateMachine.MPIStateArrays: MPIStateArray, euclidean_distance
 import ClimateMachine.Mesh.Grids:
-    DiscontinuousSpectralElementGrid, EveryDirection
+    SpectralElementGrid, EveryDirection
 import ClimateMachine.Mesh.Topologies: StackedBrickTopology
 import ClimateMachine.ODESolvers: LSRK54CarpenterKennedy, solve!, gettime
 import ClimateMachine.VTK: writevtk, writepvtu
@@ -105,7 +105,7 @@ function test_run(
     outputtime,
 )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection.jl
@@ -13,8 +13,7 @@ import ClimateMachine.DGMethods: DGFVModel, init_ode_state
 import ClimateMachine.GenericCallbacks:
     EveryXWallTimeSeconds, EveryXSimulationSteps
 import ClimateMachine.MPIStateArrays: MPIStateArray, euclidean_distance
-import ClimateMachine.Mesh.Grids:
-    SpectralElementGrid, EveryDirection
+import ClimateMachine.Mesh.Grids: SpectralElementGrid, EveryDirection
 import ClimateMachine.Mesh.Topologies: StackedBrickTopology
 import ClimateMachine.ODESolvers: LSRK54CarpenterKennedy, solve!, gettime
 import ClimateMachine.VTK: writevtk, writepvtu

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion.jl
@@ -182,7 +182,7 @@ function test_run(
     Vertical polynomial order   = %s
       """ fvmethod ArrayType FT dim direction polynomialorders[1] polynomialorders[end]
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_model_1dimex_bjfnks.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_model_1dimex_bjfnks.jl
@@ -131,7 +131,7 @@ function test_run(
     fluxBC,
 )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_periodic.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_diffusion_periodic.jl
@@ -155,7 +155,7 @@ function test_run(
 
     outputtime = Ne * dt
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_advection_sphere.jl
@@ -201,7 +201,7 @@ function test_run(
     vtkdir,
     outputtime,
 )
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_swirl.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_swirl.jl
@@ -128,7 +128,7 @@ function test_run(
     vtkdir,
     outputtime,
 )
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_bc.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/hyperdiffusion_bc.jl
@@ -164,7 +164,7 @@ function test_run(
     outputtime,
 )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
@@ -113,7 +113,7 @@ function test_run(
     outputtime,
 )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion.jl
@@ -124,7 +124,7 @@ function test_run(
     fluxBC,
 )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
@@ -130,7 +130,7 @@ function test_run(
     fluxBC,
 )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
@@ -130,7 +130,7 @@ function test_run(
     fluxBC,
 )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/pseudo1D_heat_eqn.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/pseudo1D_heat_eqn.jl
@@ -107,7 +107,7 @@ function test_run(
     dt = timeend / numberofsteps
     @info "time step" dt numberofsteps dt * numberofsteps timeend
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/advection_diffusion/variable_degree_advection_diffusion.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/variable_degree_advection_diffusion.jl
@@ -115,7 +115,7 @@ function test_run(mpicomm, dim, polynomialorders, level, ArrayType, FT)
     Vertical polynomial order   = %s
       """ ArrayType FT dim polynomialorders[1] polynomialorders[end]
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/density_current_model.jl
@@ -117,7 +117,7 @@ function test_run(
     dt,
 )
     # -------------- Define grid ----------------------------------- #
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -98,7 +98,7 @@ end
 
 function test_run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
+++ b/test/Numerics/DGMethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
@@ -27,7 +27,7 @@ include("mms_model.jl")
 
 function test_run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/compressible_navier_stokes_equations/boilerplate.jl
+++ b/test/Numerics/DGMethods/compressible_navier_stokes_equations/boilerplate.jl
@@ -34,11 +34,11 @@ include("shared_source/abstractions.jl")
 include("shared_source/callbacks.jl")
 
 """
-function coordinates(grid::DiscontinuousSpectralElementGrid)
+function coordinates(grid::SpectralElementGrid)
 # Description
 Gets the (x,y,z) coordinates corresponding to the grid
 # Arguments
-- `grid`: DiscontinuousSpectralElementGrid
+- `grid`: SpectralElementGrid
 # Return
 - `x, y, z`: views of x, y, z coordinates
 """

--- a/test/Numerics/DGMethods/compressible_navier_stokes_equations/plotting/bigfileofstuff.jl
+++ b/test/Numerics/DGMethods/compressible_navier_stokes_equations/plotting/bigfileofstuff.jl
@@ -9,9 +9,9 @@ using Base.Threads
 
 # Depending on CliMa version 
 # old, should return a tuple of polynomial orders
-# polynomialorders(::DiscontinuousSpectralElementGrid{T, dim, N}) where {T, dim, N} = Tuple([N for i in 1:dim])
+# polynomialorders(::SpectralElementGrid{T, dim, N}) where {T, dim, N} = Tuple([N for i in 1:dim])
 # new, should return a tuple of polynomial orders
-# polynomialorders(::DiscontinuousSpectralElementGrid{T, dim, N}) where {T, dim, N} = N
+# polynomialorders(::SpectralElementGrid{T, dim, N}) where {T, dim, N} = N
 
 # utils.jl
 """
@@ -38,18 +38,18 @@ function cellaverage(Q; M = nothing)
 end
 
 """
-function coordinates(grid::DiscontinuousSpectralElementGrid)
+function coordinates(grid::SpectralElementGrid)
 
 # Description
 Gets the (x,y,z) coordinates corresponding to the grid
 
 # Arguments
-- `grid`: DiscontinuousSpectralElementGrid
+- `grid`: SpectralElementGrid
 
 # Return
 - `x, y, z`: views of x, y, z coordinates
 """
-function coordinates(grid::DiscontinuousSpectralElementGrid)
+function coordinates(grid::SpectralElementGrid)
     x = view(grid.vgeo, :, grid.x1id, :)   # x-direction	
     y = view(grid.vgeo, :, grid.x2id, :)   # y-direction	
     z = view(grid.vgeo, :, grid.x3id, :)   # z-direction
@@ -63,12 +63,12 @@ function cellcenters(Q; M = nothing)
 Get the cell-centers of every element in the grid
 
 # Arguments
-- `grid`: DiscontinuousSpectralElementGrid
+- `grid`: SpectralElementGrid
 
 # Return
 - Tuple of cell-centers
 """
-function cellcenters(grid::DiscontinuousSpectralElementGrid)
+function cellcenters(grid::SpectralElementGrid)
     x, y, z = coordinates(grid)
     M = view(grid.vgeo, :, grid.Mid, :)  # mass matrix
     xC = cellaverage(x, M = M)
@@ -156,7 +156,7 @@ struct InterpolationHelper{S, T}
     cartesianindex::T
 end
 
-function InterpolationHelper(g::DiscontinuousSpectralElementGrid)
+function InterpolationHelper(g::SpectralElementGrid)
     porders = polynomialorders(g)
     if length(porders) == 3
         npx, npy, npz = porders
@@ -204,7 +204,7 @@ end
 addup(xC, tol) = sum(abs.(xC[1] .- xC) .≤ tol)
 
 # only valid for cartesian domains
-function ElementHelper(g::DiscontinuousSpectralElementGrid)
+function ElementHelper(g::SpectralElementGrid)
     porders = polynomialorders(g)
     x, y, z = coordinates(g)
     xC, yC, zC = cellcenters(g)
@@ -247,7 +247,7 @@ struct GridHelper{S, T, V}
     grid::V
 end
 
-function GridHelper(g::DiscontinuousSpectralElementGrid)
+function GridHelper(g::SpectralElementGrid)
     return GridHelper(InterpolationHelper(g), ElementHelper(g), g)
 end
 

--- a/test/Numerics/DGMethods/compressible_navier_stokes_equations/shared_source/grids.jl
+++ b/test/Numerics/DGMethods/compressible_navier_stokes_equations/shared_source/grids.jl
@@ -1,6 +1,6 @@
-import ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
+import ClimateMachine.Mesh.Grids: SpectralElementGrid
 
-function coordinates(grid::DiscontinuousSpectralElementGrid)
+function coordinates(grid::SpectralElementGrid)
     x = view(grid.vgeo, :, grid.x1id, :)   # x-direction	
     y = view(grid.vgeo, :, grid.x2id, :)   # y-direction	
     z = view(grid.vgeo, :, grid.x3id, :)   # z-direction
@@ -56,9 +56,9 @@ end
 
 # Grid Constructor
 """
-function DiscontinuousSpectralElementGrid(domain::ProductDomain; elements = nothing, polynomialorder = nothing)
+function SpectralElementGrid(domain::ProductDomain; elements = nothing, polynomialorder = nothing)
 # Description 
-Computes a DiscontinuousSpectralElementGrid as specified by a product domain
+Computes a SpectralElementGrid as specified by a product domain
 # Arguments
 -`domain`: A product domain object
 # Keyword Arguments 
@@ -71,9 +71,9 @@ Computes a DiscontinuousSpectralElementGrid as specified by a product domain
 -`brickbuilder`: default = uniform_brick_builder, 
   brickrange=uniform_brick_builder(domain, elements)
 # Return 
-A DiscontinuousSpectralElementGrid object
+A SpectralElementGrid object
 """
-function DiscontinuousSpectralElementGrid(
+function SpectralElementGrid(
     domain::ProductDomain;
     elements = nothing,
     polynomialorder = nothing,
@@ -144,7 +144,7 @@ function DiscontinuousSpectralElementGrid(
         connectivity = connectivity,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = array,
@@ -174,7 +174,7 @@ function DiscretizedDomain(
     brick_builder = uniform_brick_builder,
 )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         domain,
         elements = elements,
         polynomialorder = polynomial_order .+ overintegration_order,

--- a/test/Numerics/DGMethods/compressible_navier_stokes_equations/three_dimensional/config_sphere.jl
+++ b/test/Numerics/DGMethods/compressible_navier_stokes_equations/three_dimensional/config_sphere.jl
@@ -33,7 +33,7 @@ function Config(
     println("poly order is " * string(resolution.N))
     println("OI order is " * string(Nover))
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/conservation/sphere.jl
+++ b/test/Numerics/DGMethods/conservation/sphere.jl
@@ -161,7 +161,7 @@ function test_run(mpicomm, ArrayType, N, Nhorz, Rrange, timeend, FT, dt)
 
     topl = StackedCubedSphereTopology(mpicomm, Nhorz, Rrange)
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/courant.jl
+++ b/test/Numerics/DGMethods/courant.jl
@@ -96,7 +96,7 @@ let
 
 
 
-                grid = DiscontinuousSpectralElementGrid(
+                grid = SpectralElementGrid(
                     topl,
                     FloatType = FT,
                     DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/custom_filter.jl
+++ b/test/Numerics/DGMethods/custom_filter.jl
@@ -52,7 +52,7 @@ end
                 periodicity = ntuple(j -> true, dim),
             )
 
-            grid = ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+            grid = ClimateMachine.Mesh.Grids.SpectralElementGrid(
                 topl,
                 FloatType = FT,
                 DeviceArray = ClimateMachine.array_type(),

--- a/test/Numerics/DGMethods/grad_test.jl
+++ b/test/Numerics/DGMethods/grad_test.jl
@@ -72,7 +72,7 @@ function test_run(mpicomm, dim, direction, Ne, N, FT, ArrayType)
         connectivity = connectivity,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/grad_test_sphere.jl
+++ b/test/Numerics/DGMethods/grad_test_sphere.jl
@@ -52,7 +52,7 @@ function test_run(mpicomm, Ne_horz, Ne_vert, N, FT, ArrayType, direction)
     Rrange = range(FT(1 // 2); length = Ne_vert + 1, stop = FT(1))
     topl = StackedCubedSphereTopology(mpicomm, Ne_horz, Rrange)
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/horizontal_integral_test.jl
+++ b/test/Numerics/DGMethods/horizontal_integral_test.jl
@@ -39,7 +39,7 @@ function run_test1(mpicomm, dim, Ne, N, FT, ArrayType)
         periodicity = (false, false, false),
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,
@@ -103,7 +103,7 @@ function run_test2(mpicomm, dim, Ne, N, FT, ArrayType)
         periodicity = (false, false, false),
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,
@@ -164,7 +164,7 @@ function run_test3(mpicomm, dim, Ne, N, FT, ArrayType)
         Nvert = 2^(l - 1) * base_Nvert
         Rrange = grid1d(FT(Rinner), FT(Router); nelem = Nvert)
         topl = StackedCubedSphereTopology(mpicomm, Nhorz, Rrange)
-        grid = DiscontinuousSpectralElementGrid(
+        grid = SpectralElementGrid(
             topl,
             FloatType = FT,
             DeviceArray = ArrayType,
@@ -222,7 +222,7 @@ function run_test4(mpicomm, dim, Ne, N, FT, ArrayType)
         connectivity = :face,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,
@@ -270,7 +270,7 @@ function run_test5(mpicomm, dim, Ne, N, FT, ArrayType)
         connectivity = :face,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/integral_test.jl
+++ b/test/Numerics/DGMethods/integral_test.jl
@@ -148,7 +148,7 @@ function test_run(mpicomm, dim, Ne, N, FT, ArrayType)
         connectivity = connectivity,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/integral_test_sphere.jl
+++ b/test/Numerics/DGMethods/integral_test_sphere.jl
@@ -145,7 +145,7 @@ end
 
 using Test
 function test_run(mpicomm, topl, ArrayType, N, FT, Rinner, Router)
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/remainder_model.jl
+++ b/test/Numerics/DGMethods/remainder_model.jl
@@ -72,7 +72,7 @@ function test_run(
     )
     topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/DGMethods/vars_test.jl
+++ b/test/Numerics/DGMethods/vars_test.jl
@@ -75,7 +75,7 @@ function test_run(mpicomm, dim, Ne, N, FT, ArrayType)
         connectivity = connectivity,
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/Mesh/DSS.jl
+++ b/test/Numerics/Mesh/DSS.jl
@@ -30,7 +30,7 @@ function test_dss()
         boundary = ((1, 2), (3, 4), (5, 6)),
         connectivity = :full,
     )
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = DA,

--- a/test/Numerics/Mesh/DSS_mpi.jl
+++ b/test/Numerics/Mesh/DSS_mpi.jl
@@ -30,7 +30,7 @@ function test_dss_stacked_3d()
         boundary = ((1, 2), (3, 4), (5, 6)),
         connectivity = :full,
     )
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = DA,

--- a/test/Numerics/Mesh/Geometry.jl
+++ b/test/Numerics/Mesh/Geometry.jl
@@ -32,7 +32,7 @@ MPI.Initialized() || MPI.Init()
         periodicity = (true, true, false),
     )
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/Mesh/Grids.jl
+++ b/test/Numerics/Mesh/Grids.jl
@@ -13,7 +13,7 @@ MPI.Initialized() || MPI.Init()
         Np = prod(Nq)
         Nfp = div.(Np, Nq)
 
-        grid = DiscontinuousSpectralElementGrid(
+        grid = SpectralElementGrid(
             topology,
             FloatType = Float64,
             DeviceArray = Array,
@@ -51,7 +51,7 @@ end
         Np = prod(Nq)
         Nfp = div.(Np, Nq)
 
-        grid = DiscontinuousSpectralElementGrid(
+        grid = SpectralElementGrid(
             topology,
             FloatType = Float64,
             DeviceArray = Array,

--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -32,7 +32,7 @@ ClimateMachine.init()
             -1.0:2.0:1.0,
         )
 
-        grid = ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+        grid = ClimateMachine.Mesh.Grids.SpectralElementGrid(
             topology;
             polynomialorder = N,
             FloatType = Float64,
@@ -61,7 +61,7 @@ ClimateMachine.init()
             MPI.COMM_SELF,
             -1.0:2.0:1.0,
         )
-        grid = ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+        grid = ClimateMachine.Mesh.Grids.SpectralElementGrid(
             topology;
             polynomialorder = N,
             FloatType = Float64,
@@ -82,7 +82,7 @@ ClimateMachine.init()
             MPI.COMM_SELF,
             -1.0:2.0:1.0,
         )
-        grid = ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+        grid = ClimateMachine.Mesh.Grids.SpectralElementGrid(
             topology;
             polynomialorder = N,
             FloatType = T,
@@ -119,7 +119,7 @@ ClimateMachine.init()
             MPI.COMM_SELF,
             -1.0:2.0:1.0,
         )
-        grid = ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+        grid = ClimateMachine.Mesh.Grids.SpectralElementGrid(
             topology;
             polynomialorder = N,
             FloatType = T,
@@ -216,7 +216,7 @@ end
                 )
 
                 grid =
-                    ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+                    ClimateMachine.Mesh.Grids.SpectralElementGrid(
                         topl,
                         FloatType = FT,
                         DeviceArray = ClimateMachine.array_type(),
@@ -282,7 +282,7 @@ end
                 )
 
                 grid =
-                    ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+                    ClimateMachine.Mesh.Grids.SpectralElementGrid(
                         topl,
                         FloatType = FT,
                         DeviceArray = ClimateMachine.array_type(),
@@ -359,7 +359,7 @@ end
                 periodicity = ntuple(j -> true, dim),
             )
 
-            grid = ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+            grid = ClimateMachine.Mesh.Grids.SpectralElementGrid(
                 topl,
                 FloatType = FT,
                 DeviceArray = ClimateMachine.array_type(),
@@ -448,7 +448,7 @@ end
             boundary = (5, 6),
         )
 
-        grid = ClimateMachine.Mesh.Grids.DiscontinuousSpectralElementGrid(
+        grid = ClimateMachine.Mesh.Grids.SpectralElementGrid(
             topl,
             FloatType = FT,
             DeviceArray = ClimateMachine.array_type(),

--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -215,13 +215,12 @@ end
                     periodicity = ntuple(j -> true, dim),
                 )
 
-                grid =
-                    ClimateMachine.Mesh.Grids.SpectralElementGrid(
-                        topl,
-                        FloatType = FT,
-                        DeviceArray = ClimateMachine.array_type(),
-                        polynomialorder = N,
-                    )
+                grid = ClimateMachine.Mesh.Grids.SpectralElementGrid(
+                    topl,
+                    FloatType = FT,
+                    DeviceArray = ClimateMachine.array_type(),
+                    polynomialorder = N,
+                )
 
                 filter = ClimateMachine.Mesh.Filters.CutoffFilter(grid, 2)
 
@@ -281,13 +280,12 @@ end
                     periodicity = ntuple(j -> true, dim),
                 )
 
-                grid =
-                    ClimateMachine.Mesh.Grids.SpectralElementGrid(
-                        topl,
-                        FloatType = FT,
-                        DeviceArray = ClimateMachine.array_type(),
-                        polynomialorder = N,
-                    )
+                grid = ClimateMachine.Mesh.Grids.SpectralElementGrid(
+                    topl,
+                    FloatType = FT,
+                    DeviceArray = ClimateMachine.array_type(),
+                    polynomialorder = N,
+                )
 
                 filter = ClimateMachine.Mesh.Filters.MassPreservingCutoffFilter(
                     grid,

--- a/test/Numerics/Mesh/filter_TMAR.jl
+++ b/test/Numerics/Mesh/filter_TMAR.jl
@@ -111,7 +111,7 @@ function test_run(
     vtkdir,
     outputtime,
 )
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Numerics/Mesh/interpolation.jl
+++ b/test/Numerics/Mesh/interpolation.jl
@@ -118,7 +118,7 @@ function run_brick_interpolation_test(
         brickrange,
         periodicity = (true, true, false),
     )
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = DA,
@@ -272,7 +272,7 @@ function run_cubed_sphere_interpolation_test(
 
     topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)
 
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         FloatType = FT,
         DeviceArray = DA,

--- a/test/Numerics/Mesh/min_node_distance.jl
+++ b/test/Numerics/Mesh/min_node_distance.jl
@@ -56,7 +56,7 @@ let
                         (ξ1, ξ2, ξ3)
                     end
 
-                    grid = DiscontinuousSpectralElementGrid(
+                    grid = SpectralElementGrid(
                         topl,
                         FloatType = FT,
                         DeviceArray = ArrayType,

--- a/test/Numerics/Mesh/mpi_connect_sphere.jl
+++ b/test/Numerics/Mesh/mpi_connect_sphere.jl
@@ -26,7 +26,7 @@ function main()
         boundary = (1, 2),
         connectivity = :face,
     )
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology;
         FloatType = FT,
         DeviceArray = DA,

--- a/test/Numerics/SystemSolvers/bandedsystem.jl
+++ b/test/Numerics/SystemSolvers/bandedsystem.jl
@@ -129,7 +129,7 @@ let
                     )
 
                         # create the actual grid
-                        grid = DiscontinuousSpectralElementGrid(
+                        grid = SpectralElementGrid(
                             topl,
                             FloatType = FT,
                             DeviceArray = ArrayType,

--- a/test/Numerics/SystemSolvers/poisson.jl
+++ b/test/Numerics/SystemSolvers/poisson.jl
@@ -174,7 +174,7 @@ function test_run(
 ) where {FT}
 
     topology = BrickTopology(mpicomm, brickrange, periodicity = periodicity)
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topology,
         polynomialorder = polynomialorder,
         DeviceArray = ArrayType,

--- a/test/Ocean/ShallowWater/GyreDriver.jl
+++ b/test/Ocean/ShallowWater/GyreDriver.jl
@@ -126,7 +126,7 @@ function test_run(
     model,
     test,
 ) where {FT}
-    grid = DiscontinuousSpectralElementGrid(
+    grid = SpectralElementGrid(
         topl,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Ocean/ShallowWater/test_2D_spindown.jl
+++ b/test/Ocean/ShallowWater/test_2D_spindown.jl
@@ -47,7 +47,7 @@ function run_hydrostatic_spindown(; refDat = ())
         periodicity = (true, true),
         boundary = ((0, 0), (0, 0)),
     )
-    grid_2D = DiscontinuousSpectralElementGrid(
+    grid_2D = SpectralElementGrid(
         topl_2D,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
+++ b/test/Ocean/SplitExplicit/hydrostatic_spindown.jl
@@ -30,7 +30,7 @@ function SplitConfig(
         periodicity = (true, true),
         boundary = ((0, 0), (0, 0)),
     )
-    grid_2D = DiscontinuousSpectralElementGrid(
+    grid_2D = SpectralElementGrid(
         topl_2D,
         FloatType = FT,
         DeviceArray = ArrayType,
@@ -44,7 +44,7 @@ function SplitConfig(
         periodicity = (true, true, false),
         boundary = ((0, 0), (0, 0), (1, 2)),
     )
-    grid_3D = DiscontinuousSpectralElementGrid(
+    grid_3D = SpectralElementGrid(
         topl_3D,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Ocean/SplitExplicit/simple_box_2dt.jl
+++ b/test/Ocean/SplitExplicit/simple_box_2dt.jl
@@ -117,7 +117,7 @@ function main(; restart = 0)
     brickrange_2D = (xrange, yrange)
     topl_2D =
         BrickTopology(mpicomm, brickrange_2D, periodicity = (false, false))
-    grid_2D = DiscontinuousSpectralElementGrid(
+    grid_2D = SpectralElementGrid(
         topl_2D,
         FloatType = FT,
         DeviceArray = ArrayType,
@@ -131,7 +131,7 @@ function main(; restart = 0)
         periodicity = (false, false, false),
         boundary = ((1, 1), (1, 1), (2, 3)),
     )
-    grid_3D = DiscontinuousSpectralElementGrid(
+    grid_3D = SpectralElementGrid(
         topl_3D,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Ocean/SplitExplicit/simple_box_ivd.jl
+++ b/test/Ocean/SplitExplicit/simple_box_ivd.jl
@@ -117,7 +117,7 @@ function main(; restart = 0)
     brickrange_2D = (xrange, yrange)
     topl_2D =
         BrickTopology(mpicomm, brickrange_2D, periodicity = (false, false))
-    grid_2D = DiscontinuousSpectralElementGrid(
+    grid_2D = SpectralElementGrid(
         topl_2D,
         FloatType = FT,
         DeviceArray = ArrayType,
@@ -131,7 +131,7 @@ function main(; restart = 0)
         periodicity = (false, false, false),
         boundary = ((1, 1), (1, 1), (2, 3)),
     )
-    grid_3D = DiscontinuousSpectralElementGrid(
+    grid_3D = SpectralElementGrid(
         topl_3D,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Ocean/SplitExplicit/simple_box_rk3.jl
+++ b/test/Ocean/SplitExplicit/simple_box_rk3.jl
@@ -117,7 +117,7 @@ function main(; restart = 0)
     brickrange_2D = (xrange, yrange)
     topl_2D =
         BrickTopology(mpicomm, brickrange_2D, periodicity = (false, false))
-    grid_2D = DiscontinuousSpectralElementGrid(
+    grid_2D = SpectralElementGrid(
         topl_2D,
         FloatType = FT,
         DeviceArray = ArrayType,
@@ -131,7 +131,7 @@ function main(; restart = 0)
         periodicity = (false, false, false),
         boundary = ((1, 1), (1, 1), (2, 3)),
     )
-    grid_3D = DiscontinuousSpectralElementGrid(
+    grid_3D = SpectralElementGrid(
         topl_3D,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Ocean/SplitExplicit/simple_dbl_gyre.jl
+++ b/test/Ocean/SplitExplicit/simple_dbl_gyre.jl
@@ -127,7 +127,7 @@ function main(; restart = 0)
     brickrange_2D = (xrange, yrange)
     topl_2D =
         BrickTopology(mpicomm, brickrange_2D, periodicity = (false, false))
-    grid_2D = DiscontinuousSpectralElementGrid(
+    grid_2D = SpectralElementGrid(
         topl_2D,
         FloatType = FT,
         DeviceArray = ArrayType,
@@ -141,7 +141,7 @@ function main(; restart = 0)
         periodicity = (false, false, false),
         boundary = ((1, 1), (1, 1), (2, 3)),
     )
-    grid_3D = DiscontinuousSpectralElementGrid(
+    grid_3D = SpectralElementGrid(
         topl_3D,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Ocean/SplitExplicit/test_vertical_integral_model.jl
+++ b/test/Ocean/SplitExplicit/test_vertical_integral_model.jl
@@ -42,7 +42,7 @@ function test_vertical_integral_model(::Type{FT}, time; refDat = ()) where {FT}
         periodicity = (true, true),
         boundary = ((0, 0), (0, 0)),
     )
-    grid_2D = DiscontinuousSpectralElementGrid(
+    grid_2D = SpectralElementGrid(
         topl_2D,
         FloatType = FT,
         DeviceArray = ArrayType,
@@ -56,7 +56,7 @@ function test_vertical_integral_model(::Type{FT}, time; refDat = ()) where {FT}
         periodicity = (true, true, false),
         boundary = ((0, 0), (0, 0), (1, 2)),
     )
-    grid_3D = DiscontinuousSpectralElementGrid(
+    grid_3D = SpectralElementGrid(
         topl_3D,
         FloatType = FT,
         DeviceArray = ArrayType,

--- a/test/Utilities/SingleStackUtils/ssu_tests.jl
+++ b/test/Utilities/SingleStackUtils/ssu_tests.jl
@@ -59,7 +59,7 @@ function init_state_prognostic!(
 end
 
 function test_hmean(
-    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
+    grid::SpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     vars,
 ) where {T, dim, Ns}
@@ -69,7 +69,7 @@ function test_hmean(
 end
 
 function test_hvar(
-    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
+    grid::SpectralElementGrid{T, dim, Ns},
     Q::MPIStateArray,
     vars,
 ) where {T, dim, Ns}
@@ -79,7 +79,7 @@ function test_hvar(
 end
 
 function test_horizontally_ave(
-    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
+    grid::SpectralElementGrid{T, dim, Ns},
     Q_in::MPIStateArray,
     vars,
 ) where {T, dim, Ns}
@@ -93,7 +93,7 @@ function test_horizontally_ave(
 end
 
 function target_meanprof(
-    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
+    grid::SpectralElementGrid{T, dim, Ns},
 ) where {T, dim, Ns}
     Nqs = Ns .+ 1
     Nq_v = Nqs[end]
@@ -105,7 +105,7 @@ function target_meanprof(
 end
 
 function target_varprof(
-    grid::DiscontinuousSpectralElementGrid{T, dim, Ns},
+    grid::SpectralElementGrid{T, dim, Ns},
 ) where {T, dim, Ns}
     Nqs = Ns .+ 1
     Nq_v = Nqs[end]


### PR DESCRIPTION
### Description

As @skandalaCLIMA pointed out, the grid structure no longer has the discontinuous assumption with the addition of CG support. So, this PR changes the name from `DiscontinuousSpectralElementGrid` to `SpectralElementGrid`.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
