### PR TITLE
Add single tutorial mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ docs/build/
 docs/site/
 docs/src/tutorials/
 docs/src/generated/
+docs/transient_dir/generated/
 !docs/src/assets/*.png
 !docs/src/assets/*.svg
 

--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -102,6 +102,11 @@ if generate_tutorials
 
     # Prepend tutorials_dir
     tutorials_jl = flatten_to_array_of_strings(get_second(tutorials))
+    if run_single_tutorial
+        tutorials_jl =
+            filter(x -> occursin(tutorial_string_match, x), tutorials_jl)
+        tutorials = ["Single tutorial mode" => tutorials_jl[1]]
+    end
     println("Building literate tutorials...")
 
     @everywhere function generate_tutorial(tutorials_dir, tutorial)


### PR DESCRIPTION
### Description

This PR adds a hack in the tutorials so that we can flip a switch (`run_single_tutorial`) to run single tutorials without executing all of the other tutorials / documentation. This is quite a bit of a hack, but it does significantly reduce the single tutorial generation time:

```julia
include("docs/make.jl") # compile first, takes ~ 70 seconds
...
@time include("docs/make.jl")
....
1.310631 seconds (2.47 M allocations: 139.898 MiB, 2.17% gc time)
```

This may help alleviate tutorial development pain until Documenter.jl offers a way to build a single doc page--I don't see an open issue, but I also don't see this feature anywhere in the docs.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
