### PR TITLE
Use pkgdir instead of pathof

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,7 @@ bib = CitationBibliography(joinpath(@__DIR__, "bibliography.bib"))
 @everywhere using ClimateMachine
 @everywhere using Documenter, Literate
 
-@everywhere const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+@everywhere const clima_dir = pkgdir(ClimateMachine);
 
 @everywhere GENERATED_DIR = joinpath(source_dir, "generated") # generated files directory
 rm(GENERATED_DIR, force = true, recursive = true)

--- a/docs/src/HowToGuides/Atmos/AtmosReferenceState.md
+++ b/docs/src/HowToGuides/Atmos/AtmosReferenceState.md
@@ -4,7 +4,7 @@ Here, we plot the atmospheric reference state profiles for a few different polyn
 
 ```@example
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 using Plots
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));
 include(joinpath(clima_dir, "test", "Atmos", "Model", "get_atmos_ref_states.jl"));

--- a/docs/src/Theory/Atmos/EDMF_plots.md
+++ b/docs/src/Theory/Atmos/EDMF_plots.md
@@ -20,7 +20,7 @@ to one of the EDMF profile constructors.
 ```@example
 using UnPack
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 using ClimateMachine.Atmos: AtmosModel
 using ClimateMachine.VariableTemplates
 using Thermodynamics

--- a/test/Atmos/EDMF/bomex_edmf.jl
+++ b/test/Atmos/EDMF/bomex_edmf.jl
@@ -7,7 +7,7 @@ import ClimateMachine.DGMethods: custom_filter!
 using ClimateMachine.Mesh.Filters: apply!
 using ClimateMachine.BalanceLaws: vars_state
 using JLD2, FileIO
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 include(joinpath(clima_dir, "experiments", "AtmosLES", "bomex_model.jl"))
 include(joinpath("helper_funcs", "diagnostics_configuration.jl"))

--- a/test/Atmos/EDMF/ekman_layer.jl
+++ b/test/Atmos/EDMF/ekman_layer.jl
@@ -17,7 +17,7 @@ using ClimateMachine.SingleStackUtils
 using ClimateMachine.Checkpoint
 using ClimateMachine.BalanceLaws: vars_state
 using ClimateMachine.Atmos
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 import CLIMAParameters
 import ClimateMachine.DGMethods.FVReconstructions: FVLinear
 

--- a/test/Atmos/EDMF/report_mse_bomex.jl
+++ b/test/Atmos/EDMF/report_mse_bomex.jl
@@ -1,5 +1,5 @@
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 if parse(Bool, get(ENV, "CLIMATEMACHINE_PLOT_EDMF_COMPARISON", "false"))
     plot_dir = joinpath(clima_dir, "output", "bomex_edmf", "pycles_comparison")

--- a/test/Atmos/EDMF/report_mse_sbl_anelastic.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_anelastic.jl
@@ -1,5 +1,5 @@
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 if parse(Bool, get(ENV, "CLIMATEMACHINE_PLOT_EDMF_COMPARISON", "false"))
     plot_dir = joinpath(clima_dir, "output", "sbl_edmf", "pycles_comparison")

--- a/test/Atmos/EDMF/report_mse_sbl_coupled_edmf_an1d.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_coupled_edmf_an1d.jl
@@ -1,5 +1,5 @@
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 if parse(Bool, get(ENV, "CLIMATEMACHINE_PLOT_EDMF_COMPARISON", "false"))
     plot_dir = joinpath(clima_dir, "output", "sbl_edmf", "pycles_comparison")

--- a/test/Atmos/EDMF/report_mse_sbl_edmf.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_edmf.jl
@@ -1,5 +1,5 @@
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 if parse(Bool, get(ENV, "CLIMATEMACHINE_PLOT_EDMF_COMPARISON", "false"))
     plot_dir = joinpath(clima_dir, "output", "sbl_edmf", "pycles_comparison")

--- a/test/Atmos/EDMF/report_mse_sbl_ss_implicit.jl
+++ b/test/Atmos/EDMF/report_mse_sbl_ss_implicit.jl
@@ -1,5 +1,5 @@
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 if parse(Bool, get(ENV, "CLIMATEMACHINE_PLOT_EDMF_COMPARISON", "false"))
     plot_dir = joinpath(clima_dir, "output", "sbl_edmf", "pycles_comparison")

--- a/test/Atmos/EDMF/stable_bl_anelastic1d.jl
+++ b/test/Atmos/EDMF/stable_bl_anelastic1d.jl
@@ -6,7 +6,7 @@ using ClimateMachine.BalanceLaws: vars_state
 import ClimateMachine.BalanceLaws: projection
 import ClimateMachine.DGMethods
 using ClimateMachine.Atmos
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 import CLIMAParameters
 
 include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))

