### PR TITLE
Move solver_type to SolverConfiguration

### DIFF
--- a/experiments/AtmosLES/bomex_les.jl
+++ b/experiments/AtmosLES/bomex_les.jl
@@ -80,7 +80,6 @@ function main()
         zmax,
         param_set,
         ics;
-        solver_type = ode_solver_type,
         model = model,
     )
 

--- a/experiments/AtmosLES/bomex_single_stack.jl
+++ b/experiments/AtmosLES/bomex_single_stack.jl
@@ -61,14 +61,14 @@ function main()
         nelem_vert,
         zmax,
         param_set,
-        model;
-        solver_type = ode_solver_type,
+        model,
     )
 
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFLmax,
     )

--- a/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
+++ b/experiments/AtmosLES/cfsite_hadgem2-a_07_amip.jl
@@ -460,10 +460,9 @@ function config_cfsites(
         param_set,
         init_cfsites!,
         #ZS: multi-rate?
-        solver_type = imex_solver,
         model = model,
     )
-    return config
+    return config, imex_solver
 end
 
 # Define the diagnostics configuration (Atmos-Default)
@@ -545,7 +544,7 @@ function main()
     )
 
     # Set up driver configuration
-    driver_config = config_cfsites(
+    driver_config, ode_solver_type = config_cfsites(
         FT,
         N,
         resolution,
@@ -564,6 +563,7 @@ function main()
         driver_config,
         splines;
         init_on_cpu = true,
+        ode_solver_type = ode_solver_type,
         Courant_number = CFL,
         CFL_direction = HorizontalDirection(),
     )

--- a/experiments/AtmosLES/convective_bl_les.jl
+++ b/experiments/AtmosLES/convective_bl_les.jl
@@ -54,13 +54,13 @@ function main()
         zmax,
         param_set,
         ics,
-        solver_type = ode_solver_type,
         model = model,
     )
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFLmax,
     )

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -393,10 +393,9 @@ function config_dycoms(
         zmax,
         param_set,
         init_dycoms!,
-        solver_type = ode_solver,
         model = model,
     )
-    return config
+    return config, ode_solver
 end
 
 function config_diagnostics(driver_config, timeend)
@@ -458,7 +457,7 @@ function main()
     timeend = FT(100) #FT(4 * 60 * 60)
     Cmax = FT(1.7)     # use this for single-rate explicit LSRK144
 
-    driver_config = config_dycoms(
+    driver_config, ode_solver_type = config_dycoms(
         FT,
         N,
         resolution,
@@ -472,6 +471,7 @@ function main()
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = Cmax,
     )

--- a/experiments/AtmosLES/rising_bubble_bryan.jl
+++ b/experiments/AtmosLES/rising_bubble_bryan.jl
@@ -177,10 +177,9 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax, fast_method)
         zmax,
         param_set,
         init_risingbubble!,
-        solver_type = ode_solver,
         model = model,
     )
-    return config
+    return config, ode_solver
 end
 
 function config_diagnostics(driver_config)
@@ -228,12 +227,13 @@ function main()
     # Time-step size (s)
     Δt = FT(0.4)
 
-    driver_config =
+    driver_config, ode_solver_type =
         config_risingbubble(FT, N, resolution, xmax, ymax, zmax, fast_method)
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         ode_dt = Δt,
     )

--- a/experiments/AtmosLES/rising_bubble_theta_formulation.jl
+++ b/experiments/AtmosLES/rising_bubble_theta_formulation.jl
@@ -187,27 +187,6 @@ function config_risingbubble(
     ymax,
     zmax,
 ) where {FT}
-
-    ## Choose an Explicit Single-rate Solver from the existing [`ODESolvers`](@ref ClimateMachine.ODESolvers) options.
-    ## Apply the outer constructor to define the `ode_solver`.
-    ## The 1D-IMEX method is less appropriate for the problem given the current
-    ## mesh aspect ratio (1:1).
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    )
-    ## ode_solver = ClimateMachine.IMEXSolverType()
-    ## If the user prefers a multi-rate explicit time integrator,
-    ## the ode_solver above can be replaced with
-    ##
-    ## `ode_solver = ClimateMachine.MultirateSolverType(
-    ##    fast_model = AtmosAcousticGravityLinearModel,
-    ##    slow_method = LSRK144NiegemannDiehlBusch,
-    ##    fast_method = LSRK144NiegemannDiehlBusch,
-    ##    timestep_ratio = 10,
-    ## )`
-    ## See [ODESolvers](@ref ODESolvers-docs) for all of the available solvers.
-
-
     ## Since we want four tracers, we specify this and include the appropriate
     ## diffusivity scaling coefficients (normally these would be physically
     ## informed but for this demonstration we use integers corresponding to the
@@ -271,7 +250,6 @@ function config_risingbubble(
         zmax,                    ## Domain maximum size [m]
         param_set,               ## Parameter set.
         init_risingbubble!,      ## Function specifying initial condition
-        solver_type = ode_solver,## Time-integrator type
         model = model,           ## Model type
     )
     return config
@@ -322,11 +300,34 @@ function main()
 
     ## Assign configurations so they can be passed to the `invoke!` function
     driver_config = config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
