### PR TITLE
Add a 2nd order bc for TKE in EDMF

### DIFF
--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -13,17 +13,17 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Bomex.nc"), "r")
 
 #! format: off
 best_mse = OrderedDict()
-best_mse["prog_ρ"] = 3.4917662870524578e-02
-best_mse["prog_ρu_1"] = 3.0715053983126872e+03
-best_mse["prog_ρu_2"] = 1.2895738234435571e-03
-best_mse["prog_moisture_ρq_tot"] = 4.1331426262589094e-02
-best_mse["prog_turbconv_environment_ρatke"] = 6.7642719033564128e+02
-best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.5667226792770009e+01
-best_mse["prog_turbconv_environment_ρaq_tot_cv"] = 1.6435640302009364e+02
-best_mse["prog_turbconv_updraft_1_ρa"] = 8.0846149716813400e+01
-best_mse["prog_turbconv_updraft_1_ρaw"] = 8.5071202823418957e-02
-best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 9.0386633006301693e+00
-best_mse["prog_turbconv_updraft_1_ρaq_tot"] = 1.0803376910477082e+01
+best_mse["prog_ρ"] = 3.4917662870525668e-02
+best_mse["prog_ρu_1"] = 3.0715053983126782e+03
+best_mse["prog_ρu_2"] = 1.2895738234436555e-03
+best_mse["prog_moisture_ρq_tot"] = 4.1331426262591536e-02
+best_mse["prog_turbconv_environment_ρatke"] = 6.6020991753440228e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.5667226927542870e+01
+best_mse["prog_turbconv_environment_ρaq_tot_cv"] = 1.6436482933117330e+02
+best_mse["prog_turbconv_updraft_1_ρa"] = 8.0846479787464091e+01
+best_mse["prog_turbconv_updraft_1_ρaw"] = 8.5071173291184049e-02
+best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 9.0386635282604715e+00
+best_mse["prog_turbconv_updraft_1_ρaq_tot"] = 1.0803377258213910e+01
 #! format: on
 
 computed_mse = compute_mse(

--- a/test/Atmos/EDMF/report_mse_sbl_coupled_edmf_an1d.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_coupled_edmf_an1d.jl
@@ -13,11 +13,11 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
 
 #! format: off
 best_mse = OrderedDict()
-best_mse["prog_ρ"] = 9.3808122133551899e-03
-best_mse["prog_ρu_1"] = 6.7772082190344045e+03
-best_mse["prog_ρu_2"] = 9.5955265720838456e-01
-best_mse["prog_turbconv_environment_ρatke"] = 4.1227365663893136e+02
-best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.1270480544027635e+01
+best_mse["prog_ρ"] = 9.3808142287632006e-03
+best_mse["prog_ρu_1"] = 6.7427140307178524e+03
+best_mse["prog_ρu_2"] = 7.2306841961112966e-01
+best_mse["prog_turbconv_environment_ρatke"] = 2.9810806322235749e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.1270487249851797e+01
 best_mse["prog_turbconv_updraft_1_ρa"] = 2.7223017351724246e+02
 best_mse["prog_turbconv_updraft_1_ρaw"] = 5.5909371368198686e+02
 best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 2.7933498788454813e+02

--- a/test/Atmos/EDMF/report_mse_sbl_edmf.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_edmf.jl
@@ -13,11 +13,11 @@ data_file = Dataset(joinpath(PyCLES_output_dataset_path, "Gabls.nc"), "r")
 
 #! format: off
 best_mse = OrderedDict()
-best_mse["prog_ρ"] = 6.8766006877255519e-03
-best_mse["prog_ρu_1"] = 6.2597055026242824e+03
-best_mse["prog_ρu_2"] = 1.3231034873190784e-04
-best_mse["prog_turbconv_environment_ρatke"] = 2.6066585472739206e+02
-best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.7727378309967946e+01
+best_mse["prog_ρ"] = 6.8041561724036673e-03
+best_mse["prog_ρu_1"] = 6.2586216904022822e+03
+best_mse["prog_ρu_2"] = 1.2965826326450741e-04
+best_mse["prog_turbconv_environment_ρatke"] = 4.9035225536000081e+02
+best_mse["prog_turbconv_environment_ρaθ_liq_cv"] = 8.7727377301948991e+01
 best_mse["prog_turbconv_updraft_1_ρa"] = 1.8213581913998944e+01
 best_mse["prog_turbconv_updraft_1_ρaw"] = 1.7800899665237452e-01
 best_mse["prog_turbconv_updraft_1_ρaθ_liq"] = 1.3358308964295857e+01


### PR DESCRIPTION
This PR adds a matching TKE flux at state⁺ to that in state⁻ for the TKE so that the TKE BC will have zero flux divergence and thus will prescribed a value of surface TKE as given by the EDMF model.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [X] Documentation has been added/updated OR N/A.