--- a/test/Atmos/EDMF/stable_bl_coupled_edmf_an1d.jl
+++ b/test/Atmos/EDMF/stable_bl_coupled_edmf_an1d.jl
@@ -6,7 +6,7 @@ using ClimateMachine.BalanceLaws: vars_state
 import ClimateMachine.BalanceLaws: projection
 import ClimateMachine.DGMethods
 using ClimateMachine.Atmos
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 import CLIMAParameters
 
 include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))

--- a/test/Atmos/EDMF/stable_bl_edmf.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf.jl
@@ -3,7 +3,7 @@ using ClimateMachine
 using ClimateMachine.SingleStackUtils
 using ClimateMachine.Checkpoint
 using ClimateMachine.BalanceLaws: vars_state
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 import CLIMAParameters
 
 include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))

--- a/test/Atmos/EDMF/stable_bl_edmf_fvm.jl
+++ b/test/Atmos/EDMF/stable_bl_edmf_fvm.jl
@@ -4,7 +4,7 @@ using ClimateMachine.SingleStackUtils
 using ClimateMachine.Checkpoint
 using ClimateMachine.BalanceLaws: vars_state
 import ClimateMachine.DGMethods.FVReconstructions: FVLinear
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 import CLIMAParameters
 
 include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))

--- a/test/Atmos/EDMF/stable_bl_single_stack_implicit.jl
+++ b/test/Atmos/EDMF/stable_bl_single_stack_implicit.jl
@@ -6,7 +6,7 @@ using ClimateMachine.SingleStackUtils
 using ClimateMachine.Checkpoint
 using ClimateMachine.BalanceLaws: vars_state
 using JLD2, FileIO
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 include(joinpath(clima_dir, "experiments", "AtmosLES", "stable_bl_model.jl"))
 include("edmf_model.jl")

--- a/test/Atmos/prog_prim_conversion/runtests.jl
+++ b/test/Atmos/prog_prim_conversion/runtests.jl
@@ -10,7 +10,7 @@ using ClimateMachine
 ClimateMachine.init()
 const ArrayType = ClimateMachine.array_type()
 
-const clima_dir = dirname(dirname(pathof(ClimateMachine)))
+const clima_dir = pkgdir(ClimateMachine)
 
 using ClimateMachine.BalanceLaws
 using ClimateMachine.ConfigTypes

--- a/test/Driver/mms3.jl
+++ b/test/Driver/mms3.jl
@@ -31,7 +31,7 @@ using StaticArrays
 using Test
 using UnPack
 
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(
     clima_dir,
     "test",

--- a/test/Numerics/DGMethods/advection_diffusion/fvm_swirl.jl
+++ b/test/Numerics/DGMethods/advection_diffusion/fvm_swirl.jl
@@ -25,7 +25,7 @@ using ClimateMachine.GenericCallbacks:
 using ClimateMachine.VTK: writevtk, writepvtu
 
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)))
+const clima_dir = pkgdir(ClimateMachine)
 
 if !@isdefined integration_testing
     const integration_testing = parse(

--- a/test/Numerics/Mesh/filter_TMAR.jl
+++ b/test/Numerics/Mesh/filter_TMAR.jl
@@ -24,7 +24,7 @@ using ClimateMachine.GenericCallbacks:
 using ClimateMachine.VTK: writevtk, writepvtu
 
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(
     clima_dir,
     "test",

--- a/tutorials/Atmos/burgers_single_stack.jl
+++ b/tutorials/Atmos/burgers_single_stack.jl
@@ -121,7 +121,7 @@ const FT = Float64;
 # Initialize ClimateMachine for CPU.
 ClimateMachine.init(; disable_gpu = true);
 
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 # Load some helper functions for plotting
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));

--- a/tutorials/Atmos/burgers_single_stack_bjfnk.jl
+++ b/tutorials/Atmos/burgers_single_stack_bjfnk.jl
@@ -123,7 +123,7 @@ const FT = Float64;
 # Initialize ClimateMachine for CPU.
 ClimateMachine.init(; disable_gpu = true);
 
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 # Load some helper functions for plotting
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));

--- a/tutorials/Atmos/burgers_single_stack_fvm.jl
+++ b/tutorials/Atmos/burgers_single_stack_fvm.jl
@@ -125,7 +125,7 @@ const FT = Float64;
 # Initialize ClimateMachine for CPU.
 ClimateMachine.init(; disable_gpu = true);
 
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 # Load some helper functions for plotting
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));