+
+    ## Choose an Explicit Single-rate Solver from the existing [`ODESolvers`](@ref ClimateMachine.ODESolvers) options.
+    ## Apply the outer constructor to define the `ode_solver`.
+    ## The 1D-IMEX method is less appropriate for the problem given the current
+    ## mesh aspect ratio (1:1).
+
+    ## ode_solver = ClimateMachine.IMEXSolverType()
+    ## If the user prefers a multi-rate explicit time integrator,
+    ## the ode_solver above can be replaced with
+    ##
+    ## `ode_solver = ClimateMachine.MultirateSolverType(
+    ##    fast_model = AtmosAcousticGravityLinearModel,
+    ##    slow_method = LSRK144NiegemannDiehlBusch,
+    ##    fast_method = LSRK144NiegemannDiehlBusch,
+    ##    timestep_ratio = 10,
+    ## )`
+    ## See [ODESolvers](@ref ODESolvers-docs) for all of the available solvers.
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
         init_on_cpu = true,
+        ode_solver_type = ode_solver_type,
         Courant_number = CFL,
         CFL_direction = HorizontalDirection(),
     )

--- a/experiments/AtmosLES/schar_scalar_advection.jl
+++ b/experiments/AtmosLES/schar_scalar_advection.jl
@@ -142,12 +142,6 @@ function config_schar(FT, N, resolution, xmax, ymax, zmax)
     rayleigh_sponge =
         RayleighSponge{FT}(zmax, z_s, sponge_ampz, u_relaxation, 2)
 
-    ## Define the time integrator:
-    ## We chose an explicit single-rate LSRK144 for this problem
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    )
-
     ## Setup the source terms for this problem:
     source = (Gravity(), rayleigh_sponge)
 
@@ -186,7 +180,6 @@ function config_schar(FT, N, resolution, xmax, ymax, zmax)
         zmax,                    # Domain maximum size [m]
         param_set,               # Parameter set.
         init_schar!,             # Function specifying initial condition
-        solver_type = ode_solver,# Time-integrator type
         model = model,           # Model type
         meshwarp = setmax(warp_schar, xmax, ymax, zmax),
     )
@@ -220,10 +213,18 @@ function main()
 
     ## Assign configurations so they can be passed to the `invoke!` function
     driver_config = config_schar(FT, N, resolution, xmax, ymax, zmax)
+
+    ## Define the time integrator:
+    ## We chose an explicit single-rate LSRK144 for this problem
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFL,
     )

--- a/experiments/AtmosLES/squall_line.jl
+++ b/experiments/AtmosLES/squall_line.jl
@@ -294,8 +294,6 @@ function config_squall_line(
         source = source,
     )
 
-    ode_solver = ClimateMachine.IMEXSolverType()
-
     config = ClimateMachine.AtmosLESConfiguration(
         "Squall_line",
         N,
@@ -307,7 +305,6 @@ function config_squall_line(
         init_squall_line!,
         xmin = xmin,
         ymin = ymin,
-        solver_type = ode_solver,
         model = model,
         periodicity = (true, true, false),
         boundary = ((2, 2), (2, 2), (1, 2)),
@@ -418,11 +415,13 @@ function main()
         moisture_model,
         precipitation_model,
     )
+    ode_solver_type = ClimateMachine.IMEXSolverType()
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
         (spl_tinit, spl_qinit, spl_uinit, spl_vinit, spl_pinit);
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = Cmax,
     )

--- a/experiments/AtmosLES/stable_bl_les.jl
+++ b/experiments/AtmosLES/stable_bl_les.jl
@@ -39,9 +39,6 @@ function main(cl_args)
     timeend = FT(3600 * 0.1)
     CFLmax = FT(0.4)
 
-    # Choose default IMEX solver
-    ode_solver_type = ClimateMachine.ExplicitSolverType()
-
     C_smag_ = C_smag(param_set) #FT(0.23)
 
     model = stable_bl_model(
@@ -64,14 +61,17 @@ function main(cl_args)
         zmax,
         param_set,
         init_problem!,
-        solver_type = ode_solver_type,
         model = model,
     )
+
+    # Choose default IMEX solver
+    ode_solver_type = ClimateMachine.ExplicitSolverType()
 
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFLmax,
     )

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -94,10 +94,6 @@ function config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
 
     C_smag = FT(0.23)
 
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    )
-
     physics = AtmosPhysics{FT}(
         param_set;
         turbulence = SmagorinskyLilly{FT}(C_smag),
@@ -126,7 +122,6 @@ function config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
         zmax,
         param_set,
         init_surfacebubble!,
-        solver_type = ode_solver,
         model = model,
     )
 
@@ -175,11 +170,17 @@ function main()
     timeend = FT(2000)
 
     driver_config = config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
         init_on_cpu = true,
+        ode_solver_type = ode_solver_type,
     )
 
     dgn_ssecs = (timeend / 2) + 10

--- a/experiments/AtmosLES/taylor_green.jl
+++ b/experiments/AtmosLES/taylor_green.jl
@@ -89,9 +89,6 @@ function config_greenvortex(
     (xmin, xmax, ymin, ymax, zmin, zmax),
     resolution,
 ) where {FT}
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    )
 
     _C_smag = FT(C_smag(param_set))
     physics = AtmosPhysics{FT}(
@@ -123,7 +120,6 @@ function config_greenvortex(
         xmin = xmin,
         ymin = ymin,
         zmin = zmin,
-        solver_type = ode_solver,       # Time-integrator type
         model = model,                  # Model type
     )
     return config
@@ -204,10 +200,16 @@ function main()
         (xmin, xmax, ymin, ymax, zmin, zmax),
         resolution,
     )
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFL,
     )

