### PR TITLE
Move ocean domains & fields to utilities

### DIFF
--- a/docs/list_of_apis.jl
+++ b/docs/list_of_apis.jl
@@ -25,6 +25,8 @@ apis = [
     ],
     "Common" => [
         "Orientations" => "APIs/Common/Orientations.md",
+        "Cartesian Domains" => "APIs/Common/CartesianDomains.md",
+        "Cartesian Fields" => "APIs/Common/CartesianFields.md",
         "Spectra" => "APIs/Common/Spectra.md",
         "Surface Fluxes" => "APIs/Common/SurfaceFluxes.md",
         "Thermodynamics" => "APIs/Common/Thermodynamics.md",

--- a/docs/src/APIs/Common/CartesianDomains.md
+++ b/docs/src/APIs/Common/CartesianDomains.md
@@ -1,0 +1,9 @@
+# Cartesian Domains
+
+```@meta
+CurrentModule = ClimateMachine.CartesianDomains
+```
+
+```@docs
+RectangularDomain
+```

--- a/docs/src/APIs/Common/CartesianFields.md
+++ b/docs/src/APIs/Common/CartesianFields.md
@@ -1,0 +1,11 @@
+# Cartesian Fields
+
+```@meta
+CurrentModule = ClimateMachine.CartesianFields
+```
+
+```@docs
+SpectralElementField
+RectangularElement
+assemble
+```

--- a/docs/src/APIs/Ocean/Ocean.md
+++ b/docs/src/APIs/Ocean/Ocean.md
@@ -74,24 +74,6 @@ JLD2Writer
 ```
 
 ```@meta
-CurrentModule = ClimateMachine.Ocean.Domains
-```
-
-```@docs
-RectangularDomain
-```
-
-```@meta
-CurrentModule = ClimateMachine.Ocean.Fields
-```
-
-```@docs
-SpectralElementField
-RectangularElement
-assemble
-```
-
-```@meta
 CurrentModule = ClimateMachine.Ocean.SplitExplicit01
 ```
 

--- a/src/ClimateMachine.jl
+++ b/src/ClimateMachine.jl
@@ -27,6 +27,8 @@ include(joinpath(
 include(joinpath("Common", "SurfaceFluxes", "SurfaceFluxes.jl"))
 include(joinpath("Arrays", "MPIStateArrays.jl"))
 include(joinpath("Numerics", "Mesh", "Mesh.jl"))
+include(joinpath("Common", "CartesianDomains", "CartesianDomains.jl"))
+include(joinpath("Common", "CartesianFields", "CartesianFields.jl"))
 include(joinpath("Numerics", "DGMethods", "Courant.jl"))
 include(joinpath("BalanceLaws", "Problems.jl"))
 include(joinpath("BalanceLaws", "BalanceLaws.jl"))

--- a/src/Common/CartesianDomains/CartesianDomains.jl
+++ b/src/Common/CartesianDomains/CartesianDomains.jl
@@ -1,4 +1,4 @@
-module Domains
+module CartesianDomains
 
 export RectangularDomain
 

--- a/src/Common/CartesianDomains/rectangular_domain.jl
+++ b/src/Common/CartesianDomains/rectangular_domain.jl
@@ -1,10 +1,8 @@
 using MPI
 
-using ClimateMachine: Settings
+using ..Mesh.Topologies: StackedBrickTopology
 
-using ClimateMachine.Mesh.Topologies: StackedBrickTopology
-
-import ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
+import ..Mesh.Grids: DiscontinuousSpectralElementGrid
 
 #####
 ##### RectangularDomain
@@ -116,13 +114,12 @@ function RectangularDomain(
     )
 end
 
-array_type(domain::RectangularDomain) = Settings.array_type
 eltype(::RectangularDomain{FT}) where {FT} = FT
 
 function DiscontinuousSpectralElementGrid(
     domain::RectangularDomain{FT};
     boundary_tags = ((0, 0), (0, 0), (1, 2)),
-    array_type = Settings.array_type,
+    array_type,
     mpicomm = MPI.COMM_WORLD,
 ) where {FT}
 

--- a/src/Common/CartesianFields/CartesianFields.jl
+++ b/src/Common/CartesianFields/CartesianFields.jl
@@ -1,13 +1,13 @@
-module Fields
+module CartesianFields
 
 export SpectralElementField, assemble, data
 
 using CUDA
 using Printf
 
-using ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
-using ClimateMachine.MPIStateArrays: MPIStateArray
-using ..Domains: AbstractDomain
+using ..Mesh.Grids: DiscontinuousSpectralElementGrid
+using ..MPIStateArrays: MPIStateArray
+using ..CartesianDomains: AbstractDomain
 
 #####
 ##### SpectralElementField

--- a/src/Common/CartesianFields/rectangular_element.jl
+++ b/src/Common/CartesianFields/rectangular_element.jl
@@ -1,4 +1,4 @@
-using ..Domains: RectangularDomain
+using ..CartesianDomains: RectangularDomain
 
 #####
 ##### RectangularElement

--- a/src/Common/CartesianFields/rectangular_spectral_element_fields.jl
+++ b/src/Common/CartesianFields/rectangular_spectral_element_fields.jl
@@ -1,4 +1,4 @@
-using ..Domains: RectangularDomain
+using ..CartesianDomains: RectangularDomain
 
 """ Like a linear index... """
 function linear_coordinate(elem, domain, cpu_x, cpu_y, cpu_z)

--- a/src/Ocean/JLD2Writer.jl
+++ b/src/Ocean/JLD2Writer.jl
@@ -2,9 +2,9 @@ module JLD2Writers
 
 using JLD2
 
-using ClimateMachine.Ocean.Domains: DiscontinuousSpectralElementGrid
-using ClimateMachine.Ocean: current_step, current_time
-using ..Fields: SpectralElementField
+using ..CartesianDomains: DiscontinuousSpectralElementGrid
+using ..Ocean: current_step, current_time
+using ..CartesianFields: SpectralElementField
 
 struct JLD2Writer{A, F, M, O}
     filepath::F

--- a/src/Ocean/Ocean.jl
+++ b/src/Ocean/Ocean.jl
@@ -1,6 +1,8 @@
 module Ocean
 
 using ..BalanceLaws
+using ..CartesianDomains
+using ..CartesianFields
 using ..Problems
 
 export AbstractOceanModel,
@@ -29,9 +31,6 @@ function ocean_boundary_state! end
 function coriolis_parameter end
 function kinematic_stress end
 function surface_flux end
-
-include(joinpath("Domains", "Domains.jl"))
-include(joinpath("Fields", "Fields.jl"))
 
 include("OceanBC.jl")
 

--- a/src/Ocean/SuperModels.jl
+++ b/src/Ocean/SuperModels.jl
@@ -13,9 +13,8 @@ using ..HydrostaticBoussinesq:
     HydrostaticBoussinesqModel, NonLinearAdvectionTerm, Forcing
 
 using ..OceanProblems: InitialValueProblem, InitialConditions
-using ..Domains: array_type
 using ..Ocean: FreeSlip, Impenetrable, Insulating, OceanBC, Penetrable
-using ..Ocean.Fields: SpectralElementField
+using ..CartesianFields: SpectralElementField
 
 using ...Mesh.Filters: CutoffFilter, ExponentialFilter
 using ...Mesh.Grids: polynomialorders, DiscontinuousSpectralElementGrid

--- a/test/Common/CartesianDomains/runtests.jl
+++ b/test/Common/CartesianDomains/runtests.jl
@@ -2,9 +2,9 @@ using ClimateMachine
 
 ClimateMachine.init()
 
-using ClimateMachine.Ocean.Domains
+using ClimateMachine.CartesianDomains
 
-@testset "$(@__FILE__)" begin
+@testset "Cartesian domains" begin
 
     for FT in (Float64, Float32)
         domain = RectangularDomain(

--- a/test/Common/CartesianFields/runtests.jl
+++ b/test/Common/CartesianFields/runtests.jl
@@ -2,9 +2,9 @@ using ClimateMachine
 
 ClimateMachine.init()
 
-using ClimateMachine.Ocean.Fields: RectangularElement, assemble
+using ClimateMachine.CartesianFields: RectangularElement, assemble
 
-@testset "$(@__FILE__)" begin
+@testset "Cartesian fields" begin
 
     Nx = 3
     Ny = 4

--- a/test/Common/runtests.jl
+++ b/test/Common/runtests.jl
@@ -2,7 +2,12 @@ using Test, Pkg
 
 @testset "Common" begin
     all_tests = isempty(ARGS) || "all" in ARGS ? true : false
-    for submodule in ["Thermodynamics", "SurfaceFluxes"]
+    for submodule in [
+        "Thermodynamics",
+        "SurfaceFluxes",
+        "CartesianDomains",
+        "CartesianFields",
+    ]
         if all_tests ||
            "$submodule" in ARGS ||
            "Common/$submodule" in ARGS ||

--- a/test/Ocean/HydrostaticBoussinesqModel/test_hydrostatic_boussinesq_model.jl
+++ b/test/Ocean/HydrostaticBoussinesqModel/test_hydrostatic_boussinesq_model.jl
@@ -2,7 +2,7 @@ using ClimateMachine
 
 ClimateMachine.init()
 
-using ClimateMachine.Ocean.Domains
+using ClimateMachine.CartesianDomains
 
 using CLIMAParameters: AbstractEarthParameterSet
 struct DefaultParameters <: AbstractEarthParameterSet end

--- a/test/Ocean/runtests.jl
+++ b/test/Ocean/runtests.jl
@@ -6,8 +6,6 @@ include("../testhelpers.jl")
     runmpi(joinpath(@__DIR__, "HydrostaticBoussinesq/test_ocean_gyre_short.jl"))
     runmpi(joinpath(@__DIR__, "SplitExplicit/test_spindown_short.jl"))
     include(joinpath("OceanProblems", "test_initial_value_problem.jl"))
-    include(joinpath("Domains", "test_rectangular_domain.jl"))
-    include(joinpath("Fields", "test_rectangular_element.jl"))
     include(joinpath(
         "HydrostaticBoussinesqModel",
         "test_hydrostatic_boussinesq_model.jl",

--- a/tutorials/Ocean/geostrophic_adjustment.jl
+++ b/tutorials/Ocean/geostrophic_adjustment.jl
@@ -16,7 +16,7 @@ ClimateMachine.init()
 # deep, and discretized on a grid with 100 fourth-order elements in ``x``, and 1
 # fourth-order element in ``y, z``,
 
-using ClimateMachine.Ocean.Domains
+using ClimateMachine.CartesianDomains
 
 domain = RectangularDomain(
     Ne = (25, 1, 1),
@@ -147,7 +147,7 @@ nothing
 using Printf
 using Plots
 using ClimateMachine.GenericCallbacks: EveryXSimulationSteps
-using ClimateMachine.Ocean.Fields: assemble
+using ClimateMachine.CartesianFields: assemble
 using ClimateMachine.Ocean: current_step, current_time
 
 u, v, η, θ = model.fields

--- a/tutorials/Ocean/internal_wave.jl
+++ b/tutorials/Ocean/internal_wave.jl
@@ -14,7 +14,7 @@ ClimateMachine.init()
 #
 # We formulate a non-dimension problem in a Cartesian domain with oceanic anisotropy,
 
-using ClimateMachine.Ocean.Domains
+using ClimateMachine.CartesianDomains
 
 domain = RectangularDomain(
     Ne = (32, 1, 4),
@@ -118,7 +118,7 @@ nothing
 # cache the horizontal velocity ``u`` at periodic intervals:
 
 using ClimateMachine.Ocean: current_time
-using ClimateMachine.Ocean.Fields: assemble
+using ClimateMachine.CartesianFields: assemble
 using ClimateMachine.GenericCallbacks: EveryXSimulationTime
 
 fetched_states = []

--- a/tutorials/Ocean/shear_instability.jl
+++ b/tutorials/Ocean/shear_instability.jl
@@ -12,8 +12,8 @@ ClimateMachine.init()
 ClimateMachine.Settings.array_type = Array
 
 using ClimateMachine.Ocean
-using ClimateMachine.Ocean.Domains
-using ClimateMachine.Ocean.Fields
+using ClimateMachine.CartesianDomains
+using ClimateMachine.CartesianFields
 
 using ClimateMachine.GenericCallbacks: EveryXSimulationTime
 using ClimateMachine.Ocean: current_step, Δt, current_time


### PR DESCRIPTION
### Description

This PR moves/renames the ocean
 - Domains to `Utilities/CartesianDomains` and 
 - Fields to `Utilities/CartesianFields`

In hopes that we can share more of this functionality across more physics components.

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
