### PR TITLE
Conformal cubed sphere unwarp

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -166,10 +166,10 @@ uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 version = "4.0.4"
 
 [[CubedSphere]]
-deps = ["Elliptic", "Printf", "Requires", "Rotations", "TaylorSeries", "Test"]
-git-tree-sha1 = "b7df0c21789cb6adf5f1e2eb7a52accae5b867f6"
+deps = ["Elliptic", "Printf", "Rotations", "TaylorSeries", "Test"]
+git-tree-sha1 = "f66fabd1ee5df59a7ba47c7873a6332c19e0c03f"
 uuid = "7445602f-e544-4518-8976-18f8e8ae6cdb"
-version = "0.1.0"
+version = "0.2.0"
 
 [[DataAPI]]
 git-tree-sha1 = "dfb3b7e89e395be1e25c2ad6d7690dc29cc53b1d"

--- a/docs/src/APIs/Numerics/Meshes/Mesh.md
+++ b/docs/src/APIs/Numerics/Meshes/Mesh.md
@@ -44,6 +44,7 @@ Topologies.equiangular_cubed_sphere_unwarp
 Topologies.equidistant_cubed_sphere_warp
 Topologies.equidistant_cubed_sphere_unwarp
 Topologies.conformal_cubed_sphere_warp
+Topologies.conformal_cubed_sphere_unwarp
 Topologies.hasboundary
 Topologies.compute_lat_long
 Topologies.cubed_sphere_topo_warp

--- a/test/Numerics/Mesh/topology.jl
+++ b/test/Numerics/Mesh/topology.jl
@@ -204,6 +204,28 @@ end
     end
 end
 
+@testset "Conformal cubed_sphere_unwarp tests" begin
+    import ClimateMachine.Mesh.Topologies:
+        conformal_cubed_sphere_warp, conformal_cubed_sphere_unwarp
+
+    # Create function aliases for shorter formatting
+    ccsw = conformal_cubed_sphere_warp
+    ccsu = conformal_cubed_sphere_unwarp
+
+    for u in permutations([3.0, 2.999999999, 1.3])
+        @test all(ccsu(ccsw(u...)...) .≈ u)
+    end
+    for u in permutations([3.0, -2.999999999, 1.3])
+        @test all(ccsu(ccsw(u...)...) .≈ u)
+    end
+    for u in permutations([-3.0, 2.999999999, 1.3])
+        @test all(ccsu(ccsw(u...)...) .≈ u)
+    end
+    for u in permutations([-3.0, -2.999999999, 1.3])
+        @test all(ccsu(ccsw(u...)...) .≈ u)
+    end
+end
+
 @testset "grid1d" begin
     g = grid1d(0, 10, nelem = 10)
     @test eltype(g) == Float64


### PR DESCRIPTION
### Description
This PR finally completes work started in PR #2205  for support of conformal cubed spheres. It adds the unwarp function that was needed for visualization purposes. Many thanks to @christophernhill for adding the [inverse bits](https://github.com/CliMA/CubedSphere.jl/blob/main/src/conformal_cubed_sphere.jl#L85) in the [CubedSphere.jl](https://github.com/CliMA/CubedSphere.jl/pull/11) package. 

All tests pass.

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
