### PR TITLE
Update prescribed flux BC for general n^

### DIFF
--- a/src/Land/Model/RadiativeEnergyFlux.jl
+++ b/src/Land/Model/RadiativeEnergyFlux.jl
@@ -21,6 +21,7 @@ Structure which contains functions for shortwave albedo and
 shortwave fluxes. They are user-defined, constant across the domain
 and can be a function of time.
 
+All fluxes are assumed to be normal to the surface.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
@@ -45,6 +46,7 @@ end
 Structure which contains net shortwave flux values. The function is
 user-defined, constant across the domain and can be a function of time.
 
+All fluxes are assumed to be normal to the surface.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
@@ -65,7 +67,7 @@ end
         t::Real,
     ) where {FT}
 
-Computes the net shortwave flux as a function of time.
+Computes the net shortwave flux magnitude as a function of time.
 """
 function compute_net_sw_flux(
     nswf_model::PrescribedSwFluxAndAlbedo{FT},
@@ -81,7 +83,7 @@ end
         t::Real
     ) where {FT}
 
-Computes the net shortwave flux as a function of time.
+Computes the net shortwave flux magnitude as a function of time.
 """
 function compute_net_sw_flux(
     nswf_model::PrescribedNetSwFlux{FT},
@@ -97,8 +99,11 @@ end
         t::Real
     )
 
-Returns the net radiative energy flux as a function of time. Will
+Returns the net radiative energy flux magnitude as a function of time. Will
 include long wave fluxes in future version.
+
+The flux vector is this magnitude * -n̂, where n̂ is the normal vector pointing out
+of the domain at the surface.
 """
 function compute_net_radiative_energy_flux(
     nswf_model::AbstractNetSwFluxModel{FT},

--- a/src/Land/Model/land_bc.jl
+++ b/src/Land/Model/land_bc.jl
@@ -39,13 +39,17 @@ end
 """
     Neumann{Ff} <: AbstractBoundaryConditions
 
-A concrete type to hold the diffusive flux 
-function, if Neumann boundary conditions are desired.
+A concrete type for specifying the magnitude of an inward diffusive flux,
+normal to the domain boundary, from which a Neumann boundary condition 
+is determined and applied.
 
-Note that these are intended to be scalar values. In the boundary_state!
-functions, they are multiplied by the `ẑ` vector (i.e. the normal vector `n̂`
-to the domain at the upper boundary, and -`n̂` at the lower boundary. These
-normal vectors point out of the domain.)
+For the soil water model, the Darcy flux is defined as F⃗(Darcy) = -K∇h. 
+With the `Neumann` boundary
+condition type, the user supplies a scalar `f` such that the applied flux
+boundary conditon is F⃗(Darcy, boundary) = -f n̂, 
+where n̂ is the normal vector pointing out of the domain. For the soil heat model,
+the same rule applies, except now we have a conductive heat flux 
+F⃗(Conductive, boundary) = -κ∇T = -f n̂.
 
 # Fields
 $(DocStringExtensions.FIELDS)
@@ -59,8 +63,14 @@ end
     SurfaceDrivenWaterBoundaryConditions{FT, PD, RD} <: AbstractBoundaryConditions
 
 Boundary condition type to be used when the user wishes to 
-apply physical fluxes of water at the top of the domain (according to precipitation, runoff, and 
-evaporation rates).
+apply physical fluxes of water at the top of the domain, normal to the surface.
+The flux can be inwards or outwards, depending on the magnitude of infiltration,
+evaporation, and precipitation.
+
+Precipitation is assumed to be 
+in the ẑ direction, P⃗ = Pẑ, while evaporation is along the normal 
+direction, E⃗ = En̂. The applied boundary flux is F⃗ = f n̂, and the magnitude f is
+determined internally from P⃗, E⃗, and soil conditions.
 
 # Fields
 $(DocStringExtensions.FIELDS)
@@ -98,7 +108,7 @@ end
     SurfaceDrivenHeatBoundaryConditions{FT, SWD} <: AbstractBoundaryConditions
 
 Boundary condition type to be used when the user wishes to 
-apply physical fluxes of heat at the top of the domain 
+apply normal fluxes of heat at the top of the domain 
 (according to radiative energy fluxes).
 
 # Fields

--- a/src/Land/Model/soil_bc.jl
+++ b/src/Land/Model/soil_bc.jl
@@ -156,14 +156,10 @@ function soil_boundary_flux!(
     _...,
 )
     bc_function = bc.scalar_flux_bc