--- a/experiments/OceanBoxGCM/simple_box.jl
+++ b/experiments/OceanBoxGCM/simple_box.jl
@@ -29,6 +29,7 @@ function config_simple_box(name, resolution, dimensions, problem; BC = nothing)
     N, Nˣ, Nʸ, Nᶻ = resolution
     resolution = (Nˣ, Nʸ, Nᶻ)
 
+    solver_type = ExplicitSolverType(solver_method = LSRK144NiegemannDiehlBusch)
     config = ClimateMachine.OceanBoxGCMConfiguration(
         name,
         N,
@@ -37,7 +38,7 @@ function config_simple_box(name, resolution, dimensions, problem; BC = nothing)
         model,
     )
 
-    return config
+    return config, solver_type
 end
 
 function run_simple_box(
@@ -52,17 +53,17 @@ function run_simple_box(
     refDat = (),
 )
     if imex
-        solver_type =
+        ode_solver_type =
             ClimateMachine.IMEXSolverType(implicit_model = LinearHBModel)
         Courant_number = 0.1
     else
-        solver_type = ClimateMachine.ExplicitSolverType(
+        ode_solver_type = ClimateMachine.ExplicitSolverType(
             solver_method = LSRK144NiegemannDiehlBusch,
         )
         Courant_number = 0.4
     end
 
-    driver_config =
+    driver_config, solver_type_driver_config =
         config_simple_box(name, resolution, dimensions, problem; BC = BC)
 
     grid = driver_config.grid
@@ -81,7 +82,7 @@ function run_simple_box(
         timeend,
         driver_config,
         init_on_cpu = true,
-        ode_solver_type = solver_type,
+        ode_solver_type = ode_solver_type,
         ode_dt = Δt,
         modeldata = modeldata,
         Courant_number = Courant_number,

--- a/experiments/OceanSplitExplicit/simple_box.jl
+++ b/experiments/OceanSplitExplicit/simple_box.jl
@@ -178,7 +178,6 @@ function OceanSplitExplicitConfiguration(
         (polyorder_horz, polyorder_vert),
         FT,
         array_type,
-        solver_type,
         param_set,
         model_3D,
         mpicomm,
@@ -231,14 +230,14 @@ function config_simple_box(
         N,
         resolution,
         param_set,
-        model_3D;
-        solver_type = SplitExplicitSolverType{FT}(dt_slow, dt_fast),
+        model_3D,
     )
+    solver_type = SplitExplicitSolverType{FT}(dt_slow, dt_fast)
 
-    return config
+    return config, solver_type
 end
 
-function run_simple_box(driver_config, timespan; refDat = ())
+function run_simple_box(driver_config, timespan, dt_slow; refDat = ())
 
     timestart, timeend = timespan
     solver_config = ClimateMachine.SolverConfiguration(
@@ -246,7 +245,7 @@ function run_simple_box(driver_config, timespan; refDat = ())
         timeend,
         driver_config,
         init_on_cpu = true,
-        ode_dt = driver_config.solver_type.dt_slow,
+        ode_dt = dt_slow,
     )
 
     ## Create a callback to report state statistics for main MPIStateArrays

--- a/experiments/TestCase/risingbubble.jl
+++ b/experiments/TestCase/risingbubble.jl
@@ -92,10 +92,6 @@ end
 
 function config_risingbubble(FT, N, resolution, xmax, ymax, zmax, with_moisture)
 
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    )
-
     T_surface = FT(300)
     T_min_ref = FT(0)
     T_profile = DryAdiabaticProfile{FT}(param_set, T_surface, T_min_ref)
@@ -131,7 +127,6 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax, with_moisture)
         zmax,
         param_set,
         init_risingbubble!,
-        solver_type = ode_solver,
         model = model,
     )
     return config
@@ -203,10 +198,16 @@ function main()
 
     driver_config =
         config_risingbubble(FT, N, resolution, xmax, ymax, zmax, with_moisture)
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFL,
     )

--- a/experiments/TestCase/risingbubble_fvm.jl
+++ b/experiments/TestCase/risingbubble_fvm.jl
@@ -103,10 +103,6 @@ function config_risingbubble(
     with_moisture,
 )
 
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK54CarpenterKennedy,
-    )
-
     T_surface = FT(300)
     T_min_ref = FT(0)
     T_profile = DryAdiabaticProfile{FT}(param_set, T_surface, T_min_ref)
@@ -142,7 +138,6 @@ function config_risingbubble(
         zmax,
         param_set,
         init_risingbubble!,
-        solver_type = ode_solver,
         model = model,
         numerical_flux_first_order = RoeNumericalFlux(),
         fv_reconstruction = HBFVReconstruction(model, fv_reconstruction),
@@ -226,10 +221,16 @@ function main()
         zmax,
         with_moisture,
     )
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK54CarpenterKennedy,
+    )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFL,
     )

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -113,7 +113,6 @@ struct DriverConfiguration{FT}
     # Polynomial order tuple (polyorder_horz, polyorder_vert)
     polyorders::NTuple{2, Int}
     array_type::Any
-    solver_type::AbstractSolverType
     #
     # Model details
     param_set::AbstractParameterSet
@@ -143,7 +142,6 @@ struct DriverConfiguration{FT}
         polyorders::NTuple{2, Int},
         FT,
         array_type,
-        solver_type::AbstractSolverType,
         param_set::AbstractParameterSet,
         bl::BalanceLaw,
         mpicomm::MPI.Comm,
@@ -160,7 +158,6 @@ struct DriverConfiguration{FT}
             name,
             polyorders,
             array_type,
-            solver_type,
             param_set,
             bl,
             mpicomm,
