### PR TITLE
Rename cubedshelltopowarp -> cubed_sphere_topo_warp

### DIFF
--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -45,7 +45,7 @@ Topologies.equidistant_cubed_sphere_warp
 Topologies.equidistant_cubed_sphere_unwarp
 Topologies.hasboundary
 Topologies.compute_lat_long
-Topologies.cubedshelltopowarp
+Topologies.cubed_sphere_topo_warp
 Topologies.grid1d
 ```
 

--- a/experiments/TestCase/solid_body_rotation_mountain.jl
+++ b/experiments/TestCase/solid_body_rotation_mountain.jl
@@ -92,7 +92,7 @@ function config_solid_body_rotation(FT, poly_order, resolution, ref_state)
         model = model,
         numerical_flux_first_order = RoeNumericalFlux(),
         meshwarp = set_topofun(
-            cubedshelltopowarp,                   ## Topography warp function 
+            cubed_sphere_topo_warp,                   ## Topography warp function
             _planet_radius,                       ## Domain inner radius
             _planet_radius + domain_height,       ## Domain outer radius
             DCMIPMountain(),                      ## Problem specific dispatch

--- a/src/Numerics/Mesh/Topologies.jl
+++ b/src/Numerics/Mesh/Topologies.jl
@@ -16,7 +16,7 @@ export AbstractTopology,
     EquidistantCubedSphere,
     EquiangularCubedSphere,
     isstacked,
-    cubedshelltopowarp,
+    cubed_sphere_topo_warp,
     compute_lat_long,
     compute_analytical_topography,
     cubed_sphere_warp,
@@ -174,13 +174,13 @@ struct BoxElementTopology{dim, T, nb} <: AbstractTopology{dim, T, nb}
     bndytoface::NTuple{nb, Array{Int64, 1}}
 
     """
-    Element to locally unique vertex number; `elemtouvert[v,e]` is the `v`th vertex 
+    Element to locally unique vertex number; `elemtouvert[v,e]` is the `v`th vertex
     of element `e`
     """
     elemtouvert::Union{Array{Int64, 2}, Nothing}
 
     """
-    Vertex connectivity information for direct stiffness summation; 
+    Vertex connectivity information for direct stiffness summation;
     `vtconn[vtconnoff[i]:vtconnoff[i+1]-1] == vtconn[lvt1, lelem1, lvt2, lelem2, ....]`
     for each rank-local unique vertex number,
     where `lvt1` is the element-local vertex number of element `lelem1`, etc.
@@ -194,9 +194,9 @@ struct BoxElementTopology{dim, T, nb} <: AbstractTopology{dim, T, nb}
     vtconnoff::Union{AbstractArray{Int64, 1}, Nothing}
 
     """
-    Face connectivity information for direct stiffness summation; 
+    Face connectivity information for direct stiffness summation;
     `fcconn[ufc,:] = [lfc1, lelem1, lfc2, lelem2, ordr]`
-    where `ufc` is the rank-local unique face number, and 
+    where `ufc` is the rank-local unique face number, and
     `lfc1` is the element-local face number of element `lelem1`, etc.,
     and ordr is the relative orientation. Faces, not shared by multiple
     elements are ignored.
@@ -204,7 +204,7 @@ struct BoxElementTopology{dim, T, nb} <: AbstractTopology{dim, T, nb}
     fcconn::Union{AbstractArray{Int64, 2}, Nothing}
 
     """
-    Edge connectivity information for direct stiffness summation; 
+    Edge connectivity information for direct stiffness summation;
     `edgconn[edgconnoff[i]:edgconnoff[i+1]-1] == edgconn[ledg1, orient, lelem1, ledg2, orient, lelem2, ...]`
     for each rank-local unique edge number,
     where `ledg1` is the element-local edge number, `orient1` is orientation (forward/reverse) of dof along edge.
@@ -1965,7 +1965,7 @@ end
 
 """
     NoTopography <: AnalyticalTopography
-Allows definition of fallback methods in case cubedshelltopowarp is used with
+Allows definition of fallback methods in case cubed_sphere_topo_warp is used with
 no prescribed topography function.
 """
 struct NoTopography <: AnalyticalTopography end
@@ -2008,7 +2008,7 @@ function compute_analytical_topography(
 end
 
 """
-    cubedshelltopowarp(a, b, c, R = max(abs(a), abs(b), abs(c));
+    cubed_sphere_topo_warp(a, b, c, R = max(abs(a), abs(b), abs(c));
                        r_inner = _planet_radius,
                        r_outer = _planet_radius + domain_height,
                        topography = NoTopography())
@@ -2019,7 +2019,7 @@ spherical shell of radius `R` based on the equiangular gnomonic grid proposed by
 compute_analytical_topography function. Defaults to smooth cubed sphere unless otherwise specified
 via the AnalyticalTopography type.
 """
-function cubedshelltopowarp(
+function cubed_sphere_topo_warp(
     a,
     b,
     c,


### PR DESCRIPTION
### Description
This quick PR is to complete the renaming I had done in PR #2060  so that these functions on the cubed-sphere have all a consistent style convention (`snake_case` for accessibility)

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
