### PR TITLE
Add show method for Vars and Grad

### DIFF
--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -463,4 +463,14 @@ Base.@propagate_inbounds Base.getindex(v::AbstractVars, tup_chain::Tuple) =
 
 include("flattened_tup_chain.jl")
 
+function Base.show(io::IO, v::AbstractVars)
+    s = "$(nameof(typeof(v))) object:\n"
+    for tup in flattened_tup_chain(v, RetainArr())
+        name = join(tup, "_")
+        val = getproperty(v, wrap_val.(tup))
+        s *= "    $name = $val\n"
+    end
+    print(io, s)
+end
+
 end # module

--- a/test/Utilities/VariableTemplates/test_complex_models.jl
+++ b/test/Utilities/VariableTemplates/test_complex_models.jl
@@ -1,5 +1,6 @@
 using Test
 using StaticArrays
+using Printf
 using ClimateMachine.VariableTemplates
 using ClimateMachine.VariableTemplates: wrap_val
 import ClimateMachine.VariableTemplates
@@ -346,5 +347,9 @@ VT = VariableTemplates
     @test fnt.nest_tt_1 == Foo()
     @test fnt.nest_tt_2 == Foo()
     @test fnt.nest_t == Foo()
+
+    # Test that show doesn't break
+    sprint(show, v)
+    sprint(show, vg)
 
 end


### PR DESCRIPTION
### Description

This PR defines `Base.show` for `Vars`/`Grad`. Demo in the test suite:

```julia
v = Vars object:
    ntuple_model_1_scalar_model_x = 1.0
    ntuple_model_1_vector_model_x = Float32[2.0, 3.0, 4.0]
    ntuple_model_2_scalar_model_x = 5.0
    ntuple_model_2_vector_model_x = Float32[6.0, 7.0, 8.0]
    ntuple_model_3_scalar_model_x = 9.0
    ntuple_model_3_vector_model_x = Float32[10.0, 11.0, 12.0]
    ntuple_model_4_scalar_model_x = 13.0
    ntuple_model_4_vector_model_x = Float32[14.0, 15.0, 16.0]
    ntuple_model_5_scalar_model_x = 17.0
    ntuple_model_5_vector_model_x = Float32[18.0, 19.0, 20.0]
    vector_model_x = Float32[21.0, 22.0, 23.0]
    scalar_model_x = 24.0

vg = Grad object:
    a_1_x = [1, 1, 1]
    a_2_x = [2, 2, 2]
```

<!-- Check all the boxes below before taking the PR out of draft -->

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