@@ -206,10 +203,6 @@ function AtmosLESConfiguration(
     ymin = zero(FT),
     zmin = zero(FT),
     array_type = ClimateMachine.array_type(),
-    solver_type = IMEXSolverType(
-        implicit_solver = SingleColumnLU,
-        implicit_solver_adjustable = false,
-    ),
     physics = AtmosPhysics{FT}(param_set;),
     model = AtmosModel{FT}(
         AtmosLESConfigType,
@@ -335,7 +328,6 @@ Establishing Atmos LES configuration for %s
         (polyorder_horz, polyorder_vert),
         FT,
         array_type,
-        solver_type,
         param_set,
         model,
         mpicomm,
@@ -357,7 +349,6 @@ function AtmosGCMConfiguration(
     param_set::AbstractParameterSet,
     init_GCM!;
     array_type = ClimateMachine.array_type(),
-    solver_type = DefaultSolverType(),
     physics = AtmosPhysics{FT}(param_set),
     model = AtmosModel{FT}(
         AtmosGCMConfigType,
@@ -458,7 +449,6 @@ Establishing Atmos GCM configuration for %s
         (polyorder_horz, polyorder_vert),
         FT,
         array_type,
-        solver_type,
         param_set,
         model,
         mpicomm,
@@ -485,9 +475,6 @@ function OceanBoxGCMConfiguration(
     model;
     FT = Float64,
     array_type = ClimateMachine.array_type(),
-    solver_type = ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    ),
     mpicomm = MPI.COMM_WORLD,
     numerical_flux_first_order = RusanovNumericalFlux(),
     numerical_flux_second_order = CentralNumericalFluxSecondOrder(),
@@ -552,7 +539,6 @@ Establishing Ocean Box GCM configuration for %s
         (polyorder_horz, polyorder_vert),
         FT,
         array_type,
-        solver_type,
         param_set,
         model,
         mpicomm,
@@ -576,7 +562,6 @@ function SingleStackConfiguration(
     zmin = zero(FT),
     hmax = one(FT),
     array_type = ClimateMachine.array_type(),
-    solver_type = ExplicitSolverType(),
     mpicomm = MPI.COMM_WORLD,
     boundary = ((0, 0), (0, 0), (1, 2)),
     periodicity = (true, true, false),
@@ -658,7 +643,6 @@ Establishing single stack configuration for %s
         (polyorder_horz, polyorder_vert),
         FT,
         array_type,
-        solver_type,
         param_set,
         model,
         mpicomm,
@@ -687,7 +671,6 @@ function MultiColumnLandModel(
     array_type = ClimateMachine.array_type(),
     mpicomm = MPI.COMM_WORLD,
     boundary = ((3, 3), (3, 3), (1, 2)),
-    solver_type = ExplicitSolverType(),
     periodicity = (false, false, false),
     meshwarp = (x...) -> identity(x),
     numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
@@ -772,7 +755,6 @@ Establishing MultiColumnLandModel configuration for %s
         (polyorder_horz, polyorder_vert),
         FT,
         array_type,
-        solver_type,
         param_set,
         model,
         mpicomm,

--- a/src/Ocean/SuperModels.jl
+++ b/src/Ocean/SuperModels.jl
@@ -167,7 +167,6 @@ function HydrostaticBoussinesqSuperModel(;
         (domain.Np, domain.Np),
         eltype(domain),
         array_type,
-        timestepper,
         parameter_set(equations),
         equations,
         MPI.COMM_WORLD,

--- a/test/Atmos/EDMF/bomex_edmf.jl
+++ b/test/Atmos/EDMF/bomex_edmf.jl
@@ -127,13 +127,13 @@ function main(::Type{FT}, cl_args) where {FT}
         param_set,
         model;
         hmax = zmax,
-        solver_type = ode_solver_type,
     )
 
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFLmax,
     )

--- a/test/Atmos/EDMF/ekman_layer.jl
+++ b/test/Atmos/EDMF/ekman_layer.jl
@@ -160,13 +160,13 @@ function main(::Type{FT}, cl_args) where {FT}
         param_set,
         model;
         hmax = FT(40),
-        solver_type = ode_solver_type,
         fv_reconstruction = fv_reconstruction,
     )
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFLmax,
     )

--- a/test/Atmos/EDMF/stable_bl_anelastic1d.jl
+++ b/test/Atmos/EDMF/stable_bl_anelastic1d.jl
@@ -149,13 +149,13 @@ function main(::Type{FT}, cl_args) where {FT}
         param_set,
         model;
         hmax = FT(40),
-        solver_type = ode_solver_type,
     )
 
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFLmax,
     )

--- a/test/Atmos/EDMF/stable_bl_coupled_edmf_an1d.jl
+++ b/test/Atmos/EDMF/stable_bl_coupled_edmf_an1d.jl
@@ -146,13 +146,13 @@ function main(::Type{FT}, cl_args) where {FT}
         param_set,
         model;
         hmax = FT(40),
-        solver_type = ode_solver_type,
     )
 
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFLmax,
     )

--- a/test/Atmos/EDMF/stable_bl_edmf.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf.jl
@@ -134,13 +134,13 @@ function main(::Type{FT}, cl_args) where {FT}
         param_set,
         model;
         hmax = FT(40),
-        solver_type = ode_solver_type,
     )
 
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFLmax,
     )

--- a/test/Atmos/EDMF/stable_bl_edmf_fvm.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf_fvm.jl
@@ -139,7 +139,6 @@ function main(::Type{FT}, cl_args) where {FT}
         param_set,
         model;
         hmax = FT(40),
