### PR TITLE
Improve tips for doc string debbugging

### DIFF
--- a/.github/workflows/doc_build_common_error_messages.md
+++ b/.github/workflows/doc_build_common_error_messages.md
@@ -40,3 +40,7 @@
 ```
  - `ClimateMachine.Atmos.AtmosModel.NoOrientation` should be `ClimateMachine.Atmos.NoOrientation`
 
+## Other useful tips
+- The syntax is white space sensitive: Do not leave any extra new line between the end of the doc string (denoted by triple double-quotes `"""`) and the code of the defined method / type / module name that you are describing.
+- In the doc string, indent the method / type / module signature and do not indent the descriptive text.
+- Any method name and the corresponding signature in the doc string have to match 1:1 (be careful of missing/extra exclamation points `!`)


### PR DESCRIPTION
### Description

@charleskawczynski  here are some additional useful tips that I found myself discovering when debugging doc strings for potential warnings/errors in `Documenter.jl`. Hopefully, they can help others, too.

<!-- Provide a clear description of the content -->

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