--- a/tutorials/Land/Heat/heat_equation.jl
+++ b/tutorials/Land/Heat/heat_equation.jl
@@ -98,7 +98,7 @@ const FT = Float64;
 # Initialize ClimateMachine for CPU.
 ClimateMachine.init(; disable_gpu = true);
 
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 
 # Load some helper functions for plotting
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));

--- a/tutorials/Land/Soil/Coupled/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Coupled/equilibrium_test.jl
@@ -130,7 +130,7 @@ ClimateMachine.init()
 const FT = Float64;
 
 # Load plot helpers:
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));
 
 # Set soil parameters to be consistent with sand.

--- a/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
+++ b/tutorials/Land/Soil/Heat/bonan_heat_tutorial.jl
@@ -121,7 +121,7 @@ const param_set = EarthParameterSet();
 ClimateMachine.init()
 const FT = Float32;
 # Load functions that will help with plotting
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));
 
 # # Determine soil parameters

--- a/tutorials/Land/Soil/PhaseChange/freezing_front.jl
+++ b/tutorials/Land/Soil/PhaseChange/freezing_front.jl
@@ -118,7 +118,7 @@ ClimateMachine.init()
 const FT = Float64;
 
 # Load plot helpers:
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));
 
 

--- a/tutorials/Land/Soil/Water/equilibrium_test.jl
+++ b/tutorials/Land/Soil/Water/equilibrium_test.jl
@@ -104,7 +104,7 @@ const FT = Float64;
 ClimateMachine.init(; disable_gpu = true);
 
 # Load plot helpers:
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));
 
 # # Set up the soil model

--- a/tutorials/Numerics/DGMethods/Box1D.jl
+++ b/tutorials/Numerics/DGMethods/Box1D.jl
@@ -39,7 +39,7 @@ import ClimateMachine.BalanceLaws:
     wavespeed
 
 ClimateMachine.init(; disable_gpu = true, log_level = "warn");
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(clima_dir, "docs", "plothelpers.jl"));
 
 Base.@kwdef struct Box1D{FT, _init_q, _amplitude, _velo} <: BalanceLaw

--- a/tutorials/Numerics/DGMethods/showcase_filters.jl
+++ b/tutorials/Numerics/DGMethods/showcase_filters.jl
@@ -4,7 +4,7 @@
 # See [Filters API](https://clima.github.io/ClimateMachine.jl/latest/APIs/Numerics/Meshes/Mesh/#Filters-1) for filters interface details.
 
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(clima_dir, "tutorials", "Numerics", "DGMethods", "Box1D.jl"))
 
 const FT = Float64

--- a/tutorials/Numerics/TimeStepping/explicit_lsrk.jl
+++ b/tutorials/Numerics/TimeStepping/explicit_lsrk.jl
@@ -8,7 +8,7 @@
 # we will only run the experiment for a total of 100 simulation seconds.
 
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(
     clima_dir,
     "tutorials",

--- a/tutorials/Numerics/TimeStepping/imex_ark.jl
+++ b/tutorials/Numerics/TimeStepping/imex_ark.jl
@@ -9,7 +9,7 @@
 # Details on this test case can be found in Sec. 4.3 of [Giraldo2013](@cite).
 
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(
     clima_dir,
     "tutorials",

--- a/tutorials/Numerics/TimeStepping/mis.jl
+++ b/tutorials/Numerics/TimeStepping/mis.jl
@@ -8,7 +8,7 @@
 # we will only run the experiment for a total of 500 simulation seconds.
 
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(
     clima_dir,
     "tutorials",

--- a/tutorials/Numerics/TimeStepping/multirate_rk.jl
+++ b/tutorials/Numerics/TimeStepping/multirate_rk.jl
@@ -9,7 +9,7 @@
 # Details on this test case can be found in Sec. 4.3 of [Giraldo2013](@cite).
 
 using ClimateMachine
-const clima_dir = dirname(dirname(pathof(ClimateMachine)));
+const clima_dir = pkgdir(ClimateMachine);
 include(joinpath(
     clima_dir,
     "tutorials",


### PR DESCRIPTION
`pkgdir` is available since Julia 1.4 (https://github.com/JuliaLang/julia/blob/v1.4.0/NEWS.md) and this repo is at 1.5: 

https://github.com/CliMA/ClimateMachine.jl/blob/2f84c00ecec8cc6b1783306327397c0879f643c6/Project.toml#L104

## Details

```julia
julia> dirname(dirname(pathof(Revise))) == pkgdir(Revise)
true
```