-        solver_type = ode_solver_type,
         numerical_flux_first_order = RoeNumericalFlux(),
         fv_reconstruction = HBFVReconstruction(model, FVLinear()),
     )
@@ -148,6 +147,7 @@ function main(::Type{FT}, cl_args) where {FT}
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFLmax,
     )

--- a/test/Atmos/EDMF/stable_bl_single_stack_implicit.jl
+++ b/test/Atmos/EDMF/stable_bl_single_stack_implicit.jl
@@ -59,13 +59,13 @@ function main(::Type{FT}, cl_args) where {FT}
         param_set,
         model;
         hmax = FT(40),
-        solver_type = ode_solver_type,
     )
 
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFLmax,
     )

--- a/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_ice.jl
@@ -839,7 +839,7 @@ function main()
     init_ρ = Spline1D(z_range, ρ_range)
     init_dρ = Spline1D(z_range, dρ_range)
 
-    driver_config = config_kinematic_eddy(
+    driver_config, ode_solver_type = config_kinematic_eddy(
         FT,
         N,
         resolution,
@@ -867,6 +867,7 @@ function main()
         t_end,
         driver_config,
         (init_T, init_qt, init_p, init_ρ, init_dρ),
+        ode_solver_type = ode_solver_type,
         ode_dt = dt,
         init_on_cpu = true,
         #Courant_number = CFL,

--- a/test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_saturation_adjustment.jl
@@ -200,7 +200,7 @@ function main()
     idx_bc_bottom = 1
     idx_bc_top = 2
 
-    driver_config = config_kinematic_eddy(
+    driver_config, ode_solver_type = config_kinematic_eddy(
         FT,
         N,
         resolution,
@@ -223,10 +223,12 @@ function main()
         idx_bc_bottom,
         idx_bc_top,
     )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t_ini,
         t_end,
         driver_config;
+        ode_solver_type = ode_solver_type,
         ode_dt = dt,
         init_on_cpu = true,
         #Courant_number = CFL,

--- a/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KM_warm_rain.jl
@@ -365,7 +365,7 @@ function main()
     idx_bc_bottom = 1
     idx_bc_top = 2
 
-    driver_config = config_kinematic_eddy(
+    driver_config, ode_solver_type = config_kinematic_eddy(
         FT,
         N,
         resolution,
@@ -388,10 +388,12 @@ function main()
         idx_bc_bottom,
         idx_bc_top,
     )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t_ini,
         t_end,
         driver_config;
+        ode_solver_type = ode_solver_type,
         ode_dt = dt,
         init_on_cpu = true,
         #Courant_number = CFL,

--- a/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
+++ b/test/Atmos/Parameterizations/Microphysics/KinematicModel.jl
@@ -323,9 +323,8 @@ function config_kinematic_eddy(
         xmin = FT(0),
         ymin = FT(0),
         zmin = FT(0),
-        solver_type = ode_solver,
         model = model,
     )
 
-    return config
+    return config, ode_solver
 end

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -87,14 +87,6 @@ end
 
 function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
 
-    # Choose explicit multirate solver
-    ode_solver = ClimateMachine.MultirateSolverType(
-        fast_model = AtmosAcousticGravityLinearModel,
-        slow_method = LSRK144NiegemannDiehlBusch,
-        fast_method = LSRK144NiegemannDiehlBusch,
-        timestep_ratio = 10,
-    )
-
     # Set up the model
     T_profile = DryAdiabaticProfile{FT}(param_set)
     C_smag = FT(0.23)
@@ -121,7 +113,6 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
         zmax,
         param_set,
         init_risingbubble!,
-        solver_type = ode_solver,
         model = model,
     )
     return config
@@ -164,10 +155,20 @@ function run_brick_diagostics_fields_test()
         CFL = FT(20)
 
         driver_config = config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
+
+        # Choose explicit multirate solver
+        ode_solver_type = ClimateMachine.MultirateSolverType(
+            fast_model = AtmosAcousticGravityLinearModel,
+            slow_method = LSRK144NiegemannDiehlBusch,
+            fast_method = LSRK144NiegemannDiehlBusch,
+            timestep_ratio = 10,
+        )
+
         solver_config = ClimateMachine.SolverConfiguration(
             t0,
             timeend,
-            driver_config,
+            driver_config;
+            ode_solver_type = ode_solver_type,
             init_on_cpu = true,
             Courant_number = CFL,
         )

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -30,9 +30,6 @@ const param_set = EarthParameterSet()
 include("sin_init.jl")
 
 function config_sin_test(FT, N, resolution, xmax, ymax, zmax)
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK54CarpenterKennedy,
-    )
     config = ClimateMachine.AtmosLESConfiguration(
         "Diagnostics SIN test",
         N,
@@ -41,8 +38,7 @@ function config_sin_test(FT, N, resolution, xmax, ymax, zmax)
         ymax,
         zmax,
         param_set,
-        init_sin_test!;
-        solver_type = ode_solver,
+        init_sin_test!,
     )
 
     return config
@@ -82,10 +78,16 @@ function main()
     timeend = dt
 
     driver_config = config_sin_test(FT, N, resolution, xmax, ymax, zmax)
+
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK54CarpenterKennedy,
+    )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         ode_dt = dt,
         init_on_cpu = true,
     )

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -72,7 +72,7 @@ function main()
     # Timestep size (s)
     dt = FT(600)
 