-    # on faces at the top and bottom of the domain,
-    # the vector n̂ can point in either ± ẑ, depending on which side of the domain
-    # we are on. The user supplies a scalar flux F, such that the flux at the boundary
-    # is assumed to be F⃗ = F ẑ - i.e. the user doesn't need to worry about the normal vector.
-    # so, we take the absolute value of n̂ here.
-    # The minus sign is because the condition is applied on minus the flux.
-    # the same argument applies for the other directions.
-    diff⁺.soil.water.K∇h = abs.(n̂) * (-bc_function(aux⁻, t))
+    # See documentation for `Neumann`. The user supplies f = scalar_flux_bc
+    # such that F⃗ = -K∇h = -f n̂. 
+    # Since the BC is on K∇h, no minus sign is needed.
+    diff⁺.soil.water.K∇h = n̂ * bc_function(aux⁻, t)
 end
 
 
@@ -202,14 +198,10 @@ function soil_boundary_flux!(
     _...,
 )
     bc_function = bc.scalar_flux_bc
-    # on faces at the top and bottom of the domain,
-    # the vector n̂ can point in either ± ẑ, depending on which side of the domain
-    # we are on. The user supplies a scalar flux F, such that the flux at the boundary
-    # is assumed to be F⃗ = F ẑ - i.e. the user doesn't need to worry about the normal vector.
-    # so, we take the absolute value of n̂ here.
-    # The minus sign is because the condition is applied on minus the flux.
-    # the same argument applies for the other directions.
-    diff⁺.soil.heat.κ∇T = abs.(n̂) * (-bc_function(aux⁻, t))
+    # See documentation for `Neumann`. The user supplies f = scalar_flux_bc
+    # such that F⃗ = -κ∇T = -f n̂. 
+    # Since the BC is on κ∇T, no minus sign is needed.
+    diff⁺.soil.heat.κ∇T = n̂ * bc_function(aux⁻, t)
 end
 
 

--- a/test/Land/Model/runtests.jl
+++ b/test/Land/Model/runtests.jl
@@ -6,4 +6,5 @@ using Test, Pkg
     include("freeze_thaw_alone.jl")
     include("test_overland_flow_analytic.jl")
     include("test_physical_bc.jl")
+    include("test_radiative_energy_flux_functions.jl")
 end

--- a/test/Land/Model/test_radiative_energy_flux_functions.jl
+++ b/test/Land/Model/test_radiative_energy_flux_functions.jl
@@ -79,7 +79,8 @@ end
     end
 
 
-    soil_param_functions = SoilParamFunctions{FT}(
+    soil_param_functions = SoilParamFunctions(
+        FT;
         porosity = 0.4,
         ν_ss_gravel = 0.2,
         ν_ss_om = 0.2,

--- a/tutorials/Land/Soil/PhaseChange/freezing_front.jl
+++ b/tutorials/Land/Soil/PhaseChange/freezing_front.jl
@@ -178,10 +178,13 @@ soil_param_functions = SoilParamFunctions(
 # Initial and Boundary conditions. The default initial condition for
 # `θ_i` is zero everywhere, so we don't modify that. Furthermore, since
 # the equation for `θ_i` does not involve spatial derivatives, we don't need
-# to supply boundary conditions for it.
+# to supply boundary conditions for it. Note that Neumann fluxes, when chosen,
+# are specified by giving the magnitude of the normal flux *into* the domain.
+# In this case, the normal vector at the surface n̂ = ẑ. Internally, we multiply
+# the flux magnitude by -n̂.
 zero_flux = (aux, t) -> eltype(aux)(0.0)
 surface_heat_flux =
-    (aux, t) -> eltype(aux)(28) * (aux.soil.heat.T - eltype(aux)(273.15 - 6))
+    (aux, t) -> eltype(aux)(-28) * (aux.soil.heat.T - eltype(aux)(273.15 - 6))
 T_init = aux -> eltype(aux)(279.85)
 ϑ_l0 = (aux) -> eltype(aux)(0.33);
 


### PR DESCRIPTION
### Description
When we started the soil model, we were only considering flat single column domains. We specified Neumann fluxes by giving a scalar (magnitude of flux) at the top and bottom of the domain, and internally multiplying that by the normal vector (at the top) or minus the normal vector (at the bottom), so that, in effect, the user was specifying F = fz^ and giving f. Because we did not have any mesh warping or topography, n^ = z^ at the top, and -z^ at the bottom.

We're now dealing with topography, so we have to change the language/convention. Following atmos, Precribed fluxes are given as a scalar and then internally multiplied by -n^, so the user is specifying an inward normal flux magnitude. 

For precipitation, we assume it is aligned with the z axis, so we need to project onto the normal vector when applying a normal flux (Runoff.jl). For now, we assume radiation is normal to the surface as well, but that may have to change (depending on how/where we handle incident angles).

- [X] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
