### PR TITLE
Fix rendering of `.mp4` animations in Docs

### DIFF
--- a/tutorials/Ocean/geostrophic_adjustment.jl
+++ b/tutorials/Ocean/geostrophic_adjustment.jl
@@ -221,4 +221,4 @@ animation = @animate for p in movie_plots
     )
 end
 
-gif(animation, "geostrophic_adjustment.mp4", fps = 5) # hide
+mp4(animation, "geostrophic_adjustment.mp4", fps = 5) # hide

--- a/tutorials/Ocean/internal_wave.jl
+++ b/tutorials/Ocean/internal_wave.jl
@@ -237,4 +237,4 @@ animation = @animate for (i, state) in enumerate(fetched_states)
     )
 end
 
-gif(animation, "internal_wave.mp4", fps = 5) # hide
+mp4(animation, "internal_wave.mp4", fps = 5) # hide

--- a/tutorials/Ocean/shear_instability.jl
+++ b/tutorials/Ocean/shear_instability.jl
@@ -136,4 +136,4 @@ animation = @animate for (i, state) in enumerate(fetched_states)
     plot(u_plot, θ_plot, title = [u_title θ_title], size = (600, 250))
 end
 
-gif(animation, "shear_instability.mp4", fps = 5)
+mp4(animation, "shear_instability.mp4", fps = 5)


### PR DESCRIPTION
### Description

This PR fixes the rendering of animations in the Tutorials/Ocean section, e.g., at:
https://clima.github.io/ClimateMachine.jl/latest/generated/Ocean/geostrophic_adjustment/#Running-the-simulation-and-animating-the-results

- [x] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code is exercised in an integration test OR N/A.
- [x] Documentation has been added/updated OR N/A.