-    ode_solver = ClimateMachine.MISSolverType(;
+    ode_solver_type = ClimateMachine.MISSolverType(;
         splitting_type = ClimateMachine.SlowFastSplitting(),
         nsubsteps = (20,),
     )
@@ -101,13 +101,13 @@ function main()
         setup.domain_height,
         param_set,
         setup;
-        solver_type = ode_solver,
         model = model,
     )
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         ode_dt = dt,
     )
 

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -85,7 +85,7 @@ function main()
         source = (Gravity(),),
     )
 
-    ode_solver = ClimateMachine.MultirateSolverType(
+    ode_solver_type = ClimateMachine.MultirateSolverType(
         splitting_type = ClimateMachine.HEVISplitting(),
         fast_model = AtmosAcousticGravityLinearModel,
         implicit_solver_adjustable = true,
@@ -100,13 +100,13 @@ function main()
         setup.domain_height,
         param_set,
         setup;
-        solver_type = ode_solver,
         model = model,
     )
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         ode_dt = dt,
     )
 

--- a/test/Driver/les_driver_test.jl
+++ b/test/Driver/les_driver_test.jl
@@ -83,7 +83,6 @@ function main()
     timeend = FT(10)
     CFL = FT(0.4)
 
-    ode_solver = ClimateMachine.ExplicitSolverType()
     driver_config = ClimateMachine.AtmosLESConfiguration(
         "Driver test",
         N,
@@ -93,12 +92,13 @@ function main()
         zmax,
         param_set,
         init_test!,
-        solver_type = ode_solver,
     )
+    ode_solver_type = ClimateMachine.ExplicitSolverType()
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         Courant_number = CFL,
     )
 

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -92,7 +92,7 @@ function main()
     nsteps = ceil(Int64, timeend / ode_dt)
     ode_dt = timeend / nsteps
 
-    ode_solver = ClimateMachine.ExplicitSolverType(
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
         solver_method = LSRK54CarpenterKennedy,
     )
 
@@ -149,7 +149,6 @@ function main()
         (N, N),
         FT,
         ClimateMachine.array_type(),
-        ode_solver,
         param_set,
         model,
         MPI.COMM_WORLD,
@@ -166,7 +165,7 @@ function main()
         t0,
         timeend,
         driver_config,
-        ode_solver_type = ode_solver,
+        ode_solver_type = ode_solver_type,
         ode_dt = ode_dt,
     )
     Q₀ = solver_config.Q
@@ -187,7 +186,7 @@ function main()
         t0,
         timeend,
         driver_config,
-        ode_solver_type = ode_solver,
+        ode_solver_type = ode_solver_type,
         ode_dt = ode_dt,
     )
 

--- a/test/Ocean/HydrostaticBoussinesq/test_3D_spindown.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_3D_spindown.jl
@@ -42,7 +42,7 @@ function config_simple_box(
         fₒ = FT(0),
         β = FT(0),
     )
-
+    solver_type = ExplicitSolverType(solver_method = LSRK144NiegemannDiehlBusch)
     config = ClimateMachine.OceanBoxGCMConfiguration(
         "hydrostatic_spindown",
         N,
@@ -53,7 +53,7 @@ function config_simple_box(
         boundary = ((0, 0), (0, 0), (1, 2)),
     )
 
-    return config
+    return config, solver_type
 end
 
 function run_hydrostatic_test(; imex::Bool = false, BC = nothing, refDat = ())
@@ -87,7 +87,8 @@ function run_hydrostatic_test(; imex::Bool = false, BC = nothing, refDat = ())
         )
     end
 
-    driver = config_simple_box(FT, N, resolution, dimensions; BC = BC)
+    driver, solver_type_driver_config =
+        config_simple_box(FT, N, resolution, dimensions; BC = BC)
 
     grid = driver.grid
     N = polynomialorders(grid)

--- a/test/Ocean/SplitExplicit/test_simple_box.jl
+++ b/test/Ocean/SplitExplicit/test_simple_box.jl
@@ -39,7 +39,7 @@ const FT = Float64
         ClimateMachine.Ocean.SplitExplicit01.OceanSurfaceStressForcing(),
     )
 
-    config = config_simple_box(
+    config, solver_type = config_simple_box(
         "test_simple_box",
         resolution,
         dimensions,
@@ -48,6 +48,6 @@ const FT = Float64
         dt_fast = FT(240),
     )
 
-    run_simple_box(config, timespan; refDat = refDat)
+    run_simple_box(config, timespan, solver_type.dt_slow; refDat = refDat)
 
 end

--- a/tutorials/Atmos/agnesi_hs_lin.jl
+++ b/tutorials/Atmos/agnesi_hs_lin.jl
@@ -217,12 +217,6 @@ function config_agnesi_hs_lin(
     rayleigh_sponge =
         RayleighSponge{FT}(zmax, z_s, sponge_ampz, u_relaxation, 2)
 
-    ## Define the time integrator:
-    ## We chose an explicit single-rate LSRK144 for this problem
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    )
-
     ## Setup the source terms for this problem:
     source = (Gravity(), rayleigh_sponge)
 
@@ -256,7 +250,6 @@ function config_agnesi_hs_lin(
         zmax,                    # Domain maximum size [m]
         param_set,               # Parameter set.
         init_agnesi_hs_lin!,     # Function specifying initial condition
-        solver_type = ode_solver,# Time-integrator type
         model = model,           # Model type
         meshwarp = setmax(warp_agnesi, xmax, ymax, zmax),
     )
@@ -293,10 +286,18 @@ function main()
 
     ## Assign configurations so they can be passed to the `invoke!` function
     driver_config = config_agnesi_hs_lin(FT, N, resolution, xmax, ymax, zmax)
+
+    ## Define the time integrator:
+    ## We chose an explicit single-rate LSRK144 for this problem
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFL,
     )

