### PR TITLE
fix edmf bc issue

### DIFF
--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -13,17 +13,17 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Bomex.nc"), "r")
 
 #! format: off
 best_mse = OrderedDict()
-best_mse["prog_ρ"] = 3.4917662870525452e-02
-best_mse["prog_ρu_1"] = 3.0715053983126868e+03
-best_mse["prog_ρu_2"] = 1.2895738234435595e-03
-best_mse["prog_moisture_ρq_tot"] = 4.1331426262587470e-02
-best_mse["prog_turbconv_environment_ρatke"] = 6.7642719033845833e+02
+best_mse["prog_ρ"] = 3.4917662870524578e-02
+best_mse["prog_ρu_1"] = 3.0715053983126872e+03
+best_mse["prog_ρu_2"] = 1.2895738234435571e-03
+best_mse["prog_moisture_ρq_tot"] = 4.1331426262589094e-02
+best_mse["prog_turbconv_environment_ρatke"] = 6.7642719033564128e+02
 best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.5667226792770009e+01
-best_mse["prog_turbconv_environment_ρaq_tot_cv"] = 1.6435640302009438e+02
-best_mse["prog_turbconv_updraft_1_ρa"] = 8.0846149716812874e+01
-best_mse["prog_turbconv_updraft_1_ρaw"] = 8.5071202823418249e-02
-best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 9.0386633006301569e+00
-best_mse["prog_turbconv_updraft_1_ρaq_tot"] = 1.0803376910477068e+01
+best_mse["prog_turbconv_environment_ρaq_tot_cv"] = 1.6435640302009364e+02
+best_mse["prog_turbconv_updraft_1_ρa"] = 8.0846149716813400e+01
+best_mse["prog_turbconv_updraft_1_ρaw"] = 8.5071202823418957e-02
+best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 9.0386633006301693e+00
+best_mse["prog_turbconv_updraft_1_ρaq_tot"] = 1.0803376910477082e+01
 #! format: on
 
 computed_mse = compute_mse(

--- a/test/Atmos/EDMF/report_mse_sbl_coupled_edmf_an1d.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_coupled_edmf_an1d.jl
@@ -18,7 +18,7 @@ best_mse["prog_ρu_1"] = 6.7772082190344045e+03
 best_mse["prog_ρu_2"] = 9.5955265720838456e-01
 best_mse["prog_turbconv_environment_ρatke"] = 4.1227365663893136e+02
 best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.1270480544027635e+01
-best_mse["prog_turbconv_updraft_1_ρa"] = 2.7223013859891103e+02
+best_mse["prog_turbconv_updraft_1_ρa"] = 2.7223017351724246e+02
 best_mse["prog_turbconv_updraft_1_ρaw"] = 5.5909371368198686e+02
 best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 2.7933498788454813e+02
 #! format: on

--- a/test/Atmos/EDMF/report_mse_sbl_coupled_edmf_an1d.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_coupled_edmf_an1d.jl
@@ -14,11 +14,11 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
 #! format: off
 best_mse = OrderedDict()
 best_mse["prog_ρ"] = 9.3808122133551899e-03
-best_mse["prog_ρu_1"] = 6.7648718002912910e+03
-best_mse["prog_ρu_2"] = 8.9568591962189448e-01
-best_mse["prog_turbconv_environment_ρatke"] = 3.9877808420252154e+02
-best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.1270320241616531e+01
-best_mse["prog_turbconv_updraft_1_ρa"] = 2.7223017351724246e+02
+best_mse["prog_ρu_1"] = 6.7772082190344045e+03
+best_mse["prog_ρu_2"] = 9.5955265720838456e-01
+best_mse["prog_turbconv_environment_ρatke"] = 4.1227365663893136e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.1270480544027635e+01
+best_mse["prog_turbconv_updraft_1_ρa"] = 2.7223013859891103e+02
 best_mse["prog_turbconv_updraft_1_ρaw"] = 5.5909371368198686e+02
 best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 2.7933498788454813e+02
 #! format: on


### PR DESCRIPTION
This PR adds to the prescribed temperature BC the sum of RHS second order fluxes to fluxᵀn, located at the state⁺ level, to match the fluxes at the state⁻ level so that the flux divergence will be zero. This addition was done before only for turbulence model. 

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
