### PR TITLE
src/Numerics/Mesh/Topologies.jl: Fix docstring

### DIFF
--- a/src/Numerics/Mesh/Topologies.jl
+++ b/src/Numerics/Mesh/Topologies.jl
@@ -1483,7 +1483,7 @@ conformal_cubed_sphere_warp(a, b, c, R = max(abs(a), abs(b), abs(c))) =
     cubed_sphere_warp(ConformalCubedSphere(), a, b, c, R)
 
 """
-    cubed_sphere_unwarp(::ConformalCubedSphere, a, b, c, R = max(abs(a), abs(b), abs(c)))
+    cubed_sphere_unwarp(::ConformalCubedSphere, x1, x2, x3)
 
 The inverse of [`cubed_sphere_warp`](@ref). This function projects
 a given point `(x_1, x_2, x_3)` from the surface of a sphere onto a cube


### PR DESCRIPTION
### Description

Just a docstring improvement that was missed in PR #2246 2246

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