--- a/tutorials/Atmos/agnesi_nh_lin.jl
+++ b/tutorials/Atmos/agnesi_nh_lin.jl
@@ -211,12 +211,6 @@ function config_agnesi_hs_lin(
     rayleigh_sponge =
         RayleighSponge{FT}(zmax, z_s, sponge_ampz, u_relaxation, 2)
 
-    ## Define the time integrator:
-    ## We chose an explicit single-rate LSRK144 for this problem
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    )
-
     ## Setup the source terms for this problem:
     source = (Gravity(), rayleigh_sponge)
 
@@ -250,7 +244,6 @@ function config_agnesi_hs_lin(
         zmax,                    # Domain maximum size [m]
         param_set,               # Parameter set.
         init_agnesi_hs_lin!,     # Function specifying initial condition
-        solver_type = ode_solver,# Time-integrator type
         model = model,           # Model type
         meshwarp = setmax(warp_agnesi, xmax, ymax, zmax),
     )
@@ -287,10 +280,18 @@ function main()
 
     ## Assign configurations so they can be passed to the `invoke!` function
     driver_config = config_agnesi_hs_lin(FT, N, resolution, xmax, ymax, zmax)
+
+    ## Define the time integrator:
+    ## We chose an explicit single-rate LSRK144 for this problem
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFL,
     )

--- a/tutorials/Atmos/burgers_single_stack_bjfnk.jl
+++ b/tutorials/Atmos/burgers_single_stack_bjfnk.jl
@@ -481,7 +481,6 @@ driver_config = ClimateMachine.SingleStackConfiguration(
     param_set,
     m,
     numerical_flux_first_order = CentralNumericalFluxFirstOrder(),
-    solver_type = ode_solver_type,
 );
 
 # # Time discretization
@@ -509,8 +508,13 @@ dt = FT(50.0) * min(Fourier_bound, Courant_bound)
 # function used for initialization). 
 
 
-solver_config =
-    ClimateMachine.SolverConfiguration(t0, timeend, driver_config, ode_dt = dt);
+solver_config = ClimateMachine.SolverConfiguration(
+    t0,
+    timeend,
+    driver_config,
+    ode_dt = dt,
+    ode_solver_type = ode_solver_type,
+);
 
 
 # ## Inspect the initial conditions for a single nodal stack

--- a/tutorials/Atmos/densitycurrent.jl
+++ b/tutorials/Atmos/densitycurrent.jl
@@ -193,12 +193,6 @@ function config_densitycurrent(
     zmax,
 ) where {FT}
 
-    ## Choose an Explicit Single-rate Solver LSRK144 from the existing [ODESolvers](@ref
-    ## ODESolvers-docs) options Apply the outer constructor to define the
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    )
-
     ## The model coefficient for the turbulence closure is defined via the
     ## [CLIMAParameters
     ## package](https://CliMA.github.io/CLIMAParameters.jl/dev/) A reference
@@ -242,7 +236,6 @@ function config_densitycurrent(
         zmax,                     # Domain maximum size [m]
         param_set,                # Parameter set.
         init_densitycurrent!,     # Function specifying initial condition
-        solver_type = ode_solver, # Time-integrator type
         model = model,            # Model type
         periodicity = (false, false, false),
         boundary = ((1, 1), (1, 1), (1, 1)),   # Set all boundaries to solid walls
@@ -281,10 +274,17 @@ function main()
 
     ## Assign configurations so they can be passed to the `invoke!` function
     driver_config = config_densitycurrent(FT, N, resolution, xmax, ymax, zmax)
+
+    ## Choose an Explicit Single-rate Solver LSRK144 from the existing [ODESolvers](@ref
+    ## ODESolvers-docs) options Apply the outer constructor to define the
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFL,
     )

--- a/tutorials/Atmos/risingbubble.jl
+++ b/tutorials/Atmos/risingbubble.jl
@@ -187,26 +187,6 @@ function config_risingbubble(
     ymax,
     zmax,
 ) where {FT}
-
-    ## Choose an Explicit Single-rate Solver from the existing [`ODESolvers`](@ref ClimateMachine.ODESolvers) options.
-    ## Apply the outer constructor to define the `ode_solver`.
-    ## The 1D-IMEX method is less appropriate for the problem given the current
-    ## mesh aspect ratio (1:1).
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    )
-    ## If the user prefers a multi-rate explicit time integrator,
-    ## the ode_solver above can be replaced with
-    ##
-    ## `ode_solver = ClimateMachine.MultirateSolverType(
-    ##    fast_model = AtmosAcousticGravityLinearModel,
-    ##    slow_method = LSRK144NiegemannDiehlBusch,
-    ##    fast_method = LSRK144NiegemannDiehlBusch,
-    ##    timestep_ratio = 10,
-    ## )`
-    ## See [ODESolvers](@ref ODESolvers-docs) for all of the available solvers.
-
-
     ## Since we want four tracers, we specify this and include the appropriate
     ## diffusivity scaling coefficients (normally these would be physically
     ## informed but for this demonstration we use integers corresponding to the
@@ -252,7 +232,6 @@ function config_risingbubble(
         zmax,                    ## Domain maximum size [m]
         param_set,               ## Parameter set.
         init_risingbubble!,      ## Function specifying initial condition
-        solver_type = ode_solver,## Time-integrator type
         model = model,           ## Model type
     )
     return config
@@ -303,10 +282,30 @@ function main()
 
     ## Assign configurations so they can be passed to the `invoke!` function
     driver_config = config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
+
+    ## Choose an Explicit Single-rate Solver from the existing [`ODESolvers`](@ref ClimateMachine.ODESolvers) options.
+    ## Apply the outer constructor to define the `ode_solver`.
+    ## The 1D-IMEX method is less appropriate for the problem given the current
+    ## mesh aspect ratio (1:1).
+    ode_solver_type = ClimateMachine.ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    )
+    ## If the user prefers a multi-rate explicit time integrator,
+    ## the ode_solver above can be replaced with
+    ##
+    ## `ode_solver = ClimateMachine.MultirateSolverType(
+    ##    fast_model = AtmosAcousticGravityLinearModel,
+    ##    slow_method = LSRK144NiegemannDiehlBusch,
+    ##    fast_method = LSRK144NiegemannDiehlBusch,
+    ##    timestep_ratio = 10,
+    ## )`
+    ## See [ODESolvers](@ref ODESolvers-docs) for all of the available solvers.
+
     solver_config = ClimateMachine.SolverConfiguration(
         t0,
         timeend,
         driver_config,
+        ode_solver_type = ode_solver_type,
         init_on_cpu = true,
         Courant_number = CFL,
     )

--- a/tutorials/Numerics/TimeStepping/tutorial_acousticwave_config.jl
+++ b/tutorials/Numerics/TimeStepping/tutorial_acousticwave_config.jl
@@ -60,7 +60,7 @@ function (setup::AcousticWaveSetup)(problem, bl, state, aux, localgeo, t)
 end
 
 function run_acousticwave(
-    ode_solver,
+    ode_solver_type,
     CFL::FT,
     CFL_direction,
     timeend::FT,
@@ -100,7 +100,6 @@ function run_acousticwave(
         setup.domain_height,
         param_set,
         setup;
-        solver_type = ode_solver,
         model = model,
     )
 
@@ -110,7 +109,7 @@ function run_acousticwave(
         driver_config,
         Courant_number = CFL,
         init_on_cpu = true,
-        ode_solver_type = ode_solver,
+        ode_solver_type = ode_solver_type,
         CFL_direction = CFL_direction,
     )
 

--- a/tutorials/Numerics/TimeStepping/tutorial_risingbubble_config.jl
+++ b/tutorials/Numerics/TimeStepping/tutorial_risingbubble_config.jl
@@ -187,26 +187,6 @@ function config_risingbubble(
     ymax,
     zmax,
 ) where {FT}
-
-    ## Choose an Explicit Single-rate Solver from the existing [`ODESolvers`](@ref ClimateMachine.ODESolvers) options.
-    ## Apply the outer constructor to define the `ode_solver`.
-    ## The 1D-IMEX method is less appropriate for the problem given the current
-    ## mesh aspect ratio (1:1).
-    ode_solver = ClimateMachine.ExplicitSolverType(
-        solver_method = LSRK144NiegemannDiehlBusch,
-    )
-    ## If the user prefers a multi-rate explicit time integrator,
-    ## the ode_solver above can be replaced with
-    ##
-    ## `ode_solver = ClimateMachine.MultirateSolverType(
-    ##    fast_model = AtmosAcousticGravityLinearModel,
-    ##    slow_method = LSRK144NiegemannDiehlBusch,
-    ##    fast_method = LSRK144NiegemannDiehlBusch,
-    ##    timestep_ratio = 10,
-    ## )`
-    ## See [ODESolvers](@ref ODESolvers-docs) for all of the available solvers.
-
-
     ## Since we want four tracers, we specify this and include the appropriate
     ## diffusivity scaling coefficients (normally these would be physically
     ## informed but for this demonstration we use integers corresponding to the
@@ -252,7 +232,6 @@ function config_risingbubble(
         zmax,                    ## Domain maximum size [m]
         param_set,               ## Parameter set.
         init_risingbubble!,      ## Function specifying initial condition
-        ## solver_type = ode_solver,## Time-integrator type
         model = model,           ## Model type
     )
     return config
@@ -274,7 +253,7 @@ function config_diagnostics(driver_config)
     return ClimateMachine.DiagnosticsConfiguration([dgngrp])
 end
 
-function run_simulation(ode_solver, CFL::FT, timeend::FT) where {FT}
+function run_simulation(ode_solver_type, CFL::FT, timeend::FT) where {FT}
 
     ## We need to specify the polynomial order for the DG discretization,
     ## effective resolution, simulation end-time, the domain bounds, and the
@@ -302,7 +281,7 @@ function run_simulation(ode_solver, CFL::FT, timeend::FT) where {FT}
         driver_config,
         init_on_cpu = true,
         Courant_number = CFL,
-        ode_solver_type = ode_solver,
+        ode_solver_type = ode_solver_type,
     )
     dgn_config = config_diagnostics(driver_config)
     @show solver_config.ode_solver_type


### PR DESCRIPTION
### Description

This PR moves `solver_type` from `DriverConfiguration` to `SolverConfiguration`.

There are two reasons why this seems to be a good idea. 

 - `solver_type` seems like it belongs in `SolverConfiguration` to begin with 
 - `solver_type` is not used in any of the `DriverConfiguration` constructors, however, it _is_ used in the `SolverConfiguration` constructor
 - It can make certain solver configurations difficult to construct (see #1985)

Closes #1985.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